### PR TITLE
Davidl eicrecon fixes

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterClusterMerger.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterMerger.cc
@@ -19,7 +19,7 @@ using namespace dd4hep;
 // AlgorithmInit
 //------------------------
 void CalorimeterClusterMerger::AlgorithmInit(std::shared_ptr<spdlog::logger>& logger) {
-    m_logger=logger;
+    m_log=logger;
     return;
 }
 
@@ -41,30 +41,30 @@ void CalorimeterClusterMerger::AlgorithmProcess() {
     auto& assoc2 = m_outputAssociations;
 
     if (!split.size()) {
-      if (m_logger->level() <=spdlog::level::debug) {
-        m_logger->debug("Nothing to do for this event, returning...");
+      if (m_log->level() <=spdlog::level::debug) {
+        m_log->debug("Nothing to do for this event, returning...");
         //LOG_INFO(default_cout_logger) << "Nothing to do for this event, returning..." << LOG_END;
       }
       return;
     }
-    if (m_logger->level() <=spdlog::level::debug) {
-       m_logger->debug( "Step 0/1: Getting indexed list of clusters..." );
+    if (m_log->level() <=spdlog::level::debug) {
+       m_log->debug( "Step 0/1: Getting indexed list of clusters..." );
       //LOG_INFO(default_cout_logger) << "Step 0/1: Getting indexed list of clusters..." << LOG_END;
     }
     // get an indexed map of all vectors of clusters, indexed by mcID
     auto clusterMap = indexedClusterLists(split, assoc);
     // loop over all position clusters and match with energy clusters
-    if (m_logger->level() <=spdlog::level::debug) {
-       m_logger->debug( "Step 1/1: Merging clusters where needed" );
+    if (m_log->level() <=spdlog::level::debug) {
+       m_log->debug( "Step 1/1: Merging clusters where needed" );
     }
     for (const auto& [mcID, clusters] : clusterMap) {
-      if (m_logger->level() <=spdlog::level::debug) {
-         m_logger->debug( " --> Processing {} clusters for mcID {}",clusters.size(), mcID );
+      if (m_log->level() <=spdlog::level::debug) {
+         m_log->debug( " --> Processing {} clusters for mcID {}",clusters.size(), mcID );
       }
       if (clusters.size() == 1) {
         const auto& clus = clusters[0];
-        if (m_logger->level() <=spdlog::level::debug) {
-           m_logger->debug( "   --> Only a single cluster, energy: {} for this particle, copying",clus->getEnergy());
+        if (m_log->level() <=spdlog::level::debug) {
+           m_log->debug( "   --> Only a single cluster, energy: {} for this particle, copying",clus->getEnergy());
         }
         auto nclus= clus->clone();
         edm4eic::Cluster* new_clus = new edm4eic::Cluster(nclus);
@@ -87,8 +87,8 @@ void CalorimeterClusterMerger::AlgorithmProcess() {
         int nhits = 0;
         auto position = new_clus.getPosition();
         for (auto clus : clusters) {
-          if (m_logger->level() <=spdlog::level::debug) {
-             m_logger->debug( "   --> Adding cluster with energy: {}" , clus->getEnergy() );
+          if (m_log->level() <=spdlog::level::debug) {
+             m_log->debug( "   --> Adding cluster with energy: {}" , clus->getEnergy() );
           }
           energy += clus->getEnergy();
           energyError += clus->getEnergyError() * clus->getEnergyError();
@@ -106,8 +106,8 @@ void CalorimeterClusterMerger::AlgorithmProcess() {
         new_clus.setNhits(nhits);
         new_clus.setPosition(position / energy);
         merged.push_back( new edm4eic::Cluster(new_clus) );
-        if (m_logger->level() <=spdlog::level::debug) {
-           m_logger->debug( "   --> Merged cluster with energy: {}",new_clus.getEnergy() );
+        if (m_log->level() <=spdlog::level::debug) {
+           m_log->debug( "   --> Merged cluster with energy: {}",new_clus.getEnergy() );
         }
         auto ca = new edm4eic::MutableMCRecoClusterParticleAssociation();
         ca->setSimID(mcID);

--- a/src/algorithms/calorimetry/CalorimeterClusterMerger.h
+++ b/src/algorithms/calorimetry/CalorimeterClusterMerger.h
@@ -22,7 +22,9 @@ using namespace dd4hep;
 
 class CalorimeterClusterMerger {
 
+protected:
     // Insert any member variables here
+    std::shared_ptr<spdlog::logger> m_log;
 
 public:
     CalorimeterClusterMerger() = default;
@@ -32,8 +34,6 @@ public:
     virtual void AlgorithmProcess() ;
 
     //-------- Configuration Parameters ------------
-    //instantiate new spdlog logger
-    std::shared_ptr<spdlog::logger> m_logger;
 
     //inputs
     std::vector<const edm4eic::Cluster*> m_inputClusters;//{"InputClusters", Gaudi::DataHandle::Reader, this};
@@ -68,14 +68,14 @@ private:
       }
 
       //TODO:spdlog verbosity
-      if ( m_logger->level() <= spdlog::level::debug) {
-        m_logger->debug("--> Cluster {} has MC ID {} and energy", cluster->id(), mcID, cluster->getEnergy());
+      if ( m_log->level() <= spdlog::level::debug) {
+        m_log->debug("--> Cluster {} has MC ID {} and energy", cluster->id(), mcID, cluster->getEnergy());
         //LOG_INFO(default_cout_logger) << " --> Found cluster with mcID " << mcID << " and energy " << cluster->getEnergy() << LOG_END;
       }
 
       if (mcID < 0) {
-        if (m_logger->level() <= spdlog::level::debug) {
-          m_logger->debug("   --> WARNING: no valid MC truth link found, skipping cluster...");
+        if (m_log->level() <= spdlog::level::debug) {
+          m_log->debug("   --> WARNING: no valid MC truth link found, skipping cluster...");
           //LOG_INFO(default_cout_logger) << "   --> WARNING: no valid MC truth link found, skipping cluster..." << LOG_END;
         }
         continue;

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -28,7 +28,7 @@ using namespace dd4hep;
 
 void CalorimeterClusterRecoCoG::AlgorithmInit(std::shared_ptr<spdlog::logger>& logger) {
 
-    m_logger=logger;
+    m_log=logger;
     // update depth correction if a name is provided
     if (m_moduleDimZName != "") {
       m_depthCorrection = m_geoSvc->detector()->constantAsDouble(m_moduleDimZName);
@@ -41,7 +41,7 @@ void CalorimeterClusterRecoCoG::AlgorithmInit(std::shared_ptr<spdlog::logger>& l
     auto it = weightMethods.find(ew);
     if (it == weightMethods.end()) {
       //LOG_ERROR(default_cerr_logger) << fmt::format("Cannot find energy weighting method {}, choose one from [{}]", m_energyWeight, boost::algorithm::join(weightMethods | boost::adaptors::map_keys, ", ")) << LOG_END;
-      m_logger->error("Cannot find energy weighting method {}, choose one from [{}]", m_energyWeight, boost::algorithm::join(weightMethods | boost::adaptors::map_keys, ", "));
+      m_log->error("Cannot find energy weighting method {}, choose one from [{}]", m_energyWeight, boost::algorithm::join(weightMethods | boost::adaptors::map_keys, ", "));
       return;
     }
     weightFunc = it->second;
@@ -76,9 +76,9 @@ void CalorimeterClusterRecoCoG::AlgorithmProcess() {
     for (const auto& pcl : proto) {
       auto cl = reconstruct(pcl);
 
-      if (m_logger->level() <= spdlog::level::debug) {
+      if (m_log->level() <= spdlog::level::debug) {
         //LOG_INFO(default_cout_logger) << cl.getNhits() << " hits: " << cl.getEnergy() / GeV << " GeV, (" << cl.getPosition().x / mm << ", " << cl.getPosition().y / mm << ", " << cl.getPosition().z / mm << ")" << LOG_END;
-        m_logger->debug("{} hits: {} GeV, ({}, {}, {})", cl->getNhits(), cl->getEnergy() / GeV, cl->getPosition().x / mm, cl->getPosition().y / mm, cl->getPosition().z / mm);
+        m_log->debug("{} hits: {} GeV, ({}, {}, {})", cl->getNhits(), cl->getEnergy() / GeV, cl->getPosition().x / mm, cl->getPosition().y / mm, cl->getPosition().z / mm);
       }
       clusters.push_back(cl);
 
@@ -126,18 +126,18 @@ void CalorimeterClusterRecoCoG::AlgorithmProcess() {
         if (!(mchit != mchits.end())) {
           // break if no matching hit found for this CellID
           //LOG_WARN(default_cout_logger) << "Proto-cluster has highest energy in CellID " << pclhit->getCellID() << ", but no mc hit with that CellID was found." << LOG_END;
-          m_logger->warn("Proto-cluster has highest energy in CellID {}, but no mc hit with that CellID was found.", pclhit->getCellID());
+          m_log->warn("Proto-cluster has highest energy in CellID {}, but no mc hit with that CellID was found.", pclhit->getCellID());
           //LOG_INFO(default_cout_logger) << "Proto-cluster hits: " << LOG_END;
-          m_logger->debug("Proto-cluster hits: ");
+          m_log->debug("Proto-cluster hits: ");
           for (const auto& pclhit1: pclhits) {
             //LOG_INFO(default_cout_logger) << pclhit1.getCellID() << ": " << pclhit1.getEnergy() << LOG_END;
-            m_logger->debug("{}: {}", pclhit1.getCellID(), pclhit1.getEnergy());
+            m_log->debug("{}: {}", pclhit1.getCellID(), pclhit1.getEnergy());
           }
           //LOG_INFO(default_cout_logger) << "MC hits: " << LOG_END;
-          m_logger->debug("MC hits: ");
+          m_log->debug("MC hits: ");
           for (const auto& mchit1: mchits) {
             //LOG_INFO(default_cout_logger) << mchit1->getCellID() << ": " << mchit1->getEnergy() << LOG_END;
-            m_logger->debug("{}: {}", mchit1->getCellID(), mchit1->getEnergy());
+            m_log->debug("{}: {}", mchit1->getCellID(), mchit1->getEnergy());
           }
           break;
         }
@@ -146,15 +146,15 @@ void CalorimeterClusterRecoCoG::AlgorithmProcess() {
         const auto& mcp = (*mchit)->getContributions(0).getParticle();
 
         // debug output
-        if (m_logger->level() <= spdlog::level::debug) {
+        if (m_log->level() <= spdlog::level::debug) {
           //LOG_INFO(default_cout_logger) << "cluster has largest energy in cellID: " << pclhit->getCellID() << LOG_END;
-          m_logger->debug("cluster has largest energy in cellID: {}", pclhit->getCellID());
+          m_log->debug("cluster has largest energy in cellID: {}", pclhit->getCellID());
           //LOG_INFO(default_cout_logger) << "pcl hit with highest energy " << pclhit->getEnergy() << " at index " << pclhit->getObjectID().index << LOG_END;
-          m_logger->debug("pcl hit with highest energy {} at index {}", pclhit->getEnergy(), pclhit->getObjectID().index);
+          m_log->debug("pcl hit with highest energy {} at index {}", pclhit->getEnergy(), pclhit->getObjectID().index);
           //LOG_INFO(default_cout_logger) << "corresponding mc hit energy " << (*mchit)->getEnergy() << " at index " << (*mchit)->getObjectID().index << LOG_END;
-          m_logger->debug("corresponding mc hit energy {} at index {}", (*mchit)->getEnergy(), (*mchit)->getObjectID().index);
+          m_log->debug("corresponding mc hit energy {} at index {}", (*mchit)->getEnergy(), (*mchit)->getObjectID().index);
           //LOG_INFO(default_cout_logger) << "from MCParticle index " << mcp.getObjectID().index << ", PDG " << mcp.getPDG() << ", " << edm4eic::magnitude(mcp.getMomentum()) << LOG_END;
-          m_logger->debug("from MCParticle index {}, PDG {}, {}", mcp.getObjectID().index, mcp.getPDG(), edm4eic::magnitude(mcp.getMomentum()));
+          m_log->debug("from MCParticle index {}, PDG {}, {}", mcp.getObjectID().index, mcp.getPDG(), edm4eic::magnitude(mcp.getMomentum()));
         }
 
         // set association
@@ -168,9 +168,9 @@ void CalorimeterClusterRecoCoG::AlgorithmProcess() {
         edm4eic::MCRecoClusterParticleAssociation* cassoc = new edm4eic::MCRecoClusterParticleAssociation(*clusterassoc);
         m_outputAssociations.push_back(cassoc);
       } else {
-        if (m_logger->level() <= spdlog::level::debug) {
+        if (m_log->level() <= spdlog::level::debug) {
           //LOG_INFO(default_cout_logger) << "No mcHitCollection was provided, so no truth association will be performed." << LOG_END;
-          m_logger->debug("No mcHitCollection was provided, so no truth association will be performed.");
+          m_log->debug("No mcHitCollection was provided, so no truth association will be performed.");
         }
       }
     }

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
@@ -54,7 +54,7 @@ public:
 
     //-------- Configuration Parameters ------------
     //instantiate new spdlog logger
-    std::shared_ptr<spdlog::logger> m_logger;
+    std::shared_ptr<spdlog::logger> m_log;
 
 
     std::string m_input_simhit_tag;
@@ -92,9 +92,9 @@ edm4eic::Cluster* reconstruct(const edm4eic::ProtoCluster* pcl) const {
     cl.setNhits(pcl->hits_size());
 
     // no hits
-    if (m_logger->level() <=spdlog::level::debug) {
+    if (m_log->level() <=spdlog::level::debug) {
       //LOG_INFO(default_cout_logger) << "hit size = " << pcl->hits_size() << LOG_END;
-      m_logger->debug("hit size = {}", pcl->hits_size());
+      m_log->debug("hit size = {}", pcl->hits_size());
     }
     if (pcl->hits_size() == 0) {
       return nullptr;
@@ -111,9 +111,9 @@ edm4eic::Cluster* reconstruct(const edm4eic::ProtoCluster* pcl) const {
     for (unsigned i = 0; i < pcl->getHits().size(); ++i) {
       const auto& hit   = pcl->getHits()[i];
       const auto weight = pcl->getWeights()[i];
-      if (m_logger->level() <=spdlog::level::debug) {
+      if (m_log->level() <=spdlog::level::debug) {
         //LOG_INFO(default_cout_logger) << "hit energy = " << hit.getEnergy() << " hit weight: " << weight << LOG_END;
-        m_logger->debug("hit energy = {} hit weight: {}", hit.getEnergy(), weight);
+        m_log->debug("hit energy = {} hit weight: {}", hit.getEnergy(), weight);
       }
       auto energy = hit.getEnergy() * weight;
       totalE += energy;
@@ -145,7 +145,7 @@ edm4eic::Cluster* reconstruct(const edm4eic::ProtoCluster* pcl) const {
     }
     if (tw == 0.) {
       //LOG_WARN(default_cout_logger) << "zero total weights encountered, you may want to adjust your weighting parameter." << LOG_END;
-      m_logger->warn("zero total weights encountered, you may want to adjust your weighting parameter.");
+      m_log->warn("zero total weights encountered, you may want to adjust your weighting parameter.");
     }
     cl.setPosition(v / tw);
     cl.setPositionError({}); // @TODO: Covariance matrix
@@ -160,9 +160,9 @@ edm4eic::Cluster* reconstruct(const edm4eic::ProtoCluster* pcl) const {
         const double newR     = edm4eic::magnitude(cl.getPosition());
         const double newPhi   = edm4eic::angleAzimuthal(cl.getPosition());
         cl.setPosition(edm4eic::sphericalToVector(newR, newTheta, newPhi));
-        if (m_logger->level() <=spdlog::level::debug) {
+        if (m_log->level() <=spdlog::level::debug) {
           //LOG_INFO(default_cout_logger) << "Bound cluster position to contributing hits due to " << (overflow ? "overflow" : "underflow") << LOG_END;
-          m_logger->debug("Bound cluster position to contributing hits due to {}", (overflow ? "overflow" : "underflow"));
+          m_log->debug("Bound cluster position to contributing hits due to {}", (overflow ? "overflow" : "underflow"));
         }
       }
     }

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -55,7 +55,7 @@ void CalorimeterHitDigi::AlgorithmInit(std::shared_ptr<spdlog::logger>& logger) 
     // now, just use default values defined in header file.
 
     // set energy resolution numbers
-    m_logger=logger;
+    m_log=logger;
     for (size_t i = 0; i < u_eRes.size() && i < 3; ++i) {
         eRes[i] = u_eRes[i];
     }
@@ -70,11 +70,11 @@ void CalorimeterHitDigi::AlgorithmInit(std::shared_ptr<spdlog::logger>& logger) 
 
         // sanity checks
         if (!m_geoSvc) {
-            m_logger->error("Unable to locate Geometry Service.");
+            m_log->error("Unable to locate Geometry Service.");
             throw std::runtime_error("Unable to locate Geometry Service.");
         }
         if (m_readout.empty()) {
-            m_logger->error("readoutClass is not provided, it is needed to know the fields in readout ids.");
+            m_log->error("readoutClass is not provided, it is needed to know the fields in readout ids.");
             throw std::runtime_error("readoutClass is not provided.");
         }
 
@@ -92,13 +92,13 @@ void CalorimeterHitDigi::AlgorithmInit(std::shared_ptr<spdlog::logger>& logger) 
             ref_mask = id_desc.encode(ref_fields);
             // debug() << fmt::format("Referece id mask for the fields {:#064b}", ref_mask) << endmsg;
         } catch (...) {
-            m_logger->warn("Failed to load ID decoder for {}", m_readout);
+            m_log->warn("Failed to load ID decoder for {}", m_readout);
             japp->Quit();
             return;
         }
         id_mask = ~id_mask;
         //LOG_INFO(default_cout_logger) << fmt::format("ID mask in {:s}: {:#064b}", m_readout, id_mask) << LOG_END;
-        m_logger->info("ID mask in {:s}: {:#064b}", m_readout, id_mask);
+        m_log->info("ID mask in {:s}: {:#064b}", m_readout, id_mask);
     }
 }
 

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.h
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.h
@@ -35,7 +35,7 @@ public:
 
     //-------- Configuration Parameters ------------
     //instantiate new spdlog logger
-    std::shared_ptr<spdlog::logger> m_logger;
+    std::shared_ptr<spdlog::logger> m_log;
 
     // Name of input data type (collection)
     std::string              m_input_tag;

--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -23,7 +23,7 @@ using namespace dd4hep;
 void CalorimeterHitReco::AlgorithmInit(std::shared_ptr<spdlog::logger>& logger) {
 
     //unitless conversion
-    m_logger=logger;
+    m_log=logger;
     dyRangeADC = m_dyRangeADC * MeV;
     // threshold for firing
     thresholdADC = m_thresholdFactor * m_pedSigmaADC + m_thresholdValue;
@@ -39,7 +39,7 @@ void CalorimeterHitReco::AlgorithmInit(std::shared_ptr<spdlog::logger>& logger) 
     try{
         auto id_spec = m_geoSvc->detector()->readout(m_readout).idSpec();
     }catch(...){
-        m_logger->warn("Failed to get idSpec for {}", m_readout);
+        m_log->warn("Failed to get idSpec for {}", m_readout);
         return;
     }
 
@@ -50,27 +50,27 @@ void CalorimeterHitReco::AlgorithmInit(std::shared_ptr<spdlog::logger>& logger) 
         id_dec = id_spec.decoder();
         if (!m_sectorField.empty()) {
             sector_idx = id_dec->index(m_sectorField);
-            m_logger->info("Find sector field {}, index = {}", m_sectorField, sector_idx);
+            m_log->info("Find sector field {}, index = {}", m_sectorField, sector_idx);
         }
         if (!m_layerField.empty()) {
             layer_idx = id_dec->index(m_layerField);
-            m_logger->info("Find layer field {}, index = {}", m_layerField, sector_idx);
+            m_log->info("Find layer field {}, index = {}", m_layerField, sector_idx);
         }
     } catch (...) {
         if( !id_dec ) {
-            m_logger->warn("Failed to load ID decoder for {}", m_readout);
+            m_log->warn("Failed to load ID decoder for {}", m_readout);
             std::stringstream readouts;
             for (auto r: m_geoSvc->detector()->readouts()) readouts << "\"" << r.first << "\", ";
-            m_logger->warn("Available readouts: {}", readouts.str() );
+            m_log->warn("Available readouts: {}", readouts.str() );
         }else {
-            m_logger->warn("Failed to find field index for {}.", m_readout);
-            if (!m_sectorField.empty()) { m_logger->warn(" -- looking for sector field \"{}\".", m_sectorField); }
-            if (!m_layerField.empty()) { m_logger->warn(" -- looking for layer field  \"{}\".", m_layerField); }
+            m_log->warn("Failed to find field index for {}.", m_readout);
+            if (!m_sectorField.empty()) { m_log->warn(" -- looking for sector field \"{}\".", m_sectorField); }
+            if (!m_layerField.empty()) { m_log->warn(" -- looking for layer field  \"{}\".", m_layerField); }
             std::stringstream fields;
             for (auto field: id_spec.decoder()->fields()) fields << "\"" << field.name() << "\", ";
-            m_logger->warn("Available fields: {}", fields.str() );
-            m_logger->warn("n.b. The local position, sector id and layer id will not be correct for this.");
-            m_logger->warn("however, the position, energy, and time values should still be good.");
+            m_log->warn("Available fields: {}", fields.str() );
+            m_log->warn("n.b. The local position, sector id and layer id will not be correct for this.");
+            m_log->warn("however, the position, energy, and time values should still be good.");
         }
 
         return;
@@ -81,9 +81,9 @@ void CalorimeterHitReco::AlgorithmInit(std::shared_ptr<spdlog::logger>& logger) 
     if (!m_localDetElement.empty()) {
         try {
             local = m_geoSvc->detector()->detector(m_localDetElement);
-            m_logger->info("local coordinate system from DetElement {}", m_localDetElement);
+            m_log->info("local coordinate system from DetElement {}", m_localDetElement);
         } catch (...) {
-            m_logger->error("failed to load local coordinate system from DetElement {}", m_localDetElement);
+            m_log->error("failed to load local coordinate system from DetElement {}", m_localDetElement);
             return;
         }
     } else {
@@ -163,11 +163,11 @@ void CalorimeterHitReco::AlgorithmProcess() {
             // Error looking up cellID. Messages should already have been printed.
             // Also, see comment at top of this method.
             if( ++NcellIDerrors >= MaxCellIDerrors ){
-                m_logger->error("Maximum number of errors reached: {}", MaxCellIDerrors);
-                m_logger->error("This is likely an issue with the cellID being unknown.");
-                m_logger->error("Note: local_mask={:X} example cellID={:x}", local_mask, cellID);
-                m_logger->error("Disabling this algorithm since it requires a valid cellID.");
-                m_logger->error("(See {}:{})", __FILE__,__LINE__);
+                m_log->error("Maximum number of errors reached: {}", MaxCellIDerrors);
+                m_log->error("This is likely an issue with the cellID being unknown.");
+                m_log->error("Note: local_mask={:X} example cellID={:x}", local_mask, cellID);
+                m_log->error("Disabling this algorithm since it requires a valid cellID.");
+                m_log->error("(See {}:{})", __FILE__,__LINE__);
             }
             continue;
         }

--- a/src/algorithms/calorimetry/CalorimeterHitReco.h
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.h
@@ -34,7 +34,7 @@ public:
 
     //-------- Configuration Parameters ------------
     //instantiate new spdlog logger
-    std::shared_ptr<spdlog::logger> m_logger;
+    std::shared_ptr<spdlog::logger> m_log;
     // Name of input data type (collection)
     std::string              m_input_tag;
 

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -51,7 +51,7 @@ void CalorimeterIslandCluster::AlgorithmInit(std::shared_ptr<spdlog::logger>& lo
     // now, just use default values defined in header file.
 
 
-    m_logger=logger;
+    m_log=logger;
     // unitless conversion, keep consistency with juggler internal units (GeV, mm, ns, rad)
     // n.b. JANA reco_parms.py uses units of MeV and mm and so convert to this into internal units here
     minClusterHitEdep    = m_minClusterHitEdep * MeV;
@@ -75,9 +75,9 @@ void CalorimeterIslandCluster::AlgorithmInit(std::shared_ptr<spdlog::logger>& lo
       auto& [method, units] = distMethods[uprop.first];
       if (uprop.second.size() != units.size()) {
         //LOG_INFO(default_cout_logger) << units.size() << LOG_END;
-        m_logger->info("units.size() = {}", units.size());
+        m_log->info("units.size() = {}", units.size());
         //LOG_WARN(default_cout_logger) << fmt::format("Expect {} values from {}, received {}. ignored it.", units.size(), uprop.first,  uprop.second.size())  << LOG_END;
-        m_logger->warn("Expect {} values from {}, received {}. ignored it.", units.size(), uprop.first,  uprop.second.size());
+        m_log->warn("Expect {} values from {}, received {}. ignored it.", units.size(), uprop.first,  uprop.second.size());
         return false;
       } else {
         for (size_t i = 0; i < units.size(); ++i) {
@@ -85,7 +85,7 @@ void CalorimeterIslandCluster::AlgorithmInit(std::shared_ptr<spdlog::logger>& lo
         }
         hitsDist = method;
         //LOG_INFO(default_cout_logger) << fmt::format("Clustering uses {} with distances <= [{}]", uprop.first, fmt::join(neighbourDist, ",")) << LOG_END;
-        m_logger->info("Clustering uses {} with distances <= [{}]", uprop.first, fmt::join(neighbourDist, ","));
+        m_log->info("Clustering uses {} with distances <= [{}]", uprop.first, fmt::join(neighbourDist, ","));
       }
       return true;
     };
@@ -119,7 +119,7 @@ void CalorimeterIslandCluster::AlgorithmInit(std::shared_ptr<spdlog::logger>& lo
     }
     if (not method_found) {
         //LOG_ERROR(default_cerr_logger) << "Cannot determine the clustering coordinates" << LOG_END;
-        m_logger->error("Cannot determine the clustering coordinates");
+        m_log->error("Cannot determine the clustering coordinates");
         japp->Quit();
         return;
     }
@@ -156,10 +156,10 @@ void CalorimeterIslandCluster::AlgorithmProcess()  {
     //TODO: use the right logger
     for (size_t i = 0; i < hits.size(); ++i) {
 
-      if (m_logger->level() <=spdlog::level::debug){//msgLevel(MSG::DEBUG)) {
+      if (m_log->level() <=spdlog::level::debug){//msgLevel(MSG::DEBUG)) {
         const auto& hit = hits[i];
         //LOG_INFO(default_cout_logger) << fmt::format("hit {:d}: energy = {:.4f} MeV, local = ({:.4f}, {:.4f}) mm, global=({:.4f}, {:.4f}, {:.4f}) mm", i, hit->getEnergy() * 1000., hit->getLocal().x, hit->getLocal().y, hit->getPosition().x,  hit->getPosition().y, hit->getPosition().z) << LOG_END;
-        m_logger->info("hit {:d}: energy = {:.4f} MeV, local = ({:.4f}, {:.4f}) mm, global=({:.4f}, {:.4f}, {:.4f}) mm", i, hit->getEnergy() * 1000., hit->getLocal().x, hit->getLocal().y, hit->getPosition().x,  hit->getPosition().y, hit->getPosition().z);
+        m_log->info("hit {:d}: energy = {:.4f} MeV, local = ({:.4f}, {:.4f}) mm, global=({:.4f}, {:.4f}, {:.4f}) mm", i, hit->getEnergy() * 1000., hit->getLocal().x, hit->getLocal().y, hit->getPosition().x,  hit->getPosition().y, hit->getPosition().z);
       }
       // already in a group
       if (visits[i]) {
@@ -178,9 +178,9 @@ void CalorimeterIslandCluster::AlgorithmProcess()  {
       split_group(group, maxima, protoClusters);
       //TODO: use proper logger
 
-      if (m_logger->level() <=spdlog::level::debug){//msgLevel(MSG::DEBUG)) {
+      if (m_log->level() <=spdlog::level::debug){//msgLevel(MSG::DEBUG)) {
         //LOG_INFO(default_cout_logger) << "hits in a group: " << group.size() << ", " << "local maxima: " << maxima.size() << LOG_END;
-        m_logger->info("hits in a group: {}, local maxima: {}", group.size(), maxima.size());
+        m_log->info("hits in a group: {}, local maxima: {}", group.size(), maxima.size());
       }
     }
 

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.h
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.h
@@ -96,7 +96,7 @@ public:
 
     //-------- Configuration Parameters ------------
     //instantiate new spdlog logger
-    std::shared_ptr<spdlog::logger> m_logger;
+    std::shared_ptr<spdlog::logger> m_log;
 
     std::string m_input_tag;
     bool m_splitCluster;//{this, "splitCluster", true};
@@ -230,9 +230,9 @@ private:
                    std::vector<edm4eic::ProtoCluster *>& proto) const {
     // special cases
     if (maxima.empty()) {
-      if (m_logger->level() <= spdlog::level::info){//msgLevel(MSG::VERBOSE)) {
+      if (m_log->level() <= spdlog::level::info){//msgLevel(MSG::VERBOSE)) {
         //LOG_TRACE(default_cout_logger) << "No maxima found, not building any clusters" << LOG_END;
-        m_logger->trace("No maxima found, not building any clusters");
+        m_log->trace("No maxima found, not building any clusters");
       }
       return;
     } else if (maxima.size() == 1) {
@@ -243,7 +243,7 @@ private:
       }
       proto.push_back(new edm4eic::ProtoCluster(pcl)); // TODO: Should we be using clone() here?
 
-      m_logger->debug("A single maximum found, added one ProtoCluster");
+      m_log->debug("A single maximum found, added one ProtoCluster");
 
       return;
     }

--- a/src/algorithms/calorimetry/CalorimeterTruthClustering.cc
+++ b/src/algorithms/calorimetry/CalorimeterTruthClustering.cc
@@ -17,7 +17,9 @@ using namespace dd4hep;
 //------------------------
 // AlgorithmInit
 //------------------------
-void CalorimeterTruthClustering::AlgorithmInit() {
+void CalorimeterTruthClustering::AlgorithmInit(std::shared_ptr<spdlog::logger> &logger) {
+
+    m_log = logger;
 
     return;
 }

--- a/src/algorithms/calorimetry/CalorimeterTruthClustering.h
+++ b/src/algorithms/calorimetry/CalorimeterTruthClustering.h
@@ -13,18 +13,21 @@
 #include <edm4hep/SimCalorimeterHit.h>
 #include <edm4eic/ProtoCluster.h>
 #include <edm4eic/MutableProtoCluster.h>
+#include <spdlog/spdlog.h>
 
 
 using namespace dd4hep;
 
 class CalorimeterTruthClustering {
 
+protected:
     // Insert any member variables here
+    std::shared_ptr<spdlog::logger> m_log;
 
 public:
     CalorimeterTruthClustering() = default;
     ~CalorimeterTruthClustering(){} // better to use smart pointer?
-    virtual void AlgorithmInit() ;
+    virtual void AlgorithmInit(std::shared_ptr<spdlog::logger> &logger) ;
     virtual void AlgorithmChangeRun() ;
     virtual void AlgorithmProcess() ;
 

--- a/src/detectors/B0ECAL/CalorimeterHit_factory_B0ECalRecHits.h
+++ b/src/detectors/B0ECAL/CalorimeterHit_factory_B0ECalRecHits.h
@@ -15,6 +15,7 @@ public:
     // Constructor
     CalorimeterHit_factory_B0ECalRecHits(){
         SetTag("B0ECalRecHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -64,14 +65,6 @@ public:
         app->SetDefaultParameter("B0ECAL:B0ECalRecHits:localDetFields",   u_localDetFields);
         m_geoSvc = app->template GetService<JDD4hep_service>(); // TODO: implement named geometry service?
 
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/B0ECAL/Cluster_factory_B0ECalClusters.h
+++ b/src/detectors/B0ECAL/Cluster_factory_B0ECalClusters.h
@@ -22,6 +22,7 @@ public:
     // Constructor
     Cluster_factory_B0ECalClusters(){
         SetTag("B0ECalClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -52,16 +53,6 @@ public:
         app->SetDefaultParameter("EEMC:B0ECalClusters:enableEtaBounds",   m_enableEtaBounds);
 
         m_geoSvc = app->template GetService<JDD4hep_service>();
-
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
-
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/B0ECAL/Cluster_factory_B0ECalMergedClusters.h
+++ b/src/detectors/B0ECAL/Cluster_factory_B0ECalMergedClusters.h
@@ -21,6 +21,7 @@ public:
     // Constructor
     Cluster_factory_B0ECalMergedClusters(){
         SetTag("B0ECalMergedClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -36,12 +37,6 @@ public:
 
         app->SetDefaultParameter("EEMC:B0ECalMergedClusters:input_tag",      m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("EEMC:B0ECalMergedClusters:inputAssociations_tag",      m_inputAssociations_tag, "Name of input associations collection to use");
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/B0ECAL/ProtoCluster_factory_B0ECalIslandProtoClusters.h
+++ b/src/detectors/B0ECAL/ProtoCluster_factory_B0ECalIslandProtoClusters.h
@@ -19,6 +19,7 @@ public:
     // Constructor
     ProtoCluster_factory_B0ECalIslandProtoClusters(){
         SetTag("B0ECalIslandProtoClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -53,14 +54,6 @@ public:
         app->SetDefaultParameter("B0ECAL:B0ECalIslandProtoClusters:dimScaledLocalDistXY",    u_dimScaledLocalDistXY);
         m_geoSvc = app->template GetService<JDD4hep_service>();
 
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/B0ECAL/ProtoCluster_factory_B0ECalTruthProtoClusters.h
+++ b/src/detectors/B0ECAL/ProtoCluster_factory_B0ECalTruthProtoClusters.h
@@ -19,6 +19,7 @@ public:
     // Constructor
     ProtoCluster_factory_B0ECalTruthProtoClusters(){
         SetTag("B0ECalTruthProtoClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -30,7 +31,7 @@ public:
 
         app->SetDefaultParameter("EEMC:B0ECalTruthProtoClusters:inputHit_tag",        m_inputHit_tag, "Name of input collection to use");
 
-        AlgorithmInit();
+        AlgorithmInit(m_log);
     }
 
     //------------------------------------------

--- a/src/detectors/B0ECAL/RawCalorimeterHit_factory_B0ECalRawHits.h
+++ b/src/detectors/B0ECAL/RawCalorimeterHit_factory_B0ECalRawHits.h
@@ -27,6 +27,7 @@ public:
     // Constructor
     RawCalorimeterHit_factory_B0ECalRawHits() {
         SetTag("B0ECalRawHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -68,14 +69,6 @@ public:
         app->SetDefaultParameter("B0ECAL:B0ECalRawHits:readoutClass",     m_readout);
 
         // Call Init for generic algorithm
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/B0ECAL/TruthCluster_factory_B0ECalTruthProtoClusters.h
+++ b/src/detectors/B0ECAL/TruthCluster_factory_B0ECalTruthProtoClusters.h
@@ -17,6 +17,7 @@ public:
     // Constructor
     TruthCluster_factory_B0ECalTruthProtoClusters(){
         SetTag("B0ECalTruthProtoClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -28,7 +29,7 @@ public:
 
         app->SetDefaultParameter("EEMC:B0ECalTruthProtoClusters:inputHit_tag",        m_inputHit_tag, "Name of input collection to use");
 
-        AlgorithmInit();
+        AlgorithmInit(m_log);
     }
 
     //------------------------------------------

--- a/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelImagingRecHits.h
+++ b/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelImagingRecHits.h
@@ -19,6 +19,7 @@ public:
     // Constructor
     CalorimeterHit_factory_EcalBarrelImagingRecHits(){
         SetTag("EcalBarrelImagingRecHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -51,14 +52,6 @@ public:
         app->SetDefaultParameter("BEMC:EcalBarrelImagingRecHits:samplingFraction", m_sampFrac);
         m_geoSvc = app->template GetService<JDD4hep_service>(); // TODO: implement named geometry service?
 
-        std::string tag=this->GetTag();
-        m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
 
         initialize();
     }

--- a/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelScFiMergedHits.h
+++ b/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelScFiMergedHits.h
@@ -14,6 +14,7 @@ public:
     // Constructor
     CalorimeterHit_factory_EcalBarrelScFiMergedHits(){
         SetTag("EcalBarrelScFiMergedHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------

--- a/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelScFiRecHits.h
+++ b/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelScFiRecHits.h
@@ -15,6 +15,7 @@ public:
     // Constructor
     CalorimeterHit_factory_EcalBarrelScFiRecHits(){
         SetTag("EcalBarrelScFiRecHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -59,14 +60,6 @@ public:
         app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:samplingFraction", m_sampFrac);
         m_geoSvc = app->template GetService<JDD4hep_service>(); // TODO: implement named geometry service?
 
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelSciGlassRecHits.h
+++ b/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelSciGlassRecHits.h
@@ -15,6 +15,7 @@ public:
     // Constructor
     CalorimeterHit_factory_EcalBarrelSciGlassRecHits(){
         SetTag("EcalBarrelSciGlassRecHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -59,14 +60,6 @@ public:
         app->SetDefaultParameter("BEMC:EcalBarrelSciGlassRecHits:samplingFraction", m_sampFrac);
         m_geoSvc = app->template GetService<JDD4hep_service>(); // TODO: implement named geometry service?
 
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelImagingClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelImagingClusters.h
@@ -26,6 +26,7 @@ public:
     // Constructor
     Cluster_factory_EcalBarrelImagingClusters(){
         SetTag("EcalBarrelImagingClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -39,10 +40,6 @@ public:
 
         app->SetDefaultParameter("BEMC:EcalBarrelImagingClusters:input_protoclust_tag",        m_input_protoclust_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelImagingClusters:trackStopLayer",  m_trackStopLayer);
-
-
-        std::string tag=this->GetTag();
-        m_log = app->GetService<Log_service>()->logger(tag);
 
         initialize();
     }

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelImagingMergedClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelImagingMergedClusters.h
@@ -19,6 +19,7 @@ public:
     // Constructor
     Cluster_factory_EcalBarrelImagingMergedClusters(){
         SetTag("EcalBarrelImagingMergedClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -37,8 +38,6 @@ public:
         app->SetDefaultParameter("BEMC:EcalBarrelImagingMergedClusters:energyAssociation_tag", m_energyAssociation_tag);
         app->SetDefaultParameter("BEMC:EcalBarrelImagingMergedClusters:positionClusters_tag", m_positionClusters_tag);
         app->SetDefaultParameter("BEMC:EcalBarrelImagingMergedClusters:positionAssociations_tag", m_positionAssociations_tag);
-
-        m_log = app->GetService<Log_service>()->logger(GetTag());
 
         initialize();
     }

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelScFiClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelScFiClusters.h
@@ -22,6 +22,7 @@ public:
     // Constructor
     Cluster_factory_EcalBarrelScFiClusters(){
         SetTag("EcalBarrelScFiClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -52,16 +53,6 @@ public:
         app->SetDefaultParameter("BEMC:EcalBarrelScFiClusters:enableEtaBounds",   m_enableEtaBounds);
 
         m_geoSvc = app->template GetService<JDD4hep_service>();
-
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
-
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelSciGlassClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelSciGlassClusters.h
@@ -22,6 +22,7 @@ public:
     // Constructor
     Cluster_factory_EcalBarrelSciGlassClusters(){
         SetTag("EcalBarrelSciGlassClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -54,16 +55,6 @@ public:
         app->SetDefaultParameter("BEMC:EcalBarrelSciGlassClusters:enableEtaBounds",   m_enableEtaBounds);
 
         m_geoSvc = app->template GetService<JDD4hep_service>();
-
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
-
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelSciGlassMergedClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelSciGlassMergedClusters.h
@@ -20,6 +20,7 @@ public:
     // Constructor
     Cluster_factory_EcalBarrelSciGlassMergedClusters(){
         SetTag("EcalBarrelSciGlassMergedClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -35,12 +36,6 @@ public:
 
         app->SetDefaultParameter("BEMC:EcalBarrelSciGlassMergedClusters:input_tag", m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelSciGlassMergedClusters:inputAssociations_tag", m_inputAssociations_tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelSciGlassMergedTruthClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelSciGlassMergedTruthClusters.h
@@ -20,6 +20,7 @@ public:
     // Constructor
     Cluster_factory_EcalBarrelSciGlassMergedTruthClusters(){
         SetTag("EcalBarrelSciGlassMergedTruthClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -35,12 +36,6 @@ public:
 
         app->SetDefaultParameter("BEMC:EcalBarrelMergedSciGlassTruthClusters:input_tag", m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelMergedSciGlassTruthClusters:inputAssociations_tag", m_inputAssociations_tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelSciGlassTruthClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelSciGlassTruthClusters.h
@@ -20,6 +20,7 @@ public:
     // Constructor
     Cluster_factory_EcalBarrelSciGlassTruthClusters(){
         SetTag("EcalBarrelSciGlassTruthClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -50,16 +51,6 @@ public:
         app->SetDefaultParameter("BEMC:EcalBarrelSciGlassTruthClusters:enableEtaBounds",   m_enableEtaBounds);
 
         m_geoSvc = app->template GetService<JDD4hep_service>();
-
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
-
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelImagingProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelImagingProtoClusters.h
@@ -22,6 +22,7 @@ public:
     // Constructor
     ProtoCluster_factory_EcalBarrelImagingProtoClusters(){
         SetTag("EcalBarrelImagingProtoClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -47,9 +48,6 @@ public:
         app->SetDefaultParameter("BEMC:EcalBarrelImagingProtoClusters::minClusterCenterEdep",    m_minClusterCenterEdep);
         app->SetDefaultParameter("BEMC:EcalBarrelImagingProtoClusters::minClusterEdep",    m_minClusterEdep);
         app->SetDefaultParameter("BEMC:EcalBarrelImagingProtoClusters::minClusterNhits",    m_minClusterNhits);
-
-        std::string tag=this->GetTag();
-        m_log = app->GetService<Log_service>()->logger(tag);
 
         initialize();
     }

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelScFiProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelScFiProtoClusters.h
@@ -20,6 +20,7 @@ public:
     // Constructor
     ProtoCluster_factory_EcalBarrelScFiProtoClusters(){
         SetTag("EcalBarrelScFiProtoClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -54,14 +55,6 @@ public:
         app->SetDefaultParameter("BEMC:EcalBarrelScFiProtoClusters:dimScaledLocalDistXY",    u_dimScaledLocalDistXY);
         m_geoSvc = app->template GetService<JDD4hep_service>();
 
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
@@ -20,6 +20,7 @@ public:
     // Constructor
     ProtoCluster_factory_EcalBarrelSciGlassProtoClusters(){
         SetTag("EcalBarrelSciGlassProtoClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -54,14 +55,6 @@ public:
         app->SetDefaultParameter("BEMC:EcalBarrelSciGlassProtoClusters:dimScaledLocalDistXY",    u_dimScaledLocalDistXY);
         m_geoSvc = app->template GetService<JDD4hep_service>();
 
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelTruthSciGlassProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelTruthSciGlassProtoClusters.h
@@ -20,6 +20,7 @@ public:
     // Constructor
     ProtoCluster_factory_EcalBarrelTruthSciGlassProtoClusters(){
         SetTag("EcalBarrelTruthSciGlassProtoClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -31,7 +32,7 @@ public:
 
         app->SetDefaultParameter("BEMC:EcalBarrelTruthSciGlassProtoClusters:inputHit_tag", m_inputHit_tag, "Name of input collection to use");
 
-        AlgorithmInit();
+        AlgorithmInit(m_log);
     }
 
     //------------------------------------------

--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelImagingRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelImagingRawHits.h
@@ -27,6 +27,7 @@ public:
     // Constructor
     RawCalorimeterHit_factory_EcalBarrelImagingRawHits() {
         SetTag("EcalBarrelImagingRawHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -64,15 +65,7 @@ public:
         app->SetDefaultParameter("BEMC:EcalBarrelImagingRawHits:readoutClass",     m_readout);
 
         // Call Init for generic algorithm
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> logger = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        logger->set_level(eicrecon::ParseLogLevel(log_level_str));
-        AlgorithmInit(logger);
+        AlgorithmInit(m_log);
     }
 
     //------------------------------------------

--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelScFiRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelScFiRawHits.h
@@ -27,6 +27,7 @@ public:
     // Constructor
     RawCalorimeterHit_factory_EcalBarrelScFiRawHits() {
         SetTag("EcalBarrelScFiRawHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -65,14 +66,6 @@ public:
         app->SetDefaultParameter("BEMC:EcalBarrelScFiRawHits:readoutClass",     m_readout);
 
         // Call Init for generic algorithm
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelSciGlassRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelSciGlassRawHits.h
@@ -27,6 +27,7 @@ public:
     // Constructor
     RawCalorimeterHit_factory_EcalBarrelSciGlassRawHits() {
         SetTag("EcalBarrelSciGlassRawHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -69,14 +70,6 @@ public:
         app->SetDefaultParameter("BEMC:EcalBarrelSciGlassRawHits:readoutClass",     m_readout);
 
         // Call Init for generic algorithm
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/EEMC/CalorimeterHit_factory_EcalEndcapNRecHits.h
+++ b/src/detectors/EEMC/CalorimeterHit_factory_EcalEndcapNRecHits.h
@@ -15,6 +15,7 @@ public:
     // Constructor
     CalorimeterHit_factory_EcalEndcapNRecHits(){
         SetTag("EcalEndcapNRecHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -65,14 +66,6 @@ public:
         app->SetDefaultParameter("EEMC:EcalEndcapNRecHits:localDetFields",   u_localDetFields);
         m_geoSvc = app->template GetService<JDD4hep_service>(); // TODO: implement named geometry service?
 
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/EEMC/CalorimeterHit_factory_EcalEndcapPInsertRecHits.h
+++ b/src/detectors/EEMC/CalorimeterHit_factory_EcalEndcapPInsertRecHits.h
@@ -14,6 +14,7 @@ public:
     // Constructor
     CalorimeterHit_factory_EcalEndcapPInsertRecHits(){
         SetTag("EcalEndcapPInsertRecHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -64,14 +65,6 @@ public:
         app->SetDefaultParameter("EEMC:EcalEndcapPInsertRecHits:localDetFields",   u_localDetFields);
         m_geoSvc = app->template GetService<JDD4hep_service>(); // TODO: implement named geometry service?
 
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/EEMC/CalorimeterHit_factory_EcalEndcapPRecHits.h
+++ b/src/detectors/EEMC/CalorimeterHit_factory_EcalEndcapPRecHits.h
@@ -14,6 +14,7 @@ public:
     // Constructor
     CalorimeterHit_factory_EcalEndcapPRecHits(){
         SetTag("EcalEndcapPRecHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -64,14 +65,6 @@ public:
         app->SetDefaultParameter("EEMC:EcalEndcapPRecHits:localDetFields",   u_localDetFields);
         m_geoSvc = app->template GetService<JDD4hep_service>(); // TODO: implement named geometry service?
 
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/EEMC/Cluster_factory_EcalEndcapNClusters.h
+++ b/src/detectors/EEMC/Cluster_factory_EcalEndcapNClusters.h
@@ -35,6 +35,7 @@ public:
     // Constructor
     Cluster_factory_EcalEndcapNClusters(){
         SetTag("EcalEndcapNClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -65,16 +66,6 @@ public:
         app->SetDefaultParameter("EEMC:EcalEndcapNClusters:enableEtaBounds",   m_enableEtaBounds);
 
         m_geoSvc = app->template GetService<JDD4hep_service>();
-
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
-
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/EEMC/Cluster_factory_EcalEndcapNMergedClusters.h
+++ b/src/detectors/EEMC/Cluster_factory_EcalEndcapNMergedClusters.h
@@ -34,6 +34,7 @@ public:
     // Constructor
     Cluster_factory_EcalEndcapNMergedClusters(){
         SetTag("EcalEndcapNMergedClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -49,12 +50,6 @@ public:
 
         app->SetDefaultParameter("EEMC:EcalEndcapNMergedClusters:input_tag",      m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("EEMC:EcalEndcapNMergedClusters:inputAssociations_tag",      m_inputAssociations_tag, "Name of input associations collection to use");
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/EEMC/Cluster_factory_EcalEndcapNTruthClusters.h
+++ b/src/detectors/EEMC/Cluster_factory_EcalEndcapNTruthClusters.h
@@ -34,6 +34,7 @@ public:
     // Constructor
     Cluster_factory_EcalEndcapNTruthClusters(){
         SetTag("EcalEndcapNTruthClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -64,16 +65,6 @@ public:
         app->SetDefaultParameter("EEMC:EcalEndcapNTruthClusters:enableEtaBounds",   m_enableEtaBounds);
 
         m_geoSvc = app->template GetService<JDD4hep_service>();
-
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
-
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/EEMC/Cluster_factory_EcalEndcapPClusters.h
+++ b/src/detectors/EEMC/Cluster_factory_EcalEndcapPClusters.h
@@ -34,6 +34,7 @@ public:
     // Constructor
     Cluster_factory_EcalEndcapPClusters(){
         SetTag("EcalEndcapPClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -64,16 +65,6 @@ public:
         app->SetDefaultParameter("EEMC:EcalEndcapPClusters:enableEtaBounds",   m_enableEtaBounds);
 
         m_geoSvc = app->template GetService<JDD4hep_service>();
-
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
-
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/EEMC/Cluster_factory_EcalEndcapPInsertClusters.h
+++ b/src/detectors/EEMC/Cluster_factory_EcalEndcapPInsertClusters.h
@@ -34,6 +34,7 @@ public:
     // Constructor
     Cluster_factory_EcalEndcapPInsertClusters(){
         SetTag("EcalEndcapPInsertClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -64,16 +65,6 @@ public:
         app->SetDefaultParameter("EEMC:EcalEndcapPInsertClusters:enableEtaBounds",   m_enableEtaBounds);
 
         m_geoSvc = app->template GetService<JDD4hep_service>();
-
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
-
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/EEMC/Cluster_factory_EcalEndcapPInsertMergedClusters.h
+++ b/src/detectors/EEMC/Cluster_factory_EcalEndcapPInsertMergedClusters.h
@@ -34,6 +34,7 @@ public:
     // Constructor
     Cluster_factory_EcalEndcapPInsertMergedClusters(){
         SetTag("EcalEndcapPInsertMergedClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -44,17 +45,8 @@ public:
         m_input_tag="EcalEndcapPInsertClusters";
         m_inputAssociations_tag="EcalEndcapPInsertClustersAssociations";
 
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
         app->SetDefaultParameter("EEMC:EcalEndcapPInsertMergedClusters:input_tag",      m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("EEMC:EcalEndcapPInsertMergedClusters:inputAssociations_tag",      m_inputAssociations_tag, "Name of input associations collection to use");
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/EEMC/Cluster_factory_EcalEndcapPInsertTruthClusters.h
+++ b/src/detectors/EEMC/Cluster_factory_EcalEndcapPInsertTruthClusters.h
@@ -34,6 +34,7 @@ public:
     // Constructor
     Cluster_factory_EcalEndcapPInsertTruthClusters(){
         SetTag("EcalEndcapPInsertTruthClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -64,16 +65,6 @@ public:
         app->SetDefaultParameter("EEMC:EcalEndcapPInsertTruthClusters:enableEtaBounds",   m_enableEtaBounds);
 
         m_geoSvc = app->template GetService<JDD4hep_service>();
-
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
-
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/EEMC/Cluster_factory_EcalEndcapPMergedClusters.h
+++ b/src/detectors/EEMC/Cluster_factory_EcalEndcapPMergedClusters.h
@@ -34,6 +34,7 @@ public:
     // Constructor
     Cluster_factory_EcalEndcapPMergedClusters(){
         SetTag("EcalEndcapPMergedClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -44,17 +45,8 @@ public:
         m_input_tag="EcalEndcapPClusters";
         m_inputAssociations_tag="EcalEndcapPClustersAssociations";
 
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
         app->SetDefaultParameter("EEMC:EcalEndcapPMergedClusters:input_tag",      m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("EEMC:EcalEndcapPMergedClusters:inputAssociations_tag",      m_inputAssociations_tag, "Name of input associations collection to use");
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/EEMC/Cluster_factory_EcalEndcapPTruthClusters.h
+++ b/src/detectors/EEMC/Cluster_factory_EcalEndcapPTruthClusters.h
@@ -34,6 +34,7 @@ public:
     // Constructor
     Cluster_factory_EcalEndcapPTruthClusters(){
         SetTag("EcalEndcapPTruthClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -64,16 +65,6 @@ public:
         app->SetDefaultParameter("EEMC:EcalEndcapPTruthClusters:enableEtaBounds",   m_enableEtaBounds);
 
         m_geoSvc = app->template GetService<JDD4hep_service>();
-
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
-
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapNIslandProtoClusters.h
+++ b/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapNIslandProtoClusters.h
@@ -19,6 +19,7 @@ public:
     // Constructor
     ProtoCluster_factory_EcalEndcapNIslandProtoClusters(){
         SetTag("EcalEndcapNIslandProtoClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -54,14 +55,6 @@ public:
         app->SetDefaultParameter("EEMC:EcalEndcapNIslandProtoClusters:dimScaledLocalDistXY",    u_dimScaledLocalDistXY);
         m_geoSvc = app->template GetService<JDD4hep_service>();
 
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapNTruthProtoClusters.h
+++ b/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapNTruthProtoClusters.h
@@ -19,6 +19,7 @@ public:
     // Constructor
     ProtoCluster_factory_EcalEndcapNTruthProtoClusters(){
         SetTag("EcalEndcapNTruthProtoClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -30,7 +31,7 @@ public:
 
         app->SetDefaultParameter("EEMC:EcalEndcapNTruthProtoClusters:inputHit_tag",        m_inputHit_tag, "Name of input collection to use");
 
-        AlgorithmInit();
+        AlgorithmInit(m_log);
     }
 
     //------------------------------------------

--- a/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapPInsertIslandProtoClusters.h
+++ b/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapPInsertIslandProtoClusters.h
@@ -19,6 +19,7 @@ public:
     // Constructor
     ProtoCluster_factory_EcalEndcapPInsertIslandProtoClusters(){
         SetTag("EcalEndcapPInsertIslandProtoClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -54,14 +55,6 @@ public:
         app->SetDefaultParameter("EEMC:EcalEndcapPInsertClusters:dimScaledLocalDistXY",    u_dimScaledLocalDistXY);
         m_geoSvc = app->template GetService<JDD4hep_service>();
 
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapPInsertTruthProtoClusters.h
+++ b/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapPInsertTruthProtoClusters.h
@@ -19,6 +19,7 @@ public:
     // Constructor
     ProtoCluster_factory_EcalEndcapPInsertTruthProtoClusters(){
         SetTag("EcalEndcapPInsertTruthProtoClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -30,7 +31,7 @@ public:
 
         app->SetDefaultParameter("EEMC:EcalEndcapPInsertTruthProtoClusters:inputHit_tag",        m_inputHit_tag, "Name of input collection to use");
 
-        AlgorithmInit();
+        AlgorithmInit(m_log);
     }
 
     //------------------------------------------

--- a/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapPIslandProtoClusters.h
+++ b/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapPIslandProtoClusters.h
@@ -19,6 +19,7 @@ public:
     // Constructor
     ProtoCluster_factory_EcalEndcapPIslandProtoClusters(){
         SetTag("EcalEndcapPIslandProtoClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -54,14 +55,6 @@ public:
         app->SetDefaultParameter("EEMC:EcalEndcapPClusters:dimScaledLocalDistXY",    u_dimScaledLocalDistXY);
         m_geoSvc = app->template GetService<JDD4hep_service>();
 
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapPTruthProtoClusters.h
+++ b/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapPTruthProtoClusters.h
@@ -19,6 +19,7 @@ public:
     // Constructor
     ProtoCluster_factory_EcalEndcapPTruthProtoClusters(){
         SetTag("EcalEndcapPTruthProtoClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -30,7 +31,7 @@ public:
 
         app->SetDefaultParameter("EEMC:EcalEndcapPTruthProtoClusters:inputHit_tag",        m_inputHit_tag, "Name of input collection to use");
 
-        AlgorithmInit();
+        AlgorithmInit(m_log);
     }
 
     //------------------------------------------

--- a/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapNRawHits.h
+++ b/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapNRawHits.h
@@ -27,6 +27,7 @@ public:
     // Constructor
     RawCalorimeterHit_factory_EcalEndcapNRawHits() {
         SetTag("EcalEndcapNRawHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -68,15 +69,6 @@ public:
         app->SetDefaultParameter("EEMC:EcalEndcapNRawHits:geoServiceName",   m_geoSvcName);
         app->SetDefaultParameter("EEMC:EcalEndcapNRawHits:readoutClass",     m_readout);
 
-        // Call Init for generic algorithm
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapPInsertRawHits.h
+++ b/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapPInsertRawHits.h
@@ -27,6 +27,7 @@ public:
     // Constructor
     RawCalorimeterHit_factory_EcalEndcapPInsertRawHits() {
         SetTag("EcalEndcapPInsertRawHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -67,14 +68,6 @@ public:
         app->SetDefaultParameter("EEMC:EcalEndcapPInsertRawHits:readoutClass",     m_readout);
 
         // Call Init for generic algorithm
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapPRawHits.h
+++ b/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapPRawHits.h
@@ -27,6 +27,7 @@ public:
     // Constructor
     RawCalorimeterHit_factory_EcalEndcapPRawHits() {
         SetTag("EcalEndcapPRawHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -67,14 +68,6 @@ public:
         app->SetDefaultParameter("EEMC:EcalEndcapPRawHits:readoutClass",     m_readout);
 
         // Call Init for generic algorithm
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/HCAL/CalorimeterHit_factory_HcalBarrelMergedHits.h
+++ b/src/detectors/HCAL/CalorimeterHit_factory_HcalBarrelMergedHits.h
@@ -14,13 +14,13 @@ public:
     // Constructor
     CalorimeterHit_factory_HcalBarrelMergedHits(){
         SetTag("HcalBarrelMergedHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_log = app->GetService<Log_service>()->logger(GetTag());
 
         m_input_tag = "HcalBarrelRecHits";
 

--- a/src/detectors/HCAL/CalorimeterHit_factory_HcalBarrelRecHits.h
+++ b/src/detectors/HCAL/CalorimeterHit_factory_HcalBarrelRecHits.h
@@ -15,6 +15,7 @@ public:
     // Constructor
     CalorimeterHit_factory_HcalBarrelRecHits(){
         SetTag("HcalBarrelRecHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -64,14 +65,6 @@ public:
         app->SetDefaultParameter("HCAL:HcalBarrelRecHits:localDetFields",   u_localDetFields);
         m_geoSvc = app->template GetService<JDD4hep_service>(); // TODO: implement named geometry service?
 
-        std::string tag=this->GetTag();
-        m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/HCAL/CalorimeterHit_factory_HcalEndcapNMergedHits.h
+++ b/src/detectors/HCAL/CalorimeterHit_factory_HcalEndcapNMergedHits.h
@@ -14,6 +14,7 @@ public:
     // Constructor
     CalorimeterHit_factory_HcalEndcapNMergedHits(){
         SetTag("HcalEndcapNMergedHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------

--- a/src/detectors/HCAL/CalorimeterHit_factory_HcalEndcapNRecHits.h
+++ b/src/detectors/HCAL/CalorimeterHit_factory_HcalEndcapNRecHits.h
@@ -15,6 +15,7 @@ public:
     // Constructor
     CalorimeterHit_factory_HcalEndcapNRecHits(){
         SetTag("HcalEndcapNRecHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -64,14 +65,6 @@ public:
         app->SetDefaultParameter("HCAL:HcalEndcapNRecHits:localDetFields",   u_localDetFields);
         m_geoSvc = app->template GetService<JDD4hep_service>(); // TODO: implement named geometry service?
 
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/HCAL/CalorimeterHit_factory_HcalEndcapPInsertMergedHits.h
+++ b/src/detectors/HCAL/CalorimeterHit_factory_HcalEndcapPInsertMergedHits.h
@@ -14,6 +14,7 @@ public:
     // Constructor
     CalorimeterHit_factory_HcalEndcapPInsertMergedHits(){
         SetTag("HcalEndcapPInsertMergedHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------

--- a/src/detectors/HCAL/CalorimeterHit_factory_HcalEndcapPInsertRecHits.h
+++ b/src/detectors/HCAL/CalorimeterHit_factory_HcalEndcapPInsertRecHits.h
@@ -15,6 +15,7 @@ public:
     // Constructor
     CalorimeterHit_factory_HcalEndcapPInsertRecHits(){
         SetTag("HcalEndcapPInsertRecHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -64,14 +65,6 @@ public:
         app->SetDefaultParameter("HCAL:HcalEndcapPInsertRecHits:localDetFields",   u_localDetFields);
         m_geoSvc = app->template GetService<JDD4hep_service>(); // TODO: implement named geometry service?
 
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/HCAL/CalorimeterHit_factory_HcalEndcapPMergedHits.h
+++ b/src/detectors/HCAL/CalorimeterHit_factory_HcalEndcapPMergedHits.h
@@ -14,6 +14,7 @@ public:
     // Constructor
     CalorimeterHit_factory_HcalEndcapPMergedHits(){
         SetTag("HcalEndcapPMergedHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------

--- a/src/detectors/HCAL/CalorimeterHit_factory_HcalEndcapPRecHits.h
+++ b/src/detectors/HCAL/CalorimeterHit_factory_HcalEndcapPRecHits.h
@@ -15,6 +15,7 @@ public:
     // Constructor
     CalorimeterHit_factory_HcalEndcapPRecHits(){
         SetTag("HcalEndcapPRecHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -64,14 +65,6 @@ public:
         app->SetDefaultParameter("HCAL:HcalEndcapPRecHits:localDetFields",   u_localDetFields);
         m_geoSvc = app->template GetService<JDD4hep_service>(); // TODO: implement named geometry service?
 
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/HCAL/Cluster_factory_HcalBarrelClusters.h
+++ b/src/detectors/HCAL/Cluster_factory_HcalBarrelClusters.h
@@ -22,6 +22,7 @@ public:
     // Constructor
     Cluster_factory_HcalBarrelClusters(){
         SetTag("HcalBarrelClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -53,16 +54,6 @@ public:
         app->SetDefaultParameter("HCAL:HcalBarrelClusters:enableEtaBounds",   m_enableEtaBounds);
 
         m_geoSvc = app->template GetService<JDD4hep_service>();
-
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
-
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/HCAL/Cluster_factory_HcalBarrelTruthClusters.h
+++ b/src/detectors/HCAL/Cluster_factory_HcalBarrelTruthClusters.h
@@ -20,6 +20,7 @@ public:
     // Constructor
     Cluster_factory_HcalBarrelTruthClusters(){
         SetTag("HcalBarrelTruthClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -51,16 +52,6 @@ public:
         app->SetDefaultParameter("HCAL:HcalBarrelTruthClusters:enableEtaBounds",   m_enableEtaBounds);
 
         m_geoSvc = app->template GetService<JDD4hep_service>();
-
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
-
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/HCAL/Cluster_factory_HcalEndcapNClusters.h
+++ b/src/detectors/HCAL/Cluster_factory_HcalEndcapNClusters.h
@@ -21,6 +21,7 @@ public:
     // Constructor
     Cluster_factory_HcalEndcapNClusters(){
         SetTag("HcalEndcapNClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -52,16 +53,6 @@ public:
         app->SetDefaultParameter("HCAL:HcalEndcapNClusters:enableEtaBounds",   m_enableEtaBounds);
 
         m_geoSvc = app->template GetService<JDD4hep_service>();
-
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
-
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/HCAL/Cluster_factory_HcalEndcapNTruthClusters.h
+++ b/src/detectors/HCAL/Cluster_factory_HcalEndcapNTruthClusters.h
@@ -20,6 +20,7 @@ public:
     // Constructor
     Cluster_factory_HcalEndcapNTruthClusters(){
         SetTag("HcalEndcapNTruthClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -51,16 +52,6 @@ public:
         app->SetDefaultParameter("HCAL:HcalEndcapNTruthClusters:enableEtaBounds",   m_enableEtaBounds);
 
         m_geoSvc = app->template GetService<JDD4hep_service>();
-
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
-
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/HCAL/Cluster_factory_HcalEndcapPClusters.h
+++ b/src/detectors/HCAL/Cluster_factory_HcalEndcapPClusters.h
@@ -21,6 +21,7 @@ public:
     // Constructor
     Cluster_factory_HcalEndcapPClusters(){
         SetTag("HcalEndcapPClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -52,16 +53,6 @@ public:
         app->SetDefaultParameter("HCAL:HcalEndcapPClusters:enableEtaBounds",   m_enableEtaBounds);
 
         m_geoSvc = app->template GetService<JDD4hep_service>();
-
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
-
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/HCAL/Cluster_factory_HcalEndcapPInsertClusters.h
+++ b/src/detectors/HCAL/Cluster_factory_HcalEndcapPInsertClusters.h
@@ -21,6 +21,7 @@ public:
     // Constructor
     Cluster_factory_HcalEndcapPInsertClusters(){
         SetTag("HcalEndcapPInsertClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -52,16 +53,6 @@ public:
         app->SetDefaultParameter("HCAL:HcalEndcapPInsertClusters:enableEtaBounds",   m_enableEtaBounds);
 
         m_geoSvc = app->template GetService<JDD4hep_service>();
-
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
-
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/HCAL/Cluster_factory_HcalEndcapPInsertTruthClusters.h
+++ b/src/detectors/HCAL/Cluster_factory_HcalEndcapPInsertTruthClusters.h
@@ -20,6 +20,7 @@ public:
     // Constructor
     Cluster_factory_HcalEndcapPInsertTruthClusters(){
         SetTag("HcalEndcapPInsertTruthClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -51,16 +52,6 @@ public:
         app->SetDefaultParameter("HCAL:HcalEndcapPInsertTruthClusters:enableEtaBounds",   m_enableEtaBounds);
 
         m_geoSvc = app->template GetService<JDD4hep_service>();
-
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
-
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/HCAL/Cluster_factory_HcalEndcapPTruthClusters.h
+++ b/src/detectors/HCAL/Cluster_factory_HcalEndcapPTruthClusters.h
@@ -20,6 +20,7 @@ public:
     // Constructor
     Cluster_factory_HcalEndcapPTruthClusters(){
         SetTag("HcalEndcapPTruthClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -51,16 +52,6 @@ public:
         app->SetDefaultParameter("HCAL:HcalEndcapPTruthClusters:enableEtaBounds",   m_enableEtaBounds);
 
         m_geoSvc = app->template GetService<JDD4hep_service>();
-
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
-
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/HCAL/ProtoCluster_factory_HcalBarrelIslandProtoClusters.h
+++ b/src/detectors/HCAL/ProtoCluster_factory_HcalBarrelIslandProtoClusters.h
@@ -19,6 +19,7 @@ public:
     // Constructor
     ProtoCluster_factory_HcalBarrelIslandProtoClusters(){
         SetTag("HcalBarrelIslandProtoClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -53,14 +54,6 @@ public:
         app->SetDefaultParameter("HCAL:HcalBarrelIslandProtoClusters:dimScaledLocalDistXY",    u_dimScaledLocalDistXY);
         m_geoSvc = app->template GetService<JDD4hep_service>();
 
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/HCAL/ProtoCluster_factory_HcalBarrelTruthProtoClusters.h
+++ b/src/detectors/HCAL/ProtoCluster_factory_HcalBarrelTruthProtoClusters.h
@@ -21,6 +21,7 @@ public:
     // Constructor
     ProtoCluster_factory_HcalBarrelTruthProtoClusters(){
         SetTag("HcalBarrelTruthProtoClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -30,9 +31,7 @@ public:
         m_inputHit_tag="HcalBarrelRecHits";
         m_inputMCHit_tag="HcalBarrelHits";
 
-        m_log = app->GetService<Log_service>()->logger("HcalBarrelTruthProtoClusters");
-
-        AlgorithmInit();
+        AlgorithmInit(m_log);
     }
 
     //------------------------------------------

--- a/src/detectors/HCAL/ProtoCluster_factory_HcalEndcapNIslandProtoClusters.h
+++ b/src/detectors/HCAL/ProtoCluster_factory_HcalEndcapNIslandProtoClusters.h
@@ -20,6 +20,7 @@ public:
     // Constructor
     ProtoCluster_factory_HcalEndcapNIslandProtoClusters(){
         SetTag("HcalEndcapNIslandProtoClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -54,14 +55,6 @@ public:
         app->SetDefaultParameter("HCAL:HcalEndcapNIslandProtoClusters:dimScaledLocalDistXY",    u_dimScaledLocalDistXY);
         m_geoSvc = app->template GetService<JDD4hep_service>();
 
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/HCAL/ProtoCluster_factory_HcalEndcapNTruthProtoClusters.h
+++ b/src/detectors/HCAL/ProtoCluster_factory_HcalEndcapNTruthProtoClusters.h
@@ -20,6 +20,7 @@ public:
     // Constructor
     ProtoCluster_factory_HcalEndcapNTruthProtoClusters(){
         SetTag("HcalEndcapNTruthProtoClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -29,7 +30,7 @@ public:
         m_inputHit_tag="HcalEndcapNRecHits";
         m_inputMCHit_tag="HcalEndcapNHits";
 
-        AlgorithmInit();
+        AlgorithmInit(m_log);
     }
 
     //------------------------------------------

--- a/src/detectors/HCAL/ProtoCluster_factory_HcalEndcapPInsertIslandProtoClusters.h
+++ b/src/detectors/HCAL/ProtoCluster_factory_HcalEndcapPInsertIslandProtoClusters.h
@@ -19,6 +19,7 @@ public:
     // Constructor
     ProtoCluster_factory_HcalEndcapPInsertIslandProtoClusters(){
         SetTag("HcalEndcapPInsertIslandProtoClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -53,14 +54,6 @@ public:
         app->SetDefaultParameter("HCAL:HcalEndcapPInsertIslandProtoClusters:dimScaledLocalDistXY",    u_dimScaledLocalDistXY);
         m_geoSvc = app->template GetService<JDD4hep_service>();
 
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/HCAL/ProtoCluster_factory_HcalEndcapPInsertTruthProtoClusters.h
+++ b/src/detectors/HCAL/ProtoCluster_factory_HcalEndcapPInsertTruthProtoClusters.h
@@ -20,6 +20,7 @@ public:
     // Constructor
     ProtoCluster_factory_HcalEndcapPInsertTruthProtoClusters(){
         SetTag("HcalEndcapPInsertTruthProtoClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -29,7 +30,7 @@ public:
         m_inputHit_tag="HcalEndcapPInsertRecHits";
         m_inputMCHit_tag="HcalEndcapPInsertHits";
 
-        AlgorithmInit();
+        AlgorithmInit(m_log);
     }
 
     //------------------------------------------

--- a/src/detectors/HCAL/ProtoCluster_factory_HcalEndcapPIslandProtoClusters.h
+++ b/src/detectors/HCAL/ProtoCluster_factory_HcalEndcapPIslandProtoClusters.h
@@ -20,6 +20,7 @@ public:
     // Constructor
     ProtoCluster_factory_HcalEndcapPIslandProtoClusters(){
         SetTag("HcalEndcapPIslandProtoClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -54,14 +55,6 @@ public:
         app->SetDefaultParameter("HCAL:HcalEndcapPIslandProtoClusters:dimScaledLocalDistXY",    u_dimScaledLocalDistXY);
         m_geoSvc = app->template GetService<JDD4hep_service>();
 
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/HCAL/ProtoCluster_factory_HcalEndcapPTruthProtoClusters.h
+++ b/src/detectors/HCAL/ProtoCluster_factory_HcalEndcapPTruthProtoClusters.h
@@ -20,6 +20,7 @@ public:
     // Constructor
     ProtoCluster_factory_HcalEndcapPTruthProtoClusters(){
         SetTag("HcalEndcapPTruthProtoClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -29,7 +30,7 @@ public:
         m_inputHit_tag="HcalEndcapPRecHits";
         m_inputMCHit_tag="HcalEndcapPHits";
 
-        AlgorithmInit();
+        AlgorithmInit(m_log);
     }
 
     //------------------------------------------

--- a/src/detectors/HCAL/RawCalorimeterHit_factory_HcalBarrelRawHits.h
+++ b/src/detectors/HCAL/RawCalorimeterHit_factory_HcalBarrelRawHits.h
@@ -28,6 +28,7 @@ public:
     // Constructor
     RawCalorimeterHit_factory_HcalBarrelRawHits() {
         SetTag("HcalBarrelRawHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -67,14 +68,6 @@ public:
         app->SetDefaultParameter("HCAL:HcalBarrelRawHits:readoutClass",     m_readout);
 
         // Call Init for generic algorithm
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/HCAL/RawCalorimeterHit_factory_HcalEndcapNRawHits.h
+++ b/src/detectors/HCAL/RawCalorimeterHit_factory_HcalEndcapNRawHits.h
@@ -28,6 +28,7 @@ public:
     // Constructor
     RawCalorimeterHit_factory_HcalEndcapNRawHits() {
         SetTag("HcalEndcapNRawHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -67,14 +68,6 @@ public:
         app->SetDefaultParameter("HCAL:HcalEndcapNRawHits:readoutClass",     m_readout);
 
         // Call Init for generic algorithm
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/HCAL/RawCalorimeterHit_factory_HcalEndcapPInsertRawHits.h
+++ b/src/detectors/HCAL/RawCalorimeterHit_factory_HcalEndcapPInsertRawHits.h
@@ -28,6 +28,7 @@ public:
     // Constructor
     RawCalorimeterHit_factory_HcalEndcapPInsertRawHits() {
         SetTag("HcalEndcapPInsertRawHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -67,14 +68,6 @@ public:
         app->SetDefaultParameter("HCAL:HcalEndcapPInsertRawHits:readoutClass",     m_readout);
 
         // Call Init for generic algorithm
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/HCAL/RawCalorimeterHit_factory_HcalEndcapPRawHits.h
+++ b/src/detectors/HCAL/RawCalorimeterHit_factory_HcalEndcapPRawHits.h
@@ -28,6 +28,7 @@ public:
     // Constructor
     RawCalorimeterHit_factory_HcalEndcapPRawHits() {
         SetTag("HcalEndcapPRawHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -67,14 +68,6 @@ public:
         app->SetDefaultParameter("HCAL:HcalEndcapPRawHits:readoutClass",     m_readout);
 
         // Call Init for generic algorithm
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/RICH/ParticleID_factory_IrtHypothesis.h
+++ b/src/detectors/RICH/ParticleID_factory_IrtHypothesis.h
@@ -46,10 +46,7 @@ class ParticleID_factory_IrtHypothesis : public JFactoryT<edm4hep::ParticleID> {
       m_log = app->GetService<Log_service>()->logger(GetTag());
 
       // set log level
-      std::string log_level_str = "info";
-      auto pm = app->GetJParameterManager();
-      pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-      m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
+      m_log = japp->GetService<Log_service>()->logger(GetTag());
 
       m_log->info("\n\nUSING RICH: {}\n\n",m_detector_name);
 

--- a/src/detectors/RPOTS/RawTrackerHit_factory_ForwardRomanPotRawHits.h
+++ b/src/detectors/RPOTS/RawTrackerHit_factory_ForwardRomanPotRawHits.h
@@ -18,10 +18,13 @@ class RawTrackerHit_factory_ForwardRomanPotRawHits : public JFactoryT<edm4eic::R
 
 public:
 
+    std::shared_ptr<spdlog::logger> m_logger;
+
     //------------------------------------------
     // Constructor
     RawTrackerHit_factory_ForwardRomanPotRawHits() {
         SetTag("ForwardRomanPotRawHits");
+        m_logger = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -38,9 +41,7 @@ public:
         app->SetDefaultParameter("RPOTS:ForwardRomanPotRawHits:timeResolution",config.timeResolution );
 
         // Call init for generic algorithm
-        auto logSrvc = app->GetService<Log_service>();
-        auto logger = logSrvc->logger("RPOTS");
-        init(logger);
+        init(m_logger);
     }
 
     //------------------------------------------

--- a/src/detectors/RPOTS/ReconstructedParticle_factory_ForwardRomanPotParticles.h
+++ b/src/detectors/RPOTS/ReconstructedParticle_factory_ForwardRomanPotParticles.h
@@ -15,10 +15,13 @@ class ReconstructedParticle_factory_ForwardRomanPotParticles : public JFactoryT<
 
 public:
 
+    std::shared_ptr<spdlog::logger> m_logger;
+
     //------------------------------------------
     // Constructor
     ReconstructedParticle_factory_ForwardRomanPotParticles() {
         SetTag("ForwardRomanPotParticles");
+        m_logger = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -59,9 +62,7 @@ public:
         m_cellid_converter = geomSrvc->cellIDPositionConverter();
 
         // Call init for generic algorithm
-        auto logSrvc = app->GetService<Log_service>();
-        auto logger = logSrvc->logger("RPOTS");
-        initialize(logger);
+        initialize(m_logger);
     }
 
     //------------------------------------------

--- a/src/detectors/RPOTS/TrackerHit_factory_ForwardRomanPotRecHits.h
+++ b/src/detectors/RPOTS/TrackerHit_factory_ForwardRomanPotRecHits.h
@@ -19,10 +19,13 @@ class TrackerHit_factory_ForwardRomanPotRecHits : public JFactoryT<edm4eic::Trac
 
 public:
 
+    std::shared_ptr<spdlog::logger> m_logger;
+
     //------------------------------------------
     // Constructor
     TrackerHit_factory_ForwardRomanPotRecHits() {
         SetTag("ForwardRomanPotRecHits");
+        m_logger = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -36,11 +39,9 @@ public:
         app->SetDefaultParameter("RPOTS:ForwardRomanPotRawHits:time_resolution",config.time_resolution );
 
         // Call init for generic algorithm
-        auto logSrvc = app->GetService<Log_service>();
-        auto logger = logSrvc->logger("RPOTS");
         auto geoSvc = app->GetService<JDD4hep_service>();
         auto detector = geoSvc->detector();
-        init(detector, logger);
+        init(detector, m_logger);
     }
 
     //------------------------------------------

--- a/src/detectors/ZDC/CalorimeterHit_factory_ZDCEcalRecHits.h
+++ b/src/detectors/ZDC/CalorimeterHit_factory_ZDCEcalRecHits.h
@@ -15,6 +15,7 @@ public:
     // Constructor
     CalorimeterHit_factory_ZDCEcalRecHits(){
         SetTag("ZDCEcalRecHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -64,14 +65,6 @@ public:
         app->SetDefaultParameter("ZDC:ZDCEcalRecHits:localDetFields",   u_localDetFields);
         m_geoSvc = app->template GetService<JDD4hep_service>(); // TODO: implement named geometry service?
 
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/ZDC/Cluster_factory_ZDCEcalClusters.h
+++ b/src/detectors/ZDC/Cluster_factory_ZDCEcalClusters.h
@@ -22,6 +22,7 @@ public:
     // Constructor
     Cluster_factory_ZDCEcalClusters(){
         SetTag("ZDCEcalClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -53,16 +54,6 @@ public:
         app->SetDefaultParameter("ZDC:ZDCEcalClusters:enableEtaBounds",   m_enableEtaBounds);
 
         m_geoSvc = app->template GetService<JDD4hep_service>();
-
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
-
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/ZDC/Cluster_factory_ZDCEcalMergedClusters.h
+++ b/src/detectors/ZDC/Cluster_factory_ZDCEcalMergedClusters.h
@@ -20,6 +20,7 @@ public:
     // Constructor
     Cluster_factory_ZDCEcalMergedClusters(){
         SetTag("ZDCEcalMergedClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -29,15 +30,6 @@ public:
         //-------- Configuration Parameters ------------
         m_input_tag="ZDCEcalClusters";
         m_inputAssociations_tag="ZDCEcalClusterAssociations";
-
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/ZDC/Cluster_factory_ZDCEcalMergedTruthClusters.h
+++ b/src/detectors/ZDC/Cluster_factory_ZDCEcalMergedTruthClusters.h
@@ -20,6 +20,7 @@ public:
     // Constructor
     Cluster_factory_ZDCEcalMergedTruthClusters(){
         SetTag("ZDCEcalMergedTruthClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -29,15 +30,6 @@ public:
         //-------- Configuration Parameters ------------
         m_input_tag="ZDCEcalTruthClusters";
         m_inputAssociations_tag="ZDCEcalTruthClusterAssociations";
-
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/ZDC/Cluster_factory_ZDCEcalTruthClusters.h
+++ b/src/detectors/ZDC/Cluster_factory_ZDCEcalTruthClusters.h
@@ -20,6 +20,7 @@ public:
     // Constructor
     Cluster_factory_ZDCEcalTruthClusters(){
         SetTag("ZDCEcalTruthClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -51,16 +52,6 @@ public:
         app->SetDefaultParameter("ZDC:ZDCEcalTruthClusters:enableEtaBounds",   m_enableEtaBounds);
 
         m_geoSvc = app->template GetService<JDD4hep_service>();
-
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
-
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/ZDC/ProtoCluster_factory_ZDCEcalIslandProtoClusters.h
+++ b/src/detectors/ZDC/ProtoCluster_factory_ZDCEcalIslandProtoClusters.h
@@ -20,6 +20,7 @@ public:
     // Constructor
     ProtoCluster_factory_ZDCEcalIslandProtoClusters(){
         SetTag("ZDCEcalIslandProtoClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -56,14 +57,6 @@ public:
         app->SetDefaultParameter("ZDC:ZDCEcalIslandProtoClusters:dimScaledLocalDistXY",    u_dimScaledLocalDistXY);
         m_geoSvc = app->template GetService<JDD4hep_service>();
 
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/ZDC/ProtoCluster_factory_ZDCEcalTruthProtoClusters.h
+++ b/src/detectors/ZDC/ProtoCluster_factory_ZDCEcalTruthProtoClusters.h
@@ -20,6 +20,7 @@ public:
     // Constructor
     ProtoCluster_factory_ZDCEcalTruthProtoClusters(){
         SetTag("ZDCEcalTruthProtoClusters");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -29,7 +30,7 @@ public:
         m_inputHit_tag="ZDCEcalRecHits";
         m_inputMCHit_tag="ZDCEcalHits";
 
-        AlgorithmInit();
+        AlgorithmInit(m_log);
     }
 
     //------------------------------------------

--- a/src/detectors/ZDC/RawCalorimeterHit_factory_ZDCEcalRawHits.h
+++ b/src/detectors/ZDC/RawCalorimeterHit_factory_ZDCEcalRawHits.h
@@ -28,6 +28,7 @@ public:
     // Constructor
     RawCalorimeterHit_factory_ZDCEcalRawHits() {
         SetTag("ZDCEcalRawHits");
+        m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
     //------------------------------------------
@@ -67,14 +68,6 @@ public:
         app->SetDefaultParameter("ZDC:ZDCEcalRawHits:readoutClass",     m_readout);
 
         // Call Init for generic algorithm
-        std::string tag=this->GetTag();
-        std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        // Get log level from user parameter or default
-        std::string log_level_str = "info";
-        auto pm = app->GetJParameterManager();
-        pm->SetDefaultParameter(tag + ":LogLevel", log_level_str, "verbosity: trace, debug, info, warn, err, critical, off");
-        m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
         AlgorithmInit(m_log);
     }
 

--- a/src/services/io/podio/JEventSourcePODIOsimple.cc
+++ b/src/services/io/podio/JEventSourcePODIOsimple.cc
@@ -225,8 +225,16 @@ void JEventSourcePODIOsimple::GetEvent(std::shared_ptr<JEvent> event) {
     }
 
     // The podio supplied RootReader and EventStore are not multi-thread capable so limit to a single event in flight
-    if( m_inflight ) throw RETURN_STATUS ::kBUSY;
-    m_inflight = true;
+    // Since the JANA skip events mechanism does not seem to call FinishEvent when skipping, any flag for
+    // in-flight events will not be cleared. Thus, use the JEvent pointer so that
+    std::thread::id no_thread; // default value is no thread
+    if( processing_thread_id == no_thread ){
+        // No thread is processing event
+        processing_thread_id = std::this_thread::get_id();
+    }else if( processing_thread_id != std::this_thread::get_id() ){
+        // Another thread is already processing the event
+        throw RETURN_STATUS ::kBUSY;
+    }
 
     // Read the specified event into the EventStore and make the EventStore pointer available via JANA
     store.clear();
@@ -282,7 +290,7 @@ void JEventSourcePODIOsimple::GetEvent(std::shared_ptr<JEvent> event) {
 //------------------------------------------------------------------------------
 void JEventSourcePODIOsimple::FinishEvent(JEvent &event){
 
-    m_inflight = false;
+    processing_thread_id = std::thread::id(); // reset to no thread value
 }
 
 //------------------------------------------------------------------------------

--- a/src/services/io/podio/JEventSourcePODIOsimple.h
+++ b/src/services/io/podio/JEventSourcePODIOsimple.h
@@ -42,7 +42,7 @@ protected:
     std::set<std::string> m_INPUT_EXCLUDE_COLLECTIONS;
     bool m_run_forever=false;
 
-    bool m_inflight = false; // is an event currently in flight (and therefore using the EventStore)?
+    std::thread::id processing_thread_id;  // defaults to a "no thread" value
 
 };
 

--- a/src/services/log/Log_service.cc
+++ b/src/services/log/Log_service.cc
@@ -42,7 +42,7 @@ std::shared_ptr<spdlog::logger> Log_service::logger(const std::string &name) {
             // Set log level for this named logger allowing user to specify as config. parameter
             // e.g. EcalEndcapPRecHits:LogLevel
             std::string log_level_str = m_log_level_str;
-            m_application->SetDefaultParameter(name+":LogLevel", log_level_str, "log_level for "+name+": trace, debug, info, warn, error, critical, off (def. inherits from eicreconLogLevel)");
+            m_application->SetDefaultParameter(name+":LogLevel", log_level_str, "log_level for "+name+": trace, debug, info, warn, error, critical, off");
             logger->set_level(eicrecon::ParseLogLevel(log_level_str));
         }
         return logger;

--- a/src/services/log/Log_service.cc
+++ b/src/services/log/Log_service.cc
@@ -13,30 +13,37 @@ Log_service::Log_service(JApplication *app) {
     // All subsequent loggers are cloned from the spdlog::default_logger()
     m_application = app;
 
+    m_log_level_str = "info";
+    m_application->SetDefaultParameter("eicrecon:LogLevel", m_log_level_str, "log_level: trace, debug, info, warn, error, critical, off");
+    spdlog::default_logger()->set_level(eicrecon::ParseLogLevel(m_log_level_str));
+
+//    // Get default loggers
+//    static std::once_flag on_first_execution;
+//    std::call_once(on_first_execution, [this](){
+//        m_log_level_str = "info";
+//        m_application->SetDefaultParameter("eicrecon:LogLevel", m_log_level_str, "log_level: trace, debug, info, warn, error, critical, off");
+//        spdlog::default_logger()->set_level(eicrecon::ParseLogLevel(m_log_level_str));
+//    });
+
 }
 
 
 std::shared_ptr<spdlog::logger> Log_service::logger(const std::string &name) {
 
-    // Get default loggers
-    static std::once_flag on_first_execution;
-
-
     try {
         std::lock_guard<std::recursive_mutex> locker(m_lock);
-
-        std::call_once(on_first_execution, [this](){
-            std::string log_level_str = "info";
-            m_application->SetDefaultParameter("eicrecon:LogLevel", log_level_str, "log_level: trace, debug, info, warn, error, critical, off");
-            spdlog::default_logger()->set_level(eicrecon::ParseLogLevel(log_level_str));
-        });
-
 
         // Try to get existing logger
         auto logger = spdlog::get(name);
         if(!logger) {
             // or create a new one with current configuration
             logger = spdlog::default_logger()->clone(name);
+
+            // Set log level for this named logger allowing user to specify as config. parameter
+            // e.g. EcalEndcapPRecHits:LogLevel
+            std::string log_level_str = m_log_level_str;
+            m_application->SetDefaultParameter(name+":LogLevel", log_level_str, "log_level for "+name+": trace, debug, info, warn, error, critical, off (def. inherits from eicreconLogLevel)");
+            logger->set_level(eicrecon::ParseLogLevel(log_level_str));
         }
         return logger;
     }

--- a/src/services/log/Log_service.h
+++ b/src/services/log/Log_service.h
@@ -28,6 +28,7 @@ private:
 
     std::recursive_mutex m_lock;
     JApplication* m_application;
+    std::string m_log_level_str;
 };
 
 #endif // __Spdlog_service_h__

--- a/src/utilities/eicrecon/eicrecon_cli.cpp
+++ b/src/utilities/eicrecon/eicrecon_cli.cpp
@@ -296,6 +296,48 @@ namespace jana {
         }
     }
 
+    void PrintConfigParameters(JApplication* app){
+        /// Print a table of the currently defined configuration parameters.
+        /// n.b. this mostly duplicates a call to app->GetJParameterManager()->PrintParameters()
+        /// but avoids the issue it has of setting the values column to same
+        /// width for all parameters. (That leads to lots of whitespace being
+        /// printed due to the very long podio:output_include_collections param.
+
+        // Determine column widths
+        auto params = app->GetJParameterManager()->GetAllParameters();
+        size_t max_key_length = 0;
+        size_t max_val_length = 0;
+        size_t max_max_val_length = 32; // maximum width allowed for column.
+        for( auto &[key, p] : params ){
+            if( key.length() > max_key_length ) max_key_length = key.length();
+            if( p->GetValue().length() > max_val_length ){
+                if( p->GetValue().length() <= max_max_val_length ) max_val_length = p->GetValue().length();
+            }
+        }
+
+        std::cout << "\nConfiguration Parameters:" << std::endl;
+        std::cout << "Name" + std::string(max_key_length-4, ' ') << " : ";
+        std::cout << "Value" + std::string(max_val_length-5, ' ') << " : ";
+        std::cout << "Description" << std::endl;
+        std::cout << std::string(max_key_length+max_val_length+20, '-') << std::endl;
+        for( auto &[key, p] : params ){
+            std::stringstream ss;
+            int key_length_diff = max_key_length - key.length();
+            if( key_length_diff>0 ) ss << std::string(key_length_diff, ' ');
+            ss << key;
+            ss << " | ";
+
+            int val_length_diff = max_val_length - p->GetValue().length();
+            if( val_length_diff>0 ) ss << std::string(val_length_diff, ' ');
+            ss << p->GetValue();
+            ss << " | ";
+            ss << p->GetDescription();
+
+            std::cout << ss.str() << std::endl;
+        }
+        std::cout << std::string(max_key_length+max_val_length+20, '-') << std::endl;
+    }
+
     int Execute(JApplication* app, UserOptions &options) {
 
         std::cout << std::endl;
@@ -308,7 +350,8 @@ namespace jana {
             if (options.flags[Benchmark]) {
                 JBenchmarker benchmarker(app);  // Show benchmarking configs only if benchmarking mode specified
             }
-            app->GetJParameterManager()->PrintParameters(true);
+//            app->GetJParameterManager()->PrintParameters(true);
+            PrintConfigParameters(app);
         }
         else if (options.flags[DumpConfigs]) {
             // Load all plugins, dump parameters to file, exit without running anything


### PR DESCRIPTION
### Briefly, what does this PR introduce?

- Clean up the spdlog implementation in Calorimetery by removing a lot of duplicate code and instead use the centralized service. Now, all of the factories (except tracking) define their specific log level config parameters during their constructor call so they can be listed with eicrecon -c. The convention is to use: <collectionName>:LogLevel to set the log level of a specific factory. The global log level is set with eicrecon:LogLevel as before and is inherited by all factory loggers by default.

- Cleanup how eicrecon prints config parameters. The JANA built-in PrintParameters method uses a fixed column width for the value and description which results in some exceptionally wide columns due to the very long podio:output_include_collections parameter. This is still not perfect, but is much more readable.

- Fix jana:nskip behavior. The code now uses thread id to determine if GetEvent should declare itself busy. This is not actually working to block multi-thread use, but does allow nskip to work as expected. 

### What kind of change does this PR introduce?
- [X] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
Yes. If a user specifies to use multiple threads, the program will likely crash. This is acceptable for now in order to regain the jana:nskip functionality.

### Does this PR change default behavior?
No.