### PR TITLE
ci: update build-gcc and add build-clang tests

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -14,24 +14,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-test:
+  build-gcc:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: cvmfs-contrib/github-action-cvmfs@v2
     - uses: eic/run-cvmfs-osg-eic-shell@main
       with:
         platform-release: "jug_xl:nightly"
-        setup: /opt/detector/epic-nightly/setup.sh
         run: |
           # install this repo
-          cmake -B build -S . \
-            -DDETECTOR_LIBS_EPIC=/opt/detector/epic-nightly/lib/libepic.so \
-            -DDETECTOR_LIBS_IP6=/opt/detector/epic-nightly/lib/libip6.so
+          CC=gcc CXX=g++ cmake -B build -S .
           cmake --build build -- install
     - uses: actions/upload-artifact@v3
       with:
-        name: build-eic-shell-epic-nightly
+        name: build-gcc-eic-shell
+        path: |
+          .
+          !src/
+        if-no-files-found: error
+
+  build-clang:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - uses: eic/run-cvmfs-osg-eic-shell@main
+      with:
+        platform-release: "jug_xl:nightly"
+        run: |
+          # install this repo
+          CC=clang CXX=clang++ cmake -B build -S .
+          cmake --build build -- install
+    - uses: actions/upload-artifact@v3
+      with:
+        name: build-clang-eic-shell
         path: |
           .
           !src/


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This upated the build-gcc job and adds a build-clang test. Also removes the unused `DETECTOR_LIBS_EPIC` options.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [X] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.