### PR TITLE
288 rich detector needs dd4hep dependence

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(EICRecon VERSION 0.2.3)
+project(EICRecon VERSION 0.3.1)
 
 # Make C++17 a default
 if(NOT "${CMAKE_CXX_STANDARD}")

--- a/src/detectors/RICH/CMakeLists.txt
+++ b/src/detectors/RICH/CMakeLists.txt
@@ -18,3 +18,4 @@ plugin_glob_all(${PLUGIN_NAME})
 # Find dependencies
 plugin_add_irt(${PLUGIN_NAME})
 plugin_add_event_model(${PLUGIN_NAME})
+plugin_add_dd4hep(${PLUGIN_NAME})

--- a/src/utilities/eicrecon/CMakeLists.txt
+++ b/src/utilities/eicrecon/CMakeLists.txt
@@ -20,8 +20,11 @@ set( LINK_LIBRARIES ${JANA_LIB} ${ROOT_LIBRARIES} ${CMAKE_DL_LIBS} Threads::Thre
 add_executable( eicrecon ${SOURCES} )
 target_include_directories( eicrecon PUBLIC ${INCLUDE_DIRS})
 target_link_libraries(eicrecon ${LINK_LIBRARIES} )
+target_compile_definitions(eicrecon PRIVATE EICRECON_APP_VERSION=${CMAKE_PROJECT_VERSION})
+
 
 # Install executable
 install(TARGETS eicrecon DESTINATION bin)
+
 
 

--- a/src/utilities/eicrecon/eicrecon_cli.cpp
+++ b/src/utilities/eicrecon/eicrecon_cli.cpp
@@ -16,6 +16,15 @@
 #include <string>
 #include <filesystem>
 
+#define QUOTE(name) #name
+#define STR(macro) QUOTE(macro)
+
+#ifndef EICRECON_APP_VERSION
+#  define EICRECON_APP_VERSION Error
+#endif
+
+#define EICRECON_APP_VERSION_STR STR(EICRECON_APP_VERSION)
+
 
 namespace jana {
 
@@ -67,7 +76,7 @@ namespace jana {
     }
 
     void PrintVersion() {
-        std::cout << "      EICrecon version: " << "0.2.3" << std::endl;
+        std::cout << "      EICrecon version: " << EICRECON_APP_VERSION_STR << std::endl;
         std::cout << std::endl << std::endl;
     }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Otherwise it fails not finding DD4Hep headers. Probably it works in container as headers are installed in system directories there. Or IDK. 

### What kind of change does this PR introduce?
- [x] Bug fix (Fix issue #288)

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
NO

### Does this PR change default behavior?
NO