### PR TITLE
reco_flags.py now accepts -P parameter flags

### DIFF
--- a/src/tools/default_flags_table/reco_flags.py
+++ b/src/tools/default_flags_table/reco_flags.py
@@ -858,6 +858,13 @@ def make_flags_from_records():
 
 if __name__ == "__main__":
 
+    # Separate all parameters that starts with -P/-p from args
+    parameter_args = []
+    for arg in sys.argv:
+        if arg.startswith(("-P", "-p")):
+            parameter_args.append(arg)
+            sys.argv.remove(arg)
+
     parser = argparse.ArgumentParser(description=desc)
     parser.add_argument('input_file', help="Input file name")
     parser.add_argument('output_base_name', help="Output files names (no file extensions here)")
@@ -877,6 +884,9 @@ if __name__ == "__main__":
     ]
 
     flags_arguments = make_flags_from_records()
+
+    # Add parameters from args
+    run_command.extend(parameter_args)
 
     # Add reco_flags
     run_command.extend(flags_arguments)

--- a/src/tools/default_flags_table/reco_flags.py
+++ b/src/tools/default_flags_table/reco_flags.py
@@ -8,6 +8,9 @@
 # So if the output bin directory is in PATH one can do:#
 #    run_eicrecon_reco_flags.py -n 1000 input.edm4hep.root output_no_ext
 #
+# It is possible to pass additional jana parameters with -P flags:
+#    python3 reco_flags.py -Pjana:timeout=0 input.edm4hep.root output_no_ext
+#
 # The format of the table is:
 #  [ (flag_name, default_val, description), ... ]
 #

--- a/src/utilities/dump_flags/DumpFlags_processor.h
+++ b/src/utilities/dump_flags/DumpFlags_processor.h
@@ -54,7 +54,7 @@ private:
     std::string m_json_file_name = "";
 
     /// Print parameter summary to screen at end of job
-    bool m_print_to_screen = false;
+    bool m_print_to_screen = true;
 
     /// Print only reconstruction flags
     bool m_only_reco = true;


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Now one can pass -P flags to reco_flags.py or run_eicrecon_reco_flags.py

```bash
python3 reco_flags.py -Pjana:timeout=0 input.edm4hep.root output_base_name
```

### What kind of change does this PR introduce?
- [x] New feature (issue #__)

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [x] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

NO

### Does this PR change default behavior?

NO