### PR TITLE
Fixing #169 and make correct order of tracking data flow

### DIFF
--- a/src/global/tracking/TrackerHitCollector_factory.cc
+++ b/src/global/tracking/TrackerHitCollector_factory.cc
@@ -26,6 +26,11 @@ namespace eicrecon {
         std::string log_level_str = "info";
         app->SetDefaultParameter(param_prefix + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
         m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
+
+        // jana should not delete edm4eic::TrackerHit from this factory
+        // TrackerHits created by other factories, this factory only collect them together
+        SetFactoryFlag(JFactory::NOT_OBJECT_OWNER);
+
     }
 
     void TrackerHitCollector_factory::ChangeRun(const std::shared_ptr<const JEvent> &event) {
@@ -38,7 +43,7 @@ namespace eicrecon {
         for(auto input_tag: m_input_tags) {
             auto hits = event->Get<edm4eic::TrackerHit>(input_tag);
             for (const auto hit : hits) {
-                total_hits.push_back(new edm4eic::TrackerHit(*hit));
+                total_hits.push_back(const_cast<edm4eic::TrackerHit*>(hit));
             }
         }
         Set(total_hits);

--- a/src/global/tracking/TrackerHitCollector_factory.cc
+++ b/src/global/tracking/TrackerHitCollector_factory.cc
@@ -38,7 +38,7 @@ namespace eicrecon {
         for(auto input_tag: m_input_tags) {
             auto hits = event->Get<edm4eic::TrackerHit>(input_tag);
             for (const auto hit : hits) {
-                total_hits.push_back(const_cast<edm4eic::TrackerHit *>(hit));
+                total_hits.push_back(new edm4eic::TrackerHit(*hit));
             }
         }
         Set(total_hits);

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -31,20 +31,17 @@ void InitPlugin(JApplication *app) {
     app->Add(new JChainFactoryGeneratorT<TrackParamTruthInit_factory>(
             {"MCParticles"}, "InitTrackParams"));
 
-    // Source linker
-    app->Add(new JChainFactoryGeneratorT<TrackerSourceLinker_factory>(
-            {"BarrelTrackerHit",
-             "BarrelVertexHit",
-             "EndcapTrackerHit",
-             "MPGDTrackerHit"   },
-            "CentralTrackerSourceLinker"));
-
+    // Tracker hits collector
     app->Add(new JChainFactoryGeneratorT<TrackerHitCollector_factory>(
                      {"BarrelTrackerHit",
                       "BarrelVertexHit",
                       "EndcapTrackerHit",
                       "MPGDTrackerHit"   },
                      "trackerHits"));
+
+    // Source linker
+    app->Add(new JChainFactoryGeneratorT<TrackerSourceLinker_factory>(
+            {"trackerHits"}, "CentralTrackerSourceLinker"));
 
     app->Add(new JChainFactoryGeneratorT<CKFTracking_factory>(
             {"CentralTrackerSourceLinker"}, "CentralCKFTrajectories"));


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Made TrackerHitCollector to be in the right order of the tracking chain. Also set TrackerHitCollector  to not to own TrackerHits links closing #169

### What kind of change does this PR introduce?
- [x] Bug fix (closes #169)


### Please check if this PR fulfills the following:
- [x] Tests for the changes have been made
- [x] Documentation has been added / updated - NA
- [x] Changes have been communicated to collaborators - Yep

### Does this PR introduce breaking changes? What changes might users need to make to their code?

NO

### Does this PR change default behavior?

NO