### PR TITLE
fix: use B0ECAL not EEMC in B0EcalClusters

### DIFF
--- a/src/detectors/B0ECAL/Cluster_factory_B0ECalClusters.h
+++ b/src/detectors/B0ECAL/Cluster_factory_B0ECalClusters.h
@@ -44,13 +44,13 @@ public:
         m_enableEtaBounds=false;//{this, "enableEtaBounds", false};
 
 
-        app->SetDefaultParameter("EEMC:B0ECalClusters:input_protoclust_tag",  m_input_protoclust_tag, "Name of input collection to use");
-        app->SetDefaultParameter("EEMC:B0ECalClusters:samplingFraction",             m_sampFrac);
-        app->SetDefaultParameter("EEMC:B0ECalClusters:logWeightBase",  m_logWeightBase);
-        app->SetDefaultParameter("EEMC:B0ECalClusters:depthCorrection",     m_depthCorrection);
-        app->SetDefaultParameter("EEMC:B0ECalClusters:energyWeight",   m_energyWeight);
-        app->SetDefaultParameter("EEMC:B0ECalClusters:moduleDimZName",   m_moduleDimZName);
-        app->SetDefaultParameter("EEMC:B0ECalClusters:enableEtaBounds",   m_enableEtaBounds);
+        app->SetDefaultParameter("B0ECAL:B0ECalClusters:input_protoclust_tag",  m_input_protoclust_tag, "Name of input collection to use");
+        app->SetDefaultParameter("B0ECAL:B0ECalClusters:samplingFraction",             m_sampFrac);
+        app->SetDefaultParameter("B0ECAL:B0ECalClusters:logWeightBase",  m_logWeightBase);
+        app->SetDefaultParameter("B0ECAL:B0ECalClusters:depthCorrection",     m_depthCorrection);
+        app->SetDefaultParameter("B0ECAL:B0ECalClusters:energyWeight",   m_energyWeight);
+        app->SetDefaultParameter("B0ECAL:B0ECalClusters:moduleDimZName",   m_moduleDimZName);
+        app->SetDefaultParameter("B0ECAL:B0ECalClusters:enableEtaBounds",   m_enableEtaBounds);
 
         m_geoSvc = app->template GetService<JDD4hep_service>();
 

--- a/src/detectors/B0ECAL/Cluster_factory_B0ECalMergedClusters.h
+++ b/src/detectors/B0ECAL/Cluster_factory_B0ECalMergedClusters.h
@@ -35,8 +35,8 @@ public:
         std::string tag=this->GetTag();
         std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
 
-        app->SetDefaultParameter("EEMC:B0ECalMergedClusters:input_tag",      m_input_tag, "Name of input collection to use");
-        app->SetDefaultParameter("EEMC:B0ECalMergedClusters:inputAssociations_tag",      m_inputAssociations_tag, "Name of input associations collection to use");
+        app->SetDefaultParameter("B0ECAL:B0ECalMergedClusters:input_tag",      m_input_tag, "Name of input collection to use");
+        app->SetDefaultParameter("B0ECAL:B0ECalMergedClusters:inputAssociations_tag",      m_inputAssociations_tag, "Name of input associations collection to use");
 
         AlgorithmInit(m_log);
     }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
E.g. reco_flags defines `B0ECAL:B0ECalClusters:depthCorrection` but parameter is not called that. This makes sure the parameters also have B0ECAL prefixes.

### What kind of change does this PR introduce?
- [X] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.