### PR TITLE
Fix Imaging Barrel Ecal Clustering

### DIFF
--- a/src/algorithms/calorimetry/ImagingClusterReco.h
+++ b/src/algorithms/calorimetry/ImagingClusterReco.h
@@ -96,7 +96,7 @@ public:
             for (const auto &layer: cl_layers) {
                 auto layer_ptr = new edm4eic::Cluster( layer );
                 layers.push_back(layer_ptr);
-                cl.addToClusters(*layer_ptr);
+//                cl.addToClusters(*layer_ptr);
             }
             clusters.push_back(new edm4eic::Cluster( cl ));
 
@@ -246,7 +246,7 @@ private:
             meta += edm4eic::eta(hit.getPosition()) * energyWeight;
             mphi += edm4eic::angleAzimuthal(hit.getPosition()) * energyWeight;
             r = std::min(edm4eic::magnitude(hit.getPosition()), r);
-            cluster.addToHits(hit);
+//            cluster.addToHits(hit);
         }
         cluster.setEnergy(energy);
         cluster.setEnergyError(std::sqrt(energyError));

--- a/src/algorithms/calorimetry/TruthEnergyPositionClusterMerger.h
+++ b/src/algorithms/calorimetry/TruthEnergyPositionClusterMerger.h
@@ -88,11 +88,11 @@ public:
                 new_clus.setNhits(pclus.getNhits() + eclus.getNhits());
                 new_clus.setPosition(pclus.getPosition());
                 new_clus.setPositionError(pclus.getPositionError());
-                new_clus.addToClusters(pclus);
-                new_clus.addToClusters(eclus);
+//                new_clus.addToClusters(pclus);
+//                new_clus.addToClusters(eclus);
                 for (const auto &cl: {pclus, eclus}) {
                     for (const auto &hit: cl.getHits()) {
-                        new_clus.addToHits(hit);
+//                        new_clus.addToHits(hit);
                     }
                     new_clus.addToSubdetectorEnergies(cl.getEnergy());
                 }
@@ -123,7 +123,7 @@ public:
                     m_log->debug("   --> No matching energy cluster found, copying over position cluster" );
                 }
                 auto new_clus = pclus.clone();
-                new_clus.addToClusters(pclus);
+//                new_clus.addToClusters(pclus);
                 auto cl = new edm4eic::Cluster(new_clus);
                 merged_clus.push_back(cl);
 
@@ -155,7 +155,7 @@ public:
             new_clus.setNhits(eclus.getNhits());
             // use nominal radius of 110cm, and use start vertex theta and phi
             new_clus.setPosition(edm4eic::sphericalToVector(110. * cm, theta, phi));
-            new_clus.addToClusters(eclus);
+//            new_clus.addToClusters(eclus);
             if (m_log->level() == SPDLOG_LEVEL_DEBUG) {
                 m_log->debug( fmt::format(" --> Processing energy cluster {}, mcID: {}, energy: {}", eclus.id() ,mcID ,eclus.getEnergy() ));
                 m_log->debug( fmt::format("   --> Created new 'combined' cluster {}, energy: {}", new_clus.id(),new_clus.getEnergy() ));

--- a/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelScFiRecHits.h
+++ b/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelScFiRecHits.h
@@ -50,6 +50,9 @@ public:
 
 //        app->SetDefaultParameter("BEMC:tag",              m_input_tag);
         app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:input_tag",        m_input_tag, "Name of input collection to use");
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:readout",          m_readout );
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:layerField",       m_layerField );
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:sectorField",      m_sectorField );
         app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:capacityADC",      m_capADC);
         app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:dynamicRangeADC",  m_dyRangeADC);
         app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:pedestalMean",     m_pedMeanADC);

--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelImagingRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelImagingRawHits.h
@@ -40,7 +40,7 @@ public:
         u_eRes = {0.0, 0.02, 0.0};
         m_tRes = 0.0 * ns;
         m_capADC = 8192;
-        m_dyRangeADC = 3 * MeV;
+        m_dyRangeADC = 3; // value should be in MeV
         m_pedMeanADC = 100;
         m_pedSigmaADC = 14;
         m_resolutionTDC = 10 * picosecond;

--- a/src/services/io/podio/RootWriter.cc
+++ b/src/services/io/podio/RootWriter.cc
@@ -67,6 +67,7 @@ namespace eic {
                 collections.pop_back();
                 if( unwritable_collections.count(name) ==0 ){
                     m_log->warn( fmt::format("Unable to write collection {} to output file. Skipping.", name) );
+                    m_log->warn(e.what());
                     unwritable_collections.insert( name );
                 }
             }

--- a/src/tools/default_flags_table/reco_flags.py
+++ b/src/tools/default_flags_table/reco_flags.py
@@ -121,6 +121,9 @@ eicrecon_reco_flags = [
     ('BEMC:EcalBarrelImagingRecHits:samplingFraction',          '0.005',                           ''),
 
     ('BEMC:EcalBarrelScFiRecHits:input_tag',                    'EcalBarrelScFiRawHits',           'Name of input collection to use'),
+    ('BEMC:EcalBarrelScFiRecHits:readout',                      'EcalBarrelScFiHits',              ''),
+    ('BEMC:EcalBarrelScFiRecHits:layerField',                   'layer',                           ''),
+    ('BEMC:EcalBarrelScFiRecHits:sectorField',                  'module',                          ''),
     ('BEMC:EcalBarrelScFiRecHits:capacityADC',                  'capacityBitsADC=14',              ''),
     ('BEMC:EcalBarrelScFiRecHits:dynamicRangeADC',              '750*MeV',                         ''),
     ('BEMC:EcalBarrelScFiRecHits:pedestalMean',                 '20',                              ''),

--- a/src/tools/default_flags_table/reco_flags.py
+++ b/src/tools/default_flags_table/reco_flags.py
@@ -144,7 +144,7 @@ eicrecon_reco_flags = [
     ('BEMC:EcalBarrelImagingProtoClusters::sectorDist',         '3.0*cm',                          ''),
     ('BEMC:EcalBarrelImagingProtoClusters::minClusterHitEdep',  '0.',                              ''),
     ('BEMC:EcalBarrelImagingProtoClusters::minClusterCenterEdep', '0.',                            ''),
-    ('BEMC:EcalBarrelImagingProtoClusters::minClusterEdep',     '0.5*MeV',                         ''),
+    ('BEMC:EcalBarrelImagingProtoClusters::minClusterEdep',     '80*MeV',                          ''),
     ('BEMC:EcalBarrelImagingProtoClusters::minClusterNhits',    '5',                               ''),
 
     ('BEMC:EcalBarrelScFiProtoClusters:input_tag',              'EcalBarrelScFiMergedHits', 'Name of input collection to use'),


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This fixes the Imaging Barrel calorimeter so that the `EcalBarrelImagingClusters` and `EcalBarrelImagingMergedClusters` are written out. This was tested with single 10GeV e- events (see attached plots). 

The main issue was with podio refusing to write collections that references "untracked" objects. This is a known issue with the podio+JANA2 implementation. The "fix" was to disable adding the references to the cluster objects.

### What kind of change does this PR introduce?
- [X] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
Yes, it makes it work.

![image](https://user-images.githubusercontent.com/12838629/202089747-29d09315-48dc-45b4-bfd5-5065b98e977d.png)
