### PR TITLE
fix: MPGDTrackerHit:TimeResolution default 8 ns

### DIFF
--- a/src/detectors/MPGD/MPGD.cc
+++ b/src/detectors/MPGD/MPGD.cc
@@ -28,7 +28,7 @@ void InitPlugin(JApplication *app) {
 
     // Convert raw digitized hits into hits with geometry info (ready for tracking)
     TrackerHitReconstructionConfig hit_reco_cfg;
-    hit_reco_cfg.time_resolution = 10;
+    hit_reco_cfg.time_resolution = 8;
     app->Add(new JChainFactoryGeneratorT<TrackerHitReconstruction_factory>(
             {"MPGDTrackerRawHit"},     // Input data collection tags
             "MPGDTrackerHit",          // Output data tag


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Make MPGD defaults consistent with reco_flags. See https://github.com/eic/EICrecon/blob/main/src/tools/default_flags_table/reco_flags.py#L722-L724. @mposik1983 

### What kind of change does this PR introduce?
- [x] Bug fix (issue: reco_flags inconsistent)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, consistent with reco_flags.