### PR TITLE
fix: define sector as empty string in reco_flags.py

### DIFF
--- a/src/detectors/EEMC/CalorimeterHit_factory_EcalEndcapPInsertRecHits.h
+++ b/src/detectors/EEMC/CalorimeterHit_factory_EcalEndcapPInsertRecHits.h
@@ -42,7 +42,7 @@ public:
         m_geoSvcName="geoServiceName";
         m_readout="EcalEndcapPInsertHits";  // from ATHENA's reconstruction.py
         m_layerField="";              // from ATHENA's reconstruction.py (i.e. not defined there)
-        m_sectorField="sector";       // from ATHENA's reconstruction.py
+        m_sectorField="";             // from ATHENA's reconstruction.py
 
         m_localDetElement="";         // from ATHENA's reconstruction.py (i.e. not defined there)
         u_localDetFields={};          // from ATHENA's reconstruction.py (i.e. not defined there)

--- a/src/detectors/EEMC/CalorimeterHit_factory_EcalEndcapPRecHits.h
+++ b/src/detectors/EEMC/CalorimeterHit_factory_EcalEndcapPRecHits.h
@@ -42,7 +42,7 @@ public:
         m_geoSvcName="geoServiceName";
         m_readout="EcalEndcapPHits";  // from ATHENA's reconstruction.py
         m_layerField="";              // from ATHENA's reconstruction.py (i.e. not defined there)
-        m_sectorField="sector";       // from ATHENA's reconstruction.py
+        m_sectorField="";             // from ATHENA's reconstruction.py
 
         m_localDetElement="";         // from ATHENA's reconstruction.py (i.e. not defined there)
         u_localDetFields={};          // from ATHENA's reconstruction.py (i.e. not defined there)

--- a/src/detectors/HCAL/CalorimeterHit_factory_HcalEndcapNRecHits.h
+++ b/src/detectors/HCAL/CalorimeterHit_factory_HcalEndcapNRecHits.h
@@ -43,7 +43,7 @@ public:
         m_geoSvcName="geoServiceName";
         m_readout="HcalEndcapNHits";  // from ATHENA's reconstruction.py
         m_layerField="";              // from ATHENA's reconstruction.py (i.e. not defined there)
-        m_sectorField="sector";       // from ATHENA's reconstruction.py
+        m_sectorField="";             // from ATHENA's reconstruction.py
 
         m_localDetElement="";         // from ATHENA's reconstruction.py (i.e. not defined there)
         u_localDetFields={};          // from ATHENA's reconstruction.py (i.e. not defined there)

--- a/src/detectors/HCAL/CalorimeterHit_factory_HcalEndcapPInsertRecHits.h
+++ b/src/detectors/HCAL/CalorimeterHit_factory_HcalEndcapPInsertRecHits.h
@@ -43,7 +43,7 @@ public:
         m_geoSvcName="geoServiceName";
         m_readout="HcalEndcapPInsertHits";  // from ATHENA's reconstruction.py
         m_layerField="";              // from ATHENA's reconstruction.py (i.e. not defined there)
-        m_sectorField="sector";       // from ATHENA's reconstruction.py
+        m_sectorField="";             // from ATHENA's reconstruction.py
 
         m_localDetElement="";         // from ATHENA's reconstruction.py (i.e. not defined there)
         u_localDetFields={};          // from ATHENA's reconstruction.py (i.e. not defined there)

--- a/src/detectors/HCAL/CalorimeterHit_factory_HcalEndcapPRecHits.h
+++ b/src/detectors/HCAL/CalorimeterHit_factory_HcalEndcapPRecHits.h
@@ -43,7 +43,7 @@ public:
         m_geoSvcName="geoServiceName";
         m_readout="HcalEndcapPHits";  // from ATHENA's reconstruction.py
         m_layerField="";              // from ATHENA's reconstruction.py (i.e. not defined there)
-        m_sectorField="sector";       // from ATHENA's reconstruction.py
+        m_sectorField="";             // from ATHENA's reconstruction.py
 
         m_localDetElement="";         // from ATHENA's reconstruction.py (i.e. not defined there)
         u_localDetFields={};          // from ATHENA's reconstruction.py (i.e. not defined there)

--- a/src/detectors/HCAL/tmp2/CalorimeterHit_factory_HcalEndcapNRecHits.h
+++ b/src/detectors/HCAL/tmp2/CalorimeterHit_factory_HcalEndcapNRecHits.h
@@ -42,7 +42,7 @@ public:
         m_geoSvcName="geoServiceName";
         m_readout="HcalEndcapNHits";  // from ATHENA's reconstruction.py
         m_layerField="";              // from ATHENA's reconstruction.py (i.e. not defined there)
-        m_sectorField="sector";       // from ATHENA's reconstruction.py
+        m_sectorField="";             // from ATHENA's reconstruction.py
 
         m_localDetElement="";         // from ATHENA's reconstruction.py (i.e. not defined there)
         u_localDetFields={};          // from ATHENA's reconstruction.py (i.e. not defined there)

--- a/src/detectors/ZDC/CalorimeterHit_factory_ZDCEcalRecHits.h
+++ b/src/detectors/ZDC/CalorimeterHit_factory_ZDCEcalRecHits.h
@@ -43,7 +43,7 @@ public:
         m_geoSvcName="geoServiceName";
         m_readout="ZDCEcalHits";  // from ATHENA's reconstruction.py
         m_layerField="";              // from ATHENA's reconstruction.py (i.e. not defined there)
