### PR TITLE
Add HcalBarrel raw and reco hits to output

### DIFF
--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -84,6 +84,8 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "EcalBarrelMergedTruthClusters",
             "HcalEndcapNClusters",
             "HcalEndcapPClusters",
+            "HcalBarrelRawHits",
+            "HcalBarrelRecHits",
             "HcalBarrelClusters",
             "ZDCEcalClusters",
             "EcalEndcapNTruthClusters",


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Adds the HcalBarrelRawHits and HcalBarrelRecHits to default podio output. This well allow debug and testing of the clustering parameters with the first simulation campaign output. All the other calorimeters seem to have the corresponding quantities in the output, just not the barrel HCAL. 

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No known breaking changes. 

### Does this PR change default behavior?

Yes, the  HcalBarrelRawHits and HcalBarrelRecHits are now output by default
