### PR TITLE
Fix bug that causes crashes when trying to write certain collections

### DIFF
--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -83,7 +83,7 @@ void JEventProcessorPODIO::Init() {
     m_log = app->GetService<Log_service>()->logger("JEventProcessorPODIO");
     m_log->set_level(spdlog::level::debug);
     m_store = new eic::EventStore();
-    m_writer = std::make_shared<eic::ROOTWriter>(m_output_file, m_store);
+    m_writer = std::make_shared<eic::ROOTWriter>(m_output_file, m_store, m_log);
 
 }
 

--- a/src/services/io/podio/RootWriter.h
+++ b/src/services/io/podio/RootWriter.h
@@ -13,6 +13,8 @@
 #include <utility>
 #include <vector>
 
+#include <services/log/Log_service.h>
+
 // forward declarations
 class TFile;
 class TTree;
@@ -21,7 +23,7 @@ namespace eic {
 class ROOTWriter {
 
 public:
-  ROOTWriter(const std::string& filename, eic::EventStore* store);
+  ROOTWriter(const std::string& filename, eic::EventStore* store, std::shared_ptr<spdlog::logger> &logger);
   ~ROOTWriter();
 
   // non-copyable
@@ -55,6 +57,9 @@ private:
   std::vector<podio::root_utils::CollectionBranches> m_collectionBranches{};
 
   bool m_firstEvent{true};
+  std::set<std::string> unwritable_collections; // keep list of collections that threw exception during prepareForWrite
+
+  std::shared_ptr<spdlog::logger> m_log;
 };
 
 } // namespace eic

--- a/src/tests/podio_test/podio_test.cpp
+++ b/src/tests/podio_test/podio_test.cpp
@@ -11,7 +11,8 @@
 void write_read_test() {
     std::cout << "Hello world!" << std::endl;
     eic::EventStore es;
-    eic::ROOTWriter writer("test_out.root", &es);
+    auto logger = spdlog::default_logger();
+    eic::ROOTWriter writer("test_out.root", &es, logger);
 
     // Set up writer
     auto& hits = es.create<edm4eic::CalorimeterHitCollection>("MyFunHits");
@@ -115,7 +116,8 @@ void read_write_test() {
     reader.openFile("test_out.root"); // comes from prev test
     input_store.setReader(&reader);
 
-    eic::ROOTWriter writer("test2_out.root", &output_store);
+    auto logger = spdlog::default_logger();
+    eic::ROOTWriter writer("test2_out.root", &output_store, logger);
     output_store.create<edm4eic::ClusterCollection>("MyFunClusters");
     output_store.create<edm4eic::ClusterCollection>("MyExhilaratingClusters");
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This addresses an issue that causes podio to throw an exception when collections that have one to many relations are being written to the output file, but the relation objects themselves are marked as "untracked".

### What kind of change does this PR introduce?
- [X] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
Yes. Program will proceed with an error message now, but does not crash.