### PR TITLE
Davidl eicmkplugin eicrecon fixes

### DIFF
--- a/src/utilities/eicrecon/eicrecon_cli.cpp
+++ b/src/utilities/eicrecon/eicrecon_cli.cpp
@@ -184,7 +184,7 @@ namespace jana {
 
         std::set<std::string> set_plugins;
         // Add the plugins at $EICrecon_MY/plugins.
-        jana::GetPluginNamesFromEnvPath(set_plugins, "EICrecon_MY");
+//        jana::GetPluginNamesFromEnvPath(set_plugins, "EICrecon_MY");  // disabled as we do not want to automatically add these
 
         std::string plugins_str;  // the complete plugins list
         for (std::string s : set_plugins)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This fixes three issues:

1. Disables `eicrecon` from automatically attaching all plugins from `EICrecon_MY`
2. eicmkplugin.py generates code that links `spdlog` which is now needed by other core plugins
3. eicmkplugin.py generates code that uses the `rootfile` service for creating histograms in user histogram file.

### What kind of change does this PR introduce?
- [X] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
Fixes some issues.
