### PR TITLE
CMake improvements with plugin example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ plugins/*
 
 # CMake CLion style
 cmake-build-*/
+src/cmake-build-*/
 
 # File-based project format
 *.iws
@@ -86,7 +87,6 @@ tags
 # EMACS
 
 # -*- mode: gitignore; -*-
-*~
 \#*\#
 /.emacs.desktop
 /.emacs.desktop.lock

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,16 +48,17 @@ if(NOT DEFINED PLUGIN_OUTPUT_DIRECTORY)
     set(PLUGIN_OUTPUT_DIRECTORY "plugins")
     message(STATUS "${CMAKE_PROJECT_NAME}: Set default PLUGIN_OUTPUT_DIRECTORY")
 endif()
+message(STATUS "${CMAKE_PROJECT_NAME}: PLUGIN_OUTPUT_DIRECTORY: ${PLUGIN_OUTPUT_DIRECTORY}")
 
 # Default plugins static libraries installation directory is 'lib'
 if(NOT DEFINED PLUGIN_LIBRARY_OUTPUT_DIRECTORY)
     set(PLUGIN_LIBRARY_OUTPUT_DIRECTORY "lib")
     message(STATUS "${CMAKE_PROJECT_NAME}: Set default PLUGIN_OUTPUT_DIRECTORY")
 endif()
-
-message(STATUS "${CMAKE_PROJECT_NAME}: PLUGIN_OUTPUT_DIRECTORY: ${PLUGIN_OUTPUT_DIRECTORY}")
 message(STATUS "${CMAKE_PROJECT_NAME}: PLUGIN_LIBRARY_OUTPUT_DIRECTORY: ${PLUGIN_LIBRARY_OUTPUT_DIRECTORY}")
 
+# Set it ON for additional CMake printout
+set(EICRECON_VERBOSE_CMAKE OFF)
 
 # Add CMake additional functionality:
 include(cmake/print_functions.cmake)                        # Helpers to print fancy headers, file names, etc
@@ -72,6 +73,7 @@ print_grand_header("    B U I L D   E I C R E C O N   P A R T S    ")
 add_subdirectory( detectors/BEMC )
 add_subdirectory( services/geometry/dd4hep )
 add_subdirectory( services/io/podio )
+add_subdirectory( tests )
 
 
 # Print what we had built

--- a/src/cmake/jana_plugin.cmake
+++ b/src/cmake/jana_plugin.cmake
@@ -11,7 +11,7 @@ macro(plugin_add _name)
     add_library(${_name}_library STATIC "")
     target_include_directories(${_name}_library PUBLIC ${CMAKE_SOURCE_DIR})
     target_include_directories(${_name}_library SYSTEM PRIVATE ${fmt_INCLUDE_DIR})
-    set_target_properties(BEMC_library PROPERTIES PREFIX "lib" OUTPUT_NAME "${_name}" SUFFIX ".so")
+    set_target_properties(${_name}_library PROPERTIES PREFIX "lib" OUTPUT_NAME "${_name}" SUFFIX ".a")
 
     # Define plugin
     add_library(${_name}_plugin SHARED ${PLUGIN_SOURCES})
@@ -23,9 +23,6 @@ macro(plugin_add _name)
     install(TARGETS ${_name}_plugin DESTINATION ${PLUGIN_OUTPUT_DIRECTORY})
     install(TARGETS ${_name}_library DESTINATION ${PLUGIN_LIBRARY_OUTPUT_DIRECTORY})
 
-    # we don't want our plugins to start with 'lib' prefix. We do want them to end with '.so' rather than '.dylib'
-    # example: we want vmeson.so but not libvmeson.so or libvmeson.dylib
-    set_target_properties(${_name}_plugin PROPERTIES PREFIX "" SUFFIX ".so")
 endmacro()
 
 # target_link_libraries for both a plugin and a library

--- a/src/cmake/jana_plugin.cmake
+++ b/src/cmake/jana_plugin.cmake
@@ -1,38 +1,106 @@
 # Common macro to add plugins
-macro(add_plugin _name)
+macro(plugin_add _name)
 
