### PR TITLE
fix: eicd -> edm4eic

### DIFF
--- a/src/detectors/BEMC/TruthCluster_factory_EcalBarrelTruthProtoClusters.h
+++ b/src/detectors/BEMC/TruthCluster_factory_EcalBarrelTruthProtoClusters.h
@@ -11,7 +11,7 @@
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterTruthClustering.h>
 
-class TruthCluster_factory_EcalBarrelTruthProtoClusters : public JFactoryT<eicd::MutableProtoCluster>, CalorimeterTruthClustering {
+class TruthCluster_factory_EcalBarrelTruthProtoClusters : public JFactoryT<edm4eic::MutableProtoCluster>, CalorimeterTruthClustering {
 
 public:
     //------------------------------------------
@@ -40,7 +40,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        m_inputHits = event->Get<eicd::CalorimeterHit>(m_inputHit_tag);
+        m_inputHits = event->Get<edm4eic::CalorimeterHit>(m_inputHit_tag);
         m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(m_inputMCHit_tag);
 
         // Call Process for generic algorithm

--- a/src/detectors/EEMC/TruthCluster_factory_EcalEndcapNTruthProtoClusters.h
+++ b/src/detectors/EEMC/TruthCluster_factory_EcalEndcapNTruthProtoClusters.h
@@ -11,7 +11,7 @@
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterTruthClustering.h>
 
-class TruthCluster_factory_EcalEndcapNTruthProtoClusters : public JFactoryT<eicd::MutableProtoCluster>, CalorimeterTruthClustering {
+class TruthCluster_factory_EcalEndcapNTruthProtoClusters : public JFactoryT<edm4eic::MutableProtoCluster>, CalorimeterTruthClustering {
 
 public:
     //------------------------------------------
@@ -40,7 +40,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        m_inputHits = event->Get<eicd::CalorimeterHit>(m_inputHit_tag);
+        m_inputHits = event->Get<edm4eic::CalorimeterHit>(m_inputHit_tag);
         m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(m_inputMCHit_tag);
 
         // Call Process for generic algorithm


### PR DESCRIPTION
### Briefly, what does this PR introduce?
EICD is defunct and not included in the containers anymore. It is only a matter of time before this fails (unless it's dead code).

@faustus123 The containers without eicd are probably still rolling out to cvmfs servers around the world. I check to make sure you are not depending on this anymore in CMakeLists.txt, but apparently it still has a few occurences in source files, likely included 'by accident' through some other convoluted path.

### What kind of change does this PR introduce?
- [X] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [X] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.