### PR TITLE
Add ability to merge background events in with the primary.

### DIFF
--- a/src/services/io/podio/JEventSourcePODIOsimple.h
+++ b/src/services/io/podio/JEventSourcePODIOsimple.h
@@ -33,6 +33,9 @@ protected:
     size_t Nevents_in_file = 0;
     size_t Nevents_read = 0;
 
+    // User may optionally specify a file of background events to overlay
+    std::vector<std::tuple<podio::ROOTReader*, podio::EventStore*, uint64_t>> readers_background; // uint64_t is current event read
+
     std::string m_include_collections_str;
     std::string m_exclude_collections_str;
     std::set<std::string> m_INPUT_INCLUDE_COLLECTIONS;

--- a/src/services/io/podio/podio.cc
+++ b/src/services/io/podio/podio.cc
@@ -17,10 +17,10 @@ void InitPlugin(JApplication *app) {
     app->Add(new JEventSourceGeneratorT<JEventSourcePODIOsimple>());
 
     // Only add a EICRootWriter if the user has specified a configuration parameter relevant to writing
-    if( app->GetJParameterManager()->Exists("PODIO:OUTPUT_FILE")
-        ||  app->GetJParameterManager()->Exists("PODIO:OUTPUT_FILE_COPY_DIR")
-        ||  app->GetJParameterManager()->Exists("PODIO:OUTPUT_INCLUDE_COLLECTIONS")
-        ||  app->GetJParameterManager()->Exists("PODIO:OUTPUT_EXCLUDE_COLLECTIONS")        ){
+    if( app->GetJParameterManager()->Exists("podio:output_file")
+        ||  app->GetJParameterManager()->Exists("podio:output_file_copy_dir")
+        ||  app->GetJParameterManager()->Exists("podio:output_include_collections")
+        ||  app->GetJParameterManager()->Exists("podio:output_exclude_collections")        ){
         app->Add(new EICRootWriterSimple());
     }
 }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This allows the user to specify a second podio file containing background events that are to be merged in with the primary events at the event source. User may also specify how many background events to merge in.

This currently merges ALL objects in the background event, including generated particles. 

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No. One needs to specify the podio:background_filename to activate the new feature.