-    project(_name_project)
+    project(${_name}_project)
 
-    # Find dependencies
+    # Include fmt by default because... why not?
     find_package(fmt REQUIRED)
     set(fmt_INCLUDE_DIR ${fmt_DIR}/../../../include)
 
     # Define library
     add_library(${_name}_library STATIC "")
-    target_include_directories(${_name}_library INTERFACE ${CMAKE_SOURCE_DIR})
-    #set_target_properties(BEMC_library PROPERTIES PREFIX "lib" OUTPUT_NAME "BEMC" SUFFIX ".so")
+    target_include_directories(${_name}_library PUBLIC ${CMAKE_SOURCE_DIR})
+    target_include_directories(${_name}_library SYSTEM PRIVATE ${fmt_INCLUDE_DIR})
+    set_target_properties(BEMC_library PROPERTIES PREFIX "lib" OUTPUT_NAME "${_name}" SUFFIX ".so")
 
     # Define plugin
     add_library(${_name}_plugin SHARED ${PLUGIN_SOURCES})
     target_include_directories(${_name}_plugin PUBLIC ${CMAKE_SOURCE_DIR})
+    target_include_directories(${_name}_plugin SYSTEM PRIVATE ${fmt_INCLUDE_DIR})
     set_target_properties(${_name}_plugin PROPERTIES PREFIX "" OUTPUT_NAME "${_name}" SUFFIX ".so")
 
     # Install plugin and library
     install(TARGETS ${_name}_plugin DESTINATION ${PLUGIN_OUTPUT_DIRECTORY})
     install(TARGETS ${_name}_library DESTINATION ${PLUGIN_LIBRARY_OUTPUT_DIRECTORY})
 
-    # Install headers for plugin
-    file(GLOB ALL_HEADERS "*.h*")
-    install(FILES ${ALL_HEADERS} DESTINATION include/detectors/${_name})
-
-
-
-
     # we don't want our plugins to start with 'lib' prefix. We do want them to end with '.so' rather than '.dylib'
-    # example: we want vmeson.so but not libvmeson.so or lybvmeson.dylib
-    set_target_properties(${_name} PROPERTIES PREFIX "" SUFFIX ".so")
+    # example: we want vmeson.so but not libvmeson.so or libvmeson.dylib
+    set_target_properties(${_name}_plugin PROPERTIES PREFIX "" SUFFIX ".so")
+endmacro()
 
