### PR TITLE
Fix the linked address of the manual build guide

### DIFF
--- a/docs/Use_with_eic_shell.md
+++ b/docs/Use_with_eic_shell.md
@@ -78,4 +78,4 @@ At this point, you can [create your own user plugin](HowTo_make_plugin.md) or
 
 ## Manual compiling
 The bare-metal compiling is not encouraged, but would give you much more freedom in
-debugging. Please refer to the [complete guide](Build_bare_metal.md) for the details.
+debugging. Please refer to the [complete guide](Manual_Build.md) for the details.


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Try to address #74. Cont. of #111 #113.
Fix the linked address of the bare-metal manual build guide.


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [x] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [x] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No
