### PR TITLE
Add cli options "--list_default_plugins" and "--list_available_plugins"

### DIFF
--- a/src/utilities/eicrecon/eicrecon.cc
+++ b/src/utilities/eicrecon/eicrecon.cc
@@ -9,26 +9,28 @@
 
 #include "eicrecon_cli.h"
 
+/// The default plugins
+std::vector<std::string> EICRECON_DEFAULT_PLUGINS = {
+        "podio",
+        "dd4hep",
+        "acts",
+        "log",
+        "rootfile",
+        "algorithms_calorimetry",
+        "algorithms_tracking",
+        "algorithms_digi",
+        "BEMC",
+        "EEMC"
+};
+
 int main( int narg, char **argv)
 {
-    auto options = jana::ParseCommandLineOptions(narg, argv, false);
+    std::vector<std::string> default_plugins = EICRECON_DEFAULT_PLUGINS;
 
-    if (options.flags[jana::ShowUsage]) {
-        // Show usage information and exit immediately
-        jana::PrintUsage();
-        std::cout << std::endl << "-----------" << std::endl;
-        std::cout << "    eicrecon parameters: (specify with -Pparam=value)" << std::endl;
-        std::cout << std::endl;
-        std::cout << "        -Phistsfile=file.root    Set name for histograms/trees produced by plugins" << std::endl;
-        std::cout << std::endl;
-        std::cout << std::endl;
+    auto options = jana::GetCliOptions(narg, argv, false);
+
+    if (jana::HasPrintOnlyCliOptions(options, default_plugins))
         return -1;
-    }
-    if (options.flags[jana::ShowVersion]) {
-        // Show version information and exit immediately
-        jana::PrintVersion();
-        return -1;
-    }
 
     japp = jana::CreateJApplication(options);
 

--- a/src/utilities/eicrecon/eicrecon_cli.cpp
+++ b/src/utilities/eicrecon/eicrecon_cli.cpp
@@ -11,8 +11,38 @@
 
 #include <JANA/Services/JComponentManager.h>
 
+#include <set>
+#include <iostream>
+#include <string>
+#include <filesystem>
 
 namespace jana {
+
+    void PrintUsageOptions() {
+        std::cout << "Options:" << std::endl;
+        std::cout << "   -h   --help                  Display this message" << std::endl;
+        std::cout << "   -v   --version               Display version information" << std::endl;
+        std::cout << "   -c   --configs               Display configuration parameters" << std::endl;
+        std::cout << "   -l   --loadconfigs <file>    Load configuration parameters from file" << std::endl;
+        std::cout << "   -d   --dumpconfigs <file>    Dump configuration parameters to file" << std::endl;
+        std::cout << "   -b   --benchmark             Run in benchmark mode" << std::endl;
+        std::cout << "   -L   --list_factories        List all the factories without running" << std::endl;
+        std::cout << "   -Pkey=value                  Specify a configuration parameter" << std::endl;
+        std::cout << "   -Pplugin:param=value         Specify a parameter value for a plugin" << std::endl;
+        std::cout << std::endl;
+
+        std::cout << "   --list_default_plugins       List all the default plugins" << std::endl;
+        std::cout << "   --list_available_plugins     List plugins at $JANA_PLUGIN_PATH and $EICrecon_MY" << std::endl;
+        std::cout << std::endl << std::endl;
+    }
+
+    void PrintUsageExample() {
+
+        std::cout << "Example:" << std::endl;
+        std::cout << "    eicrecon -Pplugins=plugin1,plugin2,plugin3 -Pnthreads=8 infile.root" << std::endl;
+        std::cout << "    eicrecon -Ppodio:print_type_table=1 infile.root" << std::endl << std::endl;
+        std::cout << std::endl << std::endl;
+    }
 
     void PrintUsage() {
         /// Prints jana.cc command-line options to stdout, for use by the CLI.
@@ -21,40 +51,99 @@ namespace jana {
 
         std::cout << std::endl;
         std::cout << "Usage:" << std::endl;
-        std::cout << "    jana [options] source1 source2 ..." << std::endl << std::endl;
+        std::cout << "    eicrecon [options] source1 source2 ..." << std::endl;
+        std::cout << std::endl;
 
         std::cout << "Description:" << std::endl;
         std::cout << "    Command-line interface for running JANA plugins. This can be used to" << std::endl;
         std::cout << "    read in events and process them. Command-line flags control configuration" << std::endl;
         std::cout << "    while additional arguments denote input files, which are to be loaded and" << std::endl;
-        std::cout << "    processed by the appropriate EventSource plugin." << std::endl << std::endl;
+        std::cout << "    processed by the appropriate EventSource plugin." << std::endl;
+        std::cout << std::endl;
 
-        std::cout << "Options:" << std::endl;
-        std::cout << "   -h   --help                  Display this message" << std::endl;
         PrintUsageOptions();
-        std::cout << "Example:" << std::endl;
-        std::cout << "    jana -Pplugins=plugin1,plugin2,plugin3 -Pnthreads=8 inputfile1.txt" << std::endl << std::endl;
-
-    }
-
-    void PrintUsageOptions() {
-        std::cout << "   -v   --version               Display version information" << std::endl;
-        std::cout << "   -c   --configs               Display configuration parameters" << std::endl;
-        std::cout << "   -l   --loadconfigs <file>    Load configuration parameters from file" << std::endl;
-        std::cout << "   -d   --dumpconfigs <file>    Dump configuration parameters to file" << std::endl;
-        std::cout << "   -b   --benchmark             Run in benchmark mode" << std::endl;
-        std::cout << "   -L   --list_factories        List all the factories without running" << std::endl;
-        std::cout << "   -Pkey=value                  Specify a configuration parameter" << std::endl << std::endl;
+        PrintUsageExample();
     }
 
     void PrintVersion() {
-        /// Prints JANA version information to stdout, for use by the CLI.
+        std::cout << "      EICrecon version: " << "0.0.0" << std::endl;
+        std::cout << std::endl << std::endl;
+    }
 
-        std::cout << "          JANA version: " << JVersion::GetVersion() << std::endl;
-        std::cout << "        JANA ID string: " << JVersion::GetIDstring() << std::endl;
-        std::cout << "     JANA git revision: " << JVersion::GetRevision() << std::endl;
-        std::cout << "JANA last changed date: " << JVersion::GetDate() << std::endl;
-        std::cout << "           JANA source: " << JVersion::GetSource() << std::endl;
+    void PrintDefaultPlugins(std::vector<std::string> const& default_plugins) {
+        std::cout << "\n List default plugins:\n\n";
+        printPluginNames(default_plugins);
+        std::cout << std::endl << std::endl;
+    }
+
+    void AddPluginNamesInDir(std::set<std::string> & plugin_names, std::string dir_str) {
+        std::string full_path, filename;
+        for (const auto & entry : std::filesystem::directory_iterator(dir_str)) {
+            full_path = std::string(entry.path());   // Example: "/usr/local/plugins/Tutorial.so"
+            filename = full_path.substr(full_path.find_last_of("/") + 1);  // Example: "Tutorial.so"
+            if (filename.substr(filename.size() - 3) == ".so") {
+                std::string s = filename.substr(0, filename.size() - 3);
+//                std::cout << filename << "==> "  << s << std::endl;
+                plugin_names.insert(s);
+            }
+        }
+    }
+
+    void GetPluginNamesStrFromEnvPath(std::set<std::string> & plugin_names, const char* env_var) {
+        std::string dir_path, paths;
+
+        const char* env_p = getenv(env_var);
+        if (env_p) {
+            if (env_var == "EICrecon_MY")
+                paths = std::string(env_p) + "/plugins";
+            else
+                paths = std::string(env_p);
+
+            std::stringstream envvar_ss(paths);
+            while (getline(envvar_ss, dir_path, ':')) {
+                AddPluginNamesInDir(plugin_names, dir_path);
+            }
+        }
+    }
+
+    std::vector<std::string> GetAvailablePluginNames(std::vector<std::string> const& default_plugins) {
+        // Use set to remove duplicates.
+        /// @note The plugins will be override if you use the same plugin name at different paths.
+        std::set<std::string> set_plugin_name;
+        for (std::string s : default_plugins)
+            set_plugin_name.insert(s);
+
+        jana::GetPluginNamesStrFromEnvPath(set_plugin_name, "JANA_PLUGIN_PATH");
+        jana::GetPluginNamesStrFromEnvPath(set_plugin_name, "EICrecon_MY");
+
+        std::vector<std::string> plugin_names(set_plugin_name.begin(), set_plugin_name.end());
+        return plugin_names;
+    }
+
+    void PrintAvailablePlugins(std::vector<std::string> const& default_plugins) {
+        std::cout << "\n List available plugins:\n\n";
+        printPluginNames(GetAvailablePluginNames(default_plugins));
+        std::cout << std::endl << std::endl;
+    }
+
+    bool HasPrintOnlyCliOptions(UserOptions& options, std::vector<std::string> const& default_plugins) {
+        if (options.flags[jana::ShowUsage]) {
+            jana::PrintUsage();
+            return true;
+        }
+        if (options.flags[jana::ShowVersion]) {
+            jana::PrintVersion();
+            return true;
+        }
+        if (options.flags[jana::ShowDefaultPlugins]) {
+            jana::PrintDefaultPlugins(default_plugins);
+            return true;
+        }
+        if (options.flags[jana::ShowAvailablePlugins]) {
+            jana::PrintAvailablePlugins(default_plugins);
+            return true;
+        }
+        return false;
     }
 
     JApplication* CreateJApplication(UserOptions& options) {
@@ -65,6 +154,7 @@ namespace jana {
         }
 
         if (options.flags[ListFactories]) {
+            // Shut down the [INFO] msg by adding plugins, cpu info, etc.
             params->SetParameter(
                     "log:off",
                     "JPluginLoader,JComponentManager,JArrowProcessingController,JArrow"
@@ -171,7 +261,7 @@ namespace jana {
     }
 
 
-    UserOptions ParseCommandLineOptions(int nargs, char *argv[], bool expect_extra) {
+    UserOptions GetCliOptions(int nargs, char *argv[], bool expect_extra) {
 
         UserOptions options;
 
@@ -190,7 +280,10 @@ namespace jana {
         tokenizer["--benchmark"] = Benchmark;
         tokenizer["-L"] = ListFactories;
         tokenizer["--list_factories"] = ListFactories;
+        tokenizer["--list_default_plugins"] = ShowDefaultPlugins;
+        tokenizer["--list_available_plugins"] = ShowAvailablePlugins;
 
+        // `eicrecon` has the same effect with `eicrecon -h`
         if (nargs == 1) {
             options.flags[ShowUsage] = true;
         }
@@ -198,7 +291,7 @@ namespace jana {
         for (int i = 1; i < nargs; i++) {
 
             std::string arg = argv[i];
-            //std::cout << "Found arg " << arg << std::endl;
+            // std::cout << "Found arg " << arg << std::endl;
 
             if (argv[i][0] != '-') {
                 options.eventSources.push_back(arg);
@@ -247,6 +340,15 @@ namespace jana {
                     options.flags[ListFactories] = true;
                     break;
 
+                case ShowDefaultPlugins:
+                    options.flags[ShowDefaultPlugins] = true;
+                    break;
+
+                case ShowAvailablePlugins:
+                    options.flags[ShowAvailablePlugins] = true;
+                    break;
+
+                // TODO: add exclude plugin options
                 case Unknown:
                     if (argv[i][0] == '-' && argv[i][1] == 'P') {
 

--- a/src/utilities/eicrecon/eicrecon_cli.h
+++ b/src/utilities/eicrecon/eicrecon_cli.h
@@ -13,6 +13,8 @@ namespace jana {
         Unknown,
         ShowUsage,
         ShowVersion,
+        ShowDefaultPlugins,
+        ShowAvailablePlugins,
         ShowConfigs,
         LoadConfigs,
         DumpConfigs,
@@ -31,14 +33,34 @@ namespace jana {
         std::string dump_config_file;
     };
 
+    /// Read the user options from the command line and initialize @param options.
+    /// If there are certain flags, mark them as true.
+    /// Push the event source strings to @param options.eventSources.
+    /// Push the parameter strings to @param options.params as key-value pairs.
+    /// If the user option is to load or dump a config file, initialize @param options.load/dump_config_file
+    UserOptions GetCliOptions(int nargs, char *argv[], bool expect_extra=true);
+
+    /// If the user option contains print only flags, print the info ann return true; otherwise return false.
+    /// The print only flags include: "-v", "-h", "-L", "--list_default_plugins", "--list_available_plugins".
+    /// When these flags are effective, the application will exit immediately.
+    bool HasPrintOnlyCliOptions(UserOptions& options, std::vector<std::string> const& default_plugins);
+
     void PrintUsage();
-    void PrintUsageOptions();
     void PrintVersion();
-    UserOptions ParseCommandLineOptions(int nargs, char *argv[], bool expect_extra=true);
-    JApplication* CreateJApplication(UserOptions& options);
-    int Execute(JApplication* app, UserOptions& options);
+
+    /// List the @param default_plugins in a table.
+    /// @param default_plugins is given at the top of the eicrecon.cc.
+    void PrintDefaultPlugins(std::vector<std::string> const& default_plugins);
+
+    /// List all the available plugins at @env_var $JANA_PLUGIN_PATH and @env_var $EICrecon_MY/plugins.
+    void PrintAvailablePlugins(std::vector<std::string> const& default_plugins);
+
     void PrintFactories(JApplication* app);
     void PrintPodioCollections(JApplication* app);
+
+    JApplication* CreateJApplication(UserOptions& options);
+    int Execute(JApplication* app, UserOptions& options);
+
 }
 
 #endif //EICRECON_EICRECON_CLI_H

--- a/src/utilities/eicrecon/print_info.h
+++ b/src/utilities/eicrecon/print_info.h
@@ -23,6 +23,18 @@ void printFactoryTable(JComponentSummary const& cs) {
     std::cout << ss.str() << std::endl;
 }
 
+void printPluginNames(std::vector<std::string> const& plugin_names) {
+    JTablePrinter plugin_table;
+    plugin_table.AddColumn("Plugin name");
+    for (const auto& plugin_name : plugin_names) {
+        plugin_table | plugin_name;
+    }
+
+    std::ostringstream ss;
+    plugin_table.Render(ss);
+    std::cout << ss.str() << std::endl;
+}
+
 void printJANAHeaderIMG() {
     std::cout << "     ____      _     ___      ___       _               \n"
                  "     `MM'     dM.    `MM\\     `M'      dM.              \n"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
- eicrecon "-h"/"-v" cleanup
    - Replace "jana" with "eicrecon" in eicrecon helper info.
    - Remove "-Phistsfile=file.root" in CLI option print info.
    - Set eicrecon version to 0.0.0 instead of jana version.

- Add CLI options to list plugins
   -  "--list_default_plugins": list the default plugins without running
   - "--list_available_plugins": list all the plugins at $JANA_PLUGIN_PATH and $EICrecon_MY without running

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #90)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No
