### PR TITLE
Davidl default outputs

### DIFF
--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -57,7 +57,29 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
     );
 
     // Get the list of output collections to include/exclude
-    std::vector<std::string> output_include_collections;  // need to get as vector, then convert to set
+    std::vector<std::string> output_include_collections={
+            "MCParticles",
+            "ReconstructedParticles",
+            "TrackParameters",
+            "trackerHits",
+            "BarrelTrackerHit",
+            "EndcapTrackerHit",
+            "EcalEndcapNClusters",
+            "EcalEndcapPClusters",
+            "EcalBarrelClusters",
+            "HcalEndcapNClusters",
+            "HcalEndcapPClusters",
+            "HcalBarrelClusters",
+            "ZDCEcalClusters",
+            "EcalEndcapNTruthClusters",
+            "EcalEndcapPTruthClusters",
+            "EcalBarrelTruthClusters",
+            "HcalEndcapNTruthClusters",
+//            "HcalEndcapPTruthClusters",  // This gives lots of errors from volume manager on "unknown identifier"
+            "HcalBarrelTruthClusters",
+            "EcalBarrelTruthClusters",
+            "ZDCEcalTruthClusters"
+    };
     std::vector<std::string> output_exclude_collections;  // need to get as vector, then convert to set
     japp->SetDefaultParameter(
             "podio:output_include_collections",
@@ -69,6 +91,7 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             output_exclude_collections,
             "Comma separated list of collection names to not write out."
     );
+
     m_output_include_collections = std::set<std::string>(output_include_collections.begin(),
                                                          output_include_collections.end());
     m_output_exclude_collections = std::set<std::string>(output_exclude_collections.begin(),

--- a/src/services/io/podio/JEventSourcePODIOsimple.cc
+++ b/src/services/io/podio/JEventSourcePODIOsimple.cc
@@ -13,6 +13,7 @@
 #include <JANA/JApplication.h>
 #include <JANA/JEvent.h>
 #include <filesystem>
+#include <fmt/color.h>
 
 #include <JANA/JFactoryGenerator.h>
 
@@ -121,6 +122,18 @@ void JEventSourcePODIOsimple::Open() {
 
     // Open primary events file
     try {
+
+        // Verify file exists
+        if( ! std::filesystem::exists(GetResourceName()) ){
+            // Here we go against the standard practice of throwing an error and print
+            // the message and exit immediately. This is because we want the last message
+            // on the screen to be that the file doesn't exist.
+            auto mess = fmt::format(fmt::emphasis::bold | fg(fmt::color::red),"ERROR: ");
+            mess += fmt::format(fmt::emphasis::bold, "file: {} does not exist!",  GetResourceName());
+            std::cerr << std::endl << std::endl << mess << std::endl << std::endl;
+            _exit(-1);
+        }
+
         // Have PODIO reader open file and get the number of events from it.
         reader.openFile( GetResourceName() );
         if( ! reader.isValid() ) throw std::runtime_error( fmt::format("podio ROOTReader says {} is invalid", GetResourceName()) );

--- a/src/services/io/podio/podio.cc
+++ b/src/services/io/podio/podio.cc
@@ -15,13 +15,15 @@ void InitPlugin(JApplication *app) {
     app->Add(new JEventSourceGeneratorT<JEventSourcePODIO>());
     app->Add(new JEventSourceGeneratorT<JEventSourcePODIOsimple>());
 
+    // Disable this behavior for now so one can run eicrecon with only the
+    // input file as an argument.
     // Only add a EICRootWriter if the user has specified a configuration parameter relevant to writing
-    if( app->GetJParameterManager()->Exists("podio:output_file")
-        ||  app->GetJParameterManager()->Exists("podio:output_file_copy_dir")
-        ||  app->GetJParameterManager()->Exists("podio:output_include_collections")
-        ||  app->GetJParameterManager()->Exists("podio:output_exclude_collections")        ){
+//    if( app->GetJParameterManager()->Exists("podio:output_file")
+//        ||  app->GetJParameterManager()->Exists("podio:output_file_copy_dir")
+//        ||  app->GetJParameterManager()->Exists("podio:output_include_collections")
+//        ||  app->GetJParameterManager()->Exists("podio:output_exclude_collections")        ){
         app->Add(new JEventProcessorPODIO());
-    }
+//    }
 }
 }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This adds a default list of output collections to eicrecon so that it can be run with only a single argument: the input file. It will now automatically write most of the useful collections to the output.

This also adds a check that the input file exists before trying to open it with podio::RootReader. (I swear this is the 3rd time I've fixed this!) It will now print a bold error message and to a hard, immediate exit to ensure it is the last output from the program.

### What kind of change does this PR introduce?
- [X] Bug fix (issue #__)
- [X] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes.