### PR TITLE
fix(ci): prepend JANA_PLUGIN_PATH, not JANA_HOME

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -99,7 +99,7 @@ jobs:
         setup: /opt/detector/setup.sh
         run: |
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
-          export JANA_HOME=$PWD/lib/EICrecon
+          export JANA_PLUGIN_PATH=$PWD/lib/EICrecon${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
           chmod a+x bin/*
           $PWD/bin/eicrecon -Ppodio:output_file=rec_e_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_e_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
     - uses: actions/upload-artifact@v3
@@ -130,7 +130,7 @@ jobs:
         setup: /opt/detector/setup.sh
         run: |
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
-          export JANA_HOME=$PWD/lib/EICrecon
+          export JANA_PLUGIN_PATH=$PWD/lib/EICrecon${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
           chmod a+x bin/*
           $PWD/bin/run_eicrecon_reco_flags.py sim_e_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root rec_e_1GeV_20GeV_${{ matrix.detector_config }}          
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -99,7 +99,7 @@ jobs:
         setup: /opt/detector/setup.sh
         run: |
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
-          export JANA_PLUGIN_PATH=$PWD/lib/EICrecon${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
+          export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
           chmod a+x bin/*
           $PWD/bin/eicrecon -Ppodio:output_file=rec_e_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_e_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
     - uses: actions/upload-artifact@v3
@@ -130,7 +130,7 @@ jobs:
         setup: /opt/detector/setup.sh
         run: |
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
-          export JANA_PLUGIN_PATH=$PWD/lib/EICrecon${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
+          export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
           chmod a+x bin/*
           $PWD/bin/run_eicrecon_reco_flags.py sim_e_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root rec_e_1GeV_20GeV_${{ matrix.detector_config }}          
     - uses: actions/upload-artifact@v3


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This fixes the assumption in the CI workflows, and now doesn't overwrite `JANA_HOME` anymore but properly prepends `JANA_PLUGIN_PATH`.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: standard jana plugins not accessible)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @faustus123 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.