-    install(TARGETS ${_name}
-            DESTINATION plugins
-            PUBLIC_HEADER DESTINATION include/plugins)
+# target_link_libraries for both a plugin and a library
+macro(plugin_link_libraries _name)
+    target_link_libraries(${_name}_plugin  ${ARGN})
+    target_link_libraries(${_name}_library ${ARGN})
+endmacro()
+
+# target_include_directories for both a plugin and a library
+macro(plugin_include_directories _name)
+    target_include_directories(${_name}_plugin  ${ARGN})
+    target_include_directories(${_name}_library ${ARGN})
+endmacro()
+
+
+
+
+# runs target_sources both for library and a plugin
+macro(plugin_sources _name)
+    # This is needed as this is a macro (see cmake macro documentation)
+    set(SOURCES ${ARGN})
+
+    # Plugin don't need <plugin_name>.cc in library
+    set(PLUGIN_CC_FILE ${_name}.cc)
+    get_filename_component(PLUGIN_CC_FILE "${CMAKE_CURRENT_LIST_DIR}/${PLUGIN_CC_FILE}" ABSOLUTE)
+    list(REMOVE_ITEM SOURCES ${PLUGIN_CC_FILE})
+
+    target_sources(${_name}_plugin PRIVATE ${SOURCES})
+    target_sources(${_name}_library PRIVATE ${SOURCES})
+endmacro()
+
+# The macro grabs sources as *.cc *.cpp *.c and headers as *.h *.hh *.hpp
+# Then correctly sets sources for ${_name}_plugin and ${_name}_library targets
+# Adds headers to the correct installation directory
+macro(plugin_glob_all _name)
+
+    # But... GLOB here makes this file just hot pluggable
+    file(GLOB LIB_SRC_FILES *.cc *.cpp *.c)
+    file(GLOB PLUGIN_SRC_FILES *.cc *.cpp *.c)
+    file(GLOB HEADER_FILES *.h *.hh *.hpp)
+
+    # Library don't need <plugin_name>.cc but Plugin does
+    set(PLUGIN_CC_FILE ${_name}.cc)
+
+    # Make the path absolute as GLOB files will be absolute paths
+    get_filename_component(PLUGIN_CC_FILE_ABS "${CMAKE_CURRENT_LIST_DIR}/${PLUGIN_CC_FILE}" ABSOLUTE)
+
+    # Remove plugin.cc file from libraries
+    list(REMOVE_ITEM LIB_SRC_FILES ${PLUGIN_CC_FILE_ABS})
+
+    # We need plugin relative path for correct installation
+    string(REPLACE ${CMAKE_SOURCE_DIR} "" PLUGIN_RELATIVE_PATH ${PROJECT_SOURCE_DIR})
+
+    # >oO Debug output if needed
+    if(${EICRECON_VERBOSE_CMAKE})
+        message(STATUS "plugin_glob_all:${_name}: PLUGIN_CC_FILE   ${PLUGIN_CC_FILE}")
+        message(STATUS "plugin_glob_all:${_name}: LIB_SRC_FILES    ${LIB_SRC_FILES}")
+        message(STATUS "plugin_glob_all:${_name}: PLUGIN_SRC_FILES ${PLUGIN_SRC_FILES}")
+        message(STATUS "plugin_glob_all:${_name}: HEADER_FILES     ${HEADER_FILES}")
+        message(STATUS "plugin_glob_all:${_name}: PLUGIN_RLTV_PATH ${PLUGIN_RELATIVE_PATH}")
+    endif()
+
+    # To somehow control GLOB lets at least PRINT files we are going to compile:
+    message(STATUS "Source files:")
+    print_file_names("  " ${PLUGIN_SRC_FILES})    # Prints source files
+    message(STATUS "Plugin-only file is: ${PLUGIN_CC_FILE}")
+    message(STATUS "Header files:")
+    print_file_names("  " ${HEADER_FILES})  # Prints header files
+
+    # Add sources to target
+    target_sources(${_name}_plugin PRIVATE ${PLUGIN_SRC_FILES})
+    target_sources(${_name}_library PRIVATE ${LIB_SRC_FILES})
+
+    #Add correct headers installation
+    # Install headers for plugin
+
+    install(FILES ${HEADER_FILES} DESTINATION include/${PLUGIN_RELATIVE_PATH}/${_name})
 endmacro()

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(data_flow_test)

