### PR TITLE
fix: use `IRT/` path for `irt` include directives

### DIFF
--- a/src/services/geometry/irt/irtgeo/IrtGeo.h
+++ b/src/services/geometry/irt/irtgeo/IrtGeo.h
@@ -15,11 +15,11 @@
 #include "DD4hep/DD4hepUnits.h"
 
 // IRT
-#include "CherenkovDetectorCollection.h"
-#include "CherenkovPhotonDetector.h"
-#include "CherenkovRadiator.h"
-#include "OpticalBoundary.h"
-#include "ParametricSurface.h"
+#include "IRT/CherenkovDetectorCollection.h"
+#include "IRT/CherenkovPhotonDetector.h"
+#include "IRT/CherenkovRadiator.h"
+#include "IRT/OpticalBoundary.h"
+#include "IRT/ParametricSurface.h"
 
 class IrtGeo {
   public:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
`irt` headers are installed in their own subdirectory, so `#include` directives should be consistent with this.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No