-        m_sectorField="sector";       // from ATHENA's reconstruction.py
+        m_sectorField="";             // from ATHENA's reconstruction.py
 
         m_localDetElement="";         // from ATHENA's reconstruction.py (i.e. not defined there)
         u_localDetFields={};          // from ATHENA's reconstruction.py (i.e. not defined there)

--- a/src/tools/default_flags_table/reco_flags.py
+++ b/src/tools/default_flags_table/reco_flags.py
@@ -256,7 +256,7 @@ eicrecon_reco_flags = [
     ('EEMC:EcalEndcapPRecHits:readout',                          'EcalEndcapPHits',                ''),
     ('EEMC:EcalEndcapPRecHits:resolutionTDC',                    '1e-11',                          ''),
     ('EEMC:EcalEndcapPRecHits:samplingFraction',                 '0.03',                           '*'),
-    ('EEMC:EcalEndcapPRecHits:sectorField',                      'sector',                         ''),
+    ('EEMC:EcalEndcapPRecHits:sectorField',                      '',                               ''),
     ('EEMC:EcalEndcapPRecHits:thresholdFactor',                  '5.0',                            '*'),
     ('EEMC:EcalEndcapPRecHits:thresholdValue',                   '2',                              '*'),
 
@@ -311,7 +311,7 @@ eicrecon_reco_flags = [
     ('EEMC:EcalEndcapPInsertRecHits:readout',                          'EcalEndcapPInsertHits',          ''),
     ('EEMC:EcalEndcapPInsertRecHits:resolutionTDC',                    '1e-11',                          ''),
     ('EEMC:EcalEndcapPInsertRecHits:samplingFraction',                 '0.03',                           '*'),
-    ('EEMC:EcalEndcapPInsertRecHits:sectorField',                      'sector',                         ''),
+    ('EEMC:EcalEndcapPInsertRecHits:sectorField',                      '',                               ''),
     ('EEMC:EcalEndcapPInsertRecHits:thresholdFactor',                  '5.0',                            '*'),
     ('EEMC:EcalEndcapPInsertRecHits:thresholdValue',                   '2',                              '*'),
 
@@ -480,7 +480,7 @@ eicrecon_reco_flags = [
     ('HCAL:HcalEndcapNRecHits:readout',                          'HcalEndcapNHits',                ''),
     ('HCAL:HcalEndcapNRecHits:resolutionTDC',                    '1e-11',                          ''),
     ('HCAL:HcalEndcapNRecHits:samplingFraction',                 '0.998',                          ''),
-    ('HCAL:HcalEndcapNRecHits:sectorField',                      'sector',                         ''),
+    ('HCAL:HcalEndcapNRecHits:sectorField',                      '',                               ''),
     ('HCAL:HcalEndcapNRecHits:thresholdFactor',                  '4',                              ''),
     ('HCAL:HcalEndcapNRecHits:thresholdValue',                   '1',                              '*'),
 
@@ -544,7 +544,7 @@ eicrecon_reco_flags = [
     ('HCAL:HcalEndcapPRecHits:readout',                          'HcalEndcapPHits',                ''),
     ('HCAL:HcalEndcapPRecHits:resolutionTDC',                    '1e-11',                          ''),
     ('HCAL:HcalEndcapPRecHits:samplingFraction',                 '0.025',                          ''),
-    ('HCAL:HcalEndcapPRecHits:sectorField',                      'sector',                         ''),
+    ('HCAL:HcalEndcapPRecHits:sectorField',                      '',                               ''),
     ('HCAL:HcalEndcapPRecHits:thresholdFactor',                  '5',                              '*'),
     ('HCAL:HcalEndcapPRecHits:thresholdValue',                   '3',                              '*'),
 
@@ -609,7 +609,7 @@ eicrecon_reco_flags = [
     ('HCAL:HcalEndcapPInsertRecHits:readout',                          'HcalEndcapPInsertHits',                 ''),
     ('HCAL:HcalEndcapPInsertRecHits:resolutionTDC',                    '1e-11',                                 ''),
     ('HCAL:HcalEndcapPInsertRecHits:samplingFraction',                 '0.998',                                 ''),
-    ('HCAL:HcalEndcapPInsertRecHits:sectorField',                      'sector',                                ''),
+    ('HCAL:HcalEndcapPInsertRecHits:sectorField',                      '',                                      ''),
     ('HCAL:HcalEndcapPInsertRecHits:thresholdFactor',                  '4',                                     ''),
     ('HCAL:HcalEndcapPInsertRecHits:thresholdValue',                   '0',                                     '*'),
 
@@ -669,7 +669,7 @@ eicrecon_reco_flags = [
     ('ZDC:ZDCEcalRecHits:readout',                               'ZDCEcalHits',                    ''),
     ('ZDC:ZDCEcalRecHits:resolutionTDC',                         '1e-11',                          ''),
     ('ZDC:ZDCEcalRecHits:samplingFraction',                      '1',                              '*'),
-    ('ZDC:ZDCEcalRecHits:sectorField',                           'sector',                         ''),
+    ('ZDC:ZDCEcalRecHits:sectorField',                           '',                               ''),
     ('ZDC:ZDCEcalRecHits:thresholdFactor',                       '4',                              ''),
     ('ZDC:ZDCEcalRecHits:thresholdValue',                        '0',                              ''),
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Requires #314. Fixes #312. Set the `sectorField`

TODO:
- [x] Apply the same empty string definitions in factories.
- [x] Verify which other fields may need to be specified instead, or which other detectors need to get an empty string but have not shown up as a warning yet (ZDC Hcal for example).

### What kind of change does this PR introduce?
- [x] Bug fix (issue #312)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes. Should avoid warnings in running.