--- a/src/tests/data_flow_test/CMakeLists.txt
+++ b/src/tests/data_flow_test/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Automatically set plugin name the same as the directory name
+# Don't forget string(REPLACE " " "_" PLUGIN_NAME ${PLUGIN_NAME}) if this dir has spaces in its name
+get_filename_component(PLUGIN_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
+
+print_header(">>>>   P L U G I N :   ${PLUGIN_NAME}    <<<<")       # Fancy printing
+
+# Function creates ${PLUGIN_NAME}_plugin and ${PLUGIN_NAME}_library targets
+# Setting default includes, libraries and installation paths
+plugin_add(${PLUGIN_NAME})
+
+# Find dependencies
+find_package(JANA REQUIRED)
+find_package(EDM4HEP REQUIRED)
+find_package(podio REQUIRED)
+find_package(DD4hep REQUIRED)
+find_package(ROOT REQUIRED)
+
+# The macro grabs sources as *.cc *.cpp *.c and headers as *.h *.hh *.hpp
+# Then correctly sets sources for ${_name}_plugin and ${_name}_library targets
+# Adds headers to the correct installation directory
+plugin_glob_all(${PLUGIN_NAME})
+
+# Add include directories
+# (same as target_include_directories but for both plugin and library)
+plugin_include_directories(${PLUGIN_NAME} SYSTEM PUBLIC ${JANA_INCLUDE_DIR} ${podio_INCLUDE_DIR} ${EDM4HEP_INCLUDE_DIR} ${DD4hep_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS})
+
+# Add libraries
+# (same as target_include_directories but for both plugin and library)
+plugin_link_libraries(${PLUGIN_NAME} ${JANA_LIB})

--- a/src/tests/data_flow_test/OccupancyAnalysis.cc
+++ b/src/tests/data_flow_test/OccupancyAnalysis.cc
@@ -1,0 +1,132 @@
+#include "OccupancyAnalysis.h"
+
+#include <JANA/JApplication.h>
+#include <JANA/JEvent.h>
+
+#include <fmt/core.h>
+
+#include <edm4hep/SimCalorimeterHit.h>
+
+#include <TDirectory.h>
+#include <TCanvas.h>
+#include <TROOT.h>
+#include <TFile.h>
+#include <TTree.h>
+
+using namespace fmt;
+
+//------------------
+// OccupancyAnalysis (Constructor)
+//------------------
+OccupancyAnalysis::OccupancyAnalysis(JApplication *app) :
+	JEventProcessor(app)
+{
+}
+
+//------------------
+// Init
+//------------------
+void OccupancyAnalysis::Init()
+{
+	// Ask service locator a file to write to
+	auto file = new TFile("data_work_flow.root");
+
+	// Root related, we switch gDirectory to this file
+	file->cd();
+	fmt::print("OccupancyAnalysis::gDirectory->pwd()\n");	// >oO Debug print
+	gDirectory->pwd();
+
+	// Create a directory for this plugin. And subdirectories for series of histograms
+	_dir_main = file->mkdir("data_flow_test");
+
+    // Hits by Z distribution
+    _th1_prt_pz = new TH1F("hits_z", "Hits Z distribution [mm]", 100, -30, 30);
+    _th1_prt_pz->SetDirectory(_dir_main);
+
+    // Total xy occupancy
+    _th2_prt_pxy = new TH2F(NAME_OF(total_occ), "Total XY occupancy (all Z)", 600, -2000, 2000, 300, -2000., 2000.);
+    _th2_prt_pxy->SetDirectory(_dir_main);
+    _th2_prt_pxy->SetOption("COLSCATZ");		// Draw as heat map by default
+
+}
+
+
+//------------------
+// Process
+//------------------
+void OccupancyAnalysis::Process(const std::shared_ptr<const JEvent>& event)
+{
+
+
+    fmt::print("OccupancyAnalysis::Process() event {}\n", event->GetEventNumber());
+    auto simhits = event->Get<edm4hep::SimCalorimeterHit>("EcalBarrelHits");
+
+//	// Get hits
+//	auto hits = event->Get<minimodel::McFluxHit>();
+//
+// 	for(auto hit: hits) {
+//
+//		// Create local x,y,z,name as we will use them a lot to drag hit-> around
+//		double x = hit->x;
+//		double y = hit->y;
+//		double z = hit->z;
+//
+//		th1_hits_z->Fill(z);	// Hits over z axes
+//		total_occ->Fill(x, y);	// Total xy occupancy
+//		if(z > 0) h_part_occ->Fill(x, y);	// Hadron part xy occupancy (z > 0)
+//		if(z <= 0) e_part_occ->Fill(x, y); // electron part xy occupancy (Z < 0)
+//
+//		// Fill occupancy by layer/vol_name
+//		th2_by_layer->Get(hit->vol_name)->Fill(x, y);
+//
+//		// Fill occupancy per detector
+//		auto detector_name = VolNameToDetName(hit->vol_name);	// get detector name
+//		if(!detector_name.empty()) {
+//			th1_z_by_detector->Get(detector_name)->Fill(z);
+//			th2_by_detector->Get(detector_name)->Fill(x, y);
+//			th3_by_detector->Get(detector_name)->Fill(z, x, y);  // z, x, y is the right order here
+//			th3_hits3d->Fill(z, x, y);
+//		}
+//	}
+}
+
+
+//------------------
+// Finish
+//------------------
+void OccupancyAnalysis::Finish()
+{
+	fmt::print("OccupancyAnalysis::Finish() called\n");
+
+	// Next we want to create several pretty canvases (with histograms drawn on "same")
+	// But we don't want those canvases to pop up. So we set root to batch mode
+	// We will restore the mode afterwards
+	//bool save_is_batch = gROOT->IsBatch();
+	//gROOT->SetBatch(true);
+
+	// 3D hits distribution
+//	auto th3_by_det_canvas = new TCanvas("th3_by_det_cnv", "Occupancy of detectors");
+//	dir_main->Append(th3_by_det_canvas);
+//	for (auto& kv : th3_by_detector->GetMap()) {
+//		auto th3_hist = kv.second;
+//		th3_hist->Draw("same");
+//	}
+//	th3_by_det_canvas->GetPad(0)->BuildLegend();
+//
+//	// Hits Z by detector
+//
+//	// Create pretty canvases
+//	auto z_by_det_canvas = new TCanvas("z_by_det_cnv", "Hit Z distribution by detector");
+//	dir_main->Append(z_by_det_canvas);
+//	th1_hits_z->Draw("PLC PFC");
+//
+//	for (auto& kv : th1_z_by_detector->GetMap()) {
+//		auto hist = kv.second;
+//		hist->Draw("SAME PLC PFC");
+//		hist->SetFillStyle(3001);
+//	}
+//	z_by_det_canvas->GetPad(0)->BuildLegend();
+//
+//	gROOT->SetBatch(save_is_batch);
+}
+

--- a/src/tests/data_flow_test/OccupancyAnalysis.h
+++ b/src/tests/data_flow_test/OccupancyAnalysis.h
@@ -1,0 +1,82 @@
+#ifndef EICRECON_OCCUPANCY_ANALYSIS_H
+#define EICRECON_OCCUPANCY_ANALYSIS_H
+
+#include <TH1F.h>
+#include <TH3F.h>
+#include <TH2F.h>
+
+#include <JANA/JEventProcessor.h>
+
+class JEvent;
+class JApplication;
+
+class OccupancyAnalysis:public JEventProcessor
+{
+public:
+    explicit OccupancyAnalysis(JApplication *);
+    ~OccupancyAnalysis() override = default;
+
+    //----------------------------
+    // Init
+    //
+    // This is called once before the first call to the Process method
+    // below. You may, for example, want to open an output file here.
+    // Only one thread will call this.
+    void Init() override;
+
+    //----------------------------
+    // Process
+    //
+    // This is called for every event. Multiple threads may call this
+    // simultaneously. If you write something to an output file here
+    // then make sure to protect it with a mutex or similar mechanism.
+    // Minimize what is done while locked since that directly affects
+    // the multi-threaded performance.
+    void Process(const std::shared_ptr<const JEvent>& event) override;
+
+    //----------------------------
+    // Finish
+    //
+    // This is called once after all events have been processed. You may,
+    // for example, want to close an output file here.
+    // Only one thread will call this.
+    void Finish() override;
+
+private:
+
+    TDirectory* _dir_main;               /// Main TDirectory for this plugin 'occupancy_ana'
+    TH1F * _th1_prt_pz;                  /// MC Particles pz
+    TH2F * _th2_prt_pxy;                 /// MC Particles px,py
+
+//    std::string VolNameToDetName(const std::string& vol_name);
+//
+//    bool hits_are_produced = false;
+//    bool gen_particles_are_produced = false;
+//
+//    ej::EServicePool services;
+//    std::vector<std::string> detector_names = {"Barrel_CTD", "VTX", "GEM", "fSI"};
+//
+//    TH2F * total_occ{};
+//    TH2F * h_part_occ{};
+//    TH2F * e_part_occ{};
+//
+//
+//
+//
+//    std::recursive_mutex lock;
+//
+//    TH3F * th3_hits3d{};
+//
+//    PtrByNameMapHelper<TH3F> *th3_by_detector{};
+//    PtrByNameMapHelper<TH2F> *th2_by_detector{};
+//    PtrByNameMapHelper<TH2F> *th2_by_layer{};
+//    PtrByNameMapHelper<TH1F> *th1_z_by_detector{};
+//
+//
+//    TDirectory* dir_th2_by_detector{};    /// TDir for
+//    TDirectory* dir_th2_by_layer{};
+//    TDirectory* dir_th3_by_detector{};
+//    TDirectory* dir_th1_by_detector{};
+};
+
+#endif //EICRECON_OCCUPANCY_ANALYSIS_H

--- a/src/tests/data_flow_test/README.md
+++ b/src/tests/data_flow_test/README.md
@@ -1,0 +1,1 @@
+This is guinea pig plugin for active development phase

--- a/src/tests/data_flow_test/data_flow_test.cc
+++ b/src/tests/data_flow_test/data_flow_test.cc
@@ -1,0 +1,21 @@
+// Copyright 2022, David Lawrence
+// Subject to the terms in the LICENSE file found in the top-level directory.
+//
+//
+
+#include <JANA/JApplication.h>
+#include <JANA/JFactoryGenerator.h>
+
+#include "OccupancyAnalysis.h"
+//#include "JFactory_EcalBarrelRawCalorimeterHit.h.bck"
+//#include "JFactory_RawCalorimeterHit_EcalBarrelRawCalorimeterHits.h.bck"
+    
+extern "C" {
+    void InitPlugin(JApplication *app) {
+        InitJANAPlugin(app);
+        app->Add(new OccupancyAnalysis(app));
+        //app->Add(new JFactoryGeneratorT<JFactory_EcalBarrelRawCalorimeterHit>());
+        //app->Add(new JFactoryGeneratorT<JFactory_RawCalorimeterHit_EcalBarrelRawCalorimeterHits>());
+    }
+}
+    


### PR DESCRIPTION
- **ecce is replaced with epic (BREAKING)**
- Some meta improvements in CMake system
- Plugin boilerplate macros-es are introduced:
   - plugin_add, 
   - plugin_glob_all, 
   - plugin_include_direcotries, 
   - plugin_link_libraries
- Example plugin is made

So I've made that plugin_* macros that minimizes plugins boilerplate to: 

```cmake
# Automatically set plugin name the same as the directory name
# Don't forget string(REPLACE " " "_" PLUGIN_NAME ${PLUGIN_NAME}) if this dir has spaces in its name
get_filename_component(PLUGIN_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)

print_header(">>>>   P L U G I N :   ${PLUGIN_NAME}    <<<<")       # Fancy printing

# Function creates ${PLUGIN_NAME}_plugin and ${PLUGIN_NAME}_library targets
# Setting default includes, libraries and installation paths
plugin_add(${PLUGIN_NAME})

# Find dependencies
find_package(JANA REQUIRED)
find_package(EDM4HEP REQUIRED)
find_package(podio REQUIRED)
find_package(DD4hep REQUIRED)
find_package(ROOT REQUIRED)

# The macro grabs sources as *.cc *.cpp *.c and headers as *.h *.hh *.hpp
# Then correctly sets sources for ${_name}_plugin and ${_name}_library targets
# Adds headers to the correct installation directory
plugin_glob_all(${PLUGIN_NAME})

# Add include directories
# (same as target_include_directories but for both plugin and library)
plugin_include_directories(${PLUGIN_NAME} SYSTEM PUBLIC ${JANA_INCLUDE_DIR} ${podio_INCLUDE_DIR} ${EDM4HEP_INCLUDE_DIR} ${DD4hep_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS})

# Add libraries
# (same as target_include_directories but for both plugin and library)
plugin_link_libraries(${PLUGIN_NAME} ${JANA_LIB})
```
It creates both plugin and a library removing `${plugin_name}.cc` from a library list. 
It also provides kind of nice output like: 

```
>>>>   P L U G I N :   data_flow_test    <<<<
---------------------------------------------
-- Including DD4hepBuild.cmake
-- DD4hep uses Geant4
-- Found Python: /usr/include/python3.8 (found suitable exact version "3.8.10") found components: Development Development.Module Development.Embed 
-- |++> Using python executable:  /usr/bin/python3.8
-- Source files:
--      OccupancyAnalysis.cc
--      data_flow_test.cc
-- Plugin-only file is: data_flow_test.cc
-- Header files:
--      OccupancyAnalysis.h
-- 
```
