### PR TITLE
Move plugins installation directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 
 # Default plugins installation directory is 'plugins'
 if(NOT DEFINED PLUGIN_OUTPUT_DIRECTORY)
-    set(PLUGIN_OUTPUT_DIRECTORY "plugins")
+    set(PLUGIN_OUTPUT_DIRECTORY "lib/EICrecon/plugins")
     message(STATUS "${CMAKE_PROJECT_NAME}: Set default PLUGIN_OUTPUT_DIRECTORY")
 endif()
 message(STATUS "${CMAKE_PROJECT_NAME}: PLUGIN_OUTPUT_DIRECTORY: ${PLUGIN_OUTPUT_DIRECTORY}")
@@ -83,9 +83,18 @@ add_subdirectory( src/detectors )
 add_subdirectory( src/services )
 add_subdirectory( src/utilities )
 add_subdirectory( src/tests )
-
+add_subdirectory( src/scripts )
 
 # Print what we had built
 print_header("CMake processed subdirectories:")
 print_subdirectory_tree()
 message(STATUS "\n-------------------------------")
+
+
+# Print all cmake variables (for debugging)
+#find_package(fmt)
+#get_cmake_property(_variableNames VARIABLES)
+#list (SORT _variableNames)
+#foreach (_variableName ${_variableNames})
+#    message(STATUS "${_variableName}=${${_variableName}}")
+#endforeach()

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ source ${PODIO_HOME}/env.sh
 
 ### EDM4hep
 ~~~
-export EDM4HEP_VERSION=v00-05
+export EDM4HEP_VERSION=v00-06
 export EDM4HEP_HOME=${EICTOPDIR}/EDM4hep/${EDM4HEP_VERSION}
 export EDM4HEP=${EDM4HEP_HOME}/install 
 export EDM4HEP_ROOT=${EDM4HEP}
@@ -187,7 +187,7 @@ source ${EICTOPDIR}/root/root-6.26.04/bin/thisroot.sh
 export BOOST_VERSION=boost-1.79.0
 export JANA_VERSION=v2.0.5
 export PODIO_VERSION=v00-14-03
-export EDM4HEP_VERSION=v00-05
+export EDM4HEP_VERSION=v00-06
 export DD4HEP_VERSION=v01-20-02
 export EIGEN_VERSION=3.4.0
 export ACTS_VERSION=v19.4.0

--- a/src/scripts/CMakeLists.txt
+++ b/src/scripts/CMakeLists.txt
@@ -1,0 +1,19 @@
+
+find_package(ROOT)
+find_package(podio)
+
+if(DEFINED ENV{DETECTOR_PATH})
+    set(DETECTOR_PATH $ENV{DETECTOR_PATH})
+endif()
+if(DEFINED ENV{BEAMLINE_PATH})
+    set(BEAMLINE_PATH $ENV{BEAMLINE_PATH})
+endif()
+
+
+configure_file(eicrecon-this.sh.in  eicrecon-this.sh   @ONLY)
+configure_file(eicrecon-this.csh.in eicrecon-this.csh  @ONLY)
+
+install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/eicrecon-this.sh   DESTINATION bin)
+install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/eicrecon-this.csh  DESTINATION bin)
+
+install(PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/eicmkplugin.py     DESTINATION bin)

--- a/src/scripts/eicrecon-this.csh.in
+++ b/src/scripts/eicrecon-this.csh.in
@@ -1,0 +1,13 @@
+#!/bin/csh
+#
+# This script was automatically generated from the scripts/jana-this.csh.in file in the
+# JANA2 source directory when JANA2 was built. It can be sourced to set the environment
+# up to use this JANA2 build. This includes setting environment variables for some
+# 3rd party packages that were used to build JANA2.
+#
+
+echo "This is a placeholder for now. There are some dependancy packages that do not supply a"
+echo "csh version of their setup scripts so we cannot fully support csh here. It is recommended"
+echo "to use bash for the time being."
+
+

