### PR TITLE
Expose input tag data members as config. parameters 

### DIFF
--- a/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelImagingRecHits.h
+++ b/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelImagingRecHits.h
@@ -40,6 +40,7 @@ public:
         // Calibration!
         m_sampFrac=0.10262666247845109;// from ${DETECTOR_PATH}/calibrations/emcal_barrel_calibration.json
 
+        app->SetDefaultParameter("BEMC:EcalBarrelImagingRecHits:input_tag",        m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelImagingRecHits:layerField",       m_layerField);
         app->SetDefaultParameter("BEMC:EcalBarrelImagingRecHits:sectorField",      m_sectorField);
         app->SetDefaultParameter("BEMC:EcalBarrelImagingRecHits:capacityADC",      m_capADC);

--- a/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelRecHits.h
+++ b/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelRecHits.h
@@ -48,6 +48,7 @@ public:
         u_localDetFields={};          // from ATHENA's reconstruction.py (i.e. not defined there)
 
 //        app->SetDefaultParameter("BEMC:tag",              m_input_tag);
+        app->SetDefaultParameter("BEMC:EcalBarrelRecHits:input_tag",        m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelRecHits:capacityADC",      m_capADC);
         app->SetDefaultParameter("BEMC:EcalBarrelRecHits:dynamicRangeADC",  m_dyRangeADC);
         app->SetDefaultParameter("BEMC:EcalBarrelRecHits:pedestalMean",     m_pedMeanADC);

--- a/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelScFiRecHits.h
+++ b/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelScFiRecHits.h
@@ -48,14 +48,15 @@ public:
         u_localDetFields={"system", "module"};          // from ATHENA's reconstruction.py (i.e. not defined there)
 
 //        app->SetDefaultParameter("BEMC:tag",              m_input_tag);
-        app->SetDefaultParameter("BEMC:capacityADC",      m_capADC);
-        app->SetDefaultParameter("BEMC:dynamicRangeADC",  m_dyRangeADC);
-        app->SetDefaultParameter("BEMC:pedestalMean",     m_pedMeanADC);
-        app->SetDefaultParameter("BEMC:pedestalSigma",    m_pedSigmaADC);
-        app->SetDefaultParameter("BEMC:resolutionTDC",    m_resolutionTDC);
-        app->SetDefaultParameter("BEMC:thresholdFactor",  m_thresholdFactor);
-        app->SetDefaultParameter("BEMC:thresholdValue",   m_thresholdValue);
-        app->SetDefaultParameter("BEMC:samplingFraction", m_sampFrac);
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:input_tag",        m_input_tag, "Name of input collection to use");
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:capacityADC",      m_capADC);
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:dynamicRangeADC",  m_dyRangeADC);
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:pedestalMean",     m_pedMeanADC);
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:pedestalSigma",    m_pedSigmaADC);
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:resolutionTDC",    m_resolutionTDC);
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:thresholdFactor",  m_thresholdFactor);
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:thresholdValue",   m_thresholdValue);
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:samplingFraction", m_sampFrac);
         m_geoSvc = app->template GetService<JDD4hep_service>(); // TODO: implement named geometry service?
 
         std::string tag=this->GetTag();

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelClusters.h
@@ -43,6 +43,7 @@ public:
         m_enableEtaBounds=false;//{this, "enableEtaBounds", false};
 
 
+        app->SetDefaultParameter("BEMC:EcalBarrelClusters:input_protoclust_tag",        m_input_protoclust_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelClusters:samplingFraction",             m_sampFrac);
         app->SetDefaultParameter("BEMC:EcalBarrelClusters:logWeightBase",  m_logWeightBase);
         app->SetDefaultParameter("BEMC:EcalBarrelClusters:depthCorrection",     m_depthCorrection);

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelImagingClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelImagingClusters.h
@@ -36,6 +36,7 @@ public:
         m_input_simhit_tag="EcalBarrelHits";
         m_input_protoclust_tag="EcalBarrelImagingProtoClusters";
 
+        app->SetDefaultParameter("BEMC:EcalBarrelImagingClusters:input_protoclust_tag",        m_input_protoclust_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelImagingClusters:trackStopLayer",  m_trackStopLayer);
 
 

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelImagingMergedClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelImagingMergedClusters.h
@@ -32,6 +32,12 @@ public:
         m_positionClusters_tag = "EcalBarrelImagingClusters";
         m_positionAssociations_tag = "EcalBarrelImagingClusterAssociations";
 
+        app->SetDefaultParameter("BEMC:EcalBarrelImagingMergedClusters:inputMCParticles_tag", m_inputMCParticles_tag);
+        app->SetDefaultParameter("BEMC:EcalBarrelImagingMergedClusters:energyClusters_tag", m_energyClusters_tag);
+        app->SetDefaultParameter("BEMC:EcalBarrelImagingMergedClusters:energyAssociation_tag", m_energyAssociation_tag);
+        app->SetDefaultParameter("BEMC:EcalBarrelImagingMergedClusters:positionClusters_tag", m_positionClusters_tag);
+        app->SetDefaultParameter("BEMC:EcalBarrelImagingMergedClusters:positionAssociations_tag", m_positionAssociations_tag);
+
         m_log = app->GetService<Log_service>()->logger(GetTag());
 
         initialize();

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelMergedClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelMergedClusters.h
@@ -33,6 +33,9 @@ public:
         std::string tag=this->GetTag();
         std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
 
+        app->SetDefaultParameter("BEMC:EcalBarrelMergedClusters:input_tag", m_input_tag, "Name of input collection to use");
+        app->SetDefaultParameter("BEMC:EcalBarrelMergedClusters:inputAssociations_tag", m_inputAssociations_tag);
+
         // Get log level from user parameter or default
         std::string log_level_str = "info";
         auto pm = app->GetJParameterManager();

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelMergedTruthClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelMergedTruthClusters.h
@@ -33,6 +33,9 @@ public:
         std::string tag=this->GetTag();
         std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
 
+        app->SetDefaultParameter("BEMC:EcalBarrelMergedTruthClusters:input_tag", m_input_tag, "Name of input collection to use");
+        app->SetDefaultParameter("BEMC:EcalBarrelMergedTruthClusters:inputAssociations_tag", m_inputAssociations_tag);
+
         // Get log level from user parameter or default
         std::string log_level_str = "info";
         auto pm = app->GetJParameterManager();

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelScFiClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelScFiClusters.h
@@ -42,7 +42,7 @@ public:
         // for endcaps.
         m_enableEtaBounds=false;//{this, "enableEtaBounds", false};
 
-
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiClusters:input_protoclust_tag", m_input_protoclust_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelScFiClusters:samplingFraction",             m_sampFrac);
         app->SetDefaultParameter("BEMC:EcalBarrelScFiClusters:logWeightBase",  m_logWeightBase);
         app->SetDefaultParameter("BEMC:EcalBarrelScFiClusters:depthCorrection",     m_depthCorrection);

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelScFiClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelScFiClusters.h
@@ -47,7 +47,6 @@ public:
         app->SetDefaultParameter("BEMC:EcalBarrelScFiClusters:logWeightBase",  m_logWeightBase);
         app->SetDefaultParameter("BEMC:EcalBarrelScFiClusters:depthCorrection",     m_depthCorrection);
         app->SetDefaultParameter("BEMC:EcalBarrelScFiClusters:input_simhit_tag", m_input_simhit_tag);
-        app->SetDefaultParameter("BEMC:EcalBarrelScFiClusters:input_protoclust_tag", m_input_protoclust_tag);
         app->SetDefaultParameter("BEMC:EcalBarrelScFiClusters:energyWeight",   m_energyWeight);
         app->SetDefaultParameter("BEMC:EcalBarrelScFiClusters:moduleDimZName",   m_moduleDimZName);
         app->SetDefaultParameter("BEMC:EcalBarrelScFiClusters:enableEtaBounds",   m_enableEtaBounds);

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelTruthClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelTruthClusters.h
@@ -45,7 +45,6 @@ public:
         app->SetDefaultParameter("BEMC:EcalBarrelTruthClusters:logWeightBase",  m_logWeightBase);
         app->SetDefaultParameter("BEMC:EcalBarrelTruthClusters:depthCorrection",     m_depthCorrection);
         app->SetDefaultParameter("BEMC:EcalBarrelTruthClusters:input_simhit_tag", m_input_simhit_tag);
-        app->SetDefaultParameter("BEMC:EcalBarrelTruthClusters:input_protoclust_tag", m_input_protoclust_tag);
         app->SetDefaultParameter("BEMC:EcalBarrelTruthClusters:energyWeight",   m_energyWeight);
         app->SetDefaultParameter("BEMC:EcalBarrelTruthClusters:moduleDimZName",   m_moduleDimZName);
         app->SetDefaultParameter("BEMC:EcalBarrelTruthClusters:enableEtaBounds",   m_enableEtaBounds);

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelTruthClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelTruthClusters.h
@@ -40,7 +40,7 @@ public:
         // for endcaps.
         m_enableEtaBounds=false;//{this, "enableEtaBounds", false};
 
-
+        app->SetDefaultParameter("BEMC:EcalBarrelTruthClusters:input_protoclust_tag", m_input_protoclust_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelTruthClusters:samplingFraction",             m_sampFrac);
         app->SetDefaultParameter("BEMC:EcalBarrelTruthClusters:logWeightBase",  m_logWeightBase);
         app->SetDefaultParameter("BEMC:EcalBarrelTruthClusters:depthCorrection",     m_depthCorrection);

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelImagingProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelImagingProtoClusters.h
@@ -29,6 +29,7 @@ public:
     void Init() override{
         auto app = GetApplication();
 
+        app->SetDefaultParameter("BEMC:EcalBarrelImagingProtoClusters:input_tag", m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelImagingProtoClusters::neighbourLayersRange",    m_neighbourLayersRange);
         app->SetDefaultParameter("BEMC:EcalBarrelImagingProtoClusters::localDistXY",    u_localDistXY);
         app->SetDefaultParameter("BEMC:EcalBarrelImagingProtoClusters::layerDistEtaPhi",    u_layerDistEtaPhi);

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelImagingProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelImagingProtoClusters.h
@@ -29,6 +29,8 @@ public:
     void Init() override{
         auto app = GetApplication();
 
+        m_input_tag = "EcalBarrelImagingRecHits";
+
         app->SetDefaultParameter("BEMC:EcalBarrelImagingProtoClusters:input_tag", m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelImagingProtoClusters::neighbourLayersRange",    m_neighbourLayersRange);
         app->SetDefaultParameter("BEMC:EcalBarrelImagingProtoClusters::localDistXY",    u_localDistXY);
@@ -38,8 +40,6 @@ public:
         app->SetDefaultParameter("BEMC:EcalBarrelImagingProtoClusters::minClusterCenterEdep",    m_minClusterCenterEdep);
         app->SetDefaultParameter("BEMC:EcalBarrelImagingProtoClusters::minClusterEdep",    m_minClusterEdep);
         app->SetDefaultParameter("BEMC:EcalBarrelImagingProtoClusters::neighbourLayersRange",    m_minClusterNhits);
-
-        m_input_tag = "EcalBarrelImagingRecHits";
 
         std::string tag=this->GetTag();
         m_log = app->GetService<Log_service>()->logger(tag);

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelImagingProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelImagingProtoClusters.h
@@ -31,6 +31,12 @@ public:
 
         m_input_tag = "EcalBarrelImagingRecHits";
 
+        // from https://eicweb.phy.anl.gov/EIC/benchmarks/physics_benchmarks/-/blob/master/options/reconstruction.py#L593
+        u_localDistXY          = {2.0 * mm, 2 * mm};     //  # same layer
+        u_layerDistEtaPhi      = {10 * mrad, 10 * mrad}; //  # adjacent layer
+        m_neighbourLayersRange = 2.0;                    //  # id diff for adjacent layer
+        m_sectorDist           = 3.0 * cm;
+
         app->SetDefaultParameter("BEMC:EcalBarrelImagingProtoClusters:input_tag", m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelImagingProtoClusters::neighbourLayersRange",    m_neighbourLayersRange);
         app->SetDefaultParameter("BEMC:EcalBarrelImagingProtoClusters::localDistXY",    u_localDistXY);

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelIslandProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelIslandProtoClusters.h
@@ -41,7 +41,7 @@ public:
         u_globalDistEtaPhi={};//{this, "globalDistEtaPhi", {}};
         u_dimScaledLocalDistXY={1.8,1.8};// from ATHENA reconstruction.py
 
-
+        app->SetDefaultParameter("BEMC:EcalBarrelIslandProtoClusters:input_tag", m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelIslandProtoClusters:splitCluster",             m_splitCluster);
         app->SetDefaultParameter("BEMC:EcalBarrelIslandProtoClusters:minClusterHitEdep",  m_minClusterHitEdep);
         app->SetDefaultParameter("BEMC:EcalBarrelIslandProtoClusters:minClusterCenterEdep",     m_minClusterCenterEdep);

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelScFiProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelScFiProtoClusters.h
@@ -41,6 +41,7 @@ public:
         u_globalDistEtaPhi={};//{this, "globalDistEtaPhi", {}};
         u_dimScaledLocalDistXY={30 * dd4hep::mm, 30 * dd4hep::mm};// from ATHENA reconstruction.py
 
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:input_tag", m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:splitCluster",             m_splitCluster);
         app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:minClusterHitEdep",  m_minClusterHitEdep);
         app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:minClusterCenterEdep",     m_minClusterCenterEdep);

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelTruthProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelTruthProtoClusters.h
@@ -29,6 +29,8 @@ public:
         m_inputHit_tag="EcalBarrelRecHits";
         m_inputMCHit_tag="EcalBarrelHits";
 
+        app->SetDefaultParameter("BEMC:EcalBarrelTruthProtoClusters:inputHit_tag", m_inputHit_tag, "Name of input collection to use");
+
         AlgorithmInit();
     }
 

--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelImagingRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelImagingRawHits.h
@@ -49,6 +49,7 @@ public:
         m_geoSvc = app->GetService<JDD4hep_service>(); // TODO: implement named geometry service?
 
         // This is another option for exposing the data members as JANA configuration parameters.
+        app->SetDefaultParameter("BEMC:EcalBarrelImagingHits:input_tag", m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelImagingHits:energyResolutions",u_eRes);
         app->SetDefaultParameter("BEMC:EcalBarrelImagingHits:timeResolution",   m_tRes);
         app->SetDefaultParameter("BEMC:EcalBarrelImagingHits:capacityADC",      m_capADC);

--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelRawHits.h
@@ -55,6 +55,7 @@ public:
         
         // This is another option for exposing the data members as JANA configuration parameters.
 //        app->SetDefaultParameter("BEMC:tag",              m_input_tag);
+        app->SetDefaultParameter("BEMC:EcalBarrelRawHits:input_tag", m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelRawHits:energyResolutions",u_eRes);
         app->SetDefaultParameter("BEMC:EcalBarrelRawHits:timeResolution",   m_tRes);
         app->SetDefaultParameter("BEMC:EcalBarrelRawHits:capacityADC",      m_capADC);

--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelScFiRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelScFiRawHits.h
@@ -50,18 +50,19 @@ public:
 
         // This is another option for exposing the data members as JANA configuration parameters.
 //        app->SetDefaultParameter("BEMC:tag",              m_input_tag);
-        app->SetDefaultParameter("BEMC:energyResolutions",u_eRes);
-        app->SetDefaultParameter("BEMC:timeResolution",   m_tRes);
-        app->SetDefaultParameter("BEMC:capacityADC",      m_capADC);
-        app->SetDefaultParameter("BEMC:dynamicRangeADC",  m_dyRangeADC);
-        app->SetDefaultParameter("BEMC:pedestalMean",     m_pedMeanADC);
-        app->SetDefaultParameter("BEMC:pedestalSigma",    m_pedSigmaADC);
-        app->SetDefaultParameter("BEMC:resolutionTDC",    m_resolutionTDC);
-        app->SetDefaultParameter("BEMC:scaleResponse",    m_corrMeanScale);
-        app->SetDefaultParameter("BEMC:signalSumFields",  u_fields);
-        app->SetDefaultParameter("BEMC:fieldRefNumbers",  u_refs);
-        app->SetDefaultParameter("BEMC:geoServiceName",   m_geoSvcName);
-        app->SetDefaultParameter("BEMC:readoutClass",     m_readout);
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRawHits:input_tag", m_input_tag, "Name of input collection to use");
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRawHits:energyResolutions",u_eRes);
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRawHits:timeResolution",   m_tRes);
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRawHits:capacityADC",      m_capADC);
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRawHits:dynamicRangeADC",  m_dyRangeADC);
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRawHits:pedestalMean",     m_pedMeanADC);
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRawHits:pedestalSigma",    m_pedSigmaADC);
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRawHits:resolutionTDC",    m_resolutionTDC);
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRawHits:scaleResponse",    m_corrMeanScale);
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRawHits:signalSumFields",  u_fields);
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRawHits:fieldRefNumbers",  u_refs);
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRawHits:geoServiceName",   m_geoSvcName);
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRawHits:readoutClass",     m_readout);
 
         // Call Init for generic algorithm
         std::string tag=this->GetTag();

--- a/src/detectors/EEMC/CalorimeterHit_factory_EcalEndcapNRecHits.h
+++ b/src/detectors/EEMC/CalorimeterHit_factory_EcalEndcapNRecHits.h
@@ -48,6 +48,7 @@ public:
         u_localDetFields={};          // from ATHENA's reconstruction.py (i.e. not defined there)
 
 //        app->SetDefaultParameter("EEMC:tag",              m_input_tag);
+        app->SetDefaultParameter("EEMC:EcalEndcapNRecHits:input_tag",        m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("EEMC:EcalEndcapNRecHits:capacityADC",      m_capADC);
         app->SetDefaultParameter("EEMC:EcalEndcapNRecHits:dynamicRangeADC",  m_dyRangeADC);
         app->SetDefaultParameter("EEMC:EcalEndcapNRecHits:pedestalMean",     m_pedMeanADC);

--- a/src/detectors/EEMC/CalorimeterHit_factory_EcalEndcapPRecHits.h
+++ b/src/detectors/EEMC/CalorimeterHit_factory_EcalEndcapPRecHits.h
@@ -47,6 +47,7 @@ public:
         u_localDetFields={};          // from ATHENA's reconstruction.py (i.e. not defined there)
 
 //        app->SetDefaultParameter("EEMC:tag",              m_input_tag);
+        app->SetDefaultParameter("EEMC:EcalEndcapPRecHits:input_tag",        m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("EEMC:EcalEndcapPRecHits:capacityADC",      m_capADC);
         app->SetDefaultParameter("EEMC:EcalEndcapPRecHits:dynamicRangeADC",  m_dyRangeADC);
         app->SetDefaultParameter("EEMC:EcalEndcapPRecHits:pedestalMean",     m_pedMeanADC);

--- a/src/detectors/EEMC/Cluster_factory_EcalEndcapNClusters.h
+++ b/src/detectors/EEMC/Cluster_factory_EcalEndcapNClusters.h
@@ -43,6 +43,7 @@ public:
         m_enableEtaBounds=false;//{this, "enableEtaBounds", false};
 
 
+        app->SetDefaultParameter("EEMC:EcalEndcapNClusters:input_protoclust_tag",  m_input_protoclust_tag, "Name of input collection to use");
         app->SetDefaultParameter("EEMC:EcalEndcapNClusters:samplingFraction",             m_sampFrac);
         app->SetDefaultParameter("EEMC:EcalEndcapNClusters:logWeightBase",  m_logWeightBase);
         app->SetDefaultParameter("EEMC:EcalEndcapNClusters:depthCorrection",     m_depthCorrection);

--- a/src/detectors/EEMC/Cluster_factory_EcalEndcapNMergedClusters.h
+++ b/src/detectors/EEMC/Cluster_factory_EcalEndcapNMergedClusters.h
@@ -34,6 +34,9 @@ public:
         std::string tag=this->GetTag();
         std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
 
+        app->SetDefaultParameter("EEMC:EcalEndcapNMergedClusters:input_tag",      m_input_tag, "Name of input collection to use");
+        app->SetDefaultParameter("EEMC:EcalEndcapNMergedClusters:inputAssociations_tag",      m_inputAssociations_tag, "Name of input associations collection to use");
+
         // Get log level from user parameter or default
         std::string log_level_str = "info";
         auto pm = app->GetJParameterManager();

--- a/src/detectors/EEMC/Cluster_factory_EcalEndcapPClusters.h
+++ b/src/detectors/EEMC/Cluster_factory_EcalEndcapPClusters.h
@@ -42,6 +42,7 @@ public:
         m_enableEtaBounds=false;//{this, "enableEtaBounds", false};
 
 
+        app->SetDefaultParameter("EEMC:EcalEndcapPClusters:input_protoclust_tag",    m_input_protoclust_tag, "Name of input collection to use");
         app->SetDefaultParameter("EEMC:EcalEndcapPClusters:samplingFraction",             m_sampFrac);
         app->SetDefaultParameter("EEMC:EcalEndcapPClusters:logWeightBase",  m_logWeightBase);
         app->SetDefaultParameter("EEMC:EcalEndcapPClusters:depthCorrection",     m_depthCorrection);

--- a/src/detectors/EEMC/Cluster_factory_EcalEndcapPMergedClusters.h
+++ b/src/detectors/EEMC/Cluster_factory_EcalEndcapPMergedClusters.h
@@ -34,6 +34,9 @@ public:
         std::string tag=this->GetTag();
         std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
 
+        app->SetDefaultParameter("EEMC:EcalEndcapPMergedClusters:input_tag",      m_input_tag, "Name of input collection to use");
+        app->SetDefaultParameter("EEMC:EcalEndcapPMergedClusters:inputAssociations_tag",      m_inputAssociations_tag, "Name of input associations collection to use");
+
         // Get log level from user parameter or default
         std::string log_level_str = "info";
         auto pm = app->GetJParameterManager();

--- a/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapNIslandProtoClusters.h
+++ b/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapNIslandProtoClusters.h
@@ -41,6 +41,7 @@ public:
         u_dimScaledLocalDistXY={1.8,1.8};// from ATHENA reconstruction.py
 
 
+        app->SetDefaultParameter("EEMC:EcalEndcapNClusters:input_tag",        m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("EEMC:EcalEndcapNClusters:splitCluster",             m_splitCluster);
         app->SetDefaultParameter("EEMC:EcalEndcapNClusters:minClusterHitEdep",  m_minClusterHitEdep);
         app->SetDefaultParameter("EEMC:EcalEndcapNClusters:minClusterCenterEdep",     m_minClusterCenterEdep);

--- a/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapNTruthProtoClusters.h
+++ b/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapNTruthProtoClusters.h
@@ -28,6 +28,8 @@ public:
         m_inputHit_tag="EcalEndcapNRecHits";
         m_inputMCHit_tag="EcalEndcapNHits";
 
+        app->SetDefaultParameter("EEMC:EcalEndcapNTruthProtoClusters:inputHit_tag",        m_inputHit_tag, "Name of input collection to use");
+
         AlgorithmInit();
     }
 

--- a/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapPIslandProtoClusters.h
+++ b/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapPIslandProtoClusters.h
@@ -41,6 +41,7 @@ public:
         u_dimScaledLocalDistXY={1.8,1.8};// from ATHENA reconstruction.py
 
 
+        app->SetDefaultParameter("EEMC:EcalEndcapPClusters:input_tag",        m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("EEMC:EcalEndcapPClusters:splitCluster",             m_splitCluster);
         app->SetDefaultParameter("EEMC:EcalEndcapPClusters:minClusterHitEdep",  m_minClusterHitEdep);
         app->SetDefaultParameter("EEMC:EcalEndcapPClusters:minClusterCenterEdep",     m_minClusterCenterEdep);

--- a/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapPTruthProtoClusters.h
+++ b/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapPTruthProtoClusters.h
@@ -28,6 +28,8 @@ public:
         m_inputHit_tag="EcalEndcapPRecHits";
         m_inputMCHit_tag="EcalEndcapPHits";
 
+        app->SetDefaultParameter("EEMC:EcalEndcapPTruthProtoClusters:inputHit_tag",        m_inputHit_tag, "Name of input collection to use");
+
         AlgorithmInit();
     }
 

--- a/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapNRawHits.h
+++ b/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapNRawHits.h
@@ -54,6 +54,7 @@ public:
 
         // This is another option for exposing the data members as JANA configuration parameters.
 //        app->SetDefaultParameter("EEMC:tag",              m_input_tag);
+        app->SetDefaultParameter("EEMC:EcalEndcapNRawHits:input_tag",        m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("EEMC:EcalEndcapNRawHits:energyResolutions",u_eRes);
         app->SetDefaultParameter("EEMC:EcalEndcapNRawHits:timeResolution",   m_tRes);
         app->SetDefaultParameter("EEMC:EcalEndcapNRawHits:capacityADC",      m_capADC);

--- a/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapPRawHits.h
+++ b/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapPRawHits.h
@@ -52,6 +52,7 @@ public:
 
         // This is another option for exposing the data members as JANA configuration parameters.
 //        app->SetDefaultParameter("EEMC:tag",              m_input_tag);
+        app->SetDefaultParameter("EEMC:EcalEndcapPRawHits:input_tag",        m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("EEMC:EcalEndcapPRawHits:energyResolutions",u_eRes);
         app->SetDefaultParameter("EEMC:EcalEndcapPRawHits:timeResolution",   m_tRes);
         app->SetDefaultParameter("EEMC:EcalEndcapPRawHits:capacityADC",      m_capADC);

--- a/src/detectors/EEMC/TruthCluster_factory_EcalEndcapNTruthProtoClusters.h
+++ b/src/detectors/EEMC/TruthCluster_factory_EcalEndcapNTruthProtoClusters.h
@@ -26,6 +26,8 @@ public:
         m_inputHit_tag = "EcalEndcapNTruthProtoClusters";
         m_inputMCHit_tag = "EcalEndcapNHits";
 
+        app->SetDefaultParameter("EEMC:EcalEndcapNTruthProtoClusters:inputHit_tag",        m_inputHit_tag, "Name of input collection to use");
+
         AlgorithmInit();
     }
 

--- a/src/detectors/EEMC/TruthCluster_factory_EcalEndcapPTruthProtoClusters.h
+++ b/src/detectors/EEMC/TruthCluster_factory_EcalEndcapPTruthProtoClusters.h
@@ -26,6 +26,8 @@ public:
         m_inputHit_tag = "EcalEndcapPTruthProtoClusters";
         m_inputMCHit_tag = "EcalEndcapPHits";
 
+        app->SetDefaultParameter("EEMC:EcalEndcapPTruthProtoClusters:inputHit_tag",        m_inputHit_tag, "Name of input collection to use");
+
         AlgorithmInit();
     }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This makes most of the central detector EM calorimeter input collection names be configurable parameters.

This also fixes some naming issues with some of the imaging calorimeter config. parameters.

### What kind of change does this PR introduce?
- [X] Bug fix (issue #__)
- [X] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No