### PR TITLE
Add ReconstructedParticle and TrackParameters factories

### DIFF
--- a/src/global/tracking/ReconstructedParticle_factory.cc
+++ b/src/global/tracking/ReconstructedParticle_factory.cc
@@ -1,0 +1,46 @@
+// Created by Dmitry Romanov
+// Subject to the terms in the LICENSE file found in the top-level directory.
+//
+
+#include <JANA/JEvent.h>
+#include "ReconstructedParticle_factory.h"
+#include "services/log/Log_service.h"
+#include "extensions/spdlog/SpdlogExtensions.h"
+#include "ParticlesFromTrackFitResult.h"
+
+namespace eicrecon {
+    void ReconstructedParticle_factory::Init() {
+        auto app = GetApplication();
+
+        // This prefix will be used for parameters
+        std::string param_prefix = "GlbReco:" + GetTag();
+
+        // Get input data tags
+        app->SetDefaultParameter(param_prefix + ":InputTags", m_input_tags, "Input data tag name");
+        if(m_input_tags.empty()) {
+            m_input_tags = GetDefaultInputTags();
+        }
+
+        // Logger. Get plugin level sub-log
+        m_log = app->GetService<Log_service>()->logger(param_prefix);
+
+        // Get log level from user parameter or default
+        std::string log_level_str = "info";
+        app->SetDefaultParameter(param_prefix + ":LogLevel", log_level_str, "LogLevel: trace, debug, info, warn, err, critical, off");
+        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
+    }
+
+    void ReconstructedParticle_factory::ChangeRun(const std::shared_ptr<const JEvent> &event) {
+        // Nothing to do here
+    }
+
+    void ReconstructedParticle_factory::Process(const std::shared_ptr<const JEvent> &event) {
+        auto tracking_data = event->GetSingle<ParticlesFromTrackFitResult>("CentralTrackingParticles");
+        std::vector<edm4eic::ReconstructedParticle*> result;
+        for(size_t i=0; i < tracking_data->particles()->size(); i++) {
+            auto particle = (*tracking_data->particles())[i];
+            result.push_back(new edm4eic::ReconstructedParticle(particle));
+        }
+        Set(result);
+    }
+} // eicrecon

--- a/src/global/tracking/ReconstructedParticle_factory.h
+++ b/src/global/tracking/ReconstructedParticle_factory.h
@@ -1,0 +1,38 @@
+// Created by Dmitry Romanov
+// Subject to the terms in the LICENSE file found in the top-level directory.
+//
+
+#ifndef EICRECON_RECONSTRUCTEDPARTICLE_FACTORY_H
+#define EICRECON_RECONSTRUCTEDPARTICLE_FACTORY_H
+
+#include <edm4eic/ReconstructedParticle.h>
+#include <extensions/jana/JChainFactoryT.h>
+#include <spdlog/logger.h>
+
+namespace eicrecon {
+
+    class ReconstructedParticle_factory : public JChainFactoryT<edm4eic::ReconstructedParticle> {
+
+    public:
+        ReconstructedParticle_factory( std::vector<std::string> default_input_tags):
+            JChainFactoryT<edm4eic::ReconstructedParticle>( std::move(default_input_tags) ) {
+        }
+
+        /** One time initialization **/
+        void Init() override;
+
+        /** On run change preparations **/
+        void ChangeRun(const std::shared_ptr<const JEvent> &event) override;
+
+        /** Event by event processing **/
+        void Process(const std::shared_ptr<const JEvent> &event) override;
+
+    private:
+
+        std::shared_ptr<spdlog::logger> m_log;              /// Logger for this factory
+        std::vector<std::string> m_input_tags;              /// Tag for the input data
+    };
+
+} // eicrecon
+
+#endif //EICRECON_RECONSTRUCTEDPARTICLE_FACTORY_H

