### PR TITLE
feat: SiPM pixel gap cuts

### DIFF
--- a/src/algorithms/digi/PhotoMultiplierHitDigi.cc
+++ b/src/algorithms/digi/PhotoMultiplierHitDigi.cc
@@ -24,9 +24,14 @@ using namespace dd4hep;
 //------------------------
 // AlgorithmInit
 //------------------------
-void eicrecon::PhotoMultiplierHitDigi::AlgorithmInit(std::shared_ptr<spdlog::logger>& logger) 
+void eicrecon::PhotoMultiplierHitDigi::AlgorithmInit(dd4hep::Detector *detector, std::shared_ptr<spdlog::logger>& logger) 
 {
+    // services
+    m_cellid_converter = std::make_shared<const dd4hep::rec::CellIDPositionConverter>(*detector);
     m_log=logger;
+
+    // random number generators
+    m_random.SetSeed(m_cfg.seed);
     m_rngNorm = [&](){
         return m_random.Gaus(0., 1.0);
     };
@@ -42,6 +47,7 @@ void eicrecon::PhotoMultiplierHitDigi::AlgorithmInit(std::shared_ptr<spdlog::log
         japp->Quit();
     }
 
+    // initialize quantum efficiency table
     qe_init();
 }
 
@@ -63,19 +69,38 @@ std::vector<edm4eic::RawPMTHit*>
 eicrecon::PhotoMultiplierHitDigi::AlgorithmProcess(std::vector<const edm4hep::SimTrackerHit*>& sim_hits) {
 
         m_log->trace("{:=^70}"," call PhotoMultiplierHitDigi::AlgorithmProcess ");
-        struct HitData { uint32_t npe; double signal; double time; };
+        struct HitData {
+          uint32_t npe;
+          double signal;
+          double time;
+          Position pos;
+        };
         std::unordered_map<uint64_t, std::vector<HitData>> hit_groups;
         // collect the photon hit in the same cell
         // calculate signal
         for(const auto& ahit : sim_hits) {
             // m_log->trace("{:-<60}","Simulation Hit");
             // m_log->trace("  {:>20}: {}\n", "EDep", ahit->getEDep()/eV);
+
+            // overall safety factor
+            if (m_rngUni() > m_cfg.safetyFactor) continue;
+
             // quantum efficiency
-            if (!qe_pass(ahit->getEDep(), m_rngUni())) {
-                continue;
+            if (!qe_pass(ahit->getEDep(), m_rngUni())) continue;
+
+            // pixel gap cuts
+            // FIXME: generalize; this assumes the segmentation is `CartesianGridXY`
+            auto id = ahit->getCellID();
+            Position pos_pixel, pos_hit;
+            if(m_cfg.enablePixelGaps) {
+              pos_pixel = get_sensor_local_position( id, m_cellid_converter->position(id) );
+              pos_hit   = get_sensor_local_position( id, vec2pos(ahit->getPosition())     );
+              if( std::abs( pos_hit.x()/mm - pos_pixel.x()/mm ) > m_cfg.pixelSize/mm/2 ||
+                  std::abs( pos_hit.y()/mm - pos_pixel.y()/mm ) > m_cfg.pixelSize/mm/2
+                ) continue;
             }
-            // cell id, time, signal amplitude
-            uint64_t id = ahit->getCellID();
+
+            // cell time, signal amplitude
             double time = ahit->getTime();//ahit->getMCParticle().getTime();
             double amp = m_cfg.speMean + m_rngNorm()*m_cfg.speError;
 
@@ -92,18 +117,18 @@ eicrecon::PhotoMultiplierHitDigi::AlgorithmProcess(std::vector<const edm4hep::Si
                 }
                 // no hits group found
                 if (i >= it->second.size()) {
-                    it->second.emplace_back(HitData{1, amp + m_cfg.pedMean + m_cfg.pedError*m_rngNorm(), time});
+                    it->second.emplace_back(HitData{1, amp + m_cfg.pedMean + m_cfg.pedError*m_rngNorm(), time, pos_hit});
                 }
             } else {
-                hit_groups[id] = {HitData{1, amp + m_cfg.pedMean + m_cfg.pedError*m_rngNorm(), time}};
+                hit_groups[id] = {HitData{1, amp + m_cfg.pedMean + m_cfg.pedError*m_rngNorm(), time, pos_hit}};
             }
         }
 
         // print `hit_groups`
-        if(m_log->level()<=spdlog::level::trace)
+        if(m_log->level() <= spdlog::level::trace)
           for(auto &[id,hitVec] : hit_groups)
             for(auto &hit : hitVec)
-              m_log->trace("pixel id={:#018x} -> npe={} signal={:<5g} time={:<5g}", id, hit.npe, hit.signal, hit.time);
+              m_log->trace("hit_group: pixel id={:#018x} -> npe={} signal={:<5g} time={:<5g}", id, hit.npe, hit.signal, hit.time);
 
         // build raw hits
         std::vector<edm4eic::RawPMTHit*> raw_hits;
@@ -113,6 +138,7 @@ eicrecon::PhotoMultiplierHitDigi::AlgorithmProcess(std::vector<const edm4hep::Si
                   it.first,
                   static_cast<uint32_t>(data.signal), 
                   static_cast<uint32_t>(data.time/(m_cfg.timeStep/ns))
+                  //,pos2vec(data.pos) // TEST gap cuts; requires member `edm4hep::Vector3d position` in data model datatype
                 };
                 raw_hits.push_back(hit);
             }
