### PR TITLE
fix: define default parameters after user parameters in `reco_flags.py`

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -103,7 +103,7 @@ jobs:
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
           export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
           chmod a+x bin/*
-          $PWD/bin/eicrecon -Ppodio:output_file=rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -Pplugins=dump_flags -Pdump_flags:json=${{ matrix.detector_config }}_flags.json
+          $PWD/bin/eicrecon -Ppodio:output_file=rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -Pplugins=dump_flags,janadot -Pdump_flags:json=${{ matrix.detector_config }}_flags.json
     - uses: actions/upload-artifact@v3
       with:
         name: eicrecon_rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
@@ -113,6 +113,11 @@ jobs:
       with:
         name: ${{ matrix.detector_config }}_flags.json
         path: ${{ matrix.detector_config }}_flags.json
+        if-no-files-found: error
+    - uses: actions/upload-artifact@v3
+      with:
+        name: eicrecon_rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.dot
+        path: jana.dot
         if-no-files-found: error
 
   run_eicrecon_reco_flags-gcc:
@@ -140,7 +145,7 @@ jobs:
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
           export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
           chmod a+x bin/*
-          $PWD/bin/run_eicrecon_reco_flags.py sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }} -Pdump_flags:json=${{ matrix.detector_config }}_right_flags.json
+          $PWD/bin/run_eicrecon_reco_flags.py sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }} -Pplugins=dump_flags,janadot -Pdump_flags:json=${{ matrix.detector_config }}_right_flags.json
     - uses: actions/upload-artifact@v3
       with:
         name: run_eicrecon_reco_flags_rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
@@ -150,6 +155,11 @@ jobs:
       with:
         name: ${{ matrix.detector_config }}_right_flags.json
         path: ${{ matrix.detector_config }}_right_flags.json
+        if-no-files-found: error
+    - uses: actions/upload-artifact@v3
+      with:
+        name: run_eicrecon_reco_flags_rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.dot
+        path: jana.dot
         if-no-files-found: error
 
   diff-flags:

--- a/src/tools/default_flags_table/reco_flags.py
+++ b/src/tools/default_flags_table/reco_flags.py
@@ -913,7 +913,10 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     run_command = [
-        f"eicrecon",
+        f"eicrecon"
+    ]
+
+    default_parameters = [
         f"-Pplugins=dump_flags",
         f"-Pdump_flags:python=all_flags_dump_from_run.py",
         f"-Pjana:debug_plugin_loading=1",
@@ -928,6 +931,9 @@ if __name__ == "__main__":
 
     # Add parameters from args
     run_command.extend(parameter_args)
+
+    # Add default parameters
+    run_command.extend(default_parameters)
 
     # Add reco_flags
     run_command.extend(flags_arguments)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Allow the user to override default parameters specified by `reco_flags.py` by putting them first. Fixes #370.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #370)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added: janadot added to `run_eicrecon_reco_flags.py` test
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.