### PR TITLE
EICD support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,11 @@ print_subdirectory_tree()
 message(STATUS "\n-------------------------------")
 
 
+# Install all cmake helpers
+file(GLOB EICRECON_CMAKE_FILES cmake/*)
+install(FILES ${EICRECON_CMAKE_FILES} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cmake/EICrecon)
+
+
 # Print all cmake variables (for debugging)
 #find_package(fmt)
 #get_cmake_property(_variableNames VARIABLES)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ cmake3 --build build --target install -- -j8
 source ${JANA_HOME}/bin/jana-this.sh                # Set environment to use this
 ~~~
 
+### spdlog
+~~~
+export SPDLOG_VERSION=v1.10.0
+export SPDLOG_HOME=${EICTOPDIR}/spdlog/${SPDLOG_VERSION}
+export spdlog_ROOT=${SPDLOG_HOME}/install
+git clone https://github.com/gabime/spdlog -b ${SPDLOG_VERSION} ${SPDLOG_HOME}
+cd ${SPDLOG_HOME}
+cmake3 -S . -B build -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${spdlog_ROOT}
+cmake3 --build build --target install -- -j8
+~~~
+
+git clone https://github.com/gabime/spdlog.git
+
 ### PODIO
 ~~~
 export PODIO_VERSION=v00-14-03
@@ -197,6 +210,7 @@ source ${EICTOPDIR}/root/root-6.26.04/bin/thisroot.sh
 
 export BOOST_VERSION=boost-1.79.0
 export JANA_VERSION=v2.0.7
+export SPDLOG_VERSION=v1.10.0
 export PODIO_VERSION=v00-14-03
 export EDM4HEP_VERSION=v00-06
 export EICD_VERSION=v2.0.0
@@ -207,6 +221,7 @@ export FMT_VERSION=9.0.0
 
 export Boost_ROOT=${EICTOPDIR}/BOOST/${BOOST_VERSION}/installed
 source ${EICTOPDIR}/JANA/${JANA_VERSION}/bin/jana-this.sh
+export spdlog_ROOT=${EICTOPDIR}/spdlog/${SPDLOG_VERSION}/install
 export PODIO_HOME=${EICTOPDIR}/PODIO/${PODIO_VERSION}
 export PODIO=${PODIO_HOME}/install
 source ${PODIO_HOME}/env.sh

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ source ${EICTOPDIR}/root/root-6.26.04/bin/thisroot.sh
 
 ### JANA
 ~~~
-export JANA_VERSION=v2.0.5
+export JANA_VERSION=v2.0.7
 export JANA_HOME=${EICTOPDIR}/JANA/${JANA_VERSION}
 git clone https://github.com/JeffersonLab/JANA2 -b ${JANA_VERSION} ${JANA_HOME}
 cd ${JANA_HOME}
@@ -97,6 +97,17 @@ export EDM4HEP_ROOT=${EDM4HEP}
 git clone https://github.com/key4hep/EDM4hep -b ${EDM4HEP_VERSION} ${EDM4HEP_HOME}
 cd ${EDM4HEP_HOME}
 cmake3 -S . -B build -DCMAKE_INSTALL_PREFIX=${EDM4HEP} -DCMAKE_CXX_STANDARD=17 -DUSE_EXTERNAL_CATCH2=OFF
+cmake3 --build build --target install -- -j8
+~~~
+
+### eicd
+~~~
+export EICD_VERSION=v2.0.0
+export EICD_HOME=${EICTOPDIR}/eicd/${EICD_VERSION} 
+export EICD_ROOT=${EICD_HOME}/install 
+git clone https://github.com/eic/eicd -b ${EICD_VERSION} ${EICD_HOME}
+cd ${EICD_HOME}
+cmake3 -S . -B build -DCMAKE_INSTALL_PREFIX=${eicd_ROOT} -DCMAKE_CXX_STANDARD=17
 cmake3 --build build --target install -- -j8
 ~~~
 
@@ -185,9 +196,10 @@ source ${EICTOPDIR}/python/virtual_environments/venv/bin/activate
 source ${EICTOPDIR}/root/root-6.26.04/bin/thisroot.sh
 
 export BOOST_VERSION=boost-1.79.0
-export JANA_VERSION=v2.0.5
+export JANA_VERSION=v2.0.7
 export PODIO_VERSION=v00-14-03
 export EDM4HEP_VERSION=v00-06
+export EICD_VERSION=v2.0.0
 export DD4HEP_VERSION=v01-20-02
 export EIGEN_VERSION=3.4.0
 export ACTS_VERSION=v19.4.0
@@ -202,6 +214,8 @@ export podio_ROOT=${PODIO}
 export EDM4HEP=${EICTOPDIR}/EDM4hep/${EDM4HEP_VERSION}/install
 export EDM4HEP_ROOT=${EICTOPDIR}/EDM4hep/${EDM4HEP_VERSION}/install
 export LD_LIBRARY_PATH=${EDM4HEP_ROOT}/lib64:${LD_LIBRARY_PATH}
+export EICD_ROOT=${EICTOPDIR}/eicd/${EICD_VERSION}/install
+export LD_LIBRARY_PATH=${eicd_ROOT}/lib:${LD_LIBRARY_PATH}
 source ${EICTOPDIR}/DD4hep/${DD4HEP_VERSION}/install/bin/thisdd4hep.sh
 export Eigen3_ROOT=${EICTOPDIR}/EIGEN/${EIGEN_VERSION}
 source ${EICTOPDIR}/ACTS/${ACTS_VERSION}/install/bin/this_acts.sh

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ export EICD_HOME=${EICTOPDIR}/eicd/${EICD_VERSION}
 export EICD_ROOT=${EICD_HOME}/install 
 git clone https://github.com/eic/eicd -b ${EICD_VERSION} ${EICD_HOME}
 cd ${EICD_HOME}
-cmake3 -S . -B build -DCMAKE_INSTALL_PREFIX=${eicd_ROOT} -DCMAKE_CXX_STANDARD=17
+cmake3 -S . -B build -DCMAKE_INSTALL_PREFIX=${EICD_ROOT} -DCMAKE_CXX_STANDARD=17
 cmake3 --build build --target install -- -j8
 ~~~
 

--- a/src/scripts/eicrecon-this.sh.in
+++ b/src/scripts/eicrecon-this.sh.in
@@ -35,7 +35,17 @@ if [[ -d ${EDM4HEP} ]] ; then
     export EDM4HEP_ROOT=${EDM4HEP}
     EDM4HEP_LIBDIR=${EDM4HEP_ROOT}/lib64
     if [[ ! ":$LD_LIBRARY_PATH:" == *":$EDM4HEP_LIBDIR:"* ]]; then
-        export LD_LIBRARY_PATH="${EDM4HEP_LIBDIR}${LD_LIBRARY_PATH:+${LD_LIBRARY_PATH}}"
+        export LD_LIBRARY_PATH="${EDM4HEP_LIBDIR}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+    fi
+fi
+
+#----------------- EICD
+EICD=$( readlink -f @EICD_DIR@/../.. )
+if [[ -d ${EICD} ]] ; then
+    export EICD_ROOT=${EICD}
+    EICD_LIBDIR=$( readlink -f @EICD_DIR@/.. )
+    if [[ ! ":$LD_LIBRARY_PATH:" == *":EICD_LIBDIR:"* ]]; then
+        export LD_LIBRARY_PATH="${EICD_LIBDIR}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
     fi
 fi
 
@@ -47,9 +57,9 @@ fi
 #----------------- fmt
 if [[ -d @fmt_DIR@/../../.. ]] ; then
     export fmt_ROOT=@fmt_DIR@/../../..
-    fmt_LIBDIR=$( readlink -f ${fmt_ROOT}/lib* )
+    fmt_LIBDIR=$( readlink -f @fmt_DIR@/../.. )
     if [[ ! ":$LD_LIBRARY_PATH:" == *":$fmt_LIBDIR:"* ]]; then
-        export LD_LIBRARY_PATH="${fmt_LIBDIR}${LD_LIBRARY_PATH:+${LD_LIBRARY_PATH}}"
+        export LD_LIBRARY_PATH="${fmt_LIBDIR}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
     fi
 fi
 
@@ -70,17 +80,17 @@ fi
 # Add lib to LD_LIBRARY_PATH if not already there
 LIB_DIR=$( readlink -f ${EICrecon_ROOT}/lib )
 if [[ ! ":$LD_LIBRARY_PATH:" == *":$LIB_DIR:"* ]]; then
-    export LD_LIBRARY_PATH="${LIB_DIR}${LD_LIBRARY_PATH:+${LD_LIBRARY_PATH}}"
+    export LD_LIBRARY_PATH="${LIB_DIR}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 fi
 
 # Add plugins to JANA_PLUGIN_PATH if not already there
 PLUGINS_DIR=$( readlink -f @PLUGIN_OUTPUT_DIRECTORY@ )
 if [[ ! ":$JANA_PLUGIN_PATH:" == *":$PLUGINS_DIR:"* ]]; then
-    export JANA_PLUGIN_PATH="${PLUGINS_DIR}${JANA_PLUGIN_PATH:+${JANA_PLUGIN_PATH}}"
+    export JANA_PLUGIN_PATH="${PLUGINS_DIR}${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}"
 fi
 
 # Add plugins to ROOT_INCLUDE_PATH if not already there
 if [[ ! ":ROOT_INCLUDE_PATH:" == *":$PLUGINS_DIR:"* ]]; then
-    export ROOT_INCLUDE_PATH="${PLUGINS_DIR}${ROOT_INCLUDE_PATH:+${ROOT_INCLUDE_PATH}}"
+    export ROOT_INCLUDE_PATH="${PLUGINS_DIR}${ROOT_INCLUDE_PATH:+:${ROOT_INCLUDE_PATH}}"
 fi
 

--- a/src/services/io/podio/CMakeLists.txt
+++ b/src/services/io/podio/CMakeLists.txt
@@ -10,22 +10,26 @@ project(podio_project)
 # Find dependencies
 find_package(JANA REQUIRED)
 find_package(EDM4HEP REQUIRED)
+find_package(EICD REQUIRED)
 find_package(podio REQUIRED)
-set(PODIO_LIBRARIES EDM4HEP::edm4hep EDM4HEP::edm4hepDict podio::podioRootIO)
+find_package(fmt REQUIRED)
+set(fmt_INCLUDE_DIR ${fmt_DIR}/../../../include)
+set(EICD_INCLUDE_DIR ${EICD_DIR}/../../include)
+set(PODIO_LIBRARIES EDM4HEP::edm4hep EDM4HEP::edm4hepDict EICD::eicd EICD::eicd_utils podio::podioRootIO)
 
 # This is used to automatically run the make_datamodel_glue.py command
 # that generates the datamodel_glue.h, datamodel_includes.h, and
 # datamodel_LinkDef.h files.
 add_custom_command(
         OUTPUT  datamodel_glue.h datamodel_includes.h         # Treated as relative to CMAKE_CURRENT_BINARY_DIR
-        COMMAND python3 ${PROJECT_SOURCE_DIR}/make_datamodel_glue.py EDM4HEP_INCLUDE_DIR=${EDM4HEP_INCLUDE_DIR}
+        COMMAND python3 ${PROJECT_SOURCE_DIR}/make_datamodel_glue.py EDM4HEP_INCLUDE_DIR=${EDM4HEP_INCLUDE_DIR} EICD_INCLUDE_DIR=${EICD_INCLUDE_DIR}
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
         DEPENDS ${PROJECT_SOURCE_DIR}/make_datamodel_glue.py
 )
 
 # Create a ROOT dictionary with the vector<edm4hep::XXXData> types defined. Without
 # this, root will complain about not having a compiled CollectionProxy.
-include_directories(${EDM4HEP_INCLUDE_DIR} ${podio_INCLUDE_DIR} ${CMAKE_CURRENT_BINARY_DIR} )
+include_directories(${EDM4HEP_INCLUDE_DIR} ${EICD_INCLUDE_DIR} ${podio_INCLUDE_DIR} ${fmt_INCLUDE_DIR} ${CMAKE_CURRENT_BINARY_DIR} )
 root_generate_dictionary(G__datamodel_vectors datamodel_includes.h LINKDEF datamodel_LinkDef.h)
 
 

--- a/src/tests/BEMC_test/CMakeLists.txt
+++ b/src/tests/BEMC_test/CMakeLists.txt
@@ -24,7 +24,7 @@ target_include_directories(BEMC_test_plugin SYSTEM PUBLIC ${JANA_INCLUDE_DIR} ${
 target_link_libraries(BEMC_test_plugin ${JANA_LIB} ${ROOT_LIBRARIES})
 set_target_properties(BEMC_test_plugin PROPERTIES PREFIX "" OUTPUT_NAME "BEMC_test" SUFFIX ".so")
 
-install(TARGETS BEMC_test_plugin DESTINATION plugins)
+install(TARGETS BEMC_test_plugin DESTINATION ${PLUGIN_OUTPUT_DIRECTORY})
 
 file(GLOB my_headers "*.h*")
 install(FILES ${my_headers} DESTINATION include/BEMC_test)

--- a/src/tools/cmake_wrapper.sh
+++ b/src/tools/cmake_wrapper.sh
@@ -13,9 +13,13 @@
 # Get directrory this script resides in
 SCRIPT_DIR=`readlink -f $(dirname -- "$0")`
 
-if [ -f ${SCRIPT_DIR}/../custom_environment.sh ]; then
+if [ -f ${SCRIPT_DIR}/../../custom_environment.sh ]; then
+  echo source ${SCRIPT_DIR}/../../custom_environment.sh
+  source ${SCRIPT_DIR}/../../custom_environment.sh
+elif [ -f ${SCRIPT_DIR}/../custom_environment.sh ]; then
   echo source ${SCRIPT_DIR}/../custom_environment.sh
   source ${SCRIPT_DIR}/../custom_environment.sh
+
 fi
 
 # Run cmake


### PR DESCRIPTION
This puts in support for EICD. This includes build instructions and integration into the podio event source.

This PR also includes:

1. fixes to cmake_wrapper.sh for integrating with CLion
2. Fix to BEMC_test install location
3. Disabling of the podio version checking (which seems to be broken on the podio side, yet, seemed to work previously?)
4. Bug fixes to the generated eicrecon.sh script
5. Up the version number for JANA to v2.0.7 in the documentation (no in cmake configuration yet)
6. Installation of the cmake tools to the EICrecon install directory so they can be used for out-of-repository plugin builds.
7. Updated README with instructions for building spdlog