### PR TITLE
feat: parse parameters and units with `DDParsers`

### DIFF
--- a/src/utilities/eicrecon/CMakeLists.txt
+++ b/src/utilities/eicrecon/CMakeLists.txt
@@ -10,7 +10,14 @@ find_package(fmt     REQUIRED)
 find_package(ROOT REQUIRED COMPONENTS Core Tree Hist RIO EG)
 
 # Compile all sources into executable
-file(GLOB SOURCES *.cpp *.cc *.c  *.hpp *.hh *.h)
+set(SOURCES
+  eicrecon_cli.cpp
+  eicrecon.cc
+  parser.cc
+  eicrecon_cli.h
+  parser.h
+  print_info.h
+)
 
 set( INCLUDE_DIRS  ${PROJECT_BINARY_DIR} ${EICRECON_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR} ${JANA_INCLUDE_DIR} ${ROOT_INCLUDE_DIRS})
 set( LINK_LIBRARIES ${JANA_LIB} ${ROOT_LIBRARIES} ${CMAKE_DL_LIBS} Threads::Threads podio::podio podio::podioRootIO)
@@ -20,7 +27,15 @@ add_executable( eicrecon ${SOURCES} )
 target_include_directories( eicrecon PUBLIC ${INCLUDE_DIRS})
 target_link_libraries(eicrecon ${LINK_LIBRARIES} DD4hep::DDParsers fmt::fmt)
 target_compile_definitions(eicrecon PRIVATE EICRECON_APP_VERSION=${CMAKE_PROJECT_VERSION})
-
-
-# Install executable
 install(TARGETS eicrecon DESTINATION bin)
+
+# Define tests
+find_package(Catch2 3)
+if(Catch2_FOUND)
+  add_executable( param_parser_test param_parser_test.cc parser.cc parser.h)
+  target_include_directories( param_parser_test PUBLIC ${INCLUDE_DIRS})
+  target_link_libraries(param_parser_test ${LINK_LIBRARIES} DD4hep::DDParsers fmt::fmt Catch2::Catch2WithMain)
+  install(TARGETS param_parser_test DESTINATION bin)
+else()
+    message(STATUS "Catch2 is not found. Skipping bin/eicrecon tests...")
+endif()