--- a/src/global/tracking/TrackParameters_factory.cc
+++ b/src/global/tracking/TrackParameters_factory.cc
@@ -1,0 +1,50 @@
+// Created by Dmitry Romanov
+// Subject to the terms in the LICENSE file found in the top-level directory.
+//
+
+#include "ParticlesFromTrackFitResult.h"
+#include "TrackParameters_factory.h"
+
+#include <JANA/JEvent.h>
+
+#include <edm4eic/TrackParameters.h>
+
+#include <services/log/Log_service.h>
+#include <extensions/spdlog/SpdlogExtensions.h>
+
+namespace eicrecon {
+    void TrackParameters_factory::Init() {
+        auto app = GetApplication();
+
+        // This prefix will be used for parameters
+        std::string param_prefix = "Tracking:" + GetTag();
+
+        // Get input data tags
+        app->SetDefaultParameter(param_prefix + ":InputTags", m_input_tags, "Input data tag name");
+        if(m_input_tags.empty()) {
+            m_input_tags = GetDefaultInputTags();
+        }
+
+        // Logger. Get plugin level sub-log
+        m_log = app->GetService<Log_service>()->logger(param_prefix);
+
+        // Get log level from user parameter or default
+        std::string log_level_str = "info";
+        app->SetDefaultParameter(param_prefix + ":LogLevel", log_level_str, "LogLevel: trace, debug, info, warn, err, critical, off");
+        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
+    }
+
+    void TrackParameters_factory::ChangeRun(const std::shared_ptr<const JEvent> &event) {
+        // Nothing to do here
+    }
+
+    void TrackParameters_factory::Process(const std::shared_ptr<const JEvent> &event) {
+        auto tracking_data = event->GetSingle<ParticlesFromTrackFitResult>("CentralTrackingParticles");
+        std::vector<edm4eic::TrackParameters*> result;
+        for(size_t i=0; i < tracking_data->trackParameters()->size(); i++) {
+            auto track_params = (*tracking_data->trackParameters())[i];
+            result.push_back(new edm4eic::TrackParameters(track_params));
+        }
+        Set(result);
+    }
+} // eicrecon

--- a/src/global/tracking/TrackParameters_factory.h
+++ b/src/global/tracking/TrackParameters_factory.h
@@ -1,0 +1,38 @@
+// Created by Dmitry Romanov
+// Subject to the terms in the LICENSE file found in the top-level directory.
+//
+
+#ifndef EICRECON_TRACKPARAMETERS_FACTORY_H
+#define EICRECON_TRACKPARAMETERS_FACTORY_H
+
+#include <edm4eic/TrackParameters.h>
+#include <extensions/jana/JChainFactoryT.h>
+#include <spdlog/logger.h>
+
+namespace eicrecon {
+
+    class TrackParameters_factory : public JChainFactoryT<edm4eic::TrackParameters> {
+
+    public:
+        TrackParameters_factory(std::vector<std::string> default_input_tags ):
+        JChainFactoryT<edm4eic::TrackParameters>( std::move(default_input_tags) ) {
+        }
+
+        /** One time initialization **/
+        void Init() override;
+
+        /** On run change preparations **/
+        void ChangeRun(const std::shared_ptr<const JEvent> &event) override;
+
+        /** Event by event processing **/
+        void Process(const std::shared_ptr<const JEvent> &event) override;
+
+    private:
+
+        std::shared_ptr<spdlog::logger> m_log;              /// Logger for this factory
+        std::vector<std::string> m_input_tags;              /// Tag for the input data
+    };
+
+} // eicrecon
+
+#endif //EICRECON_TRACKPARAMETERS_FACTORY_H

--- a/src/global/tracking/TrackingResult_factory.cc
+++ b/src/global/tracking/TrackingResult_factory.cc
@@ -2,12 +2,12 @@
 // Subject to the terms in the LICENSE file found in the top-level directory.
 //
 
-#include "TrackingParticles_factory.h"
+#include "TrackingResult_factory.h"
 #include "services/log/Log_service.h"
 #include "extensions/spdlog/SpdlogExtensions.h"
 #include <JANA/JEvent.h>
 
