### PR TITLE
fix(CI): use local install, not /usr/local

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -14,7 +14,7 @@ jobs:
         - /home/runner/work/_temp:/home/runner/work/_temp
       # FIXME hard-coded: see https://github.com/actions/upload-pages-artifact/pull/14
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: |
           apk add doxygen graphviz
           doxygen Doxyfile        

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -32,6 +32,7 @@ jobs:
         path: |
           .
           !src/
+          !apt_cache/
         if-no-files-found: error
 
   build-clang:
@@ -54,6 +55,7 @@ jobs:
         path: |
           .
           !src/
+          !apt_cache/
         if-no-files-found: error
 
   ddsim:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -101,6 +101,7 @@ jobs:
           ls -al
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
           export JANA_HOME=$PWD/lib/EICrecon
+          chmod a+x bin/*
           $PWD/bin/eicrecon -Ppodio:output_file=rec_e_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_e_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
     - uses: actions/upload-artifact@v3
       with:
@@ -131,6 +132,7 @@ jobs:
         run: |
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
           export JANA_HOME=$PWD/lib/EICrecon
+          chmod a+x bin/*
           $PWD/bin/run_eicrecon_reco_flags.py sim_e_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root rec_e_1GeV_20GeV_${{ matrix.detector_config }}          
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -96,9 +96,10 @@ jobs:
         platform-release: "jug_xl:nightly"
         setup: /opt/detector/setup.sh
         run: |
+          ls -al
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
-          export JANA_HOME=/usr/local/lib/EICrecon
-          eicrecon -Ppodio:output_file=rec_e_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_e_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
+          export JANA_HOME=$PWD/lib/EICrecon
+          $PWD/bin/eicrecon -Ppodio:output_file=rec_e_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_e_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
     - uses: actions/upload-artifact@v3
       with:
         name: eicrecon_rec_e_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
@@ -127,8 +128,8 @@ jobs:
         setup: /opt/detector/setup.sh
         run: |
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
-          export JANA_HOME=/usr/local/lib/EICrecon
-          run_eicrecon_reco_flags.py sim_e_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root rec_e_1GeV_20GeV_${{ matrix.detector_config }}          
+          export JANA_HOME=$PWD/lib/EICrecon
+          $PWD/bin/run_eicrecon_reco_flags.py sim_e_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root rec_e_1GeV_20GeV_${{ matrix.detector_config }}          
     - uses: actions/upload-artifact@v3
       with:
         name: run_eicrecon_reco_flags_rec_e_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -98,7 +98,6 @@ jobs:
         platform-release: "jug_xl:nightly"
         setup: /opt/detector/setup.sh
         run: |
-          ls -al
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
           export JANA_HOME=$PWD/lib/EICrecon
           chmod a+x bin/*


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Instead of using the version of eicrecon in the $PATH, the CI job needs the explicit path to both executable and plugins that points to the extracted artifact.

Also, remove apt_cache from artifacts and upgrade actions/checkout to v3 to avoid set-output warning.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #273)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.