### PR TITLE
Add explicit dependencies on libraries

### DIFF
--- a/src/algorithms/tracking/CMakeLists.txt
+++ b/src/algorithms/tracking/CMakeLists.txt
@@ -31,7 +31,7 @@ plugin_glob_all(${PLUGIN_NAME})
 
 # Add libraries
 # (same as target_include_directories but for both plugin and library)
-plugin_link_libraries(${PLUGIN_NAME} Eigen3::Eigen)
+plugin_link_libraries(${PLUGIN_NAME} Eigen3::Eigen ROOT::EG)
 
 #
 ## Find dependencies

--- a/src/benchmarks/reconstruction/tracking_efficiency/CMakeLists.txt
+++ b/src/benchmarks/reconstruction/tracking_efficiency/CMakeLists.txt
@@ -31,4 +31,4 @@ plugin_include_directories(${PLUGIN_NAME}
 
 # Add libraries
 # (same as target_include_directories but for both plugin and library)
-plugin_link_libraries(${PLUGIN_NAME} ${ROOT_LIBRARIES} ActsCore EDM4EIC::edm4eic)
+plugin_link_libraries(${PLUGIN_NAME} ${ROOT_LIBRARIES} ActsCore log_library)

--- a/src/benchmarks/reconstruction/tracking_occupancy/CMakeLists.txt
+++ b/src/benchmarks/reconstruction/tracking_occupancy/CMakeLists.txt
@@ -27,4 +27,4 @@ plugin_include_directories(${PLUGIN_NAME}
 
 # Add libraries
 # (same as target_include_directories but for both plugin and library)
-plugin_link_libraries(${PLUGIN_NAME} ${ROOT_LIBRARIES} ActsCore EDM4EIC::edm4eic)
+plugin_link_libraries(${PLUGIN_NAME} ${ROOT_LIBRARIES} ActsCore log_library)

--- a/src/detectors/BEMC/CMakeLists.txt
+++ b/src/detectors/BEMC/CMakeLists.txt
@@ -29,6 +29,6 @@ plugin_include_directories(${PLUGIN_NAME} SYSTEM PUBLIC ${Eigen3_INCLUDE_DIR})
 # plugin_include_directories(${PLUGIN_NAME} SYSTEM PUBLIC ... )
 
 # Add libraries (works same as target_include_directories)
-plugin_link_libraries(${PLUGIN_NAME} algorithms_calorimetry_library )
+plugin_link_libraries(${PLUGIN_NAME} algorithms_calorimetry_library log_library)
 
 

--- a/src/detectors/BTOF/CMakeLists.txt
+++ b/src/detectors/BTOF/CMakeLists.txt
@@ -25,4 +25,4 @@ plugin_add_event_model(${PLUGIN_NAME})
 
 # Add libraries
 # (same as target_include_directories but for both plugin and library)
-#plugin_link_libraries(${PLUGIN_NAME} ... )
+plugin_link_libraries(${PLUGIN_NAME} digi_library tracking_library)

--- a/src/detectors/BTRK/CMakeLists.txt
+++ b/src/detectors/BTRK/CMakeLists.txt
@@ -25,5 +25,7 @@ plugin_link_libraries(${PLUGIN_NAME}
             algorithms_digi_library
             algorithms_tracking_library
             tracking_library
+            dd4hep_library
             digi_library
+            log_library
         )

--- a/src/detectors/BVTX/CMakeLists.txt
+++ b/src/detectors/BVTX/CMakeLists.txt
@@ -25,4 +25,4 @@ plugin_add_event_model(${PLUGIN_NAME})
 
 # Add libraries
 # (same as target_include_directories but for both plugin and library)
-plugin_link_libraries(${PLUGIN_NAME} algorithms_digi_library algorithms_tracking_library)
+plugin_link_libraries(${PLUGIN_NAME} algorithms_digi_library algorithms_tracking_library digi_library tracking_library)

--- a/src/detectors/ECGEM/CMakeLists.txt
+++ b/src/detectors/ECGEM/CMakeLists.txt
@@ -24,4 +24,4 @@ plugin_glob_all(${PLUGIN_NAME})
 
 # Add libraries
 # (same as target_include_directories but for both plugin and library)
-plugin_link_libraries(${PLUGIN_NAME} algorithms_digi_library algorithms_tracking_library)
+plugin_link_libraries(${PLUGIN_NAME} algorithms_digi_library algorithms_tracking_library digi_library tracking_library)

--- a/src/detectors/ECTOF/CMakeLists.txt
+++ b/src/detectors/ECTOF/CMakeLists.txt
@@ -25,4 +25,4 @@ plugin_add_event_model(${PLUGIN_NAME})
 
 # Add libraries
 # (same as target_include_directories but for both plugin and library)
-#plugin_link_libraries(${PLUGIN_NAME} ... )
+plugin_link_libraries(${PLUGIN_NAME} digi_library tracking_library)

--- a/src/detectors/ECTRK/CMakeLists.txt
+++ b/src/detectors/ECTRK/CMakeLists.txt
@@ -24,4 +24,4 @@ plugin_glob_all(${PLUGIN_NAME})
 
 # Add libraries
 # (same as target_include_directories but for both plugin and library)
-plugin_link_libraries(${PLUGIN_NAME} algorithms_digi_library algorithms_tracking_library)
+plugin_link_libraries(${PLUGIN_NAME} algorithms_digi_library algorithms_tracking_library digi_library tracking_library)

--- a/src/detectors/EEMC/CMakeLists.txt
+++ b/src/detectors/EEMC/CMakeLists.txt
@@ -23,5 +23,5 @@ plugin_add_event_model(${PLUGIN_NAME})
 # plugin_include_directories(${PLUGIN_NAME} SYSTEM PUBLIC ... )
 
 # Add libraries (works same as target_include_directories)
-plugin_link_libraries(${PLUGIN_NAME} algorithms_calorimetry_library)
+plugin_link_libraries(${PLUGIN_NAME} algorithms_calorimetry_library log_library)
 

--- a/src/detectors/HCAL/CMakeLists.txt
+++ b/src/detectors/HCAL/CMakeLists.txt
@@ -26,4 +26,4 @@ plugin_add_dd4hep(${PLUGIN_NAME})
 # plugin_include_directories(${PLUGIN_NAME} SYSTEM PUBLIC ...)
 
 # Add libraries (works same as target_include_directories)
-# plugin_link_libraries(${PLUGIN_NAME} ... )
+plugin_link_libraries(${PLUGIN_NAME} algorithms_calorimetry_library log_library)

--- a/src/detectors/MPGD/CMakeLists.txt
+++ b/src/detectors/MPGD/CMakeLists.txt
@@ -24,4 +24,4 @@ plugin_glob_all(${PLUGIN_NAME})
 
 # Add libraries
 # (same as target_include_directories but for both plugin and library)
-plugin_link_libraries(${PLUGIN_NAME} algorithms_digi_library algorithms_tracking_library)
+plugin_link_libraries(${PLUGIN_NAME} algorithms_digi_library algorithms_tracking_library digi_library tracking_library)

--- a/src/detectors/RPOTS/CMakeLists.txt
+++ b/src/detectors/RPOTS/CMakeLists.txt
@@ -25,4 +25,4 @@ plugin_add_event_model(${PLUGIN_NAME})
 #plugin_include_directories(${PLUGIN_NAME} SYSTEM PUBLIC ${podio_INCLUDE_DIR} ${EDM4EIC_INCLUDE_DIR})
 
 # Add libraries (works same as target_include_directories)
-#plugin_link_libraries(${PLUGIN_NAME} EDM4HEP::edm4hep )
+plugin_link_libraries(${PLUGIN_NAME} dd4hep_library digi_library log_library)

--- a/src/detectors/ZDC/CMakeLists.txt
+++ b/src/detectors/ZDC/CMakeLists.txt
@@ -25,4 +25,4 @@ plugin_add_event_model(${PLUGIN_NAME})
 # plugin_include_directories(${PLUGIN_NAME} SYSTEM PUBLIC ... )
 
 # Add libraries (works same as target_include_directories)
-# plugin_link_libraries(${PLUGIN_NAME} ... )
+plugin_link_libraries(${PLUGIN_NAME} algorithms_calorimetry_library log_library)

--- a/src/examples/log_example/CMakeLists.txt
+++ b/src/examples/log_example/CMakeLists.txt
@@ -13,3 +13,4 @@ plugin_add(${PLUGIN_NAME})
 # Adds headers to the correct installation directory
 plugin_glob_all(${PLUGIN_NAME})
 
+plugin_link_libraries(${PLUGIN_NAME} log_library)

--- a/src/global/digi/CMakeLists.txt
+++ b/src/global/digi/CMakeLists.txt
@@ -27,5 +27,5 @@ plugin_glob_all(${PLUGIN_NAME})
 # plugin_include_directories(${PLUGIN_NAME} SYSTEM PUBLIC ... )
 
 # Add libraries (works similar target_include_directories but for plugin targets)
-plugin_link_libraries(${PLUGIN_NAME} algorithms_digi_library algorithms_tracking_library)
+plugin_link_libraries(${PLUGIN_NAME} algorithms_digi_library algorithms_tracking_library log_library)
 

--- a/src/global/tracking/CMakeLists.txt
+++ b/src/global/tracking/CMakeLists.txt
@@ -24,7 +24,7 @@ plugin_add_event_model(${PLUGIN_NAME})
 
 # Add libraries
 # (same as target_include_directories but for both plugin and library)
-plugin_link_libraries(${PLUGIN_NAME} algorithms_digi_library algorithms_tracking_library)
+plugin_link_libraries(${PLUGIN_NAME} algorithms_digi_library algorithms_tracking_library dd4hep_library log_library)
 #
 #
 #plugin_add_acts(${PLUGIN_NAME})

--- a/src/services/geometry/acts/CMakeLists.txt
+++ b/src/services/geometry/acts/CMakeLists.txt
@@ -29,7 +29,7 @@ plugin_glob_all(${PLUGIN_NAME})
 
 # Add libraries
 # (same as target_include_directories but for both plugin and library)
-plugin_link_libraries(${PLUGIN_NAME} algorithms_digi_library algorithms_tracking_library)
+plugin_link_libraries(${PLUGIN_NAME} algorithms_digi_library algorithms_tracking_library dd4hep_library log_library)
 
 #
 ## Add include directories (works same as target_include_directories)

--- a/src/services/io/podio/CMakeLists.txt
+++ b/src/services/io/podio/CMakeLists.txt
@@ -8,18 +8,14 @@ print_header(">>>>   P L U G I N :   ${PLUGIN_NAME}    <<<<")       # Fancy prin
 project(podio_project)
 
 # Find dependencies (JANA and spdlog automatically added already)
-find_package(EDM4HEP REQUIRED)
 find_package(EDM4EIC REQUIRED)
 find_package(podio REQUIRED)
 find_package(ROOT REQUIRED COMPONENTS Core Tree Hist RIO EG)
 find_package(fmt REQUIRED)
-if(NOT DD4hep_FOUND)
-    find_package(DD4hep REQUIRED)
-endif()
 
 set(EDM4EIC_INCLUDE_DIR ${EDM4EIC_DIR}/../../include)
 set(fmt_INCLUDE_DIR ${fmt_DIR}/../../../include)
-set(INCLUDE_DIRS ${podio_INCLUDE_DIR} ${EDM4HEP_INCLUDE_DIR} ${DD4hep_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS} ${EDM4EIC_INCLUDE_DIR} ${fmt_INCLUDE_DIR})
+set(INCLUDE_DIRS ${fmt_INCLUDE_DIR})
 
 # Function creates ${PLUGIN_NAME}_plugin and ${PLUGIN_NAME}_library targets
 # Setting default includes, libraries and installation paths
@@ -44,17 +40,15 @@ include_directories( ${INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT
 root_generate_dictionary(G__datamodel_vectors datamodel_includes.h LINKDEF datamodel_LinkDef.h)
 target_sources(${PLUGIN_NAME}_plugin PRIVATE datamodel_includes.h G__datamodel_vectors.cxx)
 
-set(LINK_LIBRARIES EDM4HEP::edm4hep EDM4HEP::edm4hepDict EDM4EIC::edm4eic EDM4EIC::edm4eic_utils podio::podioRootIO)
+plugin_add_dd4hep(${PLUGIN_NAME})
+plugin_add_event_model(${PLUGIN_NAME})
+
+# Additional libraries
+plugin_link_libraries(${PLUGIN_NAME} podio::podioRootIO log_library)
 
 # Add include directories (works same as target_include_directories)
 message(STATUS "fmt_INCLUDE_DIR=${fmt_INCLUDE_DIR}")
 plugin_include_directories(${PLUGIN_NAME} SYSTEM PUBLIC ${INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/src ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/src)
-
-# Add libraries (works same as target_include_directories)
-plugin_link_libraries(${PLUGIN_NAME} ${LINK_LIBRARIES})
-
-# Additional libraries
-#plugin_link_libraries(${PLUGIN_NAME} dd4hep_library)
 
 # Install root dictionaries made by PODIO
 set(my_root_dict_files
@@ -62,16 +56,3 @@ set(my_root_dict_files
         ${PROJECT_BINARY_DIR}/libdatamodel_vectors.rootmap
         )
 install(FILES ${my_root_dict_files} DESTINATION ${PLUGIN_OUTPUT_DIRECTORY})
-
-
-return()
-
-#================================================================================================================
-
-# The following was an earlier version of this file that is disabled by the above
-# return() call. It is left here only for reference until the rewrite above is
-# established as stable.  2022-09-03 DL
-# We have git for that
-# http://thecodelesscode.com/case/41
-# 2022-10-17 DR =)
-

--- a/src/services/rootfile/CMakeLists.txt
+++ b/src/services/rootfile/CMakeLists.txt
@@ -17,3 +17,6 @@ plugin_glob_all(${PLUGIN_NAME})
 # Add cern root
 plugin_add_cern_root(${PLUGIN_NAME})
 
+# Add libraries
+# (same as target_include_directories but for both plugin and library)
+plugin_link_libraries(${PLUGIN_NAME} log_library)


### PR DESCRIPTION
This intended to address #230 in the direct way by resolving undefined symbols with explicit linking. This is to be done until or if linking with `--no-undefined` succeeds.

I understand, that this does not align with the aim of having replaceable services/algorithms, at least not in in an obvious way. However, it does improve on the status quo, where some dependencies are defined but not in a systematic way.