### PR TITLE
feat!: add IRT geometry service for RICH PID

### DIFF
--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -186,6 +186,17 @@ macro(plugin_add_acts _name)
     plugin_link_libraries(${PLUGIN_NAME} ActsCore ActsPluginIdentification ActsPluginTGeo ActsPluginJson ActsPluginDD4hep)
 endmacro()
 
+
+# Adds IRT PID reconstruction package for a plugin
+macro(plugin_add_irt _name)
+    if(NOT IRT_FOUND)
+        find_package(IRT REQUIRED)
+        set(IRT_INCLUDE_DIR ${IRT_DIR}/../../include)
+    endif()
+    plugin_include_directories(${PLUGIN_NAME} SYSTEM PUBLIC ${IRT_INCLUDE_DIR})
+    plugin_link_libraries(${PLUGIN_NAME} IRT)
+endmacro()
+
 # Adds podio, edm4hep, edm4eic for a plugin
 macro(plugin_add_event_model _name)
 

--- a/docs/get-started/manual-build.md
+++ b/docs/get-started/manual-build.md
@@ -164,6 +164,16 @@ cmake --build build --target install -- -j8
 source ${ACTS_HOME}/install/bin/this_acts.sh
 ~~~
 
+### IRT
+~~~
+export IRT_HOME=${EICTOPDIR}/irt
+export IRT_ROOT=${IRT_HOME}/install 
+git clone https://github.com/eic/irt ${IRT_HOME}
+cmake -S ${IRT_HOME} -B ${IRT_HOME}/build -DCMAKE_INSTALL_PREFIX=${IRT_ROOT}
+cmake --build ${IRT_HOME}/build -j8
+cmake --install ${IRT_HOME}/build
+~~~
+
 ### Detector Geometry
 The detector geometry itself is contained in separate repositories.
 The _EPIC_ reference detector design is in a repository

--- a/src/detectors/CMakeLists.txt
+++ b/src/detectors/CMakeLists.txt
@@ -13,3 +13,6 @@ add_subdirectory(MPGD)      # MPDG tracker
 add_subdirectory(RPOTS)     # Roman Pots
 add_subdirectory(ECTOF)     # Endcap TOF
 add_subdirectory(BTOF)      # Barrel TOF
+
+# PID detectors
+add_subdirectory(RICH)

