### PR TITLE
Move podio params to "eicrecon -c" list

### DIFF
--- a/src/services/io/podio/EICRootWriterSimple.cc
+++ b/src/services/io/podio/EICRootWriterSimple.cc
@@ -98,14 +98,17 @@ std::string EICRootWriterSimple::PutPODIODataT( JFactory *fac,  podio::EventStor
     return collection_name;
 }
 
-
+// ---------------------------------------------------------------------
+// constructor
+//
 EICRootWriterSimple::EICRootWriterSimple() {
     SetTypeName(NAME_OF_THIS); // Provide JANA with this class's name
-}
 
-void EICRootWriterSimple::Init() {
-
-    japp->SetDefaultParameter("podio:output_file", m_output_file, "Name of EDM4hep/podio output file to write to. Setting this will cause the output file to be created and written to.");
+    japp->SetDefaultParameter(
+            "podio:output_file",
+            m_output_file,
+            "Name of EDM4hep/podio output file to write to. Setting this will cause the output file to be created and written to."
+            );
 
     // Allow user to set PODIO:OUTPUT_FILE to "1" to specify using the default name.
     if( m_output_file == "1" ){
@@ -118,15 +121,33 @@ void EICRootWriterSimple::Init() {
 
     // Get the output directory path for creating a second copy of the output file at the end of processing.
     // (this is duplicating similar functionality in Juggler/Gaudi so assume it is useful).
-    japp->SetDefaultParameter("podio:output_file_copy_dir", m_output_file_copy_dir, "Directory name to make an additional copy of the output file to. Copy will be done at end of processing. Default is empty string which means do not make a copy. No check is made on path existing.");
+    japp->SetDefaultParameter(
+            "podio:output_file_copy_dir",
+            m_output_file_copy_dir,
+            "Directory name to make an additional copy of the output file to. Copy will be done at end of processing. Default is empty string which means do not make a copy. No check is made on path existing."
+            );
 
     // Get the list of output collections to include/exclude
     std::vector<std::string> output_include_collections;  // need to get as vector, then convert to set
     std::vector<std::string> output_exclude_collections;  // need to get as vector, then convert to set
-    japp->SetDefaultParameter("podio:output_include_collections", output_include_collections, "Comma separated list of collection names to write out. If not set, all collections will be written (including ones from input file). Don't set this and use PODIO:OUTPUT_EXCLUDE_COLLECTIONS to write everything except a selection.");
-    japp->SetDefaultParameter("podio:output_exclude_collections", output_exclude_collections, "Comma separated list of collection names to not write out.");
-    m_output_include_collections = std::set<std::string>(output_include_collections.begin(), output_include_collections.end());
-    m_output_exclude_collections = std::set<std::string>(output_exclude_collections.begin(), output_exclude_collections.end());
+    japp->SetDefaultParameter(
+            "podio:output_include_collections",
+            output_include_collections,
+            "Comma separated list of collection names to write out. If not set, all collections will be written (including ones from input file). Don't set this and use PODIO:OUTPUT_EXCLUDE_COLLECTIONS to write everything except a selection."
+    );
+    japp->SetDefaultParameter(
+            "podio:output_exclude_collections",
+            output_exclude_collections,
+            "Comma separated list of collection names to not write out."
+            );
+    m_output_include_collections = std::set<std::string>(output_include_collections.begin(),
+                                                         output_include_collections.end());
+    m_output_exclude_collections = std::set<std::string>(output_exclude_collections.begin(),
+                                                         output_exclude_collections.end());
+
+}
+
+void EICRootWriterSimple::Init() {
 }
 
 void EICRootWriterSimple::Process(const std::shared_ptr<const JEvent> &event) {

--- a/src/services/io/podio/JEventSourcePODIOsimple.cc
+++ b/src/services/io/podio/JEventSourcePODIOsimple.cc
@@ -66,6 +66,35 @@ JEventSourcePODIOsimple::JEventSourcePODIOsimple(std::string resource_name, JApp
 
     // Tell JANA that we want it to call the FinishEvent() method.
     EnableFinishEvent();
+
+    // Allow user to specify to recycle events forever
+    GetApplication()->SetDefaultParameter(
+            "podio:run_forever",
+            m_run_forever,
+            "set to true to recycle through events continuously"
+            );
+
+    bool print_type_table = false;
+    GetApplication()->SetDefaultParameter(
+            "podio:print_type_table",
+            print_type_table,
+            "Print list of collection names and their types"
+            );
+
+    std::string background_filename;
+    GetApplication()->SetDefaultParameter(
+            "podio:background_filename",
+            background_filename,
+            "Name of file containing background events to merge in (default is not to merge any background)"
+            );
+
+    int num_background_events=1;
+    GetApplication()->SetDefaultParameter(
+            "podio:num_background_events",
+            num_background_events,
+            "Number of background events to add to every primary event."
+    );
+
 }
 
 //------------------------------------------------------------------------------
@@ -86,17 +115,9 @@ JEventSourcePODIOsimple::~JEventSourcePODIOsimple() {
 //------------------------------------------------------------------------------
 void JEventSourcePODIOsimple::Open() {
 
-    // Allow user to specify to recycle events forever
-    GetApplication()->SetDefaultParameter("podio:run_forever", m_run_forever, "set to true to recycle through events continuously");
-
-    bool print_type_table = false;
-    GetApplication()->SetDefaultParameter("podio:print_type_table", print_type_table, "Print list of collection names and their types");
-
-    std::string background_filename;
-    GetApplication()->SetDefaultParameter("podio:background_filename", background_filename, "Name of file containing background events to merge in (default is not to merge any background)");
-
-    int num_background_events=1;
-    GetApplication()->SetDefaultParameter("podio:num_background_events", num_background_events, "Number of background events to add to every primary event.");
+    bool print_type_table = GetApplication()->GetParameterValue<bool>("podio:print_type_table");
+    std::string background_filename = GetApplication()->GetParameterValue<std::string>("podio:background_filename");;
+    int num_background_events = GetApplication()->GetParameterValue<int>("podio:num_background_events");;
 
     // Open primary events file
     try {

--- a/src/utilities/eicrecon/eicrecon_cli.cpp
+++ b/src/utilities/eicrecon/eicrecon_cli.cpp
@@ -200,11 +200,10 @@ namespace jana {
 
     void PrintPodioCollections(JApplication* app) {
         if (app->GetJParameterManager()->Exists("PODIO:PRINT_TYPE_TABLE")) {
-            auto print_type_table = app->GetJParameterManager()->FindParameter("PODIO:PRINT_TYPE_TABLE")->GetValue();
+            bool print_type_table = app->GetParameterValue<bool>("podio:print_type_table");
 
             // cli criteria: Ppodio:print_type_table=1
-            if (print_type_table == "1") {
-
+            if (print_type_table) {
                 auto event_sources = app->GetService<JComponentManager>()->get_evt_srces();
                 for (auto event_source : event_sources) {
 //                    std::cout << event_source->GetPluginName() << std::endl;  // podio.so


### PR DESCRIPTION
Try to address issue #110

- [x] Move the calls to SetDefaultParameter that are near the top of JEventSourcePodioSimple::Open to be instead in the constructor. This will cause them to be defined without having to try and open a source.
- [x] Move the calls to SetDefaultParameter that are in EICRootWriterSimple::Init() to its constructor.
- [x] ~~Modify eicrecon to load all of its default plugins when the -c option is given so that parameters defined in the plugins will be listed~~       <===== Seems no modification is required here