@@ -200,4 +226,55 @@ bool  eicrecon::PhotoMultiplierHitDigi::qe_pass(double ev, double rand) const
 
         // m_log->trace("{} eV, QE: {}\%",ev/eV,prob*100.);
         return rand <= prob;
+}
+
+
+// transform global position `pos` to sensor `id` frame position
+// IMPORTANT NOTE: this has only been tested for the dRICH; if you use it, test it carefully...
+// FIXME: here be dragons... 
+Position eicrecon::PhotoMultiplierHitDigi::get_sensor_local_position(uint64_t id, Position pos) {
+
+  // get the VolumeManagerContext for this sensitive detector
+  auto context = m_cellid_converter->findContext(id);
+
+  // transformation vector buffers
+  double xyz_l[3], xyz_e[3], xyz_g[2];
+  double pv_g[3], pv_l[3];
+
+  // get sensor position w.r.t. its parent
+  auto sensor_elem = context->element;
+  sensor_elem.placement().position().GetCoordinates(xyz_l);
+
+  // convert sensor position to global position (cf. `CellIDPositionConverter::positionNominal()`)
+  const auto& volToElement = context->toElement();
+  volToElement.LocalToMaster(xyz_l, xyz_e);
+  const auto& elementToGlobal = sensor_elem.nominal().worldTransformation();
+  elementToGlobal.LocalToMaster(xyz_e, xyz_g);
+  Position pos_sensor;
+  pos_sensor.SetCoordinates(xyz_g);
+
+  // get the position vector of `pos` w.r.t. the sensor position `pos_sensor`
+  Direction pos_pv = pos - pos_sensor;
+
+  // then transform it to the sensor's local frame
+  pos_pv.GetCoordinates(pv_g);
+  volToElement.MasterToLocalVect(pv_g, pv_l);
+  Position pos_transformed;
+  pos_transformed.SetCoordinates(pv_l);
+
+  // trace log
+  if(m_log->level() <= spdlog::level::trace) {
+    m_log->trace("pixel hit on cellID={:#018x}",id);
+    auto print_pos = [&] (std::string name, Position p) {
+      m_log->trace("  {:>30} x={:.2f} y={:.2f} z={:.2f} [mm]: ", name, p.x()/mm,  p.y()/mm,  p.z()/mm);
+    };
+    print_pos("input position",  pos);
+    print_pos("sensor position", pos_sensor);
+    print_pos("output position", pos_transformed);
+    // auto dim = m_cellid_converter->cellDimensions(id);
+    // for (size_t j = 0; j < std::size(dim); ++j)
+    //   m_log->trace("   - dimension {:<5} size: {:.2}",  j, dim[j]);
+  }
+
+  return pos_transformed;
 }

--- a/src/algorithms/digi/PhotoMultiplierHitDigi.h
+++ b/src/algorithms/digi/PhotoMultiplierHitDigi.h
@@ -21,34 +21,46 @@
 #include <spdlog/spdlog.h>
 
 #include "PhotoMultiplierHitDigiConfig.h"
