### PR TITLE
Introduced ReconstructedChargedParticles factory

### DIFF
--- a/src/algorithms/reco/ParticlesWithAssociation.h
+++ b/src/algorithms/reco/ParticlesWithAssociation.h
@@ -8,7 +8,7 @@
 #include <vector>
 
 #include <edm4eic/ReconstructedParticle.h>
-#include <edm4eic/MCRecoClusterParticleAssociation.h>
+#include <edm4eic/MCRecoParticleAssociation.h>
 
 namespace eicrecon {
 
@@ -20,6 +20,9 @@ namespace eicrecon {
                 m_particles(std::move(particles)), m_associations(std::move(associations))
                 {}
 
+
+        [[nodiscard]] const std::vector<edm4eic::ReconstructedParticle*> & particles() const {return m_particles;}
+        [[nodiscard]] const std::vector<edm4eic::MCRecoParticleAssociation*> & associations() const {return m_associations;}
 
     private:
         /// Resulting reconstructed particles

--- a/src/algorithms/tracking/ParticlesWithTruthPID.cpp
+++ b/src/algorithms/tracking/ParticlesWithTruthPID.cpp
@@ -16,136 +16,122 @@
 #include "edm4eic/vector_utils.h"
 
 #include "ParticlesWithTruthPIDConfig.h"
+#include "ParticlesWithTruthPID.h"
 #include "algorithms/reco/ParticlesWithAssociation.h"
 #include <algorithms/interfaces/WithPodConfig.h>
 
 namespace eicrecon {
 
-    class ParticlesWithTruthPID: public WithPodConfig<ParticlesWithTruthPIDConfig> {
 
-    public:
+    ParticlesWithAssociation * ParticlesWithTruthPID::execute(
+            const std::vector<const edm4hep::MCParticle *> &mc_particles,
+            const std::vector<const edm4eic::TrackParameters*> &track_params) {
+        // input collection
 
-        void init(std::shared_ptr<spdlog::logger> logger) {
-            m_log = logger;
-        }
+        /// Resulting reconstructed particles
+        std::vector<edm4eic::ReconstructedParticle *> reco_particles;
 
-        ParticlesWithAssociation *execute(
-                const std::vector<edm4hep::MCParticle> &mc_particles,
-                const std::vector<edm4eic::TrackParameters> &track_params) {
-            // input collection
-
-            /// Resulting reconstructed particles
-            std::vector<edm4eic::ReconstructedParticle *> reco_particles;
-
-            /// Resulting associations
-            std::vector<edm4eic::MCRecoParticleAssociation *> associations;
+        /// Resulting associations
+        std::vector<edm4eic::MCRecoParticleAssociation *> associations;
 
 
-            const double sinPhiOver2Tolerance = sin(0.5 * m_cfg.phiTolerance);
-            std::vector<bool> consumed(mc_particles.size(), false);
-            for (const auto &trk: track_params) {
-                const auto mom = edm4eic::sphericalToVector(1.0 / std::abs(trk.getQOverP()), trk.getTheta(),
-                                                            trk.getPhi());
-                const auto charge_rec = trk.getCharge();
-                // utility variables for matching
-                int best_match = -1;
-                double best_delta = std::numeric_limits<double>::max();
-                for (size_t ip = 0; ip < mc_particles.size(); ++ip) {
-                    const auto &mc_part = mc_particles[ip];
-                    if (consumed[ip] || mc_part.getGeneratorStatus() > 1 || mc_part.getCharge() == 0 ||
-                        mc_part.getCharge() * charge_rec < 0) {
-                        m_log->debug("ignoring non-primary/neutral/opposite charge particle");
-                        continue;
-                    }
-                    const auto &p = mc_part.getMomentum();
-                    const auto p_mag = std::hypot(p.x, p.y, p.z);
-                    const auto p_phi = std::atan2(p.y, p.x);
-                    const auto p_eta = std::atanh(p.z / p_mag);
-                    const double dp_rel = std::abs((edm4eic::magnitude(mom) - p_mag) / p_mag);
-                    // check the tolerance for sin(dphi/2) to avoid the hemisphere problem and allow
-                    // for phi rollovers
-                    const double dsphi = std::abs(sin(0.5 * (edm4eic::angleAzimuthal(mom) - p_phi)));
-                    const double deta = std::abs((edm4eic::eta(mom) - p_eta));
+        const double sinPhiOver2Tolerance = sin(0.5 * m_cfg.phiTolerance);
+        std::vector<bool> consumed(mc_particles.size(), false);
+        for (const auto &trk: track_params) {
+            const auto mom = edm4eic::sphericalToVector(1.0 / std::abs(trk->getQOverP()), trk->getTheta(), trk->getPhi());
+            const auto charge_rec = trk->getCharge();
+            // utility variables for matching
+            int best_match = -1;
+            double best_delta = std::numeric_limits<double>::max();
+            for (size_t ip = 0; ip < mc_particles.size(); ++ip) {
+                const auto &mc_part = mc_particles[ip];
+                if (consumed[ip] || mc_part->getGeneratorStatus() > 1 || mc_part->getCharge() == 0 ||
+                    mc_part->getCharge() * charge_rec < 0) {
+                    m_log->debug("ignoring non-primary/neutral/opposite charge particle");
+                    continue;
+                }
+                const auto &p = mc_part->getMomentum();
+                const auto p_mag = std::hypot(p.x, p.y, p.z);
+                const auto p_phi = std::atan2(p.y, p.x);
+                const auto p_eta = std::atanh(p.z / p_mag);
+                const double dp_rel = std::abs((edm4eic::magnitude(mom) - p_mag) / p_mag);
+                // check the tolerance for sin(dphi/2) to avoid the hemisphere problem and allow
+                // for phi rollovers
+                const double dsphi = std::abs(sin(0.5 * (edm4eic::angleAzimuthal(mom) - p_phi)));
+                const double deta = std::abs((edm4eic::eta(mom) - p_eta));
 
-                    if (dp_rel < m_cfg.pRelativeTolerance && deta < m_cfg.etaTolerance && dsphi < sinPhiOver2Tolerance) {
-                        const double delta =
-                                std::hypot(dp_rel /  m_cfg.pRelativeTolerance, deta / m_cfg.etaTolerance,
-                                           dsphi / sinPhiOver2Tolerance);
-                        if (delta < best_delta) {
-                            best_match = ip;
-                            best_delta = delta;
-                        }
+                if (dp_rel < m_cfg.pRelativeTolerance && deta < m_cfg.etaTolerance && dsphi < sinPhiOver2Tolerance) {
+                    const double delta =
+                            std::hypot(dp_rel / m_cfg.pRelativeTolerance, deta / m_cfg.etaTolerance,
+                                       dsphi / sinPhiOver2Tolerance);
+                    if (delta < best_delta) {
+                        best_match = ip;
+                        best_delta = delta;
                     }
                 }
-                auto rec_part = edm4eic::MutableReconstructedParticle();
-                int32_t best_pid = 0;
-                auto referencePoint = rec_part.referencePoint();
-                // float time          = 0;
-                float mass = 0;
-                if (best_match >= 0) {
-                    consumed[best_match] = true;
-                    const auto &best_mc_part = mc_particles[best_match];
-                    best_pid = best_mc_part.getPDG();
-                    referencePoint = {
-                            static_cast<float>(best_mc_part.getVertex().x), static_cast<float>(best_mc_part.getVertex().y),
-                            static_cast<float>(best_mc_part.getVertex().z)}; // @TODO: not sure if vertex/reference point makes sense here
-                    // time                 = mcpart.getTime();
-                    mass = best_mc_part.getMass();
+            }
+            auto rec_part = edm4eic::MutableReconstructedParticle();
+            int32_t best_pid = 0;
+            auto referencePoint = rec_part.referencePoint();
+            // float time          = 0;
+            float mass = 0;
+            if (best_match >= 0) {
+                consumed[best_match] = true;
+                const auto &best_mc_part = mc_particles[best_match];
+                best_pid = best_mc_part->getPDG();
+                referencePoint = {
+                        static_cast<float>(best_mc_part->getVertex().x), static_cast<float>(best_mc_part->getVertex().y),
+                        static_cast<float>(best_mc_part->getVertex().z)}; // @TODO: not sure if vertex/reference point makes sense here
+                // time                 = mcpart.getTime();
+                mass = best_mc_part->getMass();
+            }
+            rec_part.setType(static_cast<int16_t>(best_match >= 0 ? 0 : -1)); // @TODO: determine type codes
+            rec_part.setEnergy(std::hypot(edm4eic::magnitude(mom), mass));
+            rec_part.setMomentum(mom);
+            rec_part.setReferencePoint(referencePoint);
+            rec_part.setCharge(charge_rec);
+            rec_part.setMass(mass);
+            rec_part.setGoodnessOfPID(1); // perfect PID
+            rec_part.setPDG(best_pid);
+            // rec_part.covMatrix()  // @TODO: covariance matrix on 4-momentum
+            // Also write MC <--> truth particle association if match was found
+            if (best_match >= 0) {
+                auto rec_assoc = edm4eic::MutableMCRecoParticleAssociation();
+                rec_assoc.setRecID(rec_part.getObjectID().index);
+                rec_assoc.setSimID(mc_particles[best_match]->getObjectID().index);
+                rec_assoc.setWeight(1);
+                rec_assoc.setRec(rec_part);
+                //rec_assoc.setSim(mc[best_match]);
+                associations.emplace_back(new edm4eic::MCRecoParticleAssociation(rec_assoc));
+            }
+            if (m_log->level() <= spdlog::level::debug) {
+                if (best_match > 0) {
+                    const auto &mcpart = mc_particles[best_match];
+                    m_log->debug("Matched track with MC particle {}\n", best_match);
+                    m_log->debug("  - Track: (mom: {}, theta: {}, phi: {}, charge: {})",
+                                 edm4eic::magnitude(mom),
+                                 edm4eic::anglePolar(mom), edm4eic::angleAzimuthal(mom), charge_rec);
+                    const auto &p = mcpart->getMomentum();
+                    const auto p_mag = edm4eic::magnitude(p);
+                    const auto p_phi = edm4eic::angleAzimuthal(p);
+                    const auto p_theta = edm4eic::anglePolar(p);
+                    m_log->debug("  - MC particle: (mom: {}, theta: {}, phi: {}, charge: {}, type: {}",
+                                 p_mag, p_theta,
+                                 p_phi, mcpart->getCharge(), mcpart->getPDG());
+                } else {
+                    m_log->debug("Did not find a good match for track \n");
+                    m_log->debug("  - Track: (mom: {}, theta: {}, phi: {}, charge: {})",
+                                 edm4eic::magnitude(mom),
+                                 edm4eic::anglePolar(mom), edm4eic::angleAzimuthal(mom), charge_rec);
                 }
-                rec_part.setType(static_cast<int16_t>(best_match >= 0 ? 0 : -1)); // @TODO: determine type codes
-                rec_part.setEnergy(std::hypot(edm4eic::magnitude(mom), mass));
-                rec_part.setMomentum(mom);
-                rec_part.setReferencePoint(referencePoint);
-                rec_part.setCharge(charge_rec);
-                rec_part.setMass(mass);
-                rec_part.setGoodnessOfPID(1); // perfect PID
-                rec_part.setPDG(best_pid);
-                // rec_part.covMatrix()  // @TODO: covariance matrix on 4-momentum
-                // Also write MC <--> truth particle association if match was found
-                if (best_match >= 0) {
-                    auto rec_assoc = edm4eic::MutableMCRecoParticleAssociation();
-                    rec_assoc.setRecID(rec_part.getObjectID().index);
-                    rec_assoc.setSimID(mc_particles[best_match].getObjectID().index);
-                    rec_assoc.setWeight(1);
-                    rec_assoc.setRec(rec_part);
-                    //rec_assoc.setSim(mc[best_match]);
-                    associations.emplace_back(new edm4eic::MCRecoParticleAssociation(rec_assoc));
-                }
-                if (m_log->level() <= spdlog::level::debug) {
-                    if (best_match > 0) {
-                        const auto &mcpart = mc_particles[best_match];
-                        m_log->debug("Matched track with MC particle {}\n", best_match);
-                        m_log->debug("  - Track: (mom: {}, theta: {}, phi: {}, charge: {})",
-                                               edm4eic::magnitude(mom),
-                                               edm4eic::anglePolar(mom), edm4eic::angleAzimuthal(mom), charge_rec);
-                        const auto &p = mcpart.getMomentum();
-                        const auto p_mag = edm4eic::magnitude(p);
-                        const auto p_phi = edm4eic::angleAzimuthal(p);
-                        const auto p_theta = edm4eic::anglePolar(p);
-                        m_log->debug("  - MC particle: (mom: {}, theta: {}, phi: {}, charge: {}, type: {}",
-                                        p_mag, p_theta,
-                                        p_phi, mcpart.getCharge(), mcpart.getPDG());
-                    } else {
-                        m_log->debug("Did not find a good match for track \n");
-                        m_log->debug("  - Track: (mom: {}, theta: {}, phi: {}, charge: {})",
-                                               edm4eic::magnitude(mom),
-                                               edm4eic::anglePolar(mom), edm4eic::angleAzimuthal(mom), charge_rec);
-                    }
-                }
-
-                // Add particle to the output vector
-                reco_particles.push_back(new edm4eic::ReconstructedParticle(rec_part));
             }
 
-            // Assembling the results
-            return new ParticlesWithAssociation(std::move(reco_particles), std::move(associations));
+            // Add particle to the output vector
+            reco_particles.push_back(new edm4eic::ReconstructedParticle(rec_part));
         }
 
-    private:
+        // Assembling the results
+        return new ParticlesWithAssociation(std::move(reco_particles), std::move(associations));
+    }
 
-        std::shared_ptr<spdlog::logger> m_log;
-    }; // namespace Jug::Fast
-
-
-} // namespace eicrecon
-
+}

--- a/src/algorithms/tracking/ParticlesWithTruthPID.h
+++ b/src/algorithms/tracking/ParticlesWithTruthPID.h
@@ -5,4 +5,42 @@
 #ifndef EICRECON_PARTICLESWITHTRUTHPID_H
 #define EICRECON_PARTICLESWITHTRUTHPID_H
 
+#include <algorithm>
+#include <cmath>
+
+#include <fmt/format.h>
+
+#include <spdlog/spdlog.h>
+
+// Event Model related classes
+#include "edm4hep/MCParticleCollection.h"
+#include "edm4eic/MCRecoParticleAssociationCollection.h"
+#include "edm4eic/ReconstructedParticleCollection.h"
+#include "edm4eic/TrackParametersCollection.h"
+#include "edm4eic/vector_utils.h"
+
+#include "ParticlesWithTruthPIDConfig.h"
+#include "algorithms/reco/ParticlesWithAssociation.h"
+#include <algorithms/interfaces/WithPodConfig.h>
+
+
+namespace eicrecon {
+    class ParticlesWithTruthPID : public WithPodConfig<ParticlesWithTruthPIDConfig> {
+
+    public:
+
+        void init(std::shared_ptr<spdlog::logger> logger) {
+            m_log = logger;
+        }
+
+        ParticlesWithAssociation *execute(
+                const std::vector<const edm4hep::MCParticle *> &mc_particles,
+                const std::vector<const edm4eic::TrackParameters*> &track_params);
+
+    private:
+
+        std::shared_ptr<spdlog::logger> m_log;
+    };
+}
+
 #endif //EICRECON_PARTICLESWITHTRUTHPID_H

--- a/src/global/tracking/ReconstructedChargedParticles_factory.cc
+++ b/src/global/tracking/ReconstructedChargedParticles_factory.cc
@@ -1,0 +1,38 @@
+// Created by Dmitry Romanov
+// Subject to the terms in the LICENSE file found in the top-level directory.
+//
+
+#include "ReconstructedChargedParticles_factory.h"
+
+#include <JANA/JEvent.h>
+
+namespace eicrecon {
+    void ReconstructedChargedParticles_factory::Init() {
+        // This prefix will be used for parameters
+        std::string param_prefix = "Tracking:" + GetTag();
+
+        // Set input data tags properly
+        InitDataTags(param_prefix);
+
+        // SpdlogMixin logger initialization, sets m_log
+        InitLogger(param_prefix, "info");
+
+        // jana should not delete edm4eic::ReconstructedParticles from this factory
+        // TrackerHits created by other factories, this factory only collect them together
+        SetFactoryFlag(JFactory::NOT_OBJECT_OWNER);
+    }
+
+    void ReconstructedChargedParticles_factory::ChangeRun(const std::shared_ptr<const JEvent> &event) {
+
+    }
+
+    void ReconstructedChargedParticles_factory::Process(const std::shared_ptr<const JEvent> &event) {
+        auto prt_with_assoc = event->GetSingle<eicrecon::ParticlesWithAssociation>(GetInputTags()[0]);
+        std::vector<edm4eic::ReconstructedParticle *> result;
+        for(auto part: prt_with_assoc->particles()) {
+            result.push_back(part);
+        }
+
+        Set(std::move(result));
+    }
+} // eicrecon

--- a/src/global/tracking/ReconstructedChargedParticles_factory.h
+++ b/src/global/tracking/ReconstructedChargedParticles_factory.h
@@ -2,8 +2,8 @@
 // Subject to the terms in the LICENSE file found in the top-level directory.
 //
 
-#ifndef EICRECON_ParticlesWithTruthPID_factory_H
-#define EICRECON_ParticlesWithTruthPID_factory_H
+#ifndef EICRECON_RECONSTRUCTEDCHARGEDPARTICLES_FACTORY_H
+#define EICRECON_RECONSTRUCTEDCHARGEDPARTICLES_FACTORY_H
 
 #include <edm4eic/ReconstructedParticle.h>
 #include "extensions/jana/JChainFactoryT.h"
@@ -14,13 +14,13 @@
 
 namespace eicrecon {
 
-    class ParticlesWithTruthPID_factory :
-            public JChainFactoryT<ParticlesWithAssociation, ParticlesWithTruthPIDConfig>,
-            public SpdlogMixin<ParticlesWithTruthPID_factory> {
+    class ReconstructedChargedParticles_factory:
+            public JChainFactoryT<edm4eic::ReconstructedParticle>,
+            public SpdlogMixin<ReconstructedChargedParticles_factory> {
 
     public:
-        explicit ParticlesWithTruthPID_factory( std::vector<std::string> default_input_tags, ParticlesWithTruthPIDConfig cfg):
-            JChainFactoryT<ParticlesWithAssociation, ParticlesWithTruthPIDConfig>(std::move(default_input_tags), cfg) {
+        explicit ReconstructedChargedParticles_factory( std::vector<std::string> default_input_tags):
+            JChainFactoryT<edm4eic::ReconstructedParticle>(std::move(default_input_tags)) {
         }
 
         /** One time initialization **/
@@ -32,11 +32,8 @@ namespace eicrecon {
         /** Event by event processing **/
         void Process(const std::shared_ptr<const JEvent> &event) override;
 
-    private:
-        eicrecon::ParticlesWithTruthPID m_matching_algo;
-
     };
 
 } // eicrecon
 
-#endif //EICRECON_ParticlesWithTruthPID_factory_H
+#endif //EICRECON_RECONSTRUCTEDCHARGEDPARTICLES_FACTORY_H

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -17,7 +17,9 @@
 #include "TrackParameters_factory.h"
 #include "CKFTracking_factory.h"
 #include "TrackerHitCollector_factory.h"
-
+#include "TrackParameters_factory.h"
+#include "ParticlesWithTruthPID_factory.h"
+#include "ReconstructedChargedParticles_factory.h"
 
 //
 extern "C" {
@@ -52,6 +54,15 @@ void InitPlugin(JApplication *app) {
 
     app->Add(new JChainFactoryGeneratorT<TrackParameters_factory>(
             {"CentralTrackingParticles"}, "TrackParameters"));
+
+    app->Add(new JChainFactoryGeneratorT<ParticlesWithTruthPID_factory>(
+        {"MCParticles",         // Tag for edm4hep::MCParticle
+         "TrackParameters"},    // Tag for edm4eic::TrackParameters
+        "ChargedParticlesWithAssociations"));    // eicrecon::ParticlesWithAssociation
+
+    app->Add(new JChainFactoryGeneratorT<ReconstructedChargedParticles_factory>(
+            {"ChargedParticlesWithAssociations"},
+            "ReconstructedChargedParticles"));    // eicrecon::ParticlesWithAssociation
 }
 } // extern "C"
 

--- a/src/tests/tracking_test/TrackingTest_processor.cc
+++ b/src/tests/tracking_test/TrackingTest_processor.cc
@@ -2,6 +2,7 @@
 #include "TrackingTest_processor.h"
 #include "algorithms/tracking/JugTrack/Trajectories.hpp"
 #include "extensions/spdlog/SpdlogExtensions.h"
+#include "algorithms/reco/ParticlesWithAssociation.h"
 
 #include <JANA/JApplication.h>
 #include <JANA/JEvent.h>
@@ -80,24 +81,6 @@ void TrackingTest_processor::Process(const std::shared_ptr<const JEvent>& event)
     using namespace ROOT;
 
 
-//
-//    fmt::print("OccupancyAnalysis::Process() event {}\n", event->GetEventNumber());
-//
-//    //auto simhits = event->Get<edm4hep::SimCalorimeterHit>("EcalBarrelHits");
-//    //auto raw_hits = event->Get<edm4eic::RawTrackerHit>("BarrelTrackerRawHit");
-//
-//    auto hits = event->Get<edm4eic::TrackerHit>("BarrelTrackerHit");
-//
-    //auto result = event->GetSingle<eicrecon::TrackerSourceLinkerResult>("CentralTrackerSourceLinker");
-//    spdlog::info("Result counts sourceLinks.size()={} measurements.size()={}", result->sourceLinks->size(), result->measurements->size());
-//
-//    auto truth_init = event->Get<Jug::TrackParameters>("");
-//    spdlog::info("truth_init.size()={}", truth_init.size());
-//
-    //auto trajectories = event->Get<Jug::Trajectories>("Trajectories");
-
-//    fmt::print("BCAL {}\n", bcal[0]->getCellID());
-
     auto trk_result = event->GetSingle<ParticlesFromTrackFitResult>("CentralTrackingParticles");
 
 
@@ -119,8 +102,6 @@ void TrackingTest_processor::Process(const std::shared_ptr<const JEvent>& event)
     }
 
     auto mc_particles = event->Get<edm4hep::MCParticle>("MCParticles");
-//    fmt::print("OccupancyAnalysis::Process() mc_particles N {}\n", mc_particles.size());
-//
 
     auto particles = event->GetSingle<edm4eic::ReconstructedParticle>("ReconstructedParticles");
     auto track_params = event->GetSingle<edm4eic::TrackParameters>("TrackParameters");
@@ -141,69 +122,41 @@ void TrackingTest_processor::Process(const std::shared_ptr<const JEvent>& event)
         if(p.R()<1) continue;
 
         m_log->debug("   {:<5} {:<6} {:<7} {:>8.2f} {:>8.2f} {:>8.2f} {:>8.2f}", i, particle->getGeneratorStatus(), particle->getPDG(),  px, py, pz, p.R());
-
-//
-//        m_th1_prt_pz->Fill(pz);
-//        m_th2_prt_pxy->Fill(px, py);
-//
-//        m_th1_prt_theta->Fill(p.Theta());
-//        if(pz>0) {
-//            m_th1_prt_phi->Fill(p.Phi());
-//        } else {
-//            m_th1_prt_phi->Fill(-p.Phi());
-//        }
-//
-//        m_th1_prt_energy->Fill(p4v.E());
-//
-//
-//        /*
-//        fmt::print("OccupancyAnalysis::Process() theta  : {}\n", p.Theta());
-//        fmt::print("OccupancyAnalysis::Process() theta2 : {}\n", acos(pz/p.R()));
-//        fmt::print("OccupancyAnalysis::Process() phi    : {}\n", p.Phi());
-//        fmt::print("OccupancyAnalysis::Process() phi    : {}\n", atan(py/px));
-//         */
     }
 
-//    for(auto& trajectory: trajectories) {
-//        m_log->debug("Trajectory empty {}", trajectory->empty());
-//        m_log->debug("Trajectory multiTrajectory size {}", trajectory->multiTrajectory().size());
-//        m_log->debug("Trajectory trajectory->trackParameters(0).momentum().x() {}", trajectory->trackParameters(0).momentum().x());
-//    }
+    m_log->debug("Associations [simId] [recID] [simE] [recE] [simPDG] [recPDG]");
+    auto prt_with_assoc = event->GetSingle<eicrecon::ParticlesWithAssociation>("ChargedParticlesWithAssociations");
 
 
-auto hits = event->Get<edm4eic::TrackerHit>("trackerHits");
+    for(auto assoc: prt_with_assoc->associations()) {
 
+        auto sim = assoc->getSim();
+        auto rec = assoc->getRec();
 
+//        m_log->debug("  {:<6} {:<6} {:>8.2f} {:>8.2f} {:>8.2f} {:>8.2f}",
+//        m_log->debug("  {} {} {} {}", assoc->getSimID(), assoc->getRecID(), sim.getPDG(), rec.getPDG());
+    }
 
+    m_log->debug("Particles [objID] [PDG] [simE] [recE] [simPDG] [recPDG]");
+    for(auto part: prt_with_assoc->particles()) {
 
+        // auto sim = assoc->getSim();
+        // auto rec = assoc->getRec();
 
-//	// Get hits
-//	auto hits = event->Get<minimodel::McFluxHit>();
+        m_log->debug("  {:<6} {:<6}  {:>8.2f} {:>8.2f}", part->getObjectID().index, part->getPDG(), part->getCharge(), part->getEnergy());
 //
-// 	for(auto hit: hits) {
-//
-//		// Create local x,y,z,name as we will use them a lot to drag hit-> around
-//		double x = hit->x;
-//		double y = hit->y;
-//		double z = hit->z;
-//
-//		th1_hits_z->Fill(z);	// Hits over z axes
-//		total_occ->Fill(x, y);	// Total xy occupancy
-//		if(z > 0) h_part_occ->Fill(x, y);	// Hadron part xy occupancy (z > 0)
-//		if(z <= 0) e_part_occ->Fill(x, y); // electron part xy occupancy (Z < 0)
-//
-//		// Fill occupancy by layer/vol_name
-//		th2_by_layer->Get(hit->vol_name)->Fill(x, y);
-//
-//		// Fill occupancy per detector
-//		auto detector_name = VolNameToDetName(hit->vol_name);	// get detector name
-//		if(!detector_name.empty()) {
-//			th1_z_by_detector->Get(detector_name)->Fill(z);
-//			th2_by_detector->Get(detector_name)->Fill(x, y);
-//			th3_by_detector->Get(detector_name)->Fill(z, x, y);  // z, x, y is the right order here
-//			th3_hits3d->Fill(z, x, y);
-//		}
-//	}
+//        m_log->debug("  {} {} {} {}", assoc->getSimID(), assoc->getRecID(), sim.getPDG(), rec.getPDG());
+    }
+
+
+    m_log->debug("ReconstructedChargedParticles [objID] [PDG] [charge] [energy]");
+    auto reco_charged_particles = event->Get<edm4eic::ReconstructedParticle>("ReconstructedChargedParticles");
+    for(auto part: reco_charged_particles) {
+        m_log->debug("  {:<6} {:<6}  {:>8.2f} {:>8.2f}", part->getObjectID().index, part->getPDG(), part->getCharge(), part->getEnergy());
+    }
+//auto hits = event->Get<edm4eic::TrackerHit>("trackerHits");
+
+
 }
 
 
@@ -214,37 +167,5 @@ void TrackingTest_processor::Finish()
 {
 	fmt::print("OccupancyAnalysis::Finish() called\n");
 
-
-
-	// Next we want to create several pretty canvases (with histograms drawn on "same")
-	// But we don't want those canvases to pop up. So we set root to batch mode
-	// We will restore the mode afterwards
-	//bool save_is_batch = gROOT->IsBatch();
-	//gROOT->SetBatch(true);
-
-	// 3D hits distribution
-//	auto th3_by_det_canvas = new TCanvas("th3_by_det_cnv", "Occupancy of detectors");
-//	dir_main->Append(th3_by_det_canvas);
-//	for (auto& kv : th3_by_detector->GetMap()) {
-//		auto th3_hist = kv.second;
-//		th3_hist->Draw("same");
-//	}
-//	th3_by_det_canvas->GetPad(0)->BuildLegend();
-//
-//	// Hits Z by detector
-//
-//	// Create pretty canvases
-//	auto z_by_det_canvas = new TCanvas("z_by_det_cnv", "Hit Z distribution by detector");
-//	dir_main->Append(z_by_det_canvas);
-//	th1_hits_z->Draw("PLC PFC");
-//
-//	for (auto& kv : th1_z_by_detector->GetMap()) {
-//		auto hist = kv.second;
-//		hist->Draw("SAME PLC PFC");
-//		hist->SetFillStyle(3001);
-//	}
-//	z_by_det_canvas->GetPad(0)->BuildLegend();
-//
-//	gROOT->SetBatch(save_is_batch);
 }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Introduced `edm4eic::ReconstructedParticles` with tag `ReconstructedChargedParticles` which correspond to the same thing from Juggler. This data comes from MCParticles matching with tracks and has true PID. 

There are also minor improvement on tracking association of particles and its validation


### What kind of change does this PR introduce?
- [x] New feature (issue #__)

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [x] Documentation has been added / updated - separate issue
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

NO

### Does this PR change default behavior?

NO