--- a/src/utilities/eicrecon/CMakeLists.txt
+++ b/src/utilities/eicrecon/CMakeLists.txt
@@ -18,7 +18,7 @@ set( LINK_LIBRARIES ${JANA_LIB} ${ROOT_LIBRARIES} ${CMAKE_DL_LIBS} Threads::Thre
 # Define executable
 add_executable( eicrecon ${SOURCES} )
 target_include_directories( eicrecon PUBLIC ${INCLUDE_DIRS})
-target_link_libraries(eicrecon ${LINK_LIBRARIES} )
+target_link_libraries(eicrecon ${LINK_LIBRARIES} DD4hep::DDParsers fmt::fmt)
 target_compile_definitions(eicrecon PRIVATE EICRECON_APP_VERSION=${CMAKE_PROJECT_VERSION})
 
 

--- a/src/utilities/eicrecon/eicrecon_cli.cpp
+++ b/src/utilities/eicrecon/eicrecon_cli.cpp
@@ -4,6 +4,7 @@
 
 #include "eicrecon_cli.h"
 #include "print_info.h"
+#include "parser.h"
 
 #include <JANA/CLI/JVersion.h>
 #include <JANA/CLI/JBenchmarker.h>
@@ -404,6 +405,7 @@ namespace jana {
     UserOptions GetCliOptions(int nargs, char *argv[], bool expect_extra) {
 
         UserOptions options;
+        parser::Parser val_parser;
 
         std::map<std::string, Flag> tokenizer;
         tokenizer["-h"] = ShowUsage;
@@ -505,7 +507,10 @@ namespace jana {
                             if (options.params.find(key) != options.params.end()) {
                                 std::cout << "Duplicate parameter '" << arg << "' ignored" << std::endl;
                             } else {
-                                options.params.insert({key, val});
+                                auto val_parsed = val_parser.dd4hep_to_string(val,key);
+                                options.params.insert({ key, val_parsed.result });
+                                if (!val_parsed.success)
+                                    std::cerr << "ERROR: failed to parse '" << arg << "'" << std::endl;
                             }
                         } else {
                             std::cout << "Invalid JANA parameter '" << arg

--- a/src/utilities/eicrecon/param_parser_test.cc
+++ b/src/utilities/eicrecon/param_parser_test.cc
@@ -1,0 +1,151 @@
+// Copyright (C) 2023 Christopher Dilks
+// Subject to the terms in the LICENSE file found in the top-level directory.
+
+#include <catch2/catch_test_macros.hpp>
+#include <fmt/format.h>
+#include <functional>
+#include <sstream>
+#include <iomanip>
+
+#include "parser.h"
+
+// common methods
+// ---------------------------------------------
+
+// generate a test parameter name, with incrementing counter
+std::string KeyName(int &i, std::string key="test:param") {
+  return key + std::to_string(i++);
+}
+
+// run a test and print results
+bool RunTest(
+    std::shared_ptr<jana::parser::Parser> val_parser,
+    std::string key,
+    std::string val_in,
+    std::string val_exp,
+    std::function<bool(std::string,std::string)> check
+    )
+{
+  fmt::print("TEST {}:\n", key);
+  auto val_parsed = val_parser->dd4hep_to_string(val_in, key);
+  if(!val_parsed.success) return false;
+  auto val_out = val_parsed.result;
+  auto passed  = check(val_out, val_exp);
+  fmt::print("  RESULT:\n{:>20}: '{}'\n{:>20}: '{}'\n{:>20}: '{}'\n{:>20}: {}\n\n",
+      "Input",       val_in,
+      "Output",      val_out,
+      "Expectation", val_exp,
+      "Passed",      passed
+      );
+  return passed;
+}
+
+// tests
+// ---------------------------------------------
+TEST_CASE("Parameter Parsing", "[param_parser]" ) {
+
+  // instantiate Parser
+  auto m_parser = std::make_shared<jana::parser::Parser>();
+
+  // --------------------------------------------
+  SECTION("parse numbers, units, and math") {
+
+    // implementation: check if difference between parsed number and expected number is less than a threshold
+    int    precision      = 15;
+    double diff_threshold = std::pow(10, -precision);
+    int    i              = 1;
+    auto test_number = [&] (std::string val_in, double val_exp) {
+      std::stringstream val_exp_stream;
+      val_exp_stream << std::setprecision(precision) << val_exp;
+      auto val_exp_str = val_exp_stream.str();
+      return RunTest(
+          m_parser,
+          KeyName(i, "test:param:number"),
+          val_in,
+          val_exp_str,
+          [&] (std::string a, std::string b) { return std::abs( std::stod(a) - std::stod(b) ) < diff_threshold; }
+          );
+    };
+
+    // tests
+    REQUIRE(test_number( "7",          7            ));
+    REQUIRE(test_number( "7*6",        42           ));
+    REQUIRE(test_number( "1-10/2",     -4           ));
+    REQUIRE(test_number( "1*mm",       1            ));
+    REQUIRE(test_number( "1*m",        1000         ));
+    REQUIRE(test_number( "5*GeV",      5            ));
+    REQUIRE(test_number( "5e+3*MeV",   5            ));
+    REQUIRE(test_number( "5*keV",      5e-6         ));
+    REQUIRE(test_number( "8*ns",       8            ));
+    REQUIRE(test_number( "8*s",        8e+9         ));
+    REQUIRE(test_number( "1240*eV*nm", 1240/1e9/1e6 ));
+
+  }
+
+  // --------------------------------------------
+  SECTION("parse strings") {
+
+    // implementation: check if the string remains the same
+    int i = 1;
+    auto test_string = [&] (std::string val_in) {
+      return RunTest(
+          m_parser,
+          KeyName(i, "test:param:string"),
+          val_in,
+          val_in, // (val_exp, checking if it's the same)
+          [&] (std::string a, std::string b) { return a==b; }
+          );
+    };
+
+    // tests
+    REQUIRE(test_string( "test_string"               ));
+    REQUIRE(test_string( "this,string,is,not,a,list" )); // this string should not be parsed as a list of numbers
+    REQUIRE(test_string( ""                          )); // empty string
+    REQUIRE(test_string( "1240*ev*nm"                )); // typo in units (ev); should be parsed as string
+
+  }
+
+  // --------------------------------------------
+  SECTION("parse lists") {
+
+    // implementation: check if the numerical value difference of each list element is less than threshold
+    int    i              = 1;
+    double diff_threshold = 1e-15;
+    auto test_list = [&] (std::string val_in, std::string val_exp) {
+      auto compare_lists = [&] (std::string a, std::string b) {
+        auto tokenize = [] (std::string str) {
+          std::istringstream  token_stream(str);
+          std::string         token;
+          std::vector<double> token_list;
+          while(getline(token_stream, token, ','))
+            token_list.push_back(std::stod(token));
+          return token_list;
+        };
+        auto a_vals = tokenize(a);
+        auto b_vals = tokenize(b);
+        if(a_vals.size() != b_vals.size()) {
+          fmt::print(stderr,"  ERROR: lists have differing sizes\n");
+          return false;
+        }
+        for(unsigned k=0; k<a_vals.size(); k++) {
+          fmt::print("  compare element {}: {} vs. {}\n", k, a_vals.at(k), b_vals.at(k));
+          if( std::abs(a_vals.at(k) - b_vals.at(k)) > diff_threshold )
+            return false;
+        }
+        return true;
+      };
+      return RunTest(
+          m_parser,
+          KeyName(i, "test:param:list"),
+          val_in,
+          val_exp,
+          compare_lists
+          );
+    };
+
+    // tests
+    REQUIRE(test_list( "1,2,3,4,5",           "1,2,3,4,5"    ));
+    REQUIRE(test_list( "5e+3*MeV,8*s,6*7,11", "5,8e+9,42,11" ));
+
+  }
+}

--- a/src/utilities/eicrecon/parser.cc
+++ b/src/utilities/eicrecon/parser.cc
@@ -128,4 +128,18 @@ namespace jana::parser {
     parsed.print_error();
     return { false, expr };
   }
+
+  //-----------------------------------------------------------------------------
+
+  // get a constant from the internal dictionary, viz. for unit conversion
+  double Parser::units(const std::string& expr) {
+    auto parsed = m_eval->evaluate(expr.c_str());
+    if(parsed.status() == dd4hep::tools::Evaluator::OK)
+      return parsed.result();
+    else {
+      fmt::print(stderr,"ERROR: cannot evaluate expression {}\n",expr);
+      return 1.0;
+    }
+  }
 }
+

--- a/src/utilities/eicrecon/parser.cc
+++ b/src/utilities/eicrecon/parser.cc
@@ -142,4 +142,3 @@ namespace jana::parser {
     }
   }
 }
-

--- a/src/utilities/eicrecon/parser.cc
+++ b/src/utilities/eicrecon/parser.cc
@@ -15,9 +15,23 @@ namespace jana::parser {
     // Decide which unit system to use for parsing
     // -------------------------------------------
 
+    // EDM4hep default system
+    // 1 = millimeter = GeV = nanosecond = radian
+    m_eval = std::make_unique<dd4hep::tools::Evaluator::Object>(
+        1.e+3,                   // millimeter (per meter)
+        1./1.60217733e-25/1.e+3, // GeV (per kilogram); cf. Geant4 unit system below
+        1.e+9,                   // nanosecond (per second)
+        1./1.60217733e-10,       // nanoampere, via e+ charge (per ampere); cf. Geant4 unit system below
+        1.0,                     // kelvin
+        1.0,                     // mole
+        1.0,                     // candela
+        1.0                      // radian
+        );
+
     // DD4hep default system
     // 1 = centimeter = GeV = second = nanoampere = kelvin = mole = candela = radian = steradian
-    // NOTE: may differ from above depending on how DD4hep is configured, thus we use the `dd4hep::` names here
+    // NOTE: use the `dd4hep::` names here to be DD4hep-build-configuration invariant
+    /*
     m_eval = std::make_unique<dd4hep::tools::Evaluator::Object>(
         dd4hep::meter,
         dd4hep::kilogram,
@@ -28,13 +42,23 @@ namespace jana::parser {
         dd4hep::candela,
         dd4hep::radian
         );
+    */
 
     // Geant4 unit system
     // 1 = millimeter = MeV = nanosecond = nanoampere (via e+ charge) = kelvin = mole = candela = radian = steradian
+    // reference: <https://github.com/AIDASoft/DD4hep/blob/f6f3f7fc59fcec334aff7ee215c23287c11c54db/DDParsers/include/Evaluator/detail/Evaluator.h#L95-L99>
     /*
     m_eval = std::make_unique<dd4hep::tools::Evaluator::Object>(
-        1.e+3, 1./1.60217733e-25, 1.e+9, 1./1.60217733e-10, 1.0, 1.0, 1.0);
-        */
+        1.e+3,             // millimeter (per meter)
+        1./1.60217733e-25, // MeV (per kilogram)
+        1.e+9,             // nanosecond (per second)
+        1./1.60217733e-10, // nanoampere, via e+ charge (per ampere)
+        1.0,               // kelvin
+        1.0,               // mole
+        1.0,               // candela
+        1.0                // radian
+        );
+    */
 
   }
 

