### PR TITLE
Update the way to add default and MY plugins

### DIFF
--- a/src/utilities/eicrecon/eicrecon.cc
+++ b/src/utilities/eicrecon/eicrecon.cc
@@ -39,15 +39,8 @@ int main( int narg, char **argv)
         return -1;
 
     AddAvailablePluginsToOptionParams(options, default_plugins);
-    japp = jana::CreateJApplication(options);
 
-//    /// @note: the default plugins and the plugins at $EICrecon_MY are not managed by the JComponentManager,
-//    /// thus they will not be shown with the "eicrecon -c" option.
-//    // Add the plugins at $EICrecon_MY/plugins
-//    if(const char* env_p = std::getenv("EICrecon_MY"))
-//        japp->AddPluginPath( std::string(env_p) + "/plugins" );
-//    // Add the default plugins
-//    jana::AddDefaultPluginsToJApplication(japp, default_plugins);
+    japp = jana::CreateJApplication(options);
 
     auto exit_code = jana::Execute(japp, options);
 

--- a/src/utilities/eicrecon/eicrecon.cc
+++ b/src/utilities/eicrecon/eicrecon.cc
@@ -38,15 +38,16 @@ int main( int narg, char **argv)
     if (jana::HasPrintOnlyCliOptions(options, default_plugins))
         return -1;
 
+    AddAvailablePluginsToOptionParams(options, default_plugins);
     japp = jana::CreateJApplication(options);
 
-    /// @note: the default plugins and the plugins at $EICrecon_MY are not managed by the JComponentManager,
-    /// thus they will not be shown with the "eicrecon -c" option.
-    // Add the plugins at $EICrecon_MY/plugins
-    if(const char* env_p = std::getenv("EICrecon_MY"))
-        japp->AddPluginPath( std::string(env_p) + "/plugins" );
-    // Add the default plugins
-    jana::AddDefaultPluginsToJApplication(japp, default_plugins);
+//    /// @note: the default plugins and the plugins at $EICrecon_MY are not managed by the JComponentManager,
+//    /// thus they will not be shown with the "eicrecon -c" option.
+//    // Add the plugins at $EICrecon_MY/plugins
+//    if(const char* env_p = std::getenv("EICrecon_MY"))
+//        japp->AddPluginPath( std::string(env_p) + "/plugins" );
+//    // Add the default plugins
+//    jana::AddDefaultPluginsToJApplication(japp, default_plugins);
 
     auto exit_code = jana::Execute(japp, options);
 

--- a/src/utilities/eicrecon/eicrecon_cli.cpp
+++ b/src/utilities/eicrecon/eicrecon_cli.cpp
@@ -157,21 +157,56 @@ namespace jana {
         return false;
     }
 
