### PR TITLE
BEMC,data_flow_test: add missing library dependencies on fmt, DD4hep,EDM4HEP

### DIFF
--- a/src/detectors/BEMC/CMakeLists.txt
+++ b/src/detectors/BEMC/CMakeLists.txt
@@ -46,7 +46,7 @@ set_target_properties(BEMC_library PROPERTIES PREFIX "lib" OUTPUT_NAME "BEMC" SU
 add_library(BEMC_plugin SHARED ${PLUGIN_SOURCES})
 target_include_directories(BEMC_plugin PUBLIC ${INCLUDE_DIRS})
 target_include_directories(BEMC_plugin PUBLIC ${CMAKE_SOURCE_DIR})
-target_link_libraries(BEMC_plugin BEMC_library ${JANA_LIB})
+target_link_libraries(BEMC_plugin BEMC_library ${JANA_LIB} EDM4HEP::edm4hep DD4hep::DDCore)
 set_target_properties(BEMC_plugin PROPERTIES PREFIX "" OUTPUT_NAME "BEMC" SUFFIX ".so")
 
 # Install plugin

--- a/src/tests/data_flow_test/CMakeLists.txt
+++ b/src/tests/data_flow_test/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(EDM4HEP REQUIRED)
 find_package(podio REQUIRED)
 find_package(DD4hep REQUIRED)
 find_package(ROOT REQUIRED)
+find_package(fmt REQUIRED)
 
 # The macro grabs sources as *.cc *.cpp *.c and headers as *.h *.hh *.hpp
 # Then correctly sets sources for ${_name}_plugin and ${_name}_library targets
@@ -26,4 +27,4 @@ plugin_include_directories(${PLUGIN_NAME} SYSTEM PUBLIC ${JANA_INCLUDE_DIR} ${po
 
 # Add libraries
 # (same as target_include_directories but for both plugin and library)
-plugin_link_libraries(${PLUGIN_NAME} ${JANA_LIB})
+plugin_link_libraries(${PLUGIN_NAME} ${JANA_LIB} fmt::fmt)


### PR DESCRIPTION
Linker on macOS does not allow unresolved symbols by default.