+#include <algorithms/interfaces/WithPodConfig.h>
 
 namespace eicrecon {
 
-class PhotoMultiplierHitDigi {
+class PhotoMultiplierHitDigi : public WithPodConfig<PhotoMultiplierHitDigiConfig> {
 
     // Insert any member variables here
 
 public:
     PhotoMultiplierHitDigi() = default;
     ~PhotoMultiplierHitDigi(){}
-    void AlgorithmInit(std::shared_ptr<spdlog::logger>& logger);
+    void AlgorithmInit(dd4hep::Detector *detector, std::shared_ptr<spdlog::logger>& logger);
     void AlgorithmChangeRun();
     std::vector<edm4eic::RawPMTHit*> AlgorithmProcess(std::vector<const edm4hep::SimTrackerHit*>& sim_hits);
 
-    // configurations
-    eicrecon::PhotoMultiplierHitDigiConfig& getConfig() {return m_cfg;}
-    void applyConfig(eicrecon::PhotoMultiplierHitDigiConfig cfg) { m_cfg = cfg; }
+    // transform global position `pos` to sensor `id` frame position
+    // IMPORTANT NOTE: this has only been tested for the dRICH; if you use it, test it carefully...
+    dd4hep::Position get_sensor_local_position(uint64_t id, dd4hep::Position pos);
 
     //instantiate new spdlog logger
     std::shared_ptr<spdlog::logger> m_log;
 
+    // random number generators
     TRandomMixMax m_random;
     std::function<double()> m_rngNorm;
     std::function<double()> m_rngUni;
     //Rndm::Numbers m_rngUni, m_rngNorm;
 
+    // convert dd4hep::Position <-> edm4hep::Vector3d
+    edm4hep::Vector3d pos2vec(dd4hep::Position p) {
+      return edm4hep::Vector3d( p.x()/dd4hep::mm, p.y()/dd4hep::mm, p.z()/dd4hep::mm );
+    }
+    dd4hep::Position vec2pos(edm4hep::Vector3d v) {
+      return dd4hep::Position( v.x*dd4hep::mm, v.y*dd4hep::mm, v.z*dd4hep::mm );
+    }
+
+
 private:
-    eicrecon::PhotoMultiplierHitDigiConfig m_cfg;
+
+    std::shared_ptr<const dd4hep::rec::CellIDPositionConverter> m_cellid_converter;
 
     // std::default_random_engine generator; // TODO: need something more appropriate here
     // std::normal_distribution<double> m_normDist; // defaults to mean=0, sigma=1

--- a/src/algorithms/digi/PhotoMultiplierHitDigiConfig.h
+++ b/src/algorithms/digi/PhotoMultiplierHitDigiConfig.h
@@ -5,20 +5,31 @@
 namespace eicrecon {
   struct PhotoMultiplierHitDigiConfig {
 
+    // random number generator seed
+    unsigned long seed = 0;
+
+    // triggering
     double hitTimeWindow = 20.0*dd4hep::ns;
     double timeStep      = 0.0625*dd4hep::ns;
     double speMean       = 80.0;
     double speError      = 16.0;
     double pedMean       = 200.0;
     double pedError      = 3.0;
+
+    // SiPM pixels
+    bool   enablePixelGaps = false;          // enable/disable removal of hits in gaps between pixels
+    double pixelSize       = 3.0*dd4hep::mm; // pixel (active) size
+
+    // overall safety factor 
+    /* simulations assume the detector is ideal and perfect, but reality is
+     * often neither; use this safety factor to reduce the number of initial
+     * photon hits for a more conservative estimate of the number of
+     * photoelectrons, or set to 1 to apply no such factor
+     */
+    double safetyFactor = 1.0; // allowed range: (0,1]
     
+    // quantum efficiency
     // FIXME: figure out how users can override this, maybe an external `yaml` file
-    /*
-    std::vector<std::pair<double, double> > quantumEfficiency = { // test unit QE
-      {325*dd4hep::nm, 1.00},
-      {900*dd4hep::nm, 1.00}
-    };
-    */
     std::vector<std::pair<double, double> > quantumEfficiency = {
       {325*dd4hep::nm, 0.04},
       {340*dd4hep::nm, 0.10},
@@ -36,6 +47,12 @@ namespace eicrecon {
       {850*dd4hep::nm, 0.06},
       {900*dd4hep::nm, 0.04}
     };
+    /*
+    std::vector<std::pair<double, double> > quantumEfficiency = { // test unit QE
+      {325*dd4hep::nm, 1.00},
+      {900*dd4hep::nm, 1.00}
+    };
+    */
 
   };
 }

--- a/src/global/digi/PhotoMultiplierHitDigi_factory.cc
+++ b/src/global/digi/PhotoMultiplierHitDigi_factory.cc
@@ -22,22 +22,27 @@ void eicrecon::PhotoMultiplierHitDigi_factory::Init() {
   // Set input tags
   InitDataTags(param_prefix);
 
-  // Logger. Get plugin level sub-log
+  // Services
+  auto geo_service = app->GetService<JDD4hep_service>();
   InitLogger(param_prefix, "info");
 
   // Setup digitization algorithm
   auto cfg = GetDefaultConfig();
+  pm->SetDefaultParameter(param_prefix + ":seed",            cfg.seed,            "random number generator seed");
+  pm->SetDefaultParameter(param_prefix + ":hitTimeWindow",   cfg.hitTimeWindow,   "");
+  pm->SetDefaultParameter(param_prefix + ":timeStep",        cfg.timeStep,        "");
+  pm->SetDefaultParameter(param_prefix + ":speMean",         cfg.speMean,         "");
+  pm->SetDefaultParameter(param_prefix + ":speError",        cfg.speError,        "");
+  pm->SetDefaultParameter(param_prefix + ":pedMean",         cfg.pedMean,         "");
+  pm->SetDefaultParameter(param_prefix + ":pedError",        cfg.pedError,        "");
+  pm->SetDefaultParameter(param_prefix + ":enablePixelGaps", cfg.enablePixelGaps, "enable/disable removal of hits in gaps between pixels");
+  pm->SetDefaultParameter(param_prefix + ":pixelSize",       cfg.pixelSize,       "pixel (active) size");
+  pm->SetDefaultParameter(param_prefix + ":safetyFactor",    cfg.safetyFactor,    "overall safety factor");
   // pm->SetDefaultParameter(param_prefix + ":quantumEfficiency", cfg.quantumEfficiency, ""); // FIXME cannot use vector<pair>
-  pm->SetDefaultParameter(param_prefix + ":hitTimeWindow",     cfg.hitTimeWindow,     "");
-  pm->SetDefaultParameter(param_prefix + ":timeStep",          cfg.timeStep,          "");
-  pm->SetDefaultParameter(param_prefix + ":speMean",           cfg.speMean,           "");
-  pm->SetDefaultParameter(param_prefix + ":speError",          cfg.speError,          "");
-  pm->SetDefaultParameter(param_prefix + ":pedMean",           cfg.pedMean,           "");
-  pm->SetDefaultParameter(param_prefix + ":pedError",          cfg.pedError,          "");
 
   // Initialize digitization algorithm
   m_digi_algo.applyConfig(cfg);
-  m_digi_algo.AlgorithmInit(m_log);
+  m_digi_algo.AlgorithmInit(geo_service->detector(), m_log);
 }
 
 void eicrecon::PhotoMultiplierHitDigi_factory::ChangeRun(const std::shared_ptr<const JEvent> &event) {
@@ -54,6 +59,7 @@ void eicrecon::PhotoMultiplierHitDigi_factory::Process(const std::shared_ptr<con
         sim_hits.push_back(hit);
     } catch(std::exception &e) {
       m_log->critical(e.what());
+      throw JException(e.what());
     }
   }
 

--- a/src/global/digi/PhotoMultiplierHitDigi_factory.h
+++ b/src/global/digi/PhotoMultiplierHitDigi_factory.h
@@ -18,6 +18,7 @@
 #include <algorithms/digi/PhotoMultiplierHitDigiConfig.h>
 
 // services
+#include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 #include <extensions/spdlog/SpdlogMixin.h>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Add the ability to cut on the boundaries of an XY-segmented SiPM sensor, to simulate gaps between SiPM pixels. Also adds an overall safety factor, to account for the non-ideal reality.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
no