### PR TITLE
utilities/dump_flags: fix compilation with C++17 (second pass)

### DIFF
--- a/src/utilities/dump_flags/DumpFlags_processor.h
+++ b/src/utilities/dump_flags/DumpFlags_processor.h
@@ -105,13 +105,13 @@ private:
     std::string findCategory(std::string flag_name) { // (!) copy value is important here! don't do const& NOLINT(performance-unnecessary-value-param)
 
         // convert flag_name to lower
-        std::transform(flag_name.begin(), flag_name.end(), flag_name.begin(), std::ptr_fun<int, int>(std::tolower));
+        std::transform(flag_name.begin(), flag_name.end(), flag_name.begin(), static_cast<int (*)(int)>(&std::tolower));
 
         for(auto subsystem: m_reco_prefixes) {     // (!) copy value is important here! don't do auto&
 
             // Convert subsystem to lower
             std::string original_subsystem_name = subsystem;
-            std::transform(subsystem.begin(), subsystem.end(), subsystem.begin(), std::ptr_fun<int, int>(std::tolower));
+            std::transform(subsystem.begin(), subsystem.end(), subsystem.begin(), static_cast<int (*)(int)>(&std::tolower));
 
             // if not sure, read this
             // https://stackoverflow.com/questions/1878001/how-do-i-check-if-a-c-stdstring-starts-with-a-certain-string-and-convert-a


### PR DESCRIPTION
The `std::ptr_fun` was deprecated since C++11 and removed in C++17

```
src/utilities/dump_flags/DumpFlags_processor.h:83:84: error: no member named 'ptr_fun' in namespace 'std'
        std::transform(flag_name.begin(), flag_name.end(), flag_name.begin(), std::ptr_fun<int, int>(std::tolower));
                                                                              ~~~~~^
```

Additional regression since #286

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