--- a/src/utilities/eicrecon/parser.cc
+++ b/src/utilities/eicrecon/parser.cc
@@ -1,0 +1,107 @@
+// Copyright (C) 2022, 2023 Christopher Dilks
+// Subject to the terms in the LICENSE file found in the top-level directory.
+
+#include "parser.h"
+
+#include <fmt/format.h>
+#include <sstream>
+#include <iomanip>
+
+namespace jana::parser {
+
+  // constructor
+  Parser::Parser(bool debug, int min_precision) : m_debug(debug), m_min_precision(min_precision) {
+
+    // Decide which unit system to use for parsing
+    // -------------------------------------------
+
+    // DD4hep default system
+    // 1 = centimeter = GeV = second = nanoampere = kelvin = mole = candela = radian = steradian
+    // NOTE: may differ from above depending on how DD4hep is configured, thus we use the `dd4hep::` names here
+    m_eval = std::make_unique<dd4hep::tools::Evaluator::Object>(
+        dd4hep::meter,
+        dd4hep::kilogram,
+        dd4hep::second,
+        dd4hep::ampere,
+        dd4hep::kelvin,
+        dd4hep::mole,
+        dd4hep::candela,
+        dd4hep::radian
+        );
+
+    // Geant4 unit system
+    // 1 = millimeter = MeV = nanosecond = nanoampere (via e+ charge) = kelvin = mole = candela = radian = steradian
+    /*
+    m_eval = std::make_unique<dd4hep::tools::Evaluator::Object>(
+        1.e+3, 1./1.60217733e-25, 1.e+9, 1./1.60217733e-10, 1.0, 1.0, 1.0);
+        */
+
+  }
+
+  //-----------------------------------------------------------------------------
+
+  // evaluate DD4hep expression `expr` and return a string
+  Result<std::string> Parser::dd4hep_to_string(const std::string& expr, const std::string& key) {
+    if(m_debug) fmt::print("PARSE: dd4hep_to_string({}){}\n", expr, key==""? "" : " for key "+key);
+
+    // handle empty string, which would otherwise cause en error in parsing
+    if(expr=="") return { true, expr };
+
+    // call Evaluator::evaluate to parse units and do the math
+    auto parsed = m_eval->evaluate(expr.c_str());
+
+    // return a `Result`, with the calculated number re-stringified without any units
+    if(m_debug) fmt::print("-> status: {}\n", parsed.status());
+    switch(parsed.status()) {
+
+      case dd4hep::tools::Evaluator::OK:
+        { // likely a number that was parsed successfuly; stringify it
+          std::stringstream ss;
+          // increase stringify precision, if the user specified higher than `m_min_precision`
+          auto precision = std::max(
+              (unsigned long) m_min_precision,
+              expr.substr(0,expr.find("*")).size() // count `char`s up to first `*`
+              );
+          // stringify
+          ss << std::setprecision(precision) << parsed.result();
+          auto result = ss.str();
+          if(m_debug) fmt::print("-> evaluator result: {}\n-> string: '{}'\n", parsed.result(), result);
+          return { true, result };
+        }
+
+      case dd4hep::tools::Evaluator::ERROR_UNKNOWN_VARIABLE:
+        { // likely a string (as long as it's not any specific unit name); return `expr` as is
+          if(expr.find('*') != std::string::npos) // try to detect units typos
+            fmt::print(stderr,"WARNING: parsing '{}' as a string; is there a typo in the units?\n",expr);
+          if(m_debug) fmt::print("-> string: '{}'\n", expr);
+          return { true, expr };
+        }
+
+      case dd4hep::tools::Evaluator::ERROR_UNEXPECTED_SYMBOL:
+        { // unexpected symbol; if it's just a comma, attempt to parse as a list, otherwise complain and return `expr` as is
+          if(expr.find(',') != std::string::npos) {
+            std::string result = "";
+            bool success       = true;
+            if(m_debug) fmt::print("{:-^30}\n"," begin list ");
+            // tokenize
+            std::istringstream expr_s(expr);
+            std::string tok;
+            while(getline(expr_s, tok, ',')) { // call `dd4hep_to_string` on each list element
+              auto parsed_tok = dd4hep_to_string(tok);
+              result += "," + parsed_tok.result;
+              success &= parsed_tok.success; // innocent until proven guilty
+            }
+            result.erase(0,1); // remove leading comma
+            if(m_debug) fmt::print("{:-^30}\n-> string: {}\n", " end list ", result);
+            return { success, result };
+          }
+          break;
+        }
+    };
+
+    // likely an error; complain and return `expr` as is
+    fmt::print(stderr,"ERROR: cannot evaluate '{}'; ",expr);
+    parsed.print_error();
+    return { false, expr };
+  }
+}