--- a/src/scripts/eicrecon-this.sh.in
+++ b/src/scripts/eicrecon-this.sh.in
@@ -1,0 +1,86 @@
+#!/bin/sh
+#
+# This script was automatically generated from the src/scripts/eicrecon-this.sh.in file in the
+# EICrecon source directory when EICrecon was built. It can be sourced to set the environment
+# up to use this EICrecon build.
+#
+# This finds directories relative to this script. This should allow the entire EICrecon directory
+# to be moved and this script should still work.
+#
+# Dependency packages (i.e. JANA2 and ROOT) are setup using absolute paths
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+export EICrecon_ROOT=$( readlink -f ${SCRIPT_DIR}/.. )
+
+#----------------- JANA2
+if [[ -f @JANA_ROOT_DIR@bin/jana-this.sh ]] ; then
+    source @JANA_ROOT_DIR@bin/jana-this.sh
+fi
+
+#----------------- ROOT
+if [[ -f @ROOT_BINDIR@/thisroot.sh ]] ; then
+    source @ROOT_BINDIR@/thisroot.sh
+fi
+
+#----------------- PODIO
+PODIO=$( readlink -f @podio_LIBRARY_DIR@/.. )
+if [[ -f ${PODIO}/env.sh ]] ; then
+    source ${PODIO}/env.sh
+    export podio_ROOT=${PODIO}
+fi
+
+#----------------- EDM4hep
+EDM4HEP=$( readlink -f @EDM4HEP_DIR@/../../.. )
+if [[ -d ${EDM4HEP} ]] ; then
+    export EDM4HEP_ROOT=${EDM4HEP}
+    EDM4HEP_LIBDIR=${EDM4HEP_ROOT}/lib64
+    if [[ ! ":$LD_LIBRARY_PATH:" == *":$EDM4HEP_LIBDIR:"* ]]; then
+        export LD_LIBRARY_PATH="${EDM4HEP_LIBDIR}${LD_LIBRARY_PATH:+${LD_LIBRARY_PATH}}"
+    fi
+fi
+
+#----------------- DD4hep
+if [[ -f @DD4hep_DIR@/../bin/thisdd4hep.sh ]] ; then
+    source @DD4hep_DIR@/../bin/thisdd4hep.sh
+fi
+
+#----------------- fmt
+if [[ -d @fmt_DIR@/../../.. ]] ; then
+    export fmt_ROOT=@fmt_DIR@/../../..
+    fmt_LIBDIR=$( readlink -f ${fmt_ROOT}/lib* )
+    if [[ ! ":$LD_LIBRARY_PATH:" == *":$fmt_LIBDIR:"* ]]; then
+        export LD_LIBRARY_PATH="${fmt_LIBDIR}${LD_LIBRARY_PATH:+${LD_LIBRARY_PATH}}"
+    fi
+fi
+
+#----------------- ip6,epic detector geometry
+if [[ -f @BEAMLINE_PATH@/../../setup.sh ]]; then
+    source @BEAMLINE_PATH@/../../setup.sh
+fi
+if [[ -f @DETECTOR_PATH@/../../setup.sh ]]; then
+    source @DETECTOR_PATH@/../../setup.sh
+fi
+
+#----------------- EICrecon
+# Add bin to PATH if not already there
+if [[ ! ":$PATH:" == *":$SCRIPT_DIR:"* ]]; then
+    export PATH=${SCRIPT_DIR}:${PATH}
+fi
+
+# Add lib to LD_LIBRARY_PATH if not already there
+LIB_DIR=$( readlink -f ${EICrecon_ROOT}/lib )
+if [[ ! ":$LD_LIBRARY_PATH:" == *":$LIB_DIR:"* ]]; then
+    export LD_LIBRARY_PATH="${LIB_DIR}${LD_LIBRARY_PATH:+${LD_LIBRARY_PATH}}"
+fi
+
+# Add plugins to JANA_PLUGIN_PATH if not already there
+PLUGINS_DIR=$( readlink -f @PLUGIN_OUTPUT_DIRECTORY@ )
+if [[ ! ":$JANA_PLUGIN_PATH:" == *":$PLUGINS_DIR:"* ]]; then
+    export JANA_PLUGIN_PATH="${PLUGINS_DIR}${JANA_PLUGIN_PATH:+${JANA_PLUGIN_PATH}}"
+fi
+
+# Add plugins to ROOT_INCLUDE_PATH if not already there
+if [[ ! ":ROOT_INCLUDE_PATH:" == *":$PLUGINS_DIR:"* ]]; then
+    export ROOT_INCLUDE_PATH="${PLUGINS_DIR}${ROOT_INCLUDE_PATH:+${ROOT_INCLUDE_PATH}}"
+fi
+

