### PR TITLE
CMake minimum is 3.16. Bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,5 @@ flycheck_*.el
 *.bck
 
 bin/
+
+src/tests/pyjano/eicrecon_path.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,7 @@
 
 
 
-cmake_minimum_required(VERSION 3.9)
-cmake_policy(SET CMP0074 NEW)  # use the policy to look for <package>_ROOT envar
+cmake_minimum_required(VERSION 3.16)
 
 project(EICRecon)
 

--- a/README.md
+++ b/README.md
@@ -284,8 +284,7 @@ E.g. if you want to create a plugin named `my_plugin`
 Recommended CMake for a plugin:
 
 ```cmake
-cmake_minimum_required(VERSION 3.9)
-cmake_policy(SET CMP0074 NEW)  # use the policy to look for <package>_ROOT envar
+cmake_minimum_required(VERSION 3.16)
 
 # Automatically set plugin name the same as the direcotry name
 # Don't forget string(REPLACE " " "_" PLUGIN_NAME ${PLUGIN_NAME}) if this dir has spaces in its name

--- a/src/algorithms/CMakeLists.txt
+++ b/src/algorithms/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
-cmake_policy(SET CMP0074 NEW)  # use the policy to look for <package>_ROOT envar
+cmake_minimum_required(VERSION 3.16)
 
 print_header(">>>>   L I B R A R Y :   algorithms    <<<<")       # Fancy printing
 

--- a/src/detectors/BEMC/CMakeLists.txt
+++ b/src/detectors/BEMC/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
-cmake_policy(SET CMP0074 NEW)  # use the policy to look for <package>_ROOT envar
+cmake_minimum_required(VERSION 3.16)
 
 # Automatically set plugin name the same as the directory name
 # Don't forget string(REPLACE " " "_" PLUGIN_NAME ${PLUGIN_NAME}) if this dir has spaces in its name

--- a/src/services/geometry/dd4hep/CMakeLists.txt
+++ b/src/services/geometry/dd4hep/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
-cmake_policy(SET CMP0074 NEW)  # use the policy to look for <package>_ROOT envar
+cmake_minimum_required(VERSION 3.16)
 
 # Automatically set plugin name the same as the directory name
 get_filename_component(PLUGIN_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)

--- a/src/services/io/podio/CMakeLists.txt
+++ b/src/services/io/podio/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.9)
-cmake_policy(SET CMP0074 NEW)  # use the policy to look for <package>_ROOT envar
+cmake_minimum_required(VERSION 3.16)
+
 
 # Automatically set plugin name the same as the directory name
 get_filename_component(PLUGIN_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)

--- a/src/services/randomgenerator/CMakeLists.txt
+++ b/src/services/randomgenerator/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
-cmake_policy(SET CMP0074 NEW)  # use the policy to look for <package>_ROOT envar
+cmake_minimum_required(VERSION 3.16)
 
 get_filename_component(PLUGIN_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
 print_header(">>>>   P L U G I N :   ${PLUGIN_NAME}    <<<<")       # Fancy printing

--- a/src/tests/BEMC_test/CMakeLists.txt
+++ b/src/tests/BEMC_test/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
-cmake_policy(SET CMP0074 NEW)  # use the policy to look for <package>_ROOT envar
+cmake_minimum_required(VERSION 3.16)
 
 project(BEMC_test_project)
 

--- a/src/tests/BEMC_test/CMakeLists.txt
+++ b/src/tests/BEMC_test/CMakeLists.txt
@@ -14,7 +14,8 @@ set( BEMC_test_PLUGIN_SOURCES ${mysourcefiles} )
 
 add_library(BEMC_test_plugin SHARED ${BEMC_test_PLUGIN_SOURCES})
 
-target_include_directories(BEMC_test_plugin PUBLIC ${CMAKE_SOURCE_DIR} ${JANA_INCLUDE_DIR} ${ROOT_INCLUDE_DIRS} ${podio_INCLUDE_DIR} ${EDM4HEP_INCLUDE_DIR} )
+target_include_directories(BEMC_test_plugin PUBLIC ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(BEMC_test_plugin SYSTEM PUBLIC ${JANA_INCLUDE_DIR} ${ROOT_INCLUDE_DIRS} ${podio_INCLUDE_DIR} ${EDM4HEP_INCLUDE_DIR} )
 target_link_libraries(BEMC_test_plugin ${JANA_LIB} ${ROOT_LIBRARIES})
 set_target_properties(BEMC_test_plugin PROPERTIES PREFIX "" OUTPUT_NAME "BEMC_test" SUFFIX ".so")
 

--- a/src/utilities/eicrecon/CMakeLists.txt
+++ b/src/utilities/eicrecon/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
-cmake_policy(SET CMP0074 NEW)  # use the policy to look for <package>_ROOT envar
+cmake_minimum_required(VERSION 3.16)
 
 print_header(">>>>   E X E C U T A B L E :   algorithms    <<<<")       # Fancy printing
 

--- a/src/utilities/eicrecon/CMakeLists.txt
+++ b/src/utilities/eicrecon/CMakeLists.txt
@@ -19,7 +19,7 @@ set(SERVICES_LIBRARIES
         )
 set(DETECTOR_LIBRARIES
         BEMC_library
-        BTRK_library
+        # BTRK_library  lets exclude it until it is more ready-like
         )
 
 

--- a/src/utilities/podio_copy/CMakeLists.txt
+++ b/src/utilities/podio_copy/CMakeLists.txt
@@ -1,6 +1,4 @@
-
-cmake_minimum_required(VERSION 3.9)
-cmake_policy(SET CMP0074 NEW)  # use the policy to look for <package>_ROOT envar
+cmake_minimum_required(VERSION 3.16)
 
 set(CMAKE_CXX_STANDARD 17)
 project(podio_copy_project)

--- a/src/utilities/podio_read/CMakeLists.txt
+++ b/src/utilities/podio_read/CMakeLists.txt
@@ -1,6 +1,4 @@
-
-cmake_minimum_required(VERSION 3.9)
-cmake_policy(SET CMP0074 NEW)  # use the policy to look for <package>_ROOT envar
+cmake_minimum_required(VERSION 3.16)
 
 set(CMAKE_CXX_STANDARD 17)
 project(podio_read_project)


### PR DESCRIPTION
- CMake minimum is 3.16
- CMP0074 policy is removed (since it is not needed anymore)
- Bug fixes

Closes: #28 #36 #33 
