### PR TITLE
Correct RPOTS config param names and add them to reco_flags.py

### DIFF
--- a/src/detectors/RPOTS/ReconstructedParticle_factory_ForwardRomanPotParticles.h
+++ b/src/detectors/RPOTS/ReconstructedParticle_factory_ForwardRomanPotParticles.h
@@ -44,17 +44,17 @@ public:
         m_localDetElement="";
         u_localDetFields={};
 
-        app->SetDefaultParameter("RPOTS:ForwardRomanPotRawHits:local_x_offset_station_1",local_x_offset_station_1);
-        app->SetDefaultParameter("RPOTS:ForwardRomanPotRawHits:local_x_offset_station_2",local_x_offset_station_2);
-        app->SetDefaultParameter("RPOTS:ForwardRomanPotRawHits:local_x_slope_offset",local_x_slope_offset);
-        app->SetDefaultParameter("RPOTS:ForwardRomanPotRawHits:local_y_slope_offset",local_y_slope_offset);
-        app->SetDefaultParameter("RPOTS:ForwardRomanPotRawHits:crossingAngle",crossingAngle);
-        app->SetDefaultParameter("RPOTS:ForwardRomanPotRawHits:nomMomentum",nomMomentum);
-        app->SetDefaultParameter("RPOTS:ForwardRomanPotRawHits:m_readout",m_readout);
-        app->SetDefaultParameter("RPOTS:ForwardRomanPotRawHits:m_layerField",m_layerField);
-        app->SetDefaultParameter("RPOTS:ForwardRomanPotRawHits:m_sectorField",m_sectorField);
-        app->SetDefaultParameter("RPOTS:ForwardRomanPotRawHits:m_localDetElement",m_localDetElement);
-        app->SetDefaultParameter("RPOTS:ForwardRomanPotRawHits:u_localDetFields",u_localDetFields);
+        app->SetDefaultParameter("RPOTS:ForwardRomanPotParticles:local_x_offset_station_1",local_x_offset_station_1);
+        app->SetDefaultParameter("RPOTS:ForwardRomanPotParticles:local_x_offset_station_2",local_x_offset_station_2);
+        app->SetDefaultParameter("RPOTS:ForwardRomanPotParticles:local_x_slope_offset",local_x_slope_offset);
+        app->SetDefaultParameter("RPOTS:ForwardRomanPotParticles:local_y_slope_offset",local_y_slope_offset);
+        app->SetDefaultParameter("RPOTS:ForwardRomanPotParticles:crossingAngle",crossingAngle);
+        app->SetDefaultParameter("RPOTS:ForwardRomanPotParticles:nomMomentum",nomMomentum);
+        app->SetDefaultParameter("RPOTS:ForwardRomanPotParticles:m_readout",m_readout);
+        app->SetDefaultParameter("RPOTS:ForwardRomanPotParticles:m_layerField",m_layerField);
+        app->SetDefaultParameter("RPOTS:ForwardRomanPotParticles:m_sectorField",m_sectorField);
+        app->SetDefaultParameter("RPOTS:ForwardRomanPotParticles:m_localDetElement",m_localDetElement);
+        app->SetDefaultParameter("RPOTS:ForwardRomanPotParticles:u_localDetFields",u_localDetFields);
 
         // Connect generic algorithm to dd4hep
         auto geomSrvc = app->GetService<JDD4hep_service>();

--- a/src/detectors/RPOTS/TrackerHit_factory_ForwardRomanPotRecHits.h
+++ b/src/detectors/RPOTS/TrackerHit_factory_ForwardRomanPotRecHits.h
@@ -36,7 +36,7 @@ public:
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
         auto &config = getConfig();
         config.time_resolution = 0.0;
-        app->SetDefaultParameter("RPOTS:ForwardRomanPotRawHits:time_resolution",config.time_resolution );
+        app->SetDefaultParameter("RPOTS:ForwardRomanPotRecHits:time_resolution",config.time_resolution );
 
         // Call init for generic algorithm
         auto geoSvc = app->GetService<JDD4hep_service>();

--- a/src/tools/default_flags_table/reco_flags.py
+++ b/src/tools/default_flags_table/reco_flags.py
@@ -732,6 +732,28 @@ eicrecon_reco_flags = [
     ('tracking:CentralCKFTrajectories:EtaBins',                  '',                               'Eta Bins for ACTS CKF tracking reco'),
     ('tracking:CentralCKFTrajectories:NumMeasurementsCutOff',    '10',                             'Number of measurements Cut Off for ACTS CKF tracking'),
 
+    # ============================ F A R   F O R W A R D ===================================
+    
+    # RPOTS
+    # -----------------------------
+    ('RPOTS:ForwardRomanPotRawHits:threshold',                   '0.0',                            ''),
+    ('RPOTS:ForwardRomanPotRawHits:timeResolution',              '8.0',                            'ns'),
+    
+    ('RPOTS:ForwardRomanPotRecHits:time_resolution',             '0.0',                            ''),
+
+    ('RPOTS:ForwardRomanPotParticles:local_x_offset_station_1',  '-833.3878326',                   ''),
+    ('RPOTS:ForwardRomanPotParticles:local_x_offset_station_2',  '-924.342804',                    ''),
+    ('RPOTS:ForwardRomanPotParticles:local_x_slope_offset',      '-0.00622147',                    ''),
+    ('RPOTS:ForwardRomanPotParticles:local_y_slope_offset',      '-0.0451035',                     ''),
+    ('RPOTS:ForwardRomanPotParticles:crossingAngle',             '-0.025',                         ''),
+    ('RPOTS:ForwardRomanPotParticles:nomMomentum',               '275.0',                          ''),
+    ('RPOTS:ForwardRomanPotParticles:m_readout',                 '',                               ''),
+    ('RPOTS:ForwardRomanPotParticles:m_layerField',              '',                               ''),
+    ('RPOTS:ForwardRomanPotParticles:m_sectorField',             '',                               ''),
+    ('RPOTS:ForwardRomanPotParticles:m_localDetElement',         '',                               ''),
+    ('RPOTS:ForwardRomanPotParticles:u_localDetFields',          '',                               ''),
+
+
     # ========================= R E C O N S T R U C T I O N ================================
     ('Reco:GeneratedParticles:MomentumSmearing',                 '0',                              'Gaussian momentum smearing value'),
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?

- Fix the config. param names of the RPOTS factories to match collection names.

- Add RPOTS config. params to reco_flags.py

### What kind of change does this PR introduce?
- [X] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No