### PR TITLE
PODIO writer now activates explicitly included factories

### DIFF
--- a/src/services/io/podio/JEventProcessorPODIO.h
+++ b/src/services/io/podio/JEventProcessorPODIO.h
@@ -26,6 +26,7 @@ public:
     std::shared_ptr<eic::ROOTWriter> m_writer;
     std::mutex m_mutex;
     bool m_is_first_event = true;
+    bool m_user_included_collections = false;
     std::shared_ptr<spdlog::logger> m_log;
 
     std::string m_output_file = "podio_output.root";

--- a/src/utilities/eicrecon/eicrecon_cli.cpp
+++ b/src/utilities/eicrecon/eicrecon_cli.cpp
@@ -239,6 +239,12 @@ namespace jana {
             std::cout << "Loaded config file '" << options.load_config_file << "'." << std::endl << std::endl;
         }
 
+        // If the user hasn't specified a timeout (on cmd line or in config file), set the timeout to something reasonably high
+        if (para_mgr->FindParameter("jana:timeout") == nullptr) {
+            para_mgr->SetParameter("jana:timeout", 60); // seconds
+            para_mgr->SetParameter("jana:warmup_timeout", 60); // seconds
+        }
+
         auto app = new JApplication(para_mgr);
 
         for (auto event_src : options.eventSources) {


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Fixes two problems encountered recently:
1. PODIO writer wouldn't call factory->Create() even if user explicitly asked for it via `podio:output_include_collections`
2. eicrecon timed out when nthreads>1 (See issue #87)
 
### What kind of change does this PR introduce?
- [x] Bug fix (issue #87)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
It changes the default thread timeout to 60 seconds.
