### PR TITLE
fix: copy sys.argv before element removal in loop

### DIFF
--- a/src/tools/default_flags_table/reco_flags.py
+++ b/src/tools/default_flags_table/reco_flags.py
@@ -873,7 +873,8 @@ if __name__ == "__main__":
 
     # Separate all parameters that starts with -P/-p from args
     parameter_args = []
-    for arg in sys.argv:
+    sys_argv = sys.argv.copy()
+    for arg in sys_argv:
         if arg.startswith(("-P", "-p")):
             parameter_args.append(arg)
             sys.argv.remove(arg)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Fixes #304. When we loop over `sys.argv` and remove the current entry of `sys.argv` inside that loop, then we will skip elements in the loop. This loops over a copy, and removes from the original `sys.argv`.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #304)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators @DraTeots 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.