### PR TITLE
Draft: Use generic `algorithms` library in the the EICrecon plugins

### DIFF
--- a/src/detectors/BEMC/BEMCRawCalorimeterHit_factory.cc
+++ b/src/detectors/BEMC/BEMCRawCalorimeterHit_factory.cc
@@ -12,6 +12,10 @@
 #include <fmt/format.h>
 using namespace dd4hep;
 
+#ifdef USE_ALGORITHMS
+#include "JugDigi/CalorimeterHitDigi.h"
+#endif
+
 //
 // This algorithm converted from:
 //

--- a/src/detectors/BEMC/CMakeLists.txt
+++ b/src/detectors/BEMC/CMakeLists.txt
@@ -19,12 +19,23 @@ find_package(EDM4HEP REQUIRED)
 find_package(podio REQUIRED)
 find_package(DD4hep REQUIRED)
 find_package(ROOT REQUIRED)
+find_package(algorithms) # optional
+if(${algorithms_FOUND})
+  find_package(EICD REQUIRED)
+  message(STATUS "algorithms library found")
+  message(STATUS "${algorithms_INCLUDE_DIR}")
+  add_definitions("-DUSE_ALGORITHMS")
+  set(algorithms "algorithms::JugDigiPlugins")
+else()
+  message(STATUS "algorithms library not found.")
+  set(algorithms "")
+endif()
 
 # Add include directories (works same as target_include_directories)
 plugin_include_directories(${PLUGIN_NAME} SYSTEM PUBLIC ${podio_INCLUDE_DIR} ${EDM4HEP_INCLUDE_DIR} ${DD4hep_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS})
 
 # Add libraries (works same as target_include_directories)
-plugin_link_libraries(${PLUGIN_NAME} EDM4HEP::edm4hep DD4hep::DDCore)
+plugin_link_libraries(${PLUGIN_NAME} EDM4HEP::edm4hep DD4hep::DDCore ${algorithms})
 
 # Additional libraries
 plugin_link_libraries(${PLUGIN_NAME} dd4hep_library calorimetry_library)


### PR DESCRIPTION
**Note: this is a work in progress branch that will aim to track the `main` branch until it is ready to merge into `main`. That may not happen for some time, though.**

The `algorithms` library is a thin shared library that only depends on DD4hep and EDM4hep (and our extensions of it), and maintains the full commit and development history of all juggler algorithms. It is intended as a compatibility layer between EICrecon and key4HEP efforts and to provide a smooth transition path where continued algorithm development can happen even while algorithms are being ported to EICrecon. The goal here is to remove the need for a lot of code porting from gaudi to jana2, and instead end up with algorithms that are small, modular, self-contained, and rely by design only on the data model for interfacing.