### PR TITLE
Restore use of _exit

### DIFF
--- a/src/services/geometry/dd4hep/JDD4hep_service.cc
+++ b/src/services/geometry/dd4hep/JDD4hep_service.cc
@@ -143,7 +143,11 @@ std::string JDD4hep_service::resolveFileName(const std::string &filename, char *
                 mess += fmt::format(fmt::emphasis::bold, "file: {} does not exist!", filename);
                 mess += "\nCheck that your DETECTOR and DETECTOR_CONFIG environment variables are set correctly.";
                 std::cerr << std::endl << std::endl << mess << std::endl << std::endl; // TODO standard log here!
-                std::exit(-1);  // TODO isn't unhandled JException is a better way to abort the application
+#ifdef __APPLE__
+                std::exit(-1);  // macos does notsupport _exit()
+#else
+                _exit(-1);  // exit while bypassing exit handlers
+#endif
             }
         }
     }

--- a/src/services/geometry/dd4hep/JDD4hep_service.cc
+++ b/src/services/geometry/dd4hep/JDD4hep_service.cc
@@ -143,11 +143,7 @@ std::string JDD4hep_service::resolveFileName(const std::string &filename, char *
                 mess += fmt::format(fmt::emphasis::bold, "file: {} does not exist!", filename);
                 mess += "\nCheck that your DETECTOR and DETECTOR_CONFIG environment variables are set correctly.";
                 std::cerr << std::endl << std::endl << mess << std::endl << std::endl; // TODO standard log here!
-#ifdef __APPLE__
-                std::exit(-1);  // macos does notsupport _exit()
-#else
-                _exit(-1);  // exit while bypassing exit handlers
-#endif
+                std::_Exit(EXIT_FAILURE);
             }
         }
     }

--- a/src/services/io/podio/JEventSourcePODIOsimple.cc
+++ b/src/services/io/podio/JEventSourcePODIOsimple.cc
@@ -131,11 +131,7 @@ void JEventSourcePODIOsimple::Open() {
             auto mess = fmt::format(fmt::emphasis::bold | fg(fmt::color::red),"ERROR: ");
             mess += fmt::format(fmt::emphasis::bold, "file: {} does not exist!",  GetResourceName());
             std::cerr << std::endl << std::endl << mess << std::endl << std::endl;
-#ifdef __APPLE__
-            std::exit(EXIT_FAILURE);  // macos does notsupport _exit()
-#else
-           _exit(-1);  // exit while bypassing exit handlers
-#endif
+            std::_Exit(EXIT_FAILURE);
         }
 
         // Have PODIO reader open file and get the number of events from it.

--- a/src/services/io/podio/JEventSourcePODIOsimple.cc
+++ b/src/services/io/podio/JEventSourcePODIOsimple.cc
@@ -131,7 +131,11 @@ void JEventSourcePODIOsimple::Open() {
             auto mess = fmt::format(fmt::emphasis::bold | fg(fmt::color::red),"ERROR: ");
             mess += fmt::format(fmt::emphasis::bold, "file: {} does not exist!",  GetResourceName());
             std::cerr << std::endl << std::endl << mess << std::endl << std::endl;
-            std::exit(EXIT_FAILURE);
+#ifdef __APPLE__
+            std::exit(EXIT_FAILURE);  // macos does notsupport _exit()
+#else
+           _exit(-1);  // exit while bypassing exit handlers
+#endif
         }
 
         // Have PODIO reader open file and get the number of events from it.


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This reverses the change in PR #331 so that _exit is used unless running on macos. The use of _exit was very deliberately chosen so that the root exit handlers are bypassed, ensuring the last message on the screen is the one indicating the cause of the exit. When just using std::exit, you will get messages like the following printed *after* the message that the file doesn't exist:

~~~
Error in <TClass::LoadClassInfo>: no interpreter information for class TVirtualStreamerInfo is available even though it has a TClass initialization routine.
~~~

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [X] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No