--- a/src/utilities/eicrecon/parser.h
+++ b/src/utilities/eicrecon/parser.h
@@ -23,18 +23,28 @@ namespace jana::parser {
   class Parser {
     public:
 
-      // constructor
-      // - `debug` to enable debugging printouts
-      // - `min_precision` controls the minimum precision for re-stringified `double`s
-      //   (precision can be higher than `min_precision` if the user asks for it)
+      /* constructor
+       * - `debug` to enable debugging printouts
+       * - `min_precision` controls the minimum precision for re-stringified `double`s
+       *   (precision can be higher than `min_precision` if the user asks for it)
+       */
       Parser(bool debug=false, int min_precision=6);
       ~Parser() {}
 
-      // evaluate DD4hep expression `expr` and return a string
-      // - if `expr` is itself a string, return `expr` silently
-      // - this is useful for parsing CLI options
-      // - optionally specify `key` to clarify debugging printouts
+      /* evaluate DD4hep expression `expr` and return a string
+       * - if `expr` is itself a string, return `expr` silently
+       * - this is useful for parsing CLI options
+       * - optionally specify `key` to clarify debugging printouts
+       */
       Result<std::string> dd4hep_to_string(const std::string& expr, const std::string& key="");
+
+      /* get a constant from the internal dictionary, viz. for unit conversion
+       * - to convert global unit system (specified in constructor) to preferred units,
+       *   divide by the return value of this method
+       *   - example: to convert 1000 global length units (`mm`, if EDM4hep) to `m`, call `1000 / units("m")`
+       * - returns 1.0 upon failure (and an error message to stderr)
+       */
+      double units(const std::string& expr);
 
     private:
       std::unique_ptr<dd4hep::tools::Evaluator::Object> m_eval;

--- a/src/utilities/eicrecon/parser.h
+++ b/src/utilities/eicrecon/parser.h
@@ -1,0 +1,46 @@
+// Copyright (C) 2022, 2023 Christopher Dilks
+// Subject to the terms in the LICENSE file found in the top-level directory.
+
+#pragma once
+
+#include <string>
+#include <memory>
+
+// DD4Hep
+#include <DD4hep/DD4hepUnits.h>
+#include <Evaluator/Evaluator.h>
+#include <Evaluator/detail/Evaluator.h>
+
+namespace jana::parser {
+
+  // parsing result template
+  template<class ResultType>
+    struct Result {
+      bool success;
+      ResultType result;
+    };
+
+  // parsing class
+  class Parser {
+    public:
+
+      // constructor
+      // - `debug` to enable debugging printouts
+      // - `min_precision` controls the minimum precision for re-stringified `double`s
+      //   (precision can be higher than `min_precision` if the user asks for it)
+      Parser(bool debug=false, int min_precision=6);
+      ~Parser() {}
+
+      // evaluate DD4hep expression `expr` and return a string
+      // - if `expr` is itself a string, return `expr` silently
+      // - this is useful for parsing CLI options
+      // - optionally specify `key` to clarify debugging printouts
+      Result<std::string> dd4hep_to_string(const std::string& expr, const std::string& key="");
+
+    private:
+      std::unique_ptr<dd4hep::tools::Evaluator::Object> m_eval;
+      bool m_debug;
+      int m_min_precision;
+  };
+
+}

--- a/src/utilities/eicrecon/parser.h
+++ b/src/utilities/eicrecon/parser.h
@@ -7,7 +7,6 @@
 #include <memory>
 
 // DD4Hep
-#include <DD4hep/DD4hepUnits.h>
 #include <Evaluator/Evaluator.h>
 #include <Evaluator/detail/Evaluator.h>
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Use [DD4hep/DDParsers](https://github.com/AIDASoft/DD4hep/tree/master/DDParsers) to parse configuration parameters. This permits the user to include units that are automatically converted to an internal system of units. This internal unit system can be any preferred system we agree on and does not have to be DD4hep's system; e.g., it could be configured to parse parameters to EDM4hep's standard units.

Source code changes:
- `parser.{h,cpp}`: new class `Parser`:
  - use DD4hep/DDParsers `Evaluator` to do the parsing and math
  - hard-coded default system of units, to enforce a standard
    - straightforward to change, if we ever want to
    - other systems are included for reference, but commented out
    - under the hood, the system is set by [setSystemOfUnits.cpp](https://github.com/AIDASoft/DD4hep/blob/master/DDParsers/src/Evaluator/setSystemOfUnits.cpp)
  - this `Parser` class can be pulled out of EICrecon, should we decide to use it elsewhere; we could also replace DD4hep `Evaluator` usage with [that of CLHEP](https://gitlab.cern.ch/CLHEP/CLHEP/-/tree/develop/Evaluator), if we don't want DD4hep dependence here
- `eicrecon_cli.cpp`: use `Parser` to parse `eicrecon -c` user parameters
  - this is currently the only usage of `Parser`
  - if we move to a configuration file for configuration parameters, `Parser` could be used to read its numbers
- unit test `param_parser_test.cpp`
  - consider adding a CI job to run this and other unit tests
  - consider relocating to `src/tests/`

Some usage examples (defaulting to DD4hep's unit system, 1=cm=GeV):

![2022-12-07-011830_925x488_scrot](https://user-images.githubusercontent.com/7843751/206885796-285c16df-bd39-40f9-b2eb-854bd72b9f5b.png)

It can also handle lists, parsing each element (this example uses EDM4hep's unit system, 1=ns=GeV):

![2023-04-24-202609_1055x39_scrot](https://user-images.githubusercontent.com/7843751/234144389-06dfa657-40db-4ea8-9719-b95069cc8aa1.png)


Example unit systems:

### EDM4hep units:
```cpp
1 = millimeter = GeV = nanosecond = radian
```

### Geant4 units:
```cpp
1 = millimeter = MeV = nanosecond = nanoampere (via e+ charge) = kelvin = mole = candela = radian = steradian
```
This was assumed by `reco_flags.py` prior to https://github.com/eic/EICrecon/pull/365

### DD4hep units:
Our current `eic-shell` build of DD4hep uses the following system:
```cpp
1 = centimeter = GeV = second = nanoampere = kelvin = mole = candela = radian = steradian
```

NOTE: see https://github.com/eic/EICrecon/pull/365 for more discussion

The parser was fully compatible with the legacy `reco_flags.py`, and its results have been cross checked. Consistency with previous versions of EICrecon was verified by comparing `run_eicrecon_reco_flags.py` output, with the `-c` option used for `eicrecon`. The only differences are minor, typically dropping trailing zeros (e.g., `"4.0"` becomes `"4"`).

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
Yes, the specification of parameters and units is enhanced