-    void AddAvailablePluginsToOptionParams(UserOptions& options, std::vector<std::string> const& default_plugins) {
-        std::set<std::string> set_plugins;
-        for (std::string s : default_plugins) {
-            // TODO: have problems in loading "EEMC" or "BEMC" in this way
-            if (s != "EEMC" && s != "BEMC")
-                set_plugins.insert(s);
-        }
+    /// Detect whether the cli params @param options.params contain "-Pplugins_to_ignore=...<erase_str>...".
+    /// If true, delete @param erase_str from the original cli string "-Pplugins_to_ignore".
+    bool HasExcludeDefaultPluginsInCliParams(UserOptions& options, const std::string erase_str) {
+        auto has_ignore_plugins = options.params.find("plugins_to_ignore");
+        if (has_ignore_plugins == options.params.end())
+            return false;
 
-        // Add the plugins at $EICrecon_MY/plugins. May override with the same name.
+        // Has cli option "-Pplugins_to_ignore". Look for @param erase_str
+        size_t pos = has_ignore_plugins->second.find(erase_str);
+        if (pos == std::string::npos)  // does not contain @param erase_str
+            return false;
+
+        // Detect @param flag_str. Delete flag_str from the original cli option.
+        std::string ignore_str;
+        if (erase_str.length() + pos == has_ignore_plugins->second.length()) { // @param flag_str is at the end
+            ignore_str = has_ignore_plugins->second.erase(pos, erase_str.length());
+        } else { // erase "<flag_str>," from "-Pplugins_to_ignore".
+            ignore_str = has_ignore_plugins->second.erase(pos, erase_str.length() + 1);
+        }
+        options.params["plugins_to_ignore"] = ignore_str;
+        return true;
+    }
+
+    void AddAvailablePluginsToOptionParams(UserOptions& options, std::vector<std::string> const& default_plugins) {
+
+        std::set<std::string> set_plugins;
+        // Add the plugins at $EICrecon_MY/plugins.
         jana::GetPluginNamesFromEnvPath(set_plugins, "EICrecon_MY");
 
-        std::string plugins_str;
+        std::string plugins_str;  // the complete plugins list
         for (std::string s : set_plugins)
-            plugins_str += s + ",";  // join the string
-        options.params.insert({"plugins", plugins_str.substr(0, plugins_str.size() - 1)});   // exclude the last ","
+            plugins_str += s + ",";
+
+        // Add the default plugins into the plugin set if there is no
+        // "-Pplugins_to_ignore=default (exclude all default plugins)" option
+        if (HasExcludeDefaultPluginsInCliParams(options, "default") == false)
+            /// @note: The sequence of adding the default plugins matters.
+            /// Have to keep the original sequence to not causing troubles.
+            for (std::string s : default_plugins) {
+                plugins_str += s + ",";
+            }
+
+        // Insert other plugins in cli option "-Pplugins=pl1,pl2,..."
+        auto has_cli_plugin_params = options.params.find("plugins");
+        if (has_cli_plugin_params != options.params.end()) {
+            plugins_str += has_cli_plugin_params->second;
+            options.params["plugins"] = plugins_str;
+        } else {
+            options.params["plugins"] = plugins_str.substr(0, plugins_str.size() - 1); // exclude last ","
+        }
     }
 
     JApplication* CreateJApplication(UserOptions& options) {

--- a/src/utilities/eicrecon/eicrecon_cli.h
+++ b/src/utilities/eicrecon/eicrecon_cli.h
@@ -59,7 +59,6 @@ namespace jana {
 
     /// Add the default plugins and the plugins at $EICrecon_MY/plugins to @param options.params.
     /// It comes before creating the @class JApplication.
-    /// @note It's not used in eicrecon.cc.
     void AddAvailablePluginsToOptionParams(UserOptions& options, std::vector<std::string> const& default_plugins);
 
     void AddDefaultPluginsToJApplication(JApplication* app, std::vector<std::string> const& default_plugins);


### PR DESCRIPTION
### Briefly, what does this PR introduce?

The default plugins and $EICrecon_MY plugins were added by JApplictaion::AddPLugin(). They are not managed by the JParameterManager(), thus they will not be shown at the "eicrecon -c" option.

Now add the default and MY plugins via the cli option. Specifically, if there is a cli option says "-Pplugins_to_ignore=default", eicrecon would exclude all the default plugins. Note that we have to keep the original sequence of adding the default plugins, otherwise there would be troubles.



### What kind of change does this PR introduce?
- [x] New feature (issue #90 __)


### Demo

#### `eicrecon -c`
The default and MY plugins will be shown.
```bash 

nightly> xmei@xmei-lpt-wifi:~/eic/dev/EICrecon$ eicrecon -c
...
[INFO] Configuration Parameters
  --------------------------------------------------------------------------------------------------------------------------------------------------------------------
                Name                                                                               Value                                                                
  ---------------------------------  ---------------------------------------------------------------------------------------------------------------------------------  
                  event_source_type                                                                                                                                     
                      jana:affinity  2                                                                                                                                  
          JANA:DEBUG_PLUGIN_LOADING  0                                                                                                                                  
               jana:enable_stealing  0                                                                                                                                  
                        jana:engine  0                                                                                                                                  
               jana:event_pool_size  1                                                                                                                                  
     jana:event_processor_chunksize  1                                                                                                                                  
         jana:event_queue_threshold  80                                                                                                                                 
        jana:event_source_chunksize  40                                                                                                                                 
               jana:extended_report  0                                                                                                                                  
  jana:limit_total_events_in_flight  1                                                                                                                                  
                      jana:locality  0                                                                                                                                  
                       jana:nevents  0                                                                                                                                  
                         jana:nskip  0                                                                                                                                  
                   jana:plugin_path                                                                                                                                     
                       jana:timeout  8                                                                                                                                  
                jana:warmup_timeout  30                                                                                                                                 
                          log:debug                                                                                                                                     
                          log:error                                                                                                                                     
                          log:fatal                                                                                                                                     
                           log:info                                                                                                                                     
                            log:off                                                                                                                                     
                          log:trace                                                                                                                                     
                           log:warn                                                                                                                                     
                           nthreads  1                                                                                                                                  
                            plugins  podio,dd4hep,acts,log,rootfile,algorithms_calorimetry,algorithms_tracking,algorithms_digi,BEMC,BTRK,BVTX,ECTRK,EEMC,MPGD,tracking  
                  plugins_to_ignore                                                                                                                                     
                  RECORD_CALL_STACK  0                                                                                                                                  
  --------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

#### `eicrecon -Pplugins_to_ignore=default`
The default plugins would be excluded.

```bash
nightly> xmei@xmei-lpt-wifi:~/eic/dev/EICrecon$ eicrecon -c -Pplugins=JTest,Tutorial -Pplugins_to_ignore=default,JTest

[INFO] Configuration Parameters
  -------------------------------------------------
                Name                     Value       
  ---------------------------------  --------------  
                  event_source_type                  
                      jana:affinity  2               
          JANA:DEBUG_PLUGIN_LOADING  0               
               jana:enable_stealing  0               
                        jana:engine  0               
               jana:event_pool_size  1               
     jana:event_processor_chunksize  1               
         jana:event_queue_threshold  80              
        jana:event_source_chunksize  40              
               jana:extended_report  0               
  jana:limit_total_events_in_flight  1               
                      jana:locality  0               
                       jana:nevents  0               
                         jana:nskip  0               
                   jana:plugin_path                  
                       jana:timeout  8               
                jana:warmup_timeout  30              
                          log:debug                  
                          log:error                  
                          log:fatal                  
                           log:info                  
                            log:off                  
                          log:trace                  
                           log:warn                  
                           nthreads  1               
                            plugins  JTest,Tutorial  
                  plugins_to_ignore  JTest           
                  RECORD_CALL_STACK  0               
  -------------------------------------------------
```
