### PR TITLE
Update the way to add default plugins

### DIFF
--- a/src/utilities/eicrecon/eicrecon.cc
+++ b/src/utilities/eicrecon/eicrecon.cc
@@ -10,6 +10,7 @@
 #include "eicrecon_cli.h"
 
 /// The default plugins
+/// Add new default plugin names here and the main() will do JApplication::AddPlugin() for you.
 std::vector<std::string> EICRECON_DEFAULT_PLUGINS = {
         "podio",
         "dd4hep",
@@ -39,20 +40,13 @@ int main( int narg, char **argv)
 
     japp = jana::CreateJApplication(options);
 
-    if(const char* env_p = std::getenv("EICrecon_MY")) japp->AddPluginPath( std::string(env_p) + "/plugins" );
-
-    // TODO: add by command line paras
-    for( auto plugin : default_plugins) japp->AddPlugin( plugin );
-//    japp->AddPlugin( "podio"           );
-//    japp->AddPlugin( "dd4hep"          );
-//    japp->AddPlugin( "acts"        );
-//    japp->AddPlugin( "log"             );
-//    japp->AddPlugin( "rootfile"        );
-//    japp->AddPlugin( "algorithms_calorimetry");
-//    japp->AddPlugin( "algorithms_tracking");
-//    japp->AddPlugin( "algorithms_digi" );
-//    japp->AddPlugin( "BEMC"            );
-//    japp->AddPlugin( "EEMC"            );
+    /// @note: the default plugins and the plugins at $EICrecon_MY are not managed by the JComponentManager,
+    /// thus they will not be shown with the "eicrecon -c" option.
+    // Add the plugins at $EICrecon_MY/plugins
+    if(const char* env_p = std::getenv("EICrecon_MY"))
+        japp->AddPluginPath( std::string(env_p) + "/plugins" );
+    // Add the default plugins
+    jana::AddDefaultPluginsToJApplication(japp, default_plugins);
 
     auto exit_code = jana::Execute(japp, options);
 

--- a/src/utilities/eicrecon/eicrecon_cli.cpp
+++ b/src/utilities/eicrecon/eicrecon_cli.cpp
@@ -158,14 +158,15 @@ namespace jana {
 
     JApplication* CreateJApplication(UserOptions& options) {
 
-        auto params = new JParameterManager(); // JApplication owns params_copy, does not own eventSources
+        auto para_mgr = new JParameterManager(); // JApplication owns params_copy, does not own eventSources
+
+        // Add the cli options based on the user inputs
         for (auto pair : options.params) {
-            params->SetParameter(pair.first, pair.second);
+            para_mgr->SetParameter(pair.first, pair.second);
         }
 
         if (options.flags[ListFactories]) {
-            // Shut down the [INFO] msg by adding plugins, cpu info, etc.
-            params->SetParameter(
+            para_mgr->SetParameter(
                     "log:off",
                     "JPluginLoader,JArrowProcessingController,JArrow"
                     );
@@ -174,7 +175,7 @@ namespace jana {
         if (options.flags[LoadConfigs]) {
             // If the user specified an external config file, we should definitely use that
             try {
-                params->ReadConfigFile(options.load_config_file);
+                para_mgr->ReadConfigFile(options.load_config_file);
             }
             catch (JException &e) {
                 std::cout << "Problem loading config file '" << options.load_config_file << "'. Exiting." << std::endl
@@ -184,7 +185,7 @@ namespace jana {
             std::cout << "Loaded config file '" << options.load_config_file << "'." << std::endl << std::endl;
         }
 
-        auto app = new JApplication(params);
+        auto app = new JApplication(para_mgr);
 
         for (auto event_src : options.eventSources) {
             app->Add(event_src);

--- a/src/utilities/eicrecon/eicrecon_cli.cpp
+++ b/src/utilities/eicrecon/eicrecon_cli.cpp
@@ -167,7 +167,7 @@ namespace jana {
             // Shut down the [INFO] msg by adding plugins, cpu info, etc.
             params->SetParameter(
                     "log:off",
-                    "JPluginLoader,JComponentManager,JArrowProcessingController,JArrow"
+                    "JPluginLoader,JArrowProcessingController,JArrow"
                     );
         }
 

--- a/src/utilities/eicrecon/eicrecon_cli.h
+++ b/src/utilities/eicrecon/eicrecon_cli.h
@@ -42,7 +42,7 @@ namespace jana {
 
     /// If the user option contains print only flags, print the info ann return true; otherwise return false.
     /// The print only flags include: "-v", "-h", "-L", "--list_default_plugins", "--list_available_plugins".
-    /// When these flags are effective, the application will exit immediately.
+    /// When the info is shown, the application will exit immediately.
     bool HasPrintOnlyCliOptions(UserOptions& options, std::vector<std::string> const& default_plugins);
 
     void PrintUsage();
@@ -53,7 +53,16 @@ namespace jana {
     void PrintDefaultPlugins(std::vector<std::string> const& default_plugins);
 
     /// List all the available plugins at @env_var $JANA_PLUGIN_PATH and @env_var $EICrecon_MY/plugins.
+    /// @note Does not guarantee the effectiveness of the plugins.
+    /// @note The plugins can be override if they use the same name under different locations.
     void PrintAvailablePlugins(std::vector<std::string> const& default_plugins);
+
+    /// Add the default plugins and the plugins at $EICrecon_MY/plugins to @param options.params.
+    /// It comes before creating the @class JApplication.
+    /// @note It's not used in eicrecon.cc.
+    void AddAvailablePluginsToOptionParams(UserOptions& options, std::vector<std::string> const& default_plugins);
+
+    void AddDefaultPluginsToJApplication(JApplication* app, std::vector<std::string> const& default_plugins);
 
     void PrintFactories(JApplication* app);
     void PrintPodioCollections(JApplication* app);

--- a/src/utilities/eicrecon/eicrecon_cli.h
+++ b/src/utilities/eicrecon/eicrecon_cli.h
@@ -58,6 +58,11 @@ namespace jana {
     void PrintFactories(JApplication* app);
     void PrintPodioCollections(JApplication* app);
 
+    /// Copy the @param options params (from the cli or the config file) to a JParameterManager @var para_mgr.
+    /// Create an empty JApplication @var app.
+    /// Add the event sources got from the cli input to @var app, and then return.
+    /// @note The cli -Pkey=value pairs are not processed when the function returns. They are processed,
+    /// or, added to @var app at calling JApplication::Initialize().
     JApplication* CreateJApplication(UserOptions& options);
     int Execute(JApplication* app, UserOptions& options);
 


### PR DESCRIPTION
Try to address issue #90 
> eicrecon currently adds a set of default plugins by having a line calling AddPlugin for each. This list should be placed into a vector so it can be listed and manipulated with command line options. 

Instead of manually adding the default plugins with `japp->AddPlugin()`, wrap it into a jana member function.

#### Original way to add the default plugins
```C++
japp = jana::CreateJApplication(options);

japp->AddPlugin( "podio"            );
japp->AddPlugin( "..."            );
```

#### New way
```C++
japp = jana::CreateJApplication(options);

jana::AddDefaultPluginsToJApplication(japp, default_plugins);
```

---

