### PR TITLE
Fix parameter values for Imaging Barrel. Fix where units are applied.

### DIFF
--- a/src/algorithms/calorimetry/ImagingPixelReco.h
+++ b/src/algorithms/calorimetry/ImagingPixelReco.h
@@ -85,7 +85,7 @@ public:
         }
 
         // unitless conversion
-        dyRangeADC = m_dyRangeADC / dd4hep::GeV;
+        dyRangeADC = m_dyRangeADC;
     }
 
     void execute() {

--- a/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelImagingRecHits.h
+++ b/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelImagingRecHits.h
@@ -33,9 +33,9 @@ public:
         // length unit (from dd4hep geometry service)
         m_lUnit = dd4hep::mm; // {this, "lengthUnit", dd4hep::mm};
         // digitization parameters
-        m_capADC=8096; // {this, "capacityADC", 8096};
-        m_pedMeanADC=400; // {this, "pedestalMean", 400};
-        m_dyRangeADC=100 * MeV; // {this, "dynamicRangeADC", 100 * MeV};
+        m_capADC=8192; // {this, "capacityADC", 8096};
+        m_pedMeanADC=100; // {this, "pedestalMean", 400};
+        m_dyRangeADC=3;   // units should be MeV    {this, "dynamicRangeADC", 100 * MeV};
         m_pedSigmaADC=14; // {this, "pedestalSigma", 3.2};
         m_thresholdFactor=3.0; // {this, "thresholdFactor", 3.0};
         // Calibration!
@@ -52,6 +52,7 @@ public:
         app->SetDefaultParameter("BEMC:EcalBarrelImagingRecHits:samplingFraction", m_sampFrac);
         m_geoSvc = app->template GetService<JDD4hep_service>(); // TODO: implement named geometry service?
 
+        m_dyRangeADC *= MeV;
 
         initialize();
     }

--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelImagingRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelImagingRawHits.h
@@ -40,9 +40,9 @@ public:
         u_eRes = {0.0, 0.02, 0.0};
         m_tRes = 0.0 * ns;
         m_capADC = 8192;
-        m_dyRangeADC = 100 * MeV;
+        m_dyRangeADC = 3 * MeV;
         m_pedMeanADC = 100;
-        m_pedSigmaADC = 3.2;
+        m_pedSigmaADC = 14;
         m_resolutionTDC = 10 * picosecond;
         m_corrMeanScale = 1.0;
         m_geoSvcName = "ActsGeometryProvider";


### PR DESCRIPTION
### Briefly, what does this PR introduce?
- Fix C++ parameters to match reco_flags.py 
- Fix where units are converted for dyRangeADC (only for EcalBarrelImagingRecHits)

### What kind of change does this PR introduce?
- [X] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No