### PR TITLE
fix: pass empty flags as defined in `reco_flags.py`

### DIFF
--- a/src/tools/default_flags_table/reco_flags.py
+++ b/src/tools/default_flags_table/reco_flags.py
@@ -866,6 +866,8 @@ def make_flags_from_records():
         if record[1]:
             value = value_eval(record[1])
             flags_arguments.append(f'-P{record[0]}={value}')
+        else:
+            flags_arguments.append(f'-P{record[0]}=""')
     return flags_arguments
 
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Fixes #313. If an empty variable is explicitly defined in `reco_flags.py` then we should pass it.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #313)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, empty values are now passed to eicrecon. This may or may not lead to the same behavior as before... but at least now it is consistent behavior.