### PR TITLE
tracking:CentralCKFTrajectories:Chi2CutOff = 15

### DIFF
--- a/src/tools/default_flags_table/reco_flags.py
+++ b/src/tools/default_flags_table/reco_flags.py
@@ -532,7 +532,7 @@ eicrecon_reco_flags = [
     ('BTOF:TOFBarrelRawHit:TimeResolution',                      '0.025',                          '* [ns] Time resolution gauss smearing'),
     ('BTOF:TOFBarrelTrackerHit:TimeResolution',                  '0.025',                          '* [ns] Time resolution set to covariance matrix for CKF input'),
 
-    ('tracking:CentralCKFTrajectories:Chi2CutOff',               '50',                             'Chi2 Cut Off for ACTS CKF tracking'),
+    ('tracking:CentralCKFTrajectories:Chi2CutOff',               '15',                             'Chi2 Cut Off for ACTS CKF tracking'),
     ('tracking:CentralCKFTrajectories:EtaBins',                  '',                               'Eta Bins for ACTS CKF tracking reco'),
     ('tracking:CentralCKFTrajectories:NumMeasurementsCutOff',    '10',                             'Number of measurements Cut Off for ACTS CKF tracking'),
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Shujie in det-tracking on Mattermost has requested a chi2 cutoff of 15 for track reconstruction, based on figures demonstrated there.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue: chi2 cutoff)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators @ShujieL 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, lower chi2 cutoff, fewer outliers stored in output as accepted tracks.