### PR TITLE
Fix CI failure on redundatnt flags python generation

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -166,25 +166,7 @@ jobs:
         path: jana.dot
         if-no-files-found: error
 
-  diff-flags:
-    runs-on: ubuntu-latest
-    needs:
-      - run_eicrecon_reco_flags-gcc
-      - eicrecon-gcc
-    strategy:
-      matrix:
-        detector_config: [arches, brycecanyon]
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: ${{ matrix.detector_config }}_flags.json
-      - uses: actions/download-artifact@v3
-        with:
-          name: ${{ matrix.detector_config }}_right_flags.json
-      - run: |
-          diff ${{ matrix.detector_config }}_right_flags.json ${{ matrix.detector_config }}_flags.json
-
-   # build-docs and deploy-docs copy doxygen.yml functionality
+  # build-docs and deploy-docs copy doxygen.yml functionality
   # the difference is that these jobs use resulting artifacts from EICrecon runs
   # to embed into docs
   build-docs-advanced:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -186,7 +186,6 @@ jobs:
       - run: |
           apk add doxygen graphviz
           doxygen Doxyfile
-          cp flags.md docs/table_flags/flags.md
           cp arches_right_flags.json docs/arches_flags.json
           cp -r docs publishing_docs
           mv html publishing_docs/doxygen

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -184,39 +184,12 @@ jobs:
       - run: |
           diff ${{ matrix.detector_config }}_right_flags.json ${{ matrix.detector_config }}_flags.json
 
-  # This job is to build postprocessing of artifacts from EICrecon runs
-  generate-report:
-    runs-on: ubuntu-latest
-    needs:
-      - run_eicrecon_reco_flags-gcc
-      - eicrecon-gcc
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/download-artifact@v3
-        with:
-          name: arches_flags.json
-
-      - uses: actions/download-artifact@v3
-        with:
-          name: arches_right_flags.json
-
-      - name: Build flags table
-        run: |
-          python3 src/tools/default_flags_table/gen_markdown_tables.py --flags=arches_right_flags.json --template=docs/table_flags/flags.in.md --output=flags.md
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: flags.md
-          path: flags.md
-          if-no-files-found: error
-
-  # build-docs and deploy-docs copy doxygen.yml functionality
+   # build-docs and deploy-docs copy doxygen.yml functionality
   # the difference is that these jobs use resulting artifacts from EICrecon runs
   # to embed into docs
   build-docs-advanced:
     needs:
-      - generate-report
+      - run_eicrecon_reco_flags-gcc
     runs-on: ubuntu-latest
     container:
       image: alpine:latest
@@ -225,9 +198,6 @@ jobs:
       # FIXME hard-coded: see https://github.com/actions/upload-pages-artifact/pull/14
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
-        with:
-          name: flags.md
       - uses: actions/download-artifact@v3
         with:
           name: arches_right_flags.json


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Removes "report" step and generation of python files with flags and flags.md page. This all has been replaced by using output flags.json directly (from eicrecon run with dump_flags). Report step can be re-instantiated later... when there will be something else to report. 


### What kind of change does this PR introduce?
- [x] Bug fix (fixes #374)


### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

NO

### Does this PR change default behavior?

NO