### PR TITLE
fix: ensure reco_flags.py are propagated to defaults in factories

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -152,6 +152,24 @@ jobs:
         path: ${{ matrix.detector_config }}_right_flags.json
         if-no-files-found: error
 
+  diff-flags:
+    runs-on: ubuntu-latest
+    needs:
+      - run_eicrecon_reco_flags-gcc
+      - eicrecon-gcc
+    strategy:
+      matrix:
+        detector_config: [arches, brycecanyon]
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: ${{ matrix.detector_config }}_flags.json
+      - uses: actions/download-artifact@v3
+        with:
+          name: ${{ matrix.detector_config }}_right_flags.json
+      - run: |
+          diff ${{ matrix.detector_config }}_right_flags.json ${{ matrix.detector_config }}_flags.json
+
   # This job is to build postprocessing of artifacts from EICrecon runs
   generate-report:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This introduces the CI test to ensure flags are propagated to the factories. Then it will also include the propagation of those flags.

### What kind of change does this PR introduce?
- [X] Bug fix (issue: run_eicrecon_reco_flags.py should be phased out)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes. It will make default behavior correct.