### PR TITLE
Fix naming of EcalBarrelSciGlassTruthProtoClusters.

### DIFF
--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -25,7 +25,7 @@
 #include "Cluster_factory_EcalBarrelImagingClusters.h"
 #include "Cluster_factory_EcalBarrelImagingMergedClusters.h"
 
-#include "ProtoCluster_factory_EcalBarrelTruthSciGlassProtoClusters.h"
+#include "ProtoCluster_factory_EcalBarrelSciGlassTruthProtoClusters.h"
 #include "Cluster_factory_EcalBarrelSciGlassTruthClusters.h"
 #include "Cluster_factory_EcalBarrelSciGlassMergedTruthClusters.h"
 
@@ -54,7 +54,7 @@ extern "C" {
         app->Add(new JFactoryGeneratorT<JFactoryT<edm4eic::Cluster>>("EcalBarrelImagingLayers"));
         app->Add(new JFactoryGeneratorT<JFactoryT<edm4eic::MCRecoClusterParticleAssociation>>("EcalBarrelImagingClusterAssociations"));
 
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_EcalBarrelTruthSciGlassProtoClusters>());
+        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_EcalBarrelSciGlassTruthProtoClusters>());
         app->Add(new JFactoryGeneratorT<Cluster_factory_EcalBarrelSciGlassTruthClusters>());
         app->Add(new JFactoryGeneratorT<Cluster_factory_EcalBarrelSciGlassMergedTruthClusters>());
     }

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassTruthProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassTruthProtoClusters.h
@@ -13,13 +13,13 @@
 
 
 
-class ProtoCluster_factory_EcalBarrelTruthSciGlassProtoClusters : public JFactoryT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
+class ProtoCluster_factory_EcalBarrelSciGlassTruthProtoClusters : public JFactoryT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
 
 public:
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_EcalBarrelTruthSciGlassProtoClusters(){
-        SetTag("EcalBarrelTruthSciGlassProtoClusters");
+    ProtoCluster_factory_EcalBarrelSciGlassTruthProtoClusters(){
+        SetTag("EcalBarrelSciGlassTruthProtoClusters");
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -30,7 +30,7 @@ public:
         m_inputHit_tag="EcalBarrelSciGlassRecHits";
         m_inputMCHit_tag="EcalBarrelSciGlassHits";
 
-        app->SetDefaultParameter("BEMC:EcalBarrelTruthSciGlassProtoClusters:inputHit_tag", m_inputHit_tag, "Name of input collection to use");
+        app->SetDefaultParameter("BEMC:EcalBarrelSciGlassTruthProtoClusters:inputHit_tag", m_inputHit_tag, "Name of input collection to use");
 
         AlgorithmInit(m_log);
     }


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This fixes the name of the `EcalBarrelTruthSciGlassProtoClusters` collection which should have been `EcalBarrelSciGlassTruthProtoClusters`.

### What kind of change does this PR introduce?
- [X] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No