### PR TITLE
utilities/eicrecon: load log plugin before others

### DIFF
--- a/src/utilities/eicrecon/eicrecon.cc
+++ b/src/utilities/eicrecon/eicrecon.cc
@@ -13,9 +13,9 @@
 /// Add new default plugin names here and the main() will do JApplication::AddPlugin() for you.
 std::vector<std::string> EICRECON_DEFAULT_PLUGINS = {
 
+        "log",
         "dd4hep",
         "acts",
-        "log",
         "rootfile",
         "algorithms_calorimetry",
         "algorithms_tracking",


### PR DESCRIPTION
This reshufles plugin order in EICRECON_DEFAULT_PLUGINS to fix the following error:

```
[ERROR] JPluginLoader: Couldn't load plugin 'acts.so'
  Make sure that JANA_HOME and/or JANA_PLUGIN_PATH environment variables are set correctly.
  Paths checked:
    /lib/EICrecon/plugins//dd4hep.so  =>  Loaded successfully
    /lib/EICrecon/plugins//acts.so  =>  Loading failure: /lib/EICrecon/plugins//acts.so: undefined symbol: _ZN11Log_service6loggerERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
    ./acts.so  =>  File not found

[FATAL] Exception: Couldn't find plugin 'acts.so'
```

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
