### PR TITLE
Fix bugs in SiliconTrackerDigi

### DIFF
--- a/src/algorithms/digi/SiliconTrackerDigi.cc
+++ b/src/algorithms/digi/SiliconTrackerDigi.cc
@@ -50,12 +50,13 @@ eicrecon::SiliconTrackerDigi::produce(const std::vector<const edm4hep::SimTracke
         if (cell_hit_map.count(sim_hit->getCellID()) == 0) {
             // This cell doesn't have hits
             cell_hit_map[sim_hit->getCellID()] = {
-                    (std::int32_t) (sim_hit->getMCParticle().getTime() * 1e6 + m_gauss() * 1e3), // ns->fs
-                    (std::int32_t) std::llround(sim_hit->getEDep() * 1e6)};
+                    (std::int32_t) std::llround(sim_hit->getEDep() * 1e6),
+                    (std::int32_t) (sim_hit->getMCParticle().getTime() * 1e3 + m_gauss() * 1e3)}; // ns->ps
         } else {
             // There is previous values in the cell
             RawHit &hit = cell_hit_map[sim_hit->getCellID()];
-            hit.time_stamp = (std::int32_t) (sim_hit->getMCParticle().getTime() * 1e6 + m_gauss() * 1e3);
+            auto time_stamp = (std::int32_t) (sim_hit->getMCParticle().getTime() * 1e3 + m_gauss() * 1e3);
+            hit.time_stamp = std::min(time_stamp, hit.time_stamp);  // keep earliest time for hit
             hit.charge += (std::int32_t) std::llround(sim_hit->getEDep() * 1e6);
         }
     }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This fixes two bugs in the SiliconTrackerDigi algorithm.

1. The value for charge was being written into the timestamp and vice versa
2. The time units for the central value were changed from fs to ps. This also fixes an issue with the Gaussian smearing being in ps while the central value was in fs.

The digitized units should be revisited since 1fs LSB seems way too good. Especially for a devise that expects to have ~8ns resolution.

### What kind of change does this PR introduce?
- [X] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
