### PR TITLE
Fix getting plugins in empty or invalid paths

### DIFF
--- a/src/utilities/eicrecon/eicrecon_cli.cpp
+++ b/src/utilities/eicrecon/eicrecon_cli.cpp
@@ -26,13 +26,13 @@ namespace jana {
         std::cout << "   -l   --loadconfigs <file>    Load configuration parameters from file" << std::endl;
         std::cout << "   -d   --dumpconfigs <file>    Dump configuration parameters to file" << std::endl;
         std::cout << "   -b   --benchmark             Run in benchmark mode" << std::endl;
-        std::cout << "   -L   --list_factories        List all the factories without running" << std::endl;
+        std::cout << "   -L   --list-factories        List all the factories without running" << std::endl;
         std::cout << "   -Pkey=value                  Specify a configuration parameter" << std::endl;
         std::cout << "   -Pplugin:param=value         Specify a parameter value for a plugin" << std::endl;
         std::cout << std::endl;
 
-        std::cout << "   --list_default_plugins       List all the default plugins" << std::endl;
-        std::cout << "   --list_available_plugins     List plugins at $JANA_PLUGIN_PATH and $EICrecon_MY" << std::endl;
+        std::cout << "   --list-default-plugins       List all the default plugins" << std::endl;
+        std::cout << "   --list-available-plugins     List plugins at $JANA_PLUGIN_PATH and $EICrecon_MY" << std::endl;
         std::cout << std::endl << std::endl;
     }
 
@@ -289,9 +289,9 @@ namespace jana {
         tokenizer["-b"] = Benchmark;
         tokenizer["--benchmark"] = Benchmark;
         tokenizer["-L"] = ListFactories;
-        tokenizer["--list_factories"] = ListFactories;
-        tokenizer["--list_default_plugins"] = ShowDefaultPlugins;
-        tokenizer["--list_available_plugins"] = ShowAvailablePlugins;
+        tokenizer["--list-factories"] = ListFactories;
+        tokenizer["--list-default-plugins"] = ShowDefaultPlugins;
+        tokenizer["--list-available-plugins"] = ShowAvailablePlugins;
 
         // `eicrecon` has the same effect with `eicrecon -h`
         if (nargs == 1) {

--- a/src/utilities/eicrecon/eicrecon_cli.cpp
+++ b/src/utilities/eicrecon/eicrecon_cli.cpp
@@ -77,6 +77,12 @@ namespace jana {
     }
 
     void GetPluginNamesInDir(std::set<std::string> & plugin_names, std::string dir_str) {
+        // Edge case handler: taking care of invalid and empty dirs
+        if (std::filesystem::is_directory(dir_str) == false)
+            return;
+        if (std::filesystem::is_empty(dir_str))
+            return;
+
         std::string full_path, filename;
         for (const auto & entry : std::filesystem::directory_iterator(dir_str)) {
             full_path = std::string(entry.path());   // Example: "/usr/local/plugins/Tutorial.so"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
In #119, if
- $EICrecon_MY is set but there is no $EICrecon/plugins
- $EICrecon/plugin is empty
The "--list_available_plugins" will give error msg.

Add the handler for the above two cases.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #90 , issue #119)


### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No