--- a/src/services/geometry/dd4hep/CMakeLists.txt
+++ b/src/services/geometry/dd4hep/CMakeLists.txt
@@ -56,7 +56,7 @@ target_link_libraries(dd4hep_plugin dd4hep_library ${LINK_LIBRARIES})
 set_target_properties(dd4hep_plugin PROPERTIES PREFIX "" OUTPUT_NAME "dd4hep" SUFFIX ".so")
 
 # Install plugin
-install(TARGETS dd4hep_plugin DESTINATION plugins)
+install(TARGETS dd4hep_plugin DESTINATION ${PLUGIN_OUTPUT_DIRECTORY})
 
 # Install headers for plugin
 file(GLOB my_headers "*.h*")

--- a/src/services/io/podio/CMakeLists.txt
+++ b/src/services/io/podio/CMakeLists.txt
@@ -52,7 +52,7 @@ target_link_libraries(podio_plugin podio_library ${LINK_LIBRARIES})
 set_target_properties(podio_plugin PROPERTIES PREFIX "" OUTPUT_NAME "podio" SUFFIX ".so")
 
 # Install plugin
-install(TARGETS podio_plugin DESTINATION plugins)
+install(TARGETS podio_plugin DESTINATION ${PLUGIN_OUTPUT_DIRECTORY})
 
 # Install headers for plugin
 file(GLOB my_headers "*.h*")
@@ -66,7 +66,7 @@ install(FILES ${my_headers} DESTINATION include/services/io/podio)
 set_target_properties(podio_plugin PROPERTIES SKIP_BUILD_RPATH FALSE)
 set_target_properties(podio_plugin PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE)
 set_target_properties(podio_plugin PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
-set_target_properties(podio_plugin PROPERTIES INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/plugins)
+set_target_properties(podio_plugin PROPERTIES INSTALL_RPATH ${PLUGIN_OUTPUT_DIRECTORY})
 
 
 # Install root dictionaries made by PODIO
@@ -76,5 +76,5 @@ set(my_root_dict_files
 #        ${PROJECT_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}EDM4HEPDataModel${CMAKE_SHARED_LIBRARY_SUFFIX}
 #        ${PROJECT_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}EDM4HEPDataModelDict${CMAKE_SHARED_LIBRARY_SUFFIX}
         )
-install(FILES ${my_root_dict_files} DESTINATION plugins)
+install(FILES ${my_root_dict_files} DESTINATION ${PLUGIN_OUTPUT_DIRECTORY})
 

--- a/src/services/randomgenerator/CMakeLists.txt
+++ b/src/services/randomgenerator/CMakeLists.txt
@@ -8,6 +8,6 @@ project("RandGen_driver")
 
 add_executable("${PROJECT_NAME}" "RandGen_driver.cpp")
 
-install(TARGETS "${PROJECT_NAME}" DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
+install(TARGETS "${PROJECT_NAME}" DESTINATION "${CMAKE_SOURCE_DIR}/tests")
 #install(FILES RandGen_driver.cpp DESTINATION src)
 

--- a/src/tests/BEMC_test/CMakeLists.txt
+++ b/src/tests/BEMC_test/CMakeLists.txt
@@ -31,5 +31,5 @@ install(FILES ${my_headers} DESTINATION include/BEMC_test)
 
 # For root dictionaries
 file(GLOB my_pcms "${CMAKE_CURRENT_BINARY_DIR}/*.pcm")
-install(FILES ${my_pcms} DESTINATION plugins)
+install(FILES ${my_pcms} DESTINATION ${PLUGIN_OUTPUT_DIRECTORY})
 


### PR DESCRIPTION
This moves the plugins installation directory to be inside the lib/EICrecon directory. This follows issue #136 posted to the JANA2 repository suggesting this in order to allow installing into a common directory tree, including /usr when installing in containers.

This also implements generation of a eicrecon-this.sh environment setup file using cmake variables used in the build. This may be used to reproduce enough of the environment to build a user end plugin that is compatible. (Currently, it is not setting the compiler since that is a more complicated issue).