### PR TITLE
fix: add default Ecal Endcap N params in factories

### DIFF
--- a/src/detectors/EEMC/CalorimeterHit_factory_EcalEndcapNRecHits.h
+++ b/src/detectors/EEMC/CalorimeterHit_factory_EcalEndcapNRecHits.h
@@ -26,15 +26,15 @@ public:
         m_input_tag = "EcalEndcapNRawHits";
 
         // digitization settings, must be consistent with digi class
-        m_capADC=8096;//{this, "capacityADC", 8096};
-        m_dyRangeADC=100. * MeV;//{this, "dynamicRangeADC", 100. * MeV};
-        m_pedMeanADC=400;//{this, "pedestalMean", 400};
-        m_pedSigmaADC=3.2;//{this, "pedestalSigma", 3.2};
+        m_capADC=16384;//{this, "capacityADC", 8096};
+        m_dyRangeADC=20. * GeV;//{this, "dynamicRangeADC", 100. * MeV};
+        m_pedMeanADC=100;//{this, "pedestalMean", 400};
+        m_pedSigmaADC=1;//{this, "pedestalSigma", 3.2};
         m_resolutionTDC=10 * dd4hep::picosecond;//{this, "resolutionTDC", 10 * ps};
 
         // zero suppression values
         m_thresholdFactor=4.0;//{this, "thresholdFactor", 0.0};
-        m_thresholdValue=0.0;//{this, "thresholdValue", 0.0};
+        m_thresholdValue=3.0;//{this, "thresholdValue", 0.0};
 
         // energy correction with sampling fraction
         m_sampFrac=0.998;//{this, "samplingFraction", 1.0};

--- a/src/detectors/EEMC/Cluster_factory_EcalEndcapNTruthClusters.h
+++ b/src/detectors/EEMC/Cluster_factory_EcalEndcapNTruthClusters.h
@@ -45,8 +45,8 @@ public:
         m_input_simhit_tag="EcalEndcapNHits";
         m_input_protoclust_tag="EcalEndcapNTruthProtoClusters";
     
-        m_sampFrac=1.0;//{this, "samplingFraction", 1.0};
-        m_logWeightBase=3.6;//{this, "logWeightBase", 3.6};
+        m_sampFrac=0.03;//{this, "samplingFraction", 1.0};
+        m_logWeightBase=4.6;//{this, "logWeightBase", 3.6};
         m_depthCorrection=0.0;//{this, "depthCorrection", 0.0};
         m_energyWeight="log";//{this, "energyWeight", "log"};
         m_moduleDimZName="";//{this, "moduleDimZName", ""};

--- a/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapNRawHits.h
+++ b/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapNRawHits.h
@@ -39,10 +39,10 @@ public:
         m_input_tag = "EcalEndcapNHits";
         u_eRes = {};
         m_tRes = 0.0 * ns;
-        m_capADC = 8096;
-        m_dyRangeADC = 100 * MeV;
-        m_pedMeanADC = 400;
-        m_pedSigmaADC = 3.2;
+        m_capADC = 16384;
+        m_dyRangeADC = 20 * GeV;
+        m_pedMeanADC = 100;
+        m_pedSigmaADC = 1;
         m_resolutionTDC = 10 * picosecond;
         m_corrMeanScale = 1.0;
         u_fields={};


### PR DESCRIPTION
This propagates the EcalEndcapN parameters from reco_flags.py to the factories.