-void TrackingParticles_factory::Init() {
+void TrackingResult_factory::Init() {
     // This prefix will be used for parameters
     std::string param_prefix = "CKFTracking:" + GetTag();   // Will be something like SiTrkDigi_BarrelTrackerRawHit
 
@@ -31,11 +31,11 @@ void TrackingParticles_factory::Init() {
     m_particle_maker_algo.init(m_log);
 }
 
-void TrackingParticles_factory::ChangeRun(const std::shared_ptr<const JEvent> &event) {
+void TrackingResult_factory::ChangeRun(const std::shared_ptr<const JEvent> &event) {
 
 }
 
-void TrackingParticles_factory::Process(const std::shared_ptr<const JEvent> &event) {
+void TrackingResult_factory::Process(const std::shared_ptr<const JEvent> &event) {
     // Now we check that user provided an input names
     std::string input_tag = m_input_tags[0];
 

--- a/src/global/tracking/TrackingResult_factory.h
+++ b/src/global/tracking/TrackingResult_factory.h
@@ -2,17 +2,17 @@
 // Subject to the terms in the LICENSE file found in the top-level directory.
 //
 
-#ifndef EICRECON_TRACKINGPARTICLES_FACTORY_H
-#define EICRECON_TRACKINGPARTICLES_FACTORY_H
+#ifndef EICRECON_TRACKINGRESULT_FACTORY_H
+#define EICRECON_TRACKINGRESULT_FACTORY_H
 
 #include <algorithms/tracking/ParticlesFromTrackFitResult.h>
 #include <algorithms/tracking/ParticlesFromTrackFit.h>
 #include "extensions/jana/JChainFactoryT.h"
 #include <spdlog/logger.h>
 
-class TrackingParticles_factory: public JChainFactoryT<ParticlesFromTrackFitResult> {
+class TrackingResult_factory: public JChainFactoryT<ParticlesFromTrackFitResult> {
 public:
-    TrackingParticles_factory( std::vector<std::string> default_input_tags ):
+    TrackingResult_factory(std::vector<std::string> default_input_tags ):
     JChainFactoryT<ParticlesFromTrackFitResult>(std::move(default_input_tags) ) {
     }
 
@@ -39,4 +39,4 @@ private:
 };
 
 
-#endif //EICRECON_TRACKINGPARTICLES_FACTORY_H
+#endif //EICRECON_TRACKINGRESULT_FACTORY_H

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -4,12 +4,21 @@
 //
 
 #include <Acts/Propagator/Navigator.hpp>
+
+#include <JANA/JApplication.h>
+#include <JANA/JEvent.h>
+
+#include <extensions/jana/JChainFactoryGeneratorT.h>
+
 #include "TrackerSourceLinker_factory.h"
 #include "TrackParamTruthInit_factory.h"
-#include "TrackingParticles_factory.h"
+#include "TrackingResult_factory.h"
+#include "ReconstructedParticle_factory.h"
+#include "TrackParameters_factory.h"
 #include "CKFTracking_factory.h"
-#include <JANA/JApplication.h>
-#include <extensions/jana/JChainFactoryGeneratorT.h>
+
+
+
 
 //
 extern "C" {
@@ -32,8 +41,14 @@ void InitPlugin(JApplication *app) {
     app->Add(new JChainFactoryGeneratorT<CKFTracking_factory>(
             {"CentralTrackerSourceLinker"}, "CentralCKFTrajectories"));
 
-    app->Add(new JChainFactoryGeneratorT<TrackingParticles_factory>(
+    app->Add(new JChainFactoryGeneratorT<TrackingResult_factory>(
             {"CentralCKFTrajectories"}, "CentralTrackingParticles"));
+
+    app->Add(new JChainFactoryGeneratorT<ReconstructedParticle_factory>(
+            {"CentralTrackingParticles"}, "ReconstructedParticles"));
+
+    app->Add(new JChainFactoryGeneratorT<TrackParameters_factory>(
+            {"CentralTrackingParticles"}, "TrackParameters"));
 }
 } // extern "C"
 

--- a/src/tests/tracking_test/TrackingTest_processor.cc
+++ b/src/tests/tracking_test/TrackingTest_processor.cc
@@ -8,10 +8,6 @@
 
 #include <fmt/core.h>
 
-#include <edm4hep/SimCalorimeterHit.h>
-#include <edm4hep/MCParticle.h>
-#include <edm4eic/TrackerHit.h>
-
 #include <TDirectory.h>
 #include <TCanvas.h>
 #include <TROOT.h>
@@ -21,7 +17,12 @@
 #include <Math/GenVector/PxPyPzM4D.h>
 
 #include <spdlog/spdlog.h>
+
+#include <edm4hep/SimCalorimeterHit.h>
+#include <edm4hep/MCParticle.h>
+#include <edm4eic/TrackerHit.h>
 #include <edm4eic/TrackParameters.h>
+#include <edm4eic/ReconstructedParticle.h>
 
 #include <algorithms/tracking/TrackerSourceLinkerResult.h>
 #include <algorithms/tracking/ParticlesFromTrackFitResult.h>
@@ -120,6 +121,9 @@ void TrackingTest_processor::Process(const std::shared_ptr<const JEvent>& event)
     auto mc_particles = event->Get<edm4hep::MCParticle>("MCParticles");
 //    fmt::print("OccupancyAnalysis::Process() mc_particles N {}\n", mc_particles.size());
 //
+
+    auto particles = event->GetSingle<edm4eic::ReconstructedParticle>("ReconstructedParticles");
+    auto track_params = event->GetSingle<edm4eic::TrackParameters>("TrackParameters");
 
     m_log->debug("MC particles N={}: ", mc_particles.size());
     m_log->debug("   {:<5} {:<6} {:<7} {:>8} {:>8} {:>8} {:>8}","[i]", "status", "[PDG]",  "[px]", "[py]", "[pz]", "[P]");


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Currently ReconstructedParticles are created out of tracking results. But PID and other info should be filled also, so there should be a split in data flow to two more entities ReconstructedParticles_factory and TrackParameters_factory. It also will let easy save of data to the resulting file

### What kind of change does this PR introduce?

- [x] New feature (closes #140 )


### Please check if this PR fulfills the following:

- [x] Tests for the changes have been added
- [x] Documentation has been added (issue #122)
- [x] Changes have been communicated to collaborators - a lot =)

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No

### Does this PR change default behavior?

No 