--- a/src/detectors/RICH/CMakeLists.txt
+++ b/src/detectors/RICH/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.16)
+
+# Automatically set plugin name the same as the directory name
+# Don't forget string(REPLACE " " "_" PLUGIN_NAME ${PLUGIN_NAME}) if this dir has spaces in its name
+get_filename_component(PLUGIN_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
+
+print_header(">>>>   P L U G I N :   ${PLUGIN_NAME}    <<<<")       # Fancy printing
+
+# Function creates ${PLUGIN_NAME}_plugin and ${PLUGIN_NAME}_library targets
+# Setting default includes, libraries and installation paths
+plugin_add(${PLUGIN_NAME})
+
+# The macro grabs sources as *.cc *.cpp *.c and headers as *.h *.hh *.hpp
+# Then correctly sets sources for ${_name}_plugin and ${_name}_library targets
+# Adds headers to the correct installation directory
+plugin_glob_all(${PLUGIN_NAME})
+
+# Find dependencies
+plugin_add_irt(${PLUGIN_NAME})
+plugin_add_event_model(${PLUGIN_NAME})

--- a/src/detectors/RICH/CherenkovParticleID_factory_IrtParticleID.h
+++ b/src/detectors/RICH/CherenkovParticleID_factory_IrtParticleID.h
@@ -1,0 +1,86 @@
+// Copyright 2022, Christopher Dilks
+// Subject to the terms in the LICENSE file found in the top-level directory.
+//
+//
+
+// input is the photoelectrons, and tracking info
+// output is Cherenkov PID
+// - prepares for and calls the IRT (standalone) algorithm
+
+#pragma once
+
+#include <cmath>
+
+// JANA
+#include <JANA/JEvent.h>
+#include <JANA/JFactoryT.h>
+
+// data model
+#include <edm4hep/SimTrackerHit.h>
+#include <edm4eic/CherenkovParticleID.h>
+
+// services
+#include <services/geometry/irt/IrtGeo_service.h>
+#include <services/log/Log_service.h>
+#include <extensions/spdlog/SpdlogExtensions.h>
+
+class CherenkovParticleID_factory_IrtParticleID : public JFactoryT<edm4eic::CherenkovParticleID> {
+  public:
+
+    //------------------------------------------
+    CherenkovParticleID_factory_IrtParticleID() {
+      SetTag("IrtParticleID"); // FIXME: should be D/PFRICHIrtParticleID ?
+    }
+
+    //------------------------------------------
+    void Init() override{
+      auto app = GetApplication();
+
+      // default params
+      m_detector_name = "DRICH"; // FIXME: respect https://github.com/eic/EICrecon/pull/242
+      auto tag = "RICH:"+GetTag();
+      app->SetDefaultParameter(tag+":which_rich", m_detector_name, "Indicate which RICH to use");
+
+      // services
+      m_irtGeoSvc = app->template GetService<IrtGeo_service>();
+      m_irtGeo = m_irtGeoSvc->IrtGeometry(m_detector_name);
+      m_log = app->GetService<Log_service>()->logger(GetTag());
+
+      // set log level
+      std::string log_level_str = "info";
+      auto pm = app->GetJParameterManager();
+      pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
+      m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
+
+      m_log->info("\n\nUSING RICH: {}\n\n",m_detector_name);
+
+    }
+
+    //------------------------------------------
+    void Process(const std::shared_ptr<const JEvent> &event) override {
+
+      // inputs
+      // FIXME: will be changed to photoelectrons; until then, just use all the photon hits
+      auto photoelectrons = event->Get<edm4hep::SimTrackerHit>(m_detector_name+"Hits");
+
+      // loop over photoelectrons
+      // FIXME: at the moment, we do nothing; the current version of this factory is only meant to test the `irt` service
+      std::vector<edm4eic::CherenkovParticleID*> output_pid;
+      // for( const auto& photoelectron : photoelectrons ) {
+      //   auto pid = new edm4eic::CherenkovParticleID(
+      //       ...
+      //       );
+      //   output_pid.push_back(pid);
+      // }
+
+      // outputs
+      Set(output_pid);
+    }
+
+  private:
+    std::string m_detector_name;
+    std::shared_ptr<IrtGeo_service> m_irtGeoSvc;
+    std::shared_ptr<spdlog::logger> m_log;
+    CherenkovDetectorCollection *m_irtGeo;
+
+};

--- a/src/detectors/RICH/ParticleID_factory_IrtHypothesis.h
+++ b/src/detectors/RICH/ParticleID_factory_IrtHypothesis.h
@@ -1,11 +1,10 @@
 // Copyright 2022, Christopher Dilks
 // Subject to the terms in the LICENSE file found in the top-level directory.
-//
-//
 
-// input is the photoelectrons, and tracking info
-// output is Cherenkov PID
-// - prepares for and calls the IRT (standalone) algorithm
+/* - input: photoelectrons, tracking info
+ * - output: Cherenkov PID hypothesis and emission angle
+ * - prepares for and calls the IRT (standalone) algorithm
+ */
 
 #pragma once
 
@@ -17,19 +16,19 @@
 
 // data model
 #include <edm4hep/SimTrackerHit.h>
-#include <edm4eic/CherenkovParticleID.h>
+#include <edm4hep/ParticleID.h>
 
 // services
 #include <services/geometry/irt/IrtGeo_service.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class CherenkovParticleID_factory_IrtParticleID : public JFactoryT<edm4eic::CherenkovParticleID> {
+class ParticleID_factory_IrtHypothesis : public JFactoryT<edm4hep::ParticleID> {
   public:
 
     //------------------------------------------
-    CherenkovParticleID_factory_IrtParticleID() {
-      SetTag("IrtParticleID"); // FIXME: should be D/PFRICHIrtParticleID ?
+    ParticleID_factory_IrtHypothesis() {
+      SetTag("IrtHypothesis"); // FIXME: should be D/PFRICH-dependent name?
     }
 
     //------------------------------------------
@@ -65,9 +64,9 @@ class CherenkovParticleID_factory_IrtParticleID : public JFactoryT<edm4eic::Cher
 
       // loop over photoelectrons
       // FIXME: at the moment, we do nothing; the current version of this factory is only meant to test the `irt` service
-      std::vector<edm4eic::CherenkovParticleID*> output_pid;
+      std::vector<edm4hep::ParticleID*> output_pid;
       // for( const auto& photoelectron : photoelectrons ) {
-      //   auto pid = new edm4eic::CherenkovParticleID(
+      //   auto pid = new edm4hep::ParticleID(
       //       ...
       //       );
       //   output_pid.push_back(pid);

--- a/src/detectors/RICH/RICH.cc
+++ b/src/detectors/RICH/RICH.cc
@@ -7,7 +7,7 @@
 #include <JANA/JFactoryGenerator.h>
 
 // #include "Photon_factory_PhotoElectrons"
-#include "CherenkovParticleID_factory_IrtParticleID.h"
+#include "ParticleID_factory_IrtHypothesis.h"
 
 extern "C" {
   void InitPlugin(JApplication *app) {
@@ -20,8 +20,11 @@ extern "C" {
      */
     // app->Add(new JFactoryGeneratorT<PhotoElectron_factory_RICH>());
 
-    /* transform PhotoElectrons to Cherenonkov Particle Identification
+    /* transform PhotoElectrons to Cherenkov Particle Identification
+     * - Run the Indirect Ray Tracing (IRT) algorithm
+     * - Cherenkov angle measurement
+     * - PID hypotheses
      */
-    app->Add(new JFactoryGeneratorT<CherenkovParticleID_factory_IrtParticleID>());
+    app->Add(new JFactoryGeneratorT<ParticleID_factory_IrtHypothesis>());
   }
 }

--- a/src/detectors/RICH/RICH.cc
+++ b/src/detectors/RICH/RICH.cc
@@ -1,0 +1,27 @@
+// Copyright 2022, Christopher Dilks
+// Subject to the terms in the LICENSE file found in the top-level directory.
+//
+//
+
+#include <JANA/JApplication.h>
+#include <JANA/JFactoryGenerator.h>
+
+// #include "Photon_factory_PhotoElectrons"
+#include "CherenkovParticleID_factory_IrtParticleID.h"
+
+extern "C" {
+  void InitPlugin(JApplication *app) {
+    InitJANAPlugin(app);
+
+    /* transform RICH hits -> PhotoElectrons
+     * - handles quantum efficiency
+     * - safety factor
+     * - pixel gap cuts
+     */
+    // app->Add(new JFactoryGeneratorT<PhotoElectron_factory_RICH>());
+
+    /* transform PhotoElectrons to Cherenonkov Particle Identification
+     */
+    app->Add(new JFactoryGeneratorT<CherenkovParticleID_factory_IrtParticleID>());
+  }
+}

--- a/src/scripts/eicrecon-this.sh.in
+++ b/src/scripts/eicrecon-this.sh.in
@@ -75,6 +75,16 @@ if [[ -f @DETECTOR_PATH@/../../setup.sh ]]; then
     source @DETECTOR_PATH@/../../setup.sh
 fi
 
+#----------------- IRT
+IRT=$( readlink -f @IRT_DIR@/../.. )
+if [[ -d ${IRT} ]] ; then
+    export IRT_ROOT=${IRT}
+    IRT_LIBDIR=$( readlink -f @IRT_DIR@/.. )
+    if [[ ! ":$LD_LIBRARY_PATH:" == *":IRT_LIBDIR:"* ]]; then
+        export LD_LIBRARY_PATH="${IRT_LIBDIR}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+    fi
+fi
+
 #----------------- EICrecon
 # Add bin to PATH if not already there
 if [[ ! ":$PATH:" == *":$SCRIPT_DIR:"* ]]; then

--- a/src/services/CMakeLists.txt
+++ b/src/services/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(geometry/dd4hep)
 add_subdirectory(geometry/acts)
+add_subdirectory(geometry/irt)
 add_subdirectory(io/podio)
 add_subdirectory(randomgenerator)
 add_subdirectory(log)

--- a/src/services/geometry/irt/CMakeLists.txt
+++ b/src/services/geometry/irt/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.16)
+
+# Automatically set plugin name the same as the directory name
+# Don't forget string(REPLACE " " "_" PLUGIN_NAME ${PLUGIN_NAME}) if this dir has spaces in its name
+get_filename_component(PLUGIN_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
+
+print_header(">>>>   P L U G I N :   ${PLUGIN_NAME}    <<<<")       # Fancy printing
+
+# Function creates ${PLUGIN_NAME}_plugin and ${PLUGIN_NAME}_library targets
+# Setting default includes, libraries and installation paths
+plugin_add(${PLUGIN_NAME})
+
+# The macro grabs sources as *.cc *.cpp *.c and headers as *.h *.hh *.hpp
+# Then correctly sets sources for ${_name}_plugin and ${_name}_library targets
+# Adds headers to the correct installation directory
+plugin_glob_all(${PLUGIN_NAME})
+
+# include irtgeo/
+plugin_sources(${PLUGIN_NAME}
+  irtgeo/IrtGeo.cc
+  irtgeo/IrtGeoDRICH.cc
+  irtgeo/IrtGeoPFRICH.cc
+  )
+# plugin_include_directories(${PLUGIN_NAME} SYSTEM PUBLIC irtgeo)
+
+# Find dependencies
+plugin_add_dd4hep(${PLUGIN_NAME})
+plugin_add_irt(${PLUGIN_NAME})
+
+### DEBUGGING: dump all cmake vars (more than `cmake -LAH`)
+# message(STATUS "=============== DEBUG: DUMP ALL CMAKE VARS ===============")
+# get_cmake_property(_vars VARIABLES)
+# list(SORT _vars)
+# foreach(_var ${_vars})
+#   message(STATUS "  ${_var} = ${${_var}}")
+# endforeach()
+# message(STATUS "==========================================================")

--- a/src/services/geometry/irt/CMakeLists.txt
+++ b/src/services/geometry/irt/CMakeLists.txt
@@ -26,12 +26,3 @@ plugin_sources(${PLUGIN_NAME}
 # Find dependencies
 plugin_add_dd4hep(${PLUGIN_NAME})
 plugin_add_irt(${PLUGIN_NAME})
-
-### DEBUGGING: dump all cmake vars (more than `cmake -LAH`)
-# message(STATUS "=============== DEBUG: DUMP ALL CMAKE VARS ===============")
-# get_cmake_property(_vars VARIABLES)
-# list(SORT _vars)
-# foreach(_var ${_vars})
-#   message(STATUS "  ${_var} = ${${_var}}")
-# endforeach()
-# message(STATUS "==========================================================")

--- a/src/services/geometry/irt/IrtGeo_service.cc
+++ b/src/services/geometry/irt/IrtGeo_service.cc
@@ -1,0 +1,56 @@
+// Copyright 2022, Christopher Dilks
+// Subject to the terms in the LICENSE file found in the top-level directory.
+//
+//
+
+#include "IrtGeo_service.h"
+
+// Services ----------------------------------------------------------
+void IrtGeo_service::acquire_services(JServiceLocator *srv_locator) {
+
+  // logging service
+  auto log_service = srv_locator->get<Log_service>();
+  m_log = log_service->logger("irt");
+  std::string log_level_str = "info";
+  m_app->SetDefaultParameter("irt:LogLevel", log_level_str, "Log level for IrtGeo_service");
+  m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
+  m_log->info("IrtGeo IRT log level is set to {} ({})", log_level_str, m_log->level());
+
+  // DD4Hep geometry service
+  auto dd4hep_service = srv_locator->get<JDD4hep_service>();
+  m_dd4hepGeo = dd4hep_service->detector();
+}
+
+// IrtGeometry -----------------------------------------------------
+CherenkovDetectorCollection *IrtGeo_service::IrtGeometry(std::string detector_name) {
+
+  // initialize, if not yet initialized
+  try {
+    m_log->info("Call IrtGeo_service::Initialize");
+    auto initialize = [this,&detector_name] () {
+      if(!m_dd4hepGeo) throw JException("IrtGeo_service m_dd4hepGeo==null which should never be!");
+      // instantiate IrtGeo-derived object, depending on detector
+      auto rich = detector_name;
+      std::transform(rich.begin(), rich.end(), rich.begin(), ::toupper);
+      if     ( rich=="DRICH"  ) m_irtGeo = new IrtGeoDRICH(m_dd4hepGeo);
+      else if( rich=="PFRICH" ) m_irtGeo = new IrtGeoPFRICH(m_dd4hepGeo);
+      else throw JException(fmt::format("IrtGeo is not defined for detector '{}'",detector_name));
+    };
+    std::call_once(init_flag, initialize);
+  }
+  catch (std::exception &ex) {
+    throw JException(ex.what());
+  }
+
+  // return pointer to the CherenkovDetectorCollection
+  return m_irtGeo->GetIrtGeometry();
+}
+
+// Destructor --------------------------------------------------------
+IrtGeo_service::~IrtGeo_service(){
+  try {
+    if(m_dd4hepGeo) m_dd4hepGeo->destroyInstance();
+    m_dd4hepGeo = nullptr;
+    if(m_irtGeo) delete m_irtGeo;
+  } catch (...) {}
+}

--- a/src/services/geometry/irt/IrtGeo_service.cc
+++ b/src/services/geometry/irt/IrtGeo_service.cc
@@ -29,11 +29,13 @@ CherenkovDetectorCollection *IrtGeo_service::IrtGeometry(std::string detector_na
     m_log->info("Call IrtGeo_service::Initialize");
     auto initialize = [this,&detector_name] () {
       if(!m_dd4hepGeo) throw JException("IrtGeo_service m_dd4hepGeo==null which should never be!");
+      // allow verbose IrtGeo output, if log level is `debug` or lower
+      bool verbose = m_log->level() <= spdlog::level::debug;
       // instantiate IrtGeo-derived object, depending on detector
       auto rich = detector_name;
       std::transform(rich.begin(), rich.end(), rich.begin(), ::toupper);
-      if     ( rich=="DRICH"  ) m_irtGeo = new IrtGeoDRICH(m_dd4hepGeo);
-      else if( rich=="PFRICH" ) m_irtGeo = new IrtGeoPFRICH(m_dd4hepGeo);
+      if     ( rich=="DRICH"  ) m_irtGeo = new IrtGeoDRICH(m_dd4hepGeo,  verbose);
+      else if( rich=="PFRICH" ) m_irtGeo = new IrtGeoPFRICH(m_dd4hepGeo, verbose);
       else throw JException(fmt::format("IrtGeo is not defined for detector '{}'",detector_name));
     };
     std::call_once(init_flag, initialize);

--- a/src/services/geometry/irt/IrtGeo_service.h
+++ b/src/services/geometry/irt/IrtGeo_service.h
@@ -1,0 +1,44 @@
+// Copyright 2022, Christopher Dilks
+// Subject to the terms in the LICENSE file found in the top-level directory.
+//
+//
+
+#pragma once
+
+#include <cstdlib>
+#include <algorithm>
+
+// JANA
+#include <JANA/JApplication.h>
+#include <JANA/Services/JServiceLocator.h>
+#include <JANA/JException.h>
+
+// services
+#include <services/geometry/dd4hep/JDD4hep_service.h>
+#include <services/log/Log_service.h>
+#include <extensions/spdlog/SpdlogExtensions.h>
+
+// IrtGeo
+#include "irtgeo/IrtGeo.h"
+#include "irtgeo/IrtGeoDRICH.h"
+#include "irtgeo/IrtGeoPFRICH.h"
+
+class IrtGeo_service : public JService {
+  public:
+    IrtGeo_service(JApplication *app) : m_app(app) {}
+    ~IrtGeo_service();
+
+    // return pointer to the CherenkovDetectorCollection, given a detector
+    CherenkovDetectorCollection *IrtGeometry(std::string detector_name);
+
+  private:
+    IrtGeo_service() = default;
+    void acquire_services(JServiceLocator *) override;
+
+    std::once_flag   init_flag;
+    JApplication     *m_app       = nullptr;
+    dd4hep::Detector *m_dd4hepGeo = nullptr;
+    IrtGeo           *m_irtGeo    = nullptr;
+
+    std::shared_ptr<spdlog::logger> m_log;
+};

--- a/src/services/geometry/irt/irt.cc
+++ b/src/services/geometry/irt/irt.cc
@@ -1,0 +1,13 @@
+// Copyright 2022, Christopher Dilks
+// Subject to the terms in the LICENSE file found in the top-level directory.
+//
+//
+
+#include "IrtGeo_service.h"
+
+extern "C" {
+  void InitPlugin(JApplication *app) {
+    InitJANAPlugin(app);
+    app->ProvideService(std::make_shared<IrtGeo_service>(app) );
+  }
+}

--- a/src/services/geometry/irt/irtgeo/IrtGeo.cc
+++ b/src/services/geometry/irt/irtgeo/IrtGeo.cc
@@ -1,0 +1,43 @@
+// Copyright 2022, Christopher Dilks
+// Subject to the terms in the LICENSE file found in the top-level directory.
+//
+//
+
+#include "IrtGeo.h"
+
+IrtGeo::IrtGeo(std::string detName_, std::string compactFile_) : detName(detName_) {
+
+  // compact file name
+  std::string compactFile;
+  if(compactFile_=="") {
+    std::string DETECTOR_PATH(getenv("DETECTOR_PATH"));
+    std::string DETECTOR_CONFIG(getenv("DETECTOR_CONFIG"));
+    if(DETECTOR_PATH.empty() || DETECTOR_CONFIG.empty()) {
+      fmt::print(stderr,"ERROR: source environ.sh\n");
+      return;
+    }
+    compactFile = DETECTOR_PATH + "/" + DETECTOR_CONFIG + ".xml";
+  } else compactFile = compactFile_;
+
+  // build DD4hep detector from compact file
+  det = &dd4hep::Detector::getInstance();
+  det->fromXML(compactFile);
+
+  // set IRT and DD4hep geometry handles
+  Bind();
+}
+
+// set IRT and DD4hep geometry handles
+void IrtGeo::Bind() {
+  // DD4hep geometry handles
+  detRich = det->detector(detName);
+  posRich = detRich.placement().position();
+  // IRT geometry handles
+  irtGeometry = new CherenkovDetectorCollection();
+  irtDetector = irtGeometry->AddNewDetector(detName.c_str());
+}
+
+IrtGeo::~IrtGeo() {
+  if(irtDetector) delete irtDetector;
+  if(irtGeometry) delete irtGeometry;
+}

--- a/src/services/geometry/irt/irtgeo/IrtGeo.cc
+++ b/src/services/geometry/irt/irtgeo/IrtGeo.cc
@@ -5,15 +5,15 @@
 
 #include "IrtGeo.h"
 
-IrtGeo::IrtGeo(std::string detName_, std::string compactFile_) : detName(detName_) {
+IrtGeo::IrtGeo(std::string detName_, std::string compactFile_, bool verbose_) : detName(detName_), verbose(verbose_) {
 
-  // compact file name
+  // compact file name; if it's not been specified, try to find the default one
   std::string compactFile;
   if(compactFile_=="") {
     std::string DETECTOR_PATH(getenv("DETECTOR_PATH"));
     std::string DETECTOR_CONFIG(getenv("DETECTOR_CONFIG"));
     if(DETECTOR_PATH.empty() || DETECTOR_CONFIG.empty()) {
-      fmt::print(stderr,"ERROR: source environ.sh\n");
+      PrintLog(stderr,"ERROR: cannot find default compact file, since env vars DETECTOR_PATH and DETECTOR_CONFIG are not set");
       return;
     }
     compactFile = DETECTOR_PATH + "/" + DETECTOR_CONFIG + ".xml";

--- a/src/services/geometry/irt/irtgeo/IrtGeo.h
+++ b/src/services/geometry/irt/irtgeo/IrtGeo.h
@@ -13,7 +13,6 @@
 #include "DD4hep/Detector.h"
 #include "DDRec/CellIDPositionConverter.h"
 #include "DD4hep/DD4hepUnits.h"
-#include "DD4hep/Printout.h"
 
 // IRT
 #include "CherenkovDetectorCollection.h"
@@ -26,8 +25,10 @@ class IrtGeo {
   public:
 
     // constructor
-    IrtGeo(std::string detName_, std::string compactFile_="");
-    IrtGeo(std::string detName_, dd4hep::Detector *det_) : detName(detName_), det(det_) { Bind(); }
+    IrtGeo(std::string detName_, std::string compactFile_="", bool verbose_=false);
+    IrtGeo(std::string detName_, dd4hep::Detector *det_, bool verbose_=false)
+      : detName(detName_), det(det_), verbose(verbose_)
+    { Bind(); }
     ~IrtGeo(); 
 
     // access the full IRT geometry
@@ -49,6 +50,21 @@ class IrtGeo {
     // IRT geometry handles
     CherenkovDetectorCollection *irtGeometry;
     CherenkovDetector *irtDetector;
+
+    // logging
+    /* NOTE: EICrecon uses `spdlog` with a logging service; since `IrtGeo` is meant
+     * to be usable independent of EICrecon, it uses a custom method `PrintLog`
+     * - for compatibility with the EICrecon log service, set `IrtGeo::verbose`
+     *   based on its log level to control whether `PrintLog` prints anything
+     */
+    bool verbose;
+    template <typename... VALS> void PrintLog(std::FILE *stream, std::string message, VALS... values) {
+      if(verbose or stream==stderr)
+        fmt::print(stream, "[IrtGeo]     {}\n", fmt::format(message, values...));
+    }
+    template <typename... VALS> void PrintLog(std::string message, VALS... values) {
+      PrintLog(stdout, message, values...);
+    }
 
   private:
 

--- a/src/services/geometry/irt/irtgeo/IrtGeo.h
+++ b/src/services/geometry/irt/irtgeo/IrtGeo.h
@@ -1,0 +1,57 @@
+// Copyright 2022, Christopher Dilks
+// Subject to the terms in the LICENSE file found in the top-level directory.
+//
+//
+
+// bind IRT and DD4hep geometries for the RICHes
+#pragma once
+
+#include <string>
+#include <fmt/format.h>
+
+// DD4Hep
+#include "DD4hep/Detector.h"
+#include "DDRec/CellIDPositionConverter.h"
+#include "DD4hep/DD4hepUnits.h"
+#include "DD4hep/Printout.h"
+
+// IRT
+#include "CherenkovDetectorCollection.h"
+#include "CherenkovPhotonDetector.h"
+#include "CherenkovRadiator.h"
+#include "OpticalBoundary.h"
+#include "ParametricSurface.h"
+
+class IrtGeo {
+  public:
+
+    // constructor
+    IrtGeo(std::string detName_, std::string compactFile_="");
+    IrtGeo(std::string detName_, dd4hep::Detector *det_) : detName(detName_), det(det_) { Bind(); }
+    ~IrtGeo(); 
+
+    // access the full IRT geometry
+    CherenkovDetectorCollection *GetIrtGeometry() { return irtGeometry; }
+
+  protected:
+
+    // given DD4hep geometry, produce IRT geometry
+    virtual void DD4hep_to_IRT() = 0;
+
+    // inputs
+    std::string detName;
+
+    // DD4hep geometry handles
+    dd4hep::Detector   *det;
+    dd4hep::DetElement detRich;
+    dd4hep::Position   posRich;
+
+    // IRT geometry handles
+    CherenkovDetectorCollection *irtGeometry;
+    CherenkovDetector *irtDetector;
+
+  private:
+
+    // set all geometry handles
+    void Bind();
+};

--- a/src/services/geometry/irt/irtgeo/IrtGeoDRICH.cc
+++ b/src/services/geometry/irt/irtgeo/IrtGeoDRICH.cc
@@ -1,0 +1,215 @@
+// Copyright 2022, Christopher Dilks
+// Subject to the terms in the LICENSE file found in the top-level directory.
+//
+//
+
+#include "IrtGeoDRICH.h"
+
+void IrtGeoDRICH::DD4hep_to_IRT() {
+
+  // begin envelope
+  /* FIXME: have no connection to GEANT G4LogicalVolume pointers; however all is needed
+   * is to make them unique so that std::map work internally; resort to using integers,
+   * who cares; material pointer can seemingly be '0', and effective refractive index
+   * for all radiators will be assigned at the end by hand; FIXME: should assign it on
+   * per-photon basis, at birth, like standalone GEANT code does;
+   */
+  auto nSectors       = det->constant<int>("DRICH_RECON_nSectors");
+  auto vesselZmin     = det->constant<double>("DRICH_RECON_zmin");
+  auto gasvolMaterial = det->constant<std::string>("DRICH_RECON_gasvolMaterial");
+  TVector3 normX(1, 0,  0); // normal vectors
+  TVector3 normY(0, -1, 0);
+  auto surfEntrance = new FlatSurface((1 / dd4hep::mm) * TVector3(0, 0, vesselZmin), normX, normY);
+  for (int isec=0; isec<nSectors; isec++) {
+    auto cv = irtGeometry->SetContainerVolume(
+        irtDetector,             // Cherenkov detector
+        "GasVolume",             // name
+        isec,                    // path
+        (G4LogicalVolume*)(0x0), // G4LogicalVolume (inaccessible? use an integer instead)
+        nullptr,                 // G4RadiatorMaterial (inaccessible?)
+        surfEntrance             // surface
+        );
+    cv->SetAlternativeMaterialName(gasvolMaterial.c_str());
+  }
+
+  // photon detector
+  // - FIXME: args (G4Solid,G4Material) inaccessible?
+  auto cellMask = uint64_t(std::stoull(det->constant<std::string>("DRICH_RECON_cellMask")));
+  CherenkovPhotonDetector* irtPhotonDetector = new CherenkovPhotonDetector(nullptr, nullptr);
+  irtDetector->SetReadoutCellMask(cellMask);
+  irtGeometry->AddPhotonDetector(
+      irtDetector,      // Cherenkov detector
+      nullptr,          // G4LogicalVolume (inaccessible?)
+      irtPhotonDetector // photon detector
+      );
+  dd4hep::printout(dd4hep::ALWAYS, "IRTGEO", "cellMask = 0x%X", cellMask);
+
+  // aerogel + filter
+  /* AddFlatRadiator will create a pair of flat refractive surfaces internally;
+   * FIXME: should make a small gas gap at the upstream end of the gas volume;
+   * FIXME: do we need a sector loop?
+   */
+  auto aerogelZpos        = det->constant<double>("DRICH_RECON_aerogelZpos");
+  auto aerogelThickness   = det->constant<double>("DRICH_RECON_aerogelThickness");
+  auto aerogelMaterial    = det->constant<std::string>("DRICH_RECON_aerogelMaterial");
+  auto filterZpos         = det->constant<double>("DRICH_RECON_filterZpos");
+  auto filterThickness    = det->constant<double>("DRICH_RECON_filterThickness");
+  auto filterMaterial     = det->constant<std::string>("DRICH_RECON_filterMaterial");
+  auto aerogelFlatSurface = new FlatSurface((1 / dd4hep::mm) * TVector3(0, 0, aerogelZpos), normX, normY);
+  auto filterFlatSurface  = new FlatSurface((1 / dd4hep::mm) * TVector3(0, 0, filterZpos),  normX, normY);
+  for (int isec = 0; isec < nSectors; isec++) {
+    auto aerogelFlatRadiator = irtGeometry->AddFlatRadiator(
+        irtDetector,             // Cherenkov detector
+        "Aerogel",               // name
+        isec,                    // path
+        (G4LogicalVolume*)(0x1), // G4LogicalVolume (inaccessible? use an integer instead)
+        nullptr,                 // G4RadiatorMaterial
+        aerogelFlatSurface,      // surface
+        aerogelThickness / dd4hep::mm // surface thickness
+        );
+    auto filterFlatRadiator = irtGeometry->AddFlatRadiator(
+        irtDetector,             // Cherenkov detector
+        "Filter",                // name
+        isec,                    // path
+        (G4LogicalVolume*)(0x2), // G4LogicalVolume (inaccessible? use an integer instead)
+        nullptr,                 // G4RadiatorMaterial
+        filterFlatSurface,       // surface
+        filterThickness / dd4hep::mm // surface thickness
+        );
+    aerogelFlatRadiator->SetAlternativeMaterialName(aerogelMaterial.c_str());
+    filterFlatRadiator->SetAlternativeMaterialName(filterMaterial.c_str());
+  }
+  dd4hep::printout(dd4hep::ALWAYS, "IRTGEO", "aerogelZpos = %f cm", aerogelZpos);
+  dd4hep::printout(dd4hep::ALWAYS, "IRTGEO", "filterZpos  = %f cm", filterZpos);
+  dd4hep::printout(dd4hep::ALWAYS, "IRTGEO", "aerogel thickness = %f cm", aerogelThickness);
+  dd4hep::printout(dd4hep::ALWAYS, "IRTGEO", "filter thickness  = %f cm", filterThickness);
+
+  // sector loop
+  for (int isec = 0; isec < nSectors; isec++) {
+    std::string secName = "sec" + std::to_string(isec);
+
+    // mirrors
+    auto mirrorRadius = det->constant<double>("DRICH_RECON_mirrorRadius");
+    dd4hep::Position mirrorCenter(
+      det->constant<double>("DRICH_RECON_mirrorCenterX_"+secName),
+      det->constant<double>("DRICH_RECON_mirrorCenterY_"+secName),
+      det->constant<double>("DRICH_RECON_mirrorCenterZ_"+secName)
+      );
+    auto mirrorSphericalSurface  = new SphericalSurface(
+        (1 / dd4hep::mm) * TVector3(mirrorCenter.x(), mirrorCenter.y(), mirrorCenter.z()), mirrorRadius / dd4hep::mm);
+    auto mirrorOpticalBoundary = new OpticalBoundary(
+        irtDetector->GetContainerVolume(), // CherenkovRadiator radiator
+        mirrorSphericalSurface,            // surface
+        false                              // bool refractive
+        );
+    irtDetector->AddOpticalBoundary(isec, mirrorOpticalBoundary);
+    dd4hep::printout(dd4hep::ALWAYS, "IRTGEO", "");
+    dd4hep::printout(dd4hep::ALWAYS, "IRTGEO", "  SECTOR %d MIRROR:", isec);
+    dd4hep::printout(dd4hep::ALWAYS, "IRTGEO", "    mirror x = %f cm", mirrorCenter.x());
+    dd4hep::printout(dd4hep::ALWAYS, "IRTGEO", "    mirror y = %f cm", mirrorCenter.y());
+    dd4hep::printout(dd4hep::ALWAYS, "IRTGEO", "    mirror z = %f cm", mirrorCenter.z());
+    dd4hep::printout(dd4hep::ALWAYS, "IRTGEO", "    mirror R = %f cm", mirrorRadius);
+
+    // complete the radiator volume description; this is the rear side of the container gas volume
+    irtDetector->GetRadiator("GasVolume")->m_Borders[isec].second = mirrorSphericalSurface;
+
+    // sensor sphere (only used for validation of sensor normals)
+    auto sensorSphRadius  = det->constant<double>("DRICH_RECON_sensorSphRadius");
+    auto sensorThickness  = det->constant<double>("DRICH_RECON_sensorThickness");
+    dd4hep::Position sensorSphCenter(
+      det->constant<double>("DRICH_RECON_sensorSphCenterX_"+secName),
+      det->constant<double>("DRICH_RECON_sensorSphCenterY_"+secName),
+      det->constant<double>("DRICH_RECON_sensorSphCenterZ_"+secName)
+      );
+    dd4hep::printout(dd4hep::ALWAYS, "IRTGEO", "  SECTOR %d SENSOR SPHERE:", isec);
+    dd4hep::printout(dd4hep::ALWAYS, "IRTGEO", "    sphere x = %f cm", sensorSphCenter.x());
+    dd4hep::printout(dd4hep::ALWAYS, "IRTGEO", "    sphere y = %f cm", sensorSphCenter.y());
+    dd4hep::printout(dd4hep::ALWAYS, "IRTGEO", "    sphere z = %f cm", sensorSphCenter.z());
+    dd4hep::printout(dd4hep::ALWAYS, "IRTGEO", "    sphere R = %f cm", sensorSphRadius);
+
+    // sensor modules: search the detector tree for sensors for this sector
+    for(auto const& [de_name, detSensor] : detRich.children()) {
+      if(de_name.find("sensor_de_"+secName)!=std::string::npos) {
+
+        // get sensor info
+        auto imodsec = detSensor.id();
+        // - get sensor centroid position
+        auto pvSensor  = detSensor.placement();
+        auto posSensor = posRich + pvSensor.position();
+        // - get sensor surface position
+        dd4hep::Direction radialDir   = posSensor - sensorSphCenter; // sensor sphere radius direction
+        auto posSensorSurface = posSensor + (radialDir.Unit() * (0.5*sensorThickness));
+        // - get surface normal and in-plane vectors
+        double sensorLocalNormX[3] = {1.0, 0.0, 0.0};
+        double sensorLocalNormY[3] = {0.0, 1.0, 0.0};
+        double sensorGlobalNormX[3], sensorGlobalNormY[3];
+        pvSensor.ptr()->LocalToMasterVect(sensorLocalNormX, sensorGlobalNormX); // ignore vessel transformation, since it is a pure translation
+        pvSensor.ptr()->LocalToMasterVect(sensorLocalNormY, sensorGlobalNormY);
+
+        // validate sensor position and normal
+        // - test normal vectors
+        dd4hep::Direction normXdir, normYdir;
+        normXdir.SetCoordinates(sensorGlobalNormX);
+        normYdir.SetCoordinates(sensorGlobalNormY);
+        auto normZdir   = normXdir.Cross(normYdir);         // sensor surface normal
+        auto testOrtho  = normXdir.Dot(normYdir);           // should be zero, if normX and normY are orthogonal
+        auto testRadial = radialDir.Cross(normZdir).Mag2(); // should be zero, if sensor surface normal is parallel to sensor sphere radius
+        if(abs(testOrtho)>1e-6 || abs(testRadial)>1e-6) {
+          dd4hep::printout(dd4hep::FATAL, "IRTGEO",
+              "sensor normal is wrong: normX.normY = %f   |radialDir x normZdir|^2 = %f",
+              testOrtho,
+              testRadial
+              );
+          return;
+        }
+        // - test sensor positioning
+        auto distSensor2center = sqrt((posSensorSurface-sensorSphCenter).Mag2()); // distance between sensor sphere center and sensor surface position
+        auto testDist          = abs(distSensor2center-sensorSphRadius);          // should be zero, if sensor position w.r.t. sensor sphere center is correct
+        if(abs(testDist)>1e-6) {
+          dd4hep::printout(dd4hep::FATAL, "IRTGEO",
+              "sensor positioning is wrong: dist(sensor, sphere_center) = %f,  sphere_radius = %f,  sensor_thickness = %f,  |diff| = %g\n",
+              distSensor2center,
+              sensorSphRadius,
+              sensorThickness,
+              testDist
+              );
+          return;
+        }
+
+
+        // create the optical surface
+        auto sensorFlatSurface = new FlatSurface(
+            (1 / dd4hep::mm) * TVector3(posSensorSurface.x(), posSensorSurface.y(), posSensorSurface.z()),
+            TVector3(sensorGlobalNormX),
+            TVector3(sensorGlobalNormY)
+            );
+        irtDetector->CreatePhotonDetectorInstance(
+            isec,              // sector
+            irtPhotonDetector, // CherenkovPhotonDetector
+            imodsec,           // copy number
+            sensorFlatSurface  // surface
+            );
+        // dd4hep::printout(dd4hep::ALWAYS, "IRTGEO",
+        //     "sensor: id=0x%08X pos=(%5.2f, %5.2f, %5.2f) normX=(%5.2f, %5.2f, %5.2f) normY=(%5.2f, %5.2f, %5.2f)",
+        //     imodsec,
+        //     posSensorSurface.x(), posSensorSurface.y(), posSensorSurface.z(),
+        //     normXdir.x(),  normXdir.y(),  normXdir.z(),
+        //     normYdir.x(),  normYdir.y(),  normYdir.z()
+        //     );
+      }
+    } // search for sensors
+
+  } // sector loop
+
+  // set refractive indices
+  // FIXME: are these (weighted) averages? can we automate this?
+  std::map<std::string, double> rIndices;
+  rIndices.insert({"GasVolume", 1.00076});
+  rIndices.insert({"Aerogel", 1.0190});
+  rIndices.insert({"Filter", 1.5017});
+  for (auto const& [rName, rIndex] : rIndices) {
+    auto rad = irtDetector->GetRadiator(rName.c_str());
+    if (rad)
+      rad->SetReferenceRefractiveIndex(rIndex);
+  }
+}

--- a/src/services/geometry/irt/irtgeo/IrtGeoDRICH.h
+++ b/src/services/geometry/irt/irtgeo/IrtGeoDRICH.h
@@ -1,0 +1,20 @@
+// Copyright 2022, Christopher Dilks
+// Subject to the terms in the LICENSE file found in the top-level directory.
+//
+//
+
+// bind IRT and DD4hep geometries for the dRICH
+#pragma once
+
+#include "IrtGeo.h"
+
+class IrtGeoDRICH : public IrtGeo {
+
+  public:
+    IrtGeoDRICH(std::string compactFile_="") : IrtGeo("DRICH",compactFile_) { DD4hep_to_IRT(); }
+    IrtGeoDRICH(dd4hep::Detector *det_)      : IrtGeo("DRICH",det_)         { DD4hep_to_IRT(); }
+    ~IrtGeoDRICH() {}
+
+  protected:
+    void DD4hep_to_IRT() override;
+};

--- a/src/services/geometry/irt/irtgeo/IrtGeoDRICH.h
+++ b/src/services/geometry/irt/irtgeo/IrtGeoDRICH.h
@@ -11,8 +11,8 @@
 class IrtGeoDRICH : public IrtGeo {
 
   public:
-    IrtGeoDRICH(std::string compactFile_="") : IrtGeo("DRICH",compactFile_) { DD4hep_to_IRT(); }
-    IrtGeoDRICH(dd4hep::Detector *det_)      : IrtGeo("DRICH",det_)         { DD4hep_to_IRT(); }
+    IrtGeoDRICH(std::string compactFile_="", bool verbose_=false) : IrtGeo("DRICH",compactFile_,verbose_) { DD4hep_to_IRT(); }
+    IrtGeoDRICH(dd4hep::Detector *det_,      bool verbose_=false) : IrtGeo("DRICH",det_,verbose_)         { DD4hep_to_IRT(); }
     ~IrtGeoDRICH() {}
 
   protected:

--- a/src/services/geometry/irt/irtgeo/IrtGeoPFRICH.cc
+++ b/src/services/geometry/irt/irtgeo/IrtGeoPFRICH.cc
@@ -1,0 +1,161 @@
+// Copyright 2022, Christopher Dilks
+// Subject to the terms in the LICENSE file found in the top-level directory.
+//
+//
+
+#include "IrtGeoPFRICH.h"
+
+void IrtGeoPFRICH::DD4hep_to_IRT() {
+
+  // begin envelope
+  /* FIXME: have no connection to GEANT G4LogicalVolume pointers; however all is needed
+   * is to make them unique so that std::map work internally; resort to using integers,
+   * who cares; material pointer can seemingly be '0', and effective refractive index
+   * for all radiators will be assigned at the end by hand; FIXME: should assign it on
+   * per-photon basis, at birth, like standalone GEANT code does;
+   */
+  auto vesselZmin     = det->constant<double>("PFRICH_RECON_zmin");
+  auto gasvolMaterial = det->constant<std::string>("PFRICH_RECON_gasvolMaterial");
+  TVector3 normX(1, 0,  0); // normal vectors
+  TVector3 normY(0, 1, 0);
+  auto surfEntrance = new FlatSurface((1 / dd4hep::mm) * TVector3(0, 0, vesselZmin), normX, normY);
+  auto cv = irtGeometry->SetContainerVolume(
+      irtDetector,             // Cherenkov detector
+      "GasVolume",             // name
+      0,                       // path
+      (G4LogicalVolume*)(0x0), // G4LogicalVolume (inaccessible? use an integer instead)
+      nullptr,                 // G4RadiatorMaterial (inaccessible?)
+      surfEntrance             // surface
+      );
+  cv->SetAlternativeMaterialName(gasvolMaterial.c_str());
+
+  // photon detector
+  // - FIXME: args (G4Solid,G4Material) inaccessible?
+  auto cellMask = uint64_t(std::stoull(det->constant<std::string>("PFRICH_RECON_cellMask")));
+  CherenkovPhotonDetector* irtPhotonDetector = new CherenkovPhotonDetector(nullptr, nullptr);
+  irtDetector->SetReadoutCellMask(cellMask);
+  irtGeometry->AddPhotonDetector(
+      irtDetector,      // Cherenkov detector
+      nullptr,          // G4LogicalVolume (inaccessible?)
+      irtPhotonDetector // photon detector
+      );
+  dd4hep::printout(dd4hep::ALWAYS, "IRTGEO", "cellMask = 0x%X", cellMask);
+
+  // aerogel + filter
+  /* AddFlatRadiator will create a pair of flat refractive surfaces internally;
+   * FIXME: should make a small gas gap at the upstream end of the gas volume;
+   */
+  auto aerogelZpos        = det->constant<double>("PFRICH_RECON_aerogelZpos");
+  auto aerogelThickness   = det->constant<double>("PFRICH_RECON_aerogelThickness");
+  auto aerogelMaterial    = det->constant<std::string>("PFRICH_RECON_aerogelMaterial");
+  auto filterZpos         = det->constant<double>("PFRICH_RECON_filterZpos");
+  auto filterThickness    = det->constant<double>("PFRICH_RECON_filterThickness");
+  auto filterMaterial     = det->constant<std::string>("PFRICH_RECON_filterMaterial");
+  auto aerogelFlatSurface = new FlatSurface((1 / dd4hep::mm) * TVector3(0, 0, aerogelZpos), normX, normY);
+  auto filterFlatSurface  = new FlatSurface((1 / dd4hep::mm) * TVector3(0, 0, filterZpos),  normX, normY);
+  auto aerogelFlatRadiator = irtGeometry->AddFlatRadiator(
+      irtDetector,             // Cherenkov detector
+      "Aerogel",               // name
+      0,                       // path
+      (G4LogicalVolume*)(0x1), // G4LogicalVolume (inaccessible? use an integer instead)
+      nullptr,                 // G4RadiatorMaterial
+      aerogelFlatSurface,      // surface
+      aerogelThickness / dd4hep::mm // surface thickness
+      );
+  auto filterFlatRadiator = irtGeometry->AddFlatRadiator(
+      irtDetector,             // Cherenkov detector
+      "Filter",                // name
+      0,                       // path
+      (G4LogicalVolume*)(0x2), // G4LogicalVolume (inaccessible? use an integer instead)
+      nullptr,                 // G4RadiatorMaterial
+      filterFlatSurface,       // surface
+      filterThickness / dd4hep::mm // surface thickness
+      );
+  aerogelFlatRadiator->SetAlternativeMaterialName(aerogelMaterial.c_str());
+  filterFlatRadiator->SetAlternativeMaterialName(filterMaterial.c_str());
+  dd4hep::printout(dd4hep::ALWAYS, "IRTGEO", "aerogelZpos = %f cm", aerogelZpos);
+  dd4hep::printout(dd4hep::ALWAYS, "IRTGEO", "filterZpos  = %f cm", filterZpos);
+  dd4hep::printout(dd4hep::ALWAYS, "IRTGEO", "aerogel thickness = %f cm", aerogelThickness);
+  dd4hep::printout(dd4hep::ALWAYS, "IRTGEO", "filter thickness  = %f cm", filterThickness);
+
+  // sensor modules: search the detector tree for sensors
+  auto sensorThickness  = det->constant<double>("PFRICH_RECON_sensorThickness");
+  bool firstSensor = true;
+  for(auto const& [de_name, detSensor] : detRich.children()) {
+    if(de_name.find("sensor_de")!=std::string::npos) {
+
+      // get sensor info
+      auto imod = detSensor.id();
+      // - get sensor centroid position
+      auto pvSensor  = detSensor.placement();
+      auto posSensor = posRich + pvSensor.position();
+      // - get sensor surface position
+      dd4hep::Direction sensorNorm(0,0,1); // FIXME: generalize; this assumes planar layout, with norm along +z axis (toward IP)
+      auto posSensorSurface = posSensor + (sensorNorm.Unit() * (0.5*sensorThickness));
+      // - get surface normal and in-plane vectors
+      double sensorLocalNormX[3] = {1.0, 0.0, 0.0};
+      double sensorLocalNormY[3] = {0.0, 1.0, 0.0};
+      double sensorGlobalNormX[3], sensorGlobalNormY[3];
+      pvSensor.ptr()->LocalToMasterVect(sensorLocalNormX, sensorGlobalNormX); // ignore vessel transformation, since it is a pure translation
+      pvSensor.ptr()->LocalToMasterVect(sensorLocalNormY, sensorGlobalNormY);
+
+      // validate sensor position and normal
+      // - test normal vectors
+      dd4hep::Direction normXdir, normYdir;
+      normXdir.SetCoordinates(sensorGlobalNormX);
+      normYdir.SetCoordinates(sensorGlobalNormY);
+      auto normZdir   = normXdir.Cross(normYdir);         // sensor surface normal, given derived GlobalNormX,Y
+      auto testOrtho  = normXdir.Dot(normYdir);           // should be zero, if normX and normY are orthogonal
+      auto testRadial = sensorNorm.Cross(normZdir).Mag2(); // should be zero, if sensor surface normal is as expected
+      if(abs(testOrtho)>1e-6 || abs(testRadial)>1e-6) {
+        dd4hep::printout(dd4hep::FATAL, "IRTGEO",
+            "sensor normal is wrong: normX.normY = %f   |sensorNorm x normZdir|^2 = %f",
+            testOrtho,
+            testRadial
+            );
+        return;
+      }
+
+      // create the optical surface
+      auto sensorFlatSurface = new FlatSurface(
+          (1 / dd4hep::mm) * TVector3(posSensorSurface.x(), posSensorSurface.y(), posSensorSurface.z()),
+          TVector3(sensorGlobalNormX),
+          TVector3(sensorGlobalNormY)
+          );
+      irtDetector->CreatePhotonDetectorInstance(
+          0,                 // sector
+          irtPhotonDetector, // CherenkovPhotonDetector
+          imod,              // copy number
+          sensorFlatSurface  // surface
+          );
+      dd4hep::printout(dd4hep::ALWAYS, "IRTGEO",
+          "sensor: id=0x%08X pos=(%5.2f, %5.2f, %5.2f) normX=(%5.2f, %5.2f, %5.2f) normY=(%5.2f, %5.2f, %5.2f)",
+          imod,
+          posSensorSurface.x(), posSensorSurface.y(), posSensorSurface.z(),
+          normXdir.x(),  normXdir.y(),  normXdir.z(),
+          normYdir.x(),  normYdir.y(),  normYdir.z()
+          );
+
+      // complete the radiator volume description; this is the rear side of the container gas volume
+      // Yes, since there are no mirrors in this detector, just close the gas radiator volume by hand (once), 
+      // assuming that all the sensors will be sitting at roughly the same location along the beam line anyway;
+      if(firstSensor) {
+        irtDetector->GetRadiator("GasVolume")->m_Borders[0].second = dynamic_cast<ParametricSurface*>(sensorFlatSurface);
+        firstSensor = false;
+      }
+
+    } // if sensor found
+  } // search for sensors
+
+  // set refractive indices
+  // FIXME: are these (weighted) averages? can we automate this? We should avoid hard-coded numbers here!
+  std::map<std::string, double> rIndices;
+  rIndices.insert({"GasVolume", 1.0013});
+  rIndices.insert({"Aerogel", 1.0190});
+  rIndices.insert({"Filter", 1.5017});
+  for (auto const& [rName, rIndex] : rIndices) {
+    auto rad = irtDetector->GetRadiator(rName.c_str());
+    if (rad)
+      rad->SetReferenceRefractiveIndex(rIndex);
+  }
+}

--- a/src/services/geometry/irt/irtgeo/IrtGeoPFRICH.cc
+++ b/src/services/geometry/irt/irtgeo/IrtGeoPFRICH.cc
@@ -39,7 +39,7 @@ void IrtGeoPFRICH::DD4hep_to_IRT() {
       nullptr,          // G4LogicalVolume (inaccessible?)
       irtPhotonDetector // photon detector
       );
-  dd4hep::printout(dd4hep::ALWAYS, "IRTGEO", "cellMask = 0x%X", cellMask);
+  PrintLog("cellMask = {:#X}", cellMask);
 
   // aerogel + filter
   /* AddFlatRadiator will create a pair of flat refractive surfaces internally;
@@ -73,10 +73,10 @@ void IrtGeoPFRICH::DD4hep_to_IRT() {
       );
   aerogelFlatRadiator->SetAlternativeMaterialName(aerogelMaterial.c_str());
   filterFlatRadiator->SetAlternativeMaterialName(filterMaterial.c_str());
-  dd4hep::printout(dd4hep::ALWAYS, "IRTGEO", "aerogelZpos = %f cm", aerogelZpos);
-  dd4hep::printout(dd4hep::ALWAYS, "IRTGEO", "filterZpos  = %f cm", filterZpos);
-  dd4hep::printout(dd4hep::ALWAYS, "IRTGEO", "aerogel thickness = %f cm", aerogelThickness);
-  dd4hep::printout(dd4hep::ALWAYS, "IRTGEO", "filter thickness  = %f cm", filterThickness);
+  PrintLog("aerogelZpos = {:f} cm", aerogelZpos);
+  PrintLog("filterZpos  = {:f} cm", filterZpos);
+  PrintLog("aerogel thickness = {:f} cm", aerogelThickness);
+  PrintLog("filter thickness  = {:f} cm", filterThickness);
 
   // sensor modules: search the detector tree for sensors
   auto sensorThickness  = det->constant<double>("PFRICH_RECON_sensorThickness");
@@ -108,8 +108,8 @@ void IrtGeoPFRICH::DD4hep_to_IRT() {
       auto testOrtho  = normXdir.Dot(normYdir);           // should be zero, if normX and normY are orthogonal
       auto testRadial = sensorNorm.Cross(normZdir).Mag2(); // should be zero, if sensor surface normal is as expected
       if(abs(testOrtho)>1e-6 || abs(testRadial)>1e-6) {
-        dd4hep::printout(dd4hep::FATAL, "IRTGEO",
-            "sensor normal is wrong: normX.normY = %f   |sensorNorm x normZdir|^2 = %f",
+        PrintLog(stderr,
+            "sensor normal is wrong: normX.normY = {:f}   |sensorNorm x normZdir|^2 = {:f}",
             testOrtho,
             testRadial
             );
@@ -128,8 +128,8 @@ void IrtGeoPFRICH::DD4hep_to_IRT() {
           imod,              // copy number
           sensorFlatSurface  // surface
           );
-      dd4hep::printout(dd4hep::ALWAYS, "IRTGEO",
-          "sensor: id=0x%08X pos=(%5.2f, %5.2f, %5.2f) normX=(%5.2f, %5.2f, %5.2f) normY=(%5.2f, %5.2f, %5.2f)",
+      PrintLog(
+          "sensor: id={:#08X} pos=({:5.2f}, {:5.2f}, {:5.2f}) normX=({:5.2f}, {:5.2f}, {:5.2f}) normY=({:5.2f}, {:5.2f}, {:5.2f})",
           imod,
           posSensorSurface.x(), posSensorSurface.y(), posSensorSurface.z(),
           normXdir.x(),  normXdir.y(),  normXdir.z(),

--- a/src/services/geometry/irt/irtgeo/IrtGeoPFRICH.h
+++ b/src/services/geometry/irt/irtgeo/IrtGeoPFRICH.h
@@ -1,0 +1,20 @@
+// Copyright 2022, Christopher Dilks
+// Subject to the terms in the LICENSE file found in the top-level directory.
+//
+//
+
+// bind IRT and DD4hep geometries for the pfRICH
+#pragma once
+
+#include "IrtGeo.h"
+
+class IrtGeoPFRICH : public IrtGeo {
+
+  public:
+    IrtGeoPFRICH(std::string compactFile_="") : IrtGeo("PFRICH",compactFile_) { DD4hep_to_IRT(); }
+    IrtGeoPFRICH(dd4hep::Detector *det_)      : IrtGeo("PFRICH",det_)         { DD4hep_to_IRT(); }
+    ~IrtGeoPFRICH() {}
+
+  protected:
+    void DD4hep_to_IRT() override;
+};

--- a/src/services/geometry/irt/irtgeo/IrtGeoPFRICH.h
+++ b/src/services/geometry/irt/irtgeo/IrtGeoPFRICH.h
@@ -11,8 +11,8 @@
 class IrtGeoPFRICH : public IrtGeo {
 
   public:
-    IrtGeoPFRICH(std::string compactFile_="") : IrtGeo("PFRICH",compactFile_) { DD4hep_to_IRT(); }
-    IrtGeoPFRICH(dd4hep::Detector *det_)      : IrtGeo("PFRICH",det_)         { DD4hep_to_IRT(); }
+    IrtGeoPFRICH(std::string compactFile_="", bool verbose_=false) : IrtGeo("PFRICH",compactFile_,verbose_) { DD4hep_to_IRT(); }
+    IrtGeoPFRICH(dd4hep::Detector *det_,      bool verbose_=false) : IrtGeo("PFRICH",det_,verbose_)         { DD4hep_to_IRT(); }
     ~IrtGeoPFRICH() {}
 
   protected:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
- introduces dependence on the standalone `irt` library (viz. `libIRT`)
- add `IrtGeo` class hierarchy for binding `dd4hep` geometry and `irt` geometry; these `IrtGeo` classes can also be used standalone, outside of `EICrecon`
- adds new service `geometry/irt`, similar to `geometry/acts`; it uses `IrtGeo` to produce the necessary `libIRT` objects from the `DD4hep` geometry
- begin `RICH` factories, to test the new `geometry/irt` service

To test, run:
```bash
eicrecon -Pplugins=irt,RICH -Ppodio:output_include_collections=IrtHypothesis [simulation file with DRICHHits]
```

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [x] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No