### PR TITLE
treewide: use std::exit

### DIFF
--- a/src/services/geometry/dd4hep/JDD4hep_service.cc
+++ b/src/services/geometry/dd4hep/JDD4hep_service.cc
@@ -143,7 +143,7 @@ std::string JDD4hep_service::resolveFileName(const std::string &filename, char *
                 mess += fmt::format(fmt::emphasis::bold, "file: {} does not exist!", filename);
                 mess += "\nCheck that your DETECTOR and DETECTOR_CONFIG environment variables are set correctly.";
                 std::cerr << std::endl << std::endl << mess << std::endl << std::endl; // TODO standard log here!
-                _exit(-1);  // TODO isn't unhandled JException is a better way to abort the application
+                std::exit(-1);  // TODO isn't unhandled JException is a better way to abort the application
             }
         }
     }

--- a/src/services/io/podio/JEventSourcePODIOsimple.cc
+++ b/src/services/io/podio/JEventSourcePODIOsimple.cc
@@ -131,7 +131,7 @@ void JEventSourcePODIOsimple::Open() {
             auto mess = fmt::format(fmt::emphasis::bold | fg(fmt::color::red),"ERROR: ");
             mess += fmt::format(fmt::emphasis::bold, "file: {} does not exist!",  GetResourceName());
             std::cerr << std::endl << std::endl << mess << std::endl << std::endl;
-            _exit(-1);
+            std::exit(EXIT_FAILURE);
         }
 
         // Have PODIO reader open file and get the number of events from it.


### PR DESCRIPTION
Fixes compilation errors on macOS:

```
src/services/geometry/dd4hep/JDD4hep_service.cc:146:17: error: use of undeclared identifier '_exit'
                _exit(-1);  // TODO isn't unhandled JException is a better way to abort the application
                ^
```

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No