### PR TITLE
Improve DD4Hep service control by environment variables

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -7,6 +7,7 @@
     * [Add Factory](howtos/add_factory.md)
     * [Make Plugin.md](howtos/make_plugin.md)
 * Design
+    * [Flags&Env](design/common_flags_env.md)
     * [Cmake](design/cmake.md)
     * [Logging](design/logging.md)
     * [Tracking](design/tracking.md)

--- a/docs/design/common_flags.md
+++ b/docs/design/common_flags.md
@@ -1,0 +1,35 @@
+# EICrecon common flags
+
+
+
+## Geometry: 
+
+
+#### Environment variables:
+
+- **DETECTOR_PATH** - path where DD4Hep detector
+- **DETECTOR_CONFIG** - name of xml file with DD4Hep detector description without '.xml' extension
+
+If both variables are set, EICrecon by default tries to open:
+
+```bash
+${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml
+```
+
+`dd4hep:xml_files` (see below), overwrites the default.  
+
+
+#### Flags:
+
+**dd4hep:xml_files** - Comma separated list of XML files describing the DD4hep geometry.
+**dd4hep:print_level** - Set DD4hep print level (see DD4hep/Printout.h)
+
+If xml_files are given and DETECTOR_PATH is set, then EICrecon first tries to open xml_file[i] if it fails, it tries
+`${DETECTOR_PATH}/file`
+
+```bash
+
+eicrecon ... -Pdd4hep:xml_files=/full/path/epic.xml   # good
+eicrecon ... -Pdd4hep:xml_files=epic.xml              # good if $DETECTOR_PATH is set /full/path/
+eicrecon ... -Pdd4hep:xml_files=epic                  # fail, contrary to DETECTOR_CONFIG, this should be with extension
+```

--- a/docs/design/common_flags_env.md
+++ b/docs/design/common_flags_env.md
@@ -1,5 +1,9 @@
-# EICrecon common flags
+# EICrecon common flags and environment
 
+This page does not provide all available run flags/parameters for EICrecon.
+There are many more parameters that can be used in algorithms. 
+Moreover dynamically attached plugins add their own parameters. 
+Here is a list of common flags/parameters and environment variables to conrtrol the core flow of EICrecon execution.  
 
 
 ## Geometry: 
@@ -24,7 +28,7 @@ ${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml
 **dd4hep:xml_files** - Comma separated list of XML files describing the DD4hep geometry.
 **dd4hep:print_level** - Set DD4hep print level (see DD4hep/Printout.h)
 
-If xml_files are given and DETECTOR_PATH is set, then EICrecon first tries to open xml_file[i] if it fails, it tries
+If xml_files are given and DETECTOR_PATH is set, then EICrecon first tries to open xml_file\[i\] if it fails, it tries
 `${DETECTOR_PATH}/file`
 
 ```bash

--- a/src/services/geometry/dd4hep/JDD4hep_service.h
+++ b/src/services/geometry/dd4hep/JDD4hep_service.h
@@ -53,7 +53,7 @@ private:
     JApplication *app = nullptr;
     dd4hep::Detector* m_dd4hepGeo = nullptr;
 	std::shared_ptr<const dd4hep::rec::CellIDPositionConverter> m_cellid_converter = nullptr;
-    std::vector<std::string> m_xmlFileNames;
+    std::vector<std::string> m_xml_files;
 };
 
 #endif // __JDD4hep_service_h__


### PR DESCRIPTION
### Briefly, what does this PR introduce?

- Add DETECTOR_CONFIG 
- DETECTOR env still there but deprecated
- Improve how DETECTOR_PATH is used with `dd4hep:xml_files`. From docs: 

**dd4hep:xml_files** - Comma separated list of XML files describing the DD4hep geometry.

If xml_files are given and DETECTOR_PATH is set, then EICrecon first tries to open xml_file\[i\] if it fails, it tries
`${DETECTOR_PATH}/file`

```bash

eicrecon ... -Pdd4hep:xml_files=/full/path/epic.xml   # good
eicrecon ... -Pdd4hep:xml_files=epic.xml              # good if $DETECTOR_PATH is set /full/path/
eicrecon ... -Pdd4hep:xml_files=epic                  # fail, contrary to DETECTOR_CONFIG, this should be with extension
```

### What kind of change does this PR introduce?
- [x] New feature (fixes issue #184)


### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [x] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

NO

### Does this PR change default behavior?

NO
