### PR TITLE
Add cli option "-L"/"--list_factories"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ src/services/io/podio/datamodel_glue.h
 # Indirectory builds
 include/*
 plugins/*
+build/*
 
 ##### C++ basic gitignore #####
 

--- a/src/utilities/eicrecon/eicrecon.cc
+++ b/src/utilities/eicrecon/eicrecon.cc
@@ -7,7 +7,7 @@
 
 #include <TFile.h>
 
-#include <JANA/CLI/JMain.h>
+#include "eicrecon_cli.h"
 
 int main( int narg, char **argv)
 {
@@ -34,6 +34,7 @@ int main( int narg, char **argv)
 
     if(const char* env_p = std::getenv("EICrecon_MY")) japp->AddPluginPath( std::string(env_p) + "/plugins" );
 
+    // TODO: add by command line paras
     japp->AddPlugin( "podio"           );
     japp->AddPlugin( "dd4hep"          );
     japp->AddPlugin( "acts"        );

--- a/src/utilities/eicrecon/eicrecon_cli.cpp
+++ b/src/utilities/eicrecon/eicrecon_cli.cpp
@@ -9,6 +9,10 @@
 #include <JANA/CLI/JBenchmarker.h>
 #include <JANA/CLI/JSignalHandler.h>
 
+#include <JANA/Services/JComponentManager.h>
+
+#include <JANA/JEventSource.h>
+
 
 namespace jana {
 
@@ -89,6 +93,25 @@ namespace jana {
         std::cout << std::endl;
     }
 
+    void PrintPodioCollections(JApplication* app) {
+        if (app->GetJParameterManager()->Exists("PODIO:PRINT_TYPE_TABLE")) {
+            auto print_type_table = app->GetJParameterManager()->FindParameter("PODIO:PRINT_TYPE_TABLE")->GetValue();
+
+            // cli criteria: Ppodio:print_type_table=1
+            if (print_type_table == "1") {
+
+                auto event_sources = app->GetService<JComponentManager>()->get_evt_srces();
+                for (auto event_source : event_sources) {
+//                    std::cout << event_source->GetPluginName() << std::endl;  // podio.so
+//                    std::cout << event_source->GetResourceName() << std::endl;
+                    if (event_source->GetPluginName().find("podio") != std::string::npos)
+                        event_source->DoInitialize();
+                }
+            }
+
+        }
+    }
+
     int Execute(JApplication* app, UserOptions &options) {
 
         std::cout << std::endl;
@@ -104,8 +127,8 @@ namespace jana {
                      "((   ,M9  d'      YM. M      \\MM   d'      YM. ,M'      \n"
                      " YMMMM9 _dM_     _dMM_M_      \\M _dM_     _dMM_MMMMMMMM " << std::endl << std::endl;
 
-        // std::cout << "JANA " << JVersion::GetVersion() << " [" << JVersion::GetRevision() << "]" << std::endl;
         JSignalHandler::register_handlers(app);
+        // std::cout << "JANA " << JVersion::GetVersion() << " [" << JVersion::GetRevision() << "]" << std::endl;
 
         if (options.flags[ShowConfigs]) {
             // Load all plugins, collect all parameters, exit without running anything
@@ -130,6 +153,9 @@ namespace jana {
         else if (options.flags[ListFactories]) {
             app->Initialize();
             PrintFactories(app);
+
+            // TODO: more elegant processing here
+            PrintPodioCollections(app);
         }
         else {
             // Run JANA in normal mode

--- a/src/utilities/eicrecon/eicrecon_cli.cpp
+++ b/src/utilities/eicrecon/eicrecon_cli.cpp
@@ -3,12 +3,11 @@
 //
 
 #include "eicrecon_cli.h"
+#include "print_info.h"
 
 #include <JANA/CLI/JVersion.h>
 #include <JANA/CLI/JBenchmarker.h>
 #include <JANA/CLI/JSignalHandler.h>
-
-
 
 
 namespace jana {
@@ -42,6 +41,7 @@ namespace jana {
         std::cout << "   -l   --loadconfigs <file>    Load configuration parameters from file" << std::endl;
         std::cout << "   -d   --dumpconfigs <file>    Dump configuration parameters to file" << std::endl;
         std::cout << "   -b   --benchmark             Run in benchmark mode" << std::endl;
+        std::cout << "   -L   --list_factories        List all the factories without running" << std::endl;
         std::cout << "   -Pkey=value                  Specify a configuration parameter" << std::endl << std::endl;
     }
 
@@ -84,16 +84,9 @@ namespace jana {
     }
 
     void PrintFactories(JApplication* app) {
-        auto cs = app->GetComponentSummary();
-
-        std::cout << "************** Print all the factories ************" << std::endl;
-        std::cout << " Plugin | Object name | Tag" << std::endl;
-
-        for (const auto& factory : cs.factories) {
-            std::cout << factory.plugin_name << "|";
-            std::cout << factory.object_name << "|";
-            std::cout << factory.factory_tag << std::endl;
-        }
+        std::cout << std::endl << "List all the factories:" << std::endl << std::endl;
+        printFactoryTable(app->GetComponentSummary());
+        std::cout << std::endl;
     }
 
     int Execute(JApplication* app, UserOptions &options) {
@@ -134,6 +127,10 @@ namespace jana {
             JBenchmarker benchmarker(app); // Benchmarking params override default params
             benchmarker.RunUntilFinished(); // Benchmarker will control JApp Run/Stop
         }
+        else if (options.flags[ListFactories]) {
+            app->Initialize();
+            PrintFactories(app);
+        }
         else {
             // Run JANA in normal mode
             try {
@@ -169,6 +166,8 @@ namespace jana {
         tokenizer["--dumpconfigs"] = DumpConfigs;
         tokenizer["-b"] = Benchmark;
         tokenizer["--benchmark"] = Benchmark;
+        tokenizer["-L"] = ListFactories;
+        tokenizer["--list_factories"] = ListFactories;
 
         if (nargs == 1) {
             options.flags[ShowUsage] = true;
@@ -220,6 +219,10 @@ namespace jana {
                     } else {
                         options.dump_config_file = "jana.config";
                     }
+                    break;
+
+                case ListFactories:
+                    options.flags[ListFactories] = true;
                     break;
 
                 case Unknown:

--- a/src/utilities/eicrecon/eicrecon_cli.cpp
+++ b/src/utilities/eicrecon/eicrecon_cli.cpp
@@ -115,17 +115,6 @@ namespace jana {
     int Execute(JApplication* app, UserOptions &options) {
 
         std::cout << std::endl;
-        std::cout << "     ____      _     ___      ___       _               \n"
-                     "     `MM'     dM.    `MM\\     `M'      dM.              \n"
-                     "      MM     ,MMb     MMM\\     M      ,MMb              \n"
-                     "      MM     d'YM.    M\\MM\\    M      d'YM.      ____   \n"
-                     "      MM    ,P `Mb    M \\MM\\   M     ,P `Mb     6MMMMb  \n"
-                     "      MM    d'  YM.   M  \\MM\\  M     d'  YM.   MM'  `Mb \n"
-                     "      MM   ,P   `Mb   M   \\MM\\ M    ,P   `Mb        ,MM \n"
-                     "      MM   d'    YM.  M    \\MM\\M    d'    YM.      ,MM' \n"
-                     "(8)   MM  ,MMMMMMMMb  M     \\MMM   ,MMMMMMMMb    ,M'    \n"
-                     "((   ,M9  d'      YM. M      \\MM   d'      YM. ,M'      \n"
-                     " YMMMM9 _dM_     _dMM_M_      \\M _dM_     _dMM_MMMMMMMM " << std::endl << std::endl;
 
         JSignalHandler::register_handlers(app);
         // std::cout << "JANA " << JVersion::GetVersion() << " [" << JVersion::GetRevision() << "]" << std::endl;
@@ -160,6 +149,7 @@ namespace jana {
         else {
             // Run JANA in normal mode
             try {
+                printJANAHeaderIMG();
                 app->Run();
             }
             catch (JException& e) {

--- a/src/utilities/eicrecon/eicrecon_cli.cpp
+++ b/src/utilities/eicrecon/eicrecon_cli.cpp
@@ -11,8 +11,6 @@
 
 #include <JANA/Services/JComponentManager.h>
 
-#include <JANA/JEventSource.h>
-
 
 namespace jana {
 
@@ -66,6 +64,13 @@ namespace jana {
             params->SetParameter(pair.first, pair.second);
         }
 
+        if (options.flags[ListFactories]) {
+            params->SetParameter(
+                    "log:off",
+                    "JPluginLoader,JComponentManager,JArrowProcessingController,JArrow"
+                    );
+        }
+
         if (options.flags[LoadConfigs]) {
             // If the user specified an external config file, we should definitely use that
             try {
@@ -116,7 +121,6 @@ namespace jana {
 
         std::cout << std::endl;
 
-        JSignalHandler::register_handlers(app);
         // std::cout << "JANA " << JVersion::GetVersion() << " [" << JVersion::GetRevision() << "]" << std::endl;
 
         if (options.flags[ShowConfigs]) {
@@ -135,6 +139,7 @@ namespace jana {
             app->GetJParameterManager()->WriteConfigFile(options.dump_config_file);
         }
         else if (options.flags[Benchmark]) {
+            JSignalHandler::register_handlers(app);
             // Run JANA in benchmark mode
             JBenchmarker benchmarker(app); // Benchmarking params override default params
             benchmarker.RunUntilFinished(); // Benchmarker will control JApp Run/Stop
@@ -150,6 +155,7 @@ namespace jana {
             // Run JANA in normal mode
             try {
                 printJANAHeaderIMG();
+                JSignalHandler::register_handlers(app);
                 app->Run();
             }
             catch (JException& e) {

--- a/src/utilities/eicrecon/eicrecon_cli.cpp
+++ b/src/utilities/eicrecon/eicrecon_cli.cpp
@@ -1,0 +1,248 @@
+//
+// Created by xmei on 9/7/22.
+//
+
+#include "eicrecon_cli.h"
+
+#include <JANA/CLI/JVersion.h>
+#include <JANA/CLI/JBenchmarker.h>
+#include <JANA/CLI/JSignalHandler.h>
+
+
+
+
+namespace jana {
+
+    void PrintUsage() {
+        /// Prints jana.cc command-line options to stdout, for use by the CLI.
+        /// This does not include JANA parameters, which come from
+        /// JParameterManager::PrintParameters() instead.
+
+        std::cout << std::endl;
+        std::cout << "Usage:" << std::endl;
+        std::cout << "    jana [options] source1 source2 ..." << std::endl << std::endl;
+
+        std::cout << "Description:" << std::endl;
+        std::cout << "    Command-line interface for running JANA plugins. This can be used to" << std::endl;
+        std::cout << "    read in events and process them. Command-line flags control configuration" << std::endl;
+        std::cout << "    while additional arguments denote input files, which are to be loaded and" << std::endl;
+        std::cout << "    processed by the appropriate EventSource plugin." << std::endl << std::endl;
+
+        std::cout << "Options:" << std::endl;
+        std::cout << "   -h   --help                  Display this message" << std::endl;
+        PrintUsageOptions();
+        std::cout << "Example:" << std::endl;
+        std::cout << "    jana -Pplugins=plugin1,plugin2,plugin3 -Pnthreads=8 inputfile1.txt" << std::endl << std::endl;
+
+    }
+
+    void PrintUsageOptions() {
+        std::cout << "   -v   --version               Display version information" << std::endl;
+        std::cout << "   -c   --configs               Display configuration parameters" << std::endl;
+        std::cout << "   -l   --loadconfigs <file>    Load configuration parameters from file" << std::endl;
+        std::cout << "   -d   --dumpconfigs <file>    Dump configuration parameters to file" << std::endl;
+        std::cout << "   -b   --benchmark             Run in benchmark mode" << std::endl;
+        std::cout << "   -Pkey=value                  Specify a configuration parameter" << std::endl << std::endl;
+    }
+
+    void PrintVersion() {
+        /// Prints JANA version information to stdout, for use by the CLI.
+
+        std::cout << "          JANA version: " << JVersion::GetVersion() << std::endl;
+        std::cout << "        JANA ID string: " << JVersion::GetIDstring() << std::endl;
+        std::cout << "     JANA git revision: " << JVersion::GetRevision() << std::endl;
+        std::cout << "JANA last changed date: " << JVersion::GetDate() << std::endl;
+        std::cout << "           JANA source: " << JVersion::GetSource() << std::endl;
+    }
+
+    JApplication* CreateJApplication(UserOptions& options) {
+
+        auto params = new JParameterManager(); // JApplication owns params_copy, does not own eventSources
+        for (auto pair : options.params) {
+            params->SetParameter(pair.first, pair.second);
+        }
+
+        if (options.flags[LoadConfigs]) {
+            // If the user specified an external config file, we should definitely use that
+            try {
+                params->ReadConfigFile(options.load_config_file);
+            }
+            catch (JException &e) {
+                std::cout << "Problem loading config file '" << options.load_config_file << "'. Exiting." << std::endl
+                          << std::endl;
+                exit(-1);
+            }
+            std::cout << "Loaded config file '" << options.load_config_file << "'." << std::endl << std::endl;
+        }
+
+        auto app = new JApplication(params);
+
+        for (auto event_src : options.eventSources) {
+            app->Add(event_src);
+        }
+        return app;
+    }
+
+    void PrintFactories(JApplication* app) {
+        auto cs = app->GetComponentSummary();
+
+        std::cout << "************** Print all the factories ************" << std::endl;
+        std::cout << " Plugin | Object name | Tag" << std::endl;
+
+        for (const auto& factory : cs.factories) {
+            std::cout << factory.plugin_name << "|";
+            std::cout << factory.object_name << "|";
+            std::cout << factory.factory_tag << std::endl;
+        }
+    }
+
+    int Execute(JApplication* app, UserOptions &options) {
+
+        std::cout << std::endl;
+        std::cout << "     ____      _     ___      ___       _               \n"
+                     "     `MM'     dM.    `MM\\     `M'      dM.              \n"
+                     "      MM     ,MMb     MMM\\     M      ,MMb              \n"
+                     "      MM     d'YM.    M\\MM\\    M      d'YM.      ____   \n"
+                     "      MM    ,P `Mb    M \\MM\\   M     ,P `Mb     6MMMMb  \n"
+                     "      MM    d'  YM.   M  \\MM\\  M     d'  YM.   MM'  `Mb \n"
+                     "      MM   ,P   `Mb   M   \\MM\\ M    ,P   `Mb        ,MM \n"
+                     "      MM   d'    YM.  M    \\MM\\M    d'    YM.      ,MM' \n"
+                     "(8)   MM  ,MMMMMMMMb  M     \\MMM   ,MMMMMMMMb    ,M'    \n"
+                     "((   ,M9  d'      YM. M      \\MM   d'      YM. ,M'      \n"
+                     " YMMMM9 _dM_     _dMM_M_      \\M _dM_     _dMM_MMMMMMMM " << std::endl << std::endl;
+
+        // std::cout << "JANA " << JVersion::GetVersion() << " [" << JVersion::GetRevision() << "]" << std::endl;
+        JSignalHandler::register_handlers(app);
+
+        if (options.flags[ShowConfigs]) {
+            // Load all plugins, collect all parameters, exit without running anything
+            app->Initialize();
+            if (options.flags[Benchmark]) {
+                JBenchmarker benchmarker(app);  // Show benchmarking configs only if benchmarking mode specified
+            }
+            app->GetJParameterManager()->PrintParameters(true);
+        }
+        else if (options.flags[DumpConfigs]) {
+            // Load all plugins, dump parameters to file, exit without running anything
+            app->Initialize();
+            std::cout << std::endl << "Writing configuration options to file: " << options.dump_config_file
+                      << std::endl;
+            app->GetJParameterManager()->WriteConfigFile(options.dump_config_file);
+        }
+        else if (options.flags[Benchmark]) {
+            // Run JANA in benchmark mode
+            JBenchmarker benchmarker(app); // Benchmarking params override default params
+            benchmarker.RunUntilFinished(); // Benchmarker will control JApp Run/Stop
+        }
+        else {
+            // Run JANA in normal mode
+            try {
+                app->Run();
+            }
+            catch (JException& e) {
+                std::cout << "----------------------------------------------------------" << std::endl;
+                std::cout << e << std::endl;
+            }
+            catch (std::runtime_error& e) {
+                std::cout << "----------------------------------------------------------" << std::endl;
+                std::cout << "Exception: " << e.what() << std::endl;
+            }
+        }
+        return (int) app->GetExitCode();
+    }
+
+
+    UserOptions ParseCommandLineOptions(int nargs, char *argv[], bool expect_extra) {
+
+        UserOptions options;
+
+        std::map<std::string, Flag> tokenizer;
+        tokenizer["-h"] = ShowUsage;
+        tokenizer["--help"] = ShowUsage;
+        tokenizer["-v"] = ShowVersion;
+        tokenizer["--version"] = ShowVersion;
+        tokenizer["-c"] = ShowConfigs;
+        tokenizer["--configs"] = ShowConfigs;
+        tokenizer["-l"] = LoadConfigs;
+        tokenizer["--loadconfigs"] = LoadConfigs;
+        tokenizer["-d"] = DumpConfigs;
+        tokenizer["--dumpconfigs"] = DumpConfigs;
+        tokenizer["-b"] = Benchmark;
+        tokenizer["--benchmark"] = Benchmark;
+
+        if (nargs == 1) {
+            options.flags[ShowUsage] = true;
+        }
+
+        for (int i = 1; i < nargs; i++) {
+
+            std::string arg = argv[i];
+            //std::cout << "Found arg " << arg << std::endl;
+
+            if (argv[i][0] != '-') {
+                options.eventSources.push_back(arg);
+                continue;
+            }
+
+            switch (tokenizer[arg]) {
+
+                case Benchmark:
+                    options.flags[Benchmark] = true;
+                    break;
+
+                case ShowUsage:
+                    options.flags[ShowUsage] = true;
+                    break;
+
+                case ShowVersion:
+                    options.flags[ShowVersion] = true;
+                    break;
+
+                case ShowConfigs:
+                    options.flags[ShowConfigs] = true;
+                    break;
+
+                case LoadConfigs:
+                    options.flags[LoadConfigs] = true;
+                    if (i + 1 < nargs && argv[i + 1][0] != '-') {
+                        options.load_config_file = argv[i + 1];
+                        i += 1;
+                    } else {
+                        options.load_config_file = "jana.config";
+                    }
+                    break;
+
+                case DumpConfigs:
+                    options.flags[DumpConfigs] = true;
+                    if (i + 1 < nargs && argv[i + 1][0] != '-') {
+                        options.dump_config_file = argv[i + 1];
+                        i += 1;
+                    } else {
+                        options.dump_config_file = "jana.config";
+                    }
+                    break;
+
+                case Unknown:
+                    if (argv[i][0] == '-' && argv[i][1] == 'P') {
+
+                        size_t pos = arg.find("=");
+                        if ((pos != std::string::npos) && (pos > 2)) {
+                            std::string key = arg.substr(2, pos - 2);
+                            std::string val = arg.substr(pos + 1);
+                            options.params.insert({key, val});
+                        } else {
+                            std::cout << "Invalid JANA parameter '" << arg
+                                      << "': Expected format -Pkey=value" << std::endl;
+                            options.flags[ShowConfigs] = true;
+                        }
+                    } else {
+                        if (!expect_extra) {
+                            std::cout << "Invalid command line flag '" << arg << "'" << std::endl;
+                            options.flags[ShowUsage] = true;
+                        }
+                    }
+            }
+        }
+        return options;
+    }
+}

--- a/src/utilities/eicrecon/eicrecon_cli.h
+++ b/src/utilities/eicrecon/eicrecon_cli.h
@@ -1,0 +1,34 @@
+//
+// Created by xmei on 9/7/22.
+//
+
+#ifndef EICRECON_EICRECON_CLI_H
+#define EICRECON_EICRECON_CLI_H
+
+#include <JANA/JApplication.h>
+
+namespace jana {
+
+    enum Flag {Unknown, ShowUsage, ShowVersion, ShowConfigs, LoadConfigs, DumpConfigs, Benchmark};
+
+    struct UserOptions {
+        /// Code representation of all user options.
+        /// This lets us cleanly separate args parsing from execution.
+
+        std::map<Flag, bool> flags;
+        std::map<std::string, std::string> params;
+        std::vector<std::string> eventSources;
+        std::string load_config_file;
+        std::string dump_config_file;
+    };
+
+    void PrintUsage();
+    void PrintUsageOptions();
+    void PrintVersion();
+    UserOptions ParseCommandLineOptions(int nargs, char *argv[], bool expect_extra=true);
+    JApplication* CreateJApplication(UserOptions& options);
+    int Execute(JApplication* app, UserOptions& options);
+
+}
+
+#endif //EICRECON_EICRECON_CLI_H

--- a/src/utilities/eicrecon/eicrecon_cli.h
+++ b/src/utilities/eicrecon/eicrecon_cli.h
@@ -38,7 +38,7 @@ namespace jana {
     JApplication* CreateJApplication(UserOptions& options);
     int Execute(JApplication* app, UserOptions& options);
     void PrintFactories(JApplication* app);
-
+    void PrintPodioCollections(JApplication* app);
 }
 
 #endif //EICRECON_EICRECON_CLI_H

--- a/src/utilities/eicrecon/eicrecon_cli.h
+++ b/src/utilities/eicrecon/eicrecon_cli.h
@@ -9,7 +9,16 @@
 
 namespace jana {
 
-    enum Flag {Unknown, ShowUsage, ShowVersion, ShowConfigs, LoadConfigs, DumpConfigs, Benchmark};
+    enum Flag {
+        Unknown,
+        ShowUsage,
+        ShowVersion,
+        ShowConfigs,
+        LoadConfigs,
+        DumpConfigs,
+        Benchmark,
+        ListFactories
+    };
 
     struct UserOptions {
         /// Code representation of all user options.
@@ -28,6 +37,7 @@ namespace jana {
     UserOptions ParseCommandLineOptions(int nargs, char *argv[], bool expect_extra=true);
     JApplication* CreateJApplication(UserOptions& options);
     int Execute(JApplication* app, UserOptions& options);
+    void PrintFactories(JApplication* app);
 
 }
 

--- a/src/utilities/eicrecon/print_info.h
+++ b/src/utilities/eicrecon/print_info.h
@@ -23,4 +23,18 @@ void printFactoryTable(JComponentSummary const& cs) {
     std::cout << ss.str() << std::endl;
 }
 
+void printJANAHeaderIMG() {
+    std::cout << "     ____      _     ___      ___       _               \n"
+                 "     `MM'     dM.    `MM\\     `M'      dM.              \n"
+                 "      MM     ,MMb     MMM\\     M      ,MMb              \n"
+                 "      MM     d'YM.    M\\MM\\    M      d'YM.      ____   \n"
+                 "      MM    ,P `Mb    M \\MM\\   M     ,P `Mb     6MMMMb  \n"
+                 "      MM    d'  YM.   M  \\MM\\  M     d'  YM.   MM'  `Mb \n"
+                 "      MM   ,P   `Mb   M   \\MM\\ M    ,P   `Mb        ,MM \n"
+                 "      MM   d'    YM.  M    \\MM\\M    d'    YM.      ,MM' \n"
+                 "(8)   MM  ,MMMMMMMMb  M     \\MMM   ,MMMMMMMMb    ,M'    \n"
+                 "((   ,M9  d'      YM. M      \\MM   d'      YM. ,M'      \n"
+                 " YMMMM9 _dM_     _dMM_M_      \\M _dM_     _dMM_MMMMMMMM " << std::endl << std::endl;
+}
+
 #endif //EICRECON_PRINT_INFO_H

--- a/src/utilities/eicrecon/print_info.h
+++ b/src/utilities/eicrecon/print_info.h
@@ -1,0 +1,26 @@
+//
+// Created by xmei on 9/8/22.
+//
+
+#ifndef EICRECON_PRINT_INFO_H
+#define EICRECON_PRINT_INFO_H
+
+#include <iostream>
+#include <iomanip>
+#include <JANA/Utils/JTablePrinter.h>
+
+void printFactoryTable(JComponentSummary const& cs) {
+    JTablePrinter factory_table;
+    factory_table.AddColumn("Plugin");
+    factory_table.AddColumn("Object name");
+    factory_table.AddColumn("Tag");
+    for (const auto& factory : cs.factories) {
+        factory_table | factory.plugin_name | factory.object_name | factory.factory_tag;
+    }
+
+    std::ostringstream ss;
+    factory_table.Render(ss);
+    std::cout << ss.str() << std::endl;
+}
+
+#endif //EICRECON_PRINT_INFO_H


### PR DESCRIPTION
### Briefly, what does this PR introduce?
- Add "-L"/"--list_factories" as a cli option. Print the factories given by [JComponentSummary](https://github.com/cissieAB/JANA2/blob/master/src/libraries/JANA/JApplication.h#L98). Use [JTablePrinter](https://github.com/cissieAB/JANA2/blob/master/src/libraries/JANA/Utils/JTablePrinter.h) to do the work.
- Turn off the irrelevant logger information given this option.
- Keep "-Ppodio:print_type_table=1" working with this option

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #61 _)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
Unclear. It better to split the jana::Flag into two categories: run and not run app. Otherwise when the option number increases, the logic will become too complicated to manage.
Eg. the behavior of "-b -L"

### Does this PR change default behavior?
If this option is given, the application will not run.