### PR TITLE
Davidl janaversion

### DIFF
--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -30,6 +30,18 @@ struct InsertFacIntoStore {
     }
 };
 
+/// This is used to activate the factory using the standard JEvent::Get
+/// call. It is done this way so that the factory call stack recording
+/// mechanism can work properly.
+template <typename PodioT, typename PodioCollectionT>
+struct GetFactoryObjects {
+    size_t operator() (const std::shared_ptr<const JEvent> &event, JFactory* fac) {
+        auto objs = event->Get<PodioT>( fac->GetTag() );
+        return objs.size();
+    }
+};
+
+
 JEventProcessorPODIO::JEventProcessorPODIO() {
     SetTypeName(NAME_OF_THIS); // Provide JANA with this class's name
 
@@ -285,7 +297,7 @@ void JEventProcessorPODIO::Process(const std::shared_ptr<const JEvent> &event) {
                 // actually ran. If the user didn't specify any collections in the include list, we don't: For factories
                 // that had not already been triggered by an EventProcessor, we simply write out zero objects.
                 m_log->trace("Ensuring factory '{}:{}' has been called.", fac->GetObjectName(), fac->GetTag());
-                fac->Create(event, mApplication, event->GetRunNumber());
+                auto result = CallWithPODIOType<GetFactoryObjects, size_t, decltype(event), decltype(fac)>(fac->GetObjectName(), event, fac);
             }
             auto result = CallWithPODIOType<InsertFacIntoStore, size_t, JFactory*, eic::EventStore*, bool>(fac->GetObjectName(), fac, m_store, m_is_first_event);
 

--- a/src/utilities/eicrecon/eicrecon_cli.cpp
+++ b/src/utilities/eicrecon/eicrecon_cli.cpp
@@ -32,6 +32,7 @@ namespace jana {
         std::cout << "Options:" << std::endl;
         std::cout << "   -h   --help                  Display this message" << std::endl;
         std::cout << "   -v   --version               Display version information" << std::endl;
+        std::cout << "   -j   --janaversion           Display JANA version information" << std::endl;
         std::cout << "   -c   --configs               Display configuration parameters" << std::endl;
         std::cout << "   -l   --loadconfigs <file>    Load configuration parameters from file" << std::endl;
         std::cout << "   -d   --dumpconfigs <file>    Dump configuration parameters to file" << std::endl;
@@ -76,8 +77,11 @@ namespace jana {
     }
 
     void PrintVersion() {
-        std::cout << "      EICrecon version: " << EICRECON_APP_VERSION_STR << std::endl;
-        std::cout << std::endl << std::endl;
+        std::cout << "EICrecon version: " << EICRECON_APP_VERSION_STR << std::endl;
+    }
+
+    void PrintJANAVersion() {
+        std::cout << "JANA version: " << JVersion::GetVersion() << std::endl;
     }
 
     void PrintDefaultPlugins(std::vector<std::string> const& default_plugins) {
@@ -153,6 +157,10 @@ namespace jana {
         }
         if (options.flags[jana::ShowVersion]) {
             jana::PrintVersion();
+            return true;
+        }
+        if (options.flags[jana::ShowJANAVersion]) {
+            jana::PrintJANAVersion();
             return true;
         }
         if (options.flags[jana::ShowDefaultPlugins]) {
@@ -402,6 +410,8 @@ namespace jana {
         tokenizer["--help"] = ShowUsage;
         tokenizer["-v"] = ShowVersion;
         tokenizer["--version"] = ShowVersion;
+        tokenizer["-j"] = ShowJANAVersion;
+        tokenizer["--janaversion"] = ShowJANAVersion;
         tokenizer["-c"] = ShowConfigs;
         tokenizer["--configs"] = ShowConfigs;
         tokenizer["-l"] = LoadConfigs;
@@ -442,6 +452,10 @@ namespace jana {
 
                 case ShowVersion:
                     options.flags[ShowVersion] = true;
+                    break;
+
+                case ShowJANAVersion:
+                    options.flags[ShowJANAVersion] = true;
                     break;
 
                 case ShowConfigs:

--- a/src/utilities/eicrecon/eicrecon_cli.h
+++ b/src/utilities/eicrecon/eicrecon_cli.h
@@ -13,6 +13,7 @@ namespace jana {
         Unknown,
         ShowUsage,
         ShowVersion,
+        ShowJANAVersion,
         ShowDefaultPlugins,
         ShowAvailablePlugins,
         ShowConfigs,


### PR DESCRIPTION
### Briefly, what does this PR introduce?
- Change how objects from factories are retrieved for podio:output_include_collections so the call graph is properly recorded by JAN internal tracking feature.

- Add -j,--janaversion command line option to eicrecon so one can see the version of JANA it was compiled against.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [X] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No