### PR TITLE
feat: support Acts-20.2.0 and beyond (within 20.x release series)

### DIFF
--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -176,7 +176,7 @@ macro(plugin_add_acts _name)
 
     if(NOT Acts_FOUND)
         find_package(Acts REQUIRED COMPONENTS Core PluginIdentification PluginTGeo PluginJson PluginDD4hep)
-        set(Acts_VERSION_MIN "20.0.0")
+        set(Acts_VERSION_MIN "20.2.0")
         set(Acts_VERSION "${Acts_VERSION_MAJOR}.${Acts_VERSION_MINOR}.${Acts_VERSION_PATCH}")
         if(${Acts_VERSION} VERSION_LESS ${Acts_VERSION_MIN}
                 AND NOT "${Acts_VERSION}" STREQUAL "9.9.9")

--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -176,7 +176,7 @@ macro(plugin_add_acts _name)
 
     if(NOT Acts_FOUND)
         find_package(Acts REQUIRED COMPONENTS Core PluginIdentification PluginTGeo PluginJson PluginDD4hep)
-        set(Acts_VERSION_MIN "19.0.0")
+        set(Acts_VERSION_MIN "20.0.0")
         set(Acts_VERSION "${Acts_VERSION_MAJOR}.${Acts_VERSION_MINOR}.${Acts_VERSION_PATCH}")
         if(${Acts_VERSION} VERSION_LESS ${Acts_VERSION_MIN}
                 AND NOT "${Acts_VERSION}" STREQUAL "9.9.9")

--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -99,11 +99,18 @@ namespace eicrecon {
         Acts::MeasurementSelector measSel{m_sourcelinkSelectorCfg};
         //Acts::MeasurementSelector measSel;
 
-        Acts::CombinatorialKalmanFilterExtensions extensions;
+        Acts::CombinatorialKalmanFilterExtensions<Acts::VectorMultiTrajectory>
+                extensions;
         extensions.calibrator.connect<&eicrecon::MeasurementCalibrator::calibrate>(&calibrator);
-        extensions.updater.connect<&Acts::GainMatrixUpdater::operator()>(&kfUpdater);
-        extensions.smoother.connect<&Acts::GainMatrixSmoother::operator()>(&kfSmoother);
-        extensions.measurementSelector.connect<&Acts::MeasurementSelector::select>(&measSel);
+        extensions.updater.connect<
+                &Acts::GainMatrixUpdater::operator()<Acts::VectorMultiTrajectory>>(
+                &kfUpdater);
+        extensions.smoother.connect<
+                &Acts::GainMatrixSmoother::operator()<Acts::VectorMultiTrajectory>>(
+                &kfSmoother);
+        extensions.measurementSelector.connect<
+                &Acts::MeasurementSelector::select<Acts::VectorMultiTrajectory>>(
+                &measSel);
 
         eicrecon::IndexSourceLinkAccessor slAccessor;
         slAccessor.container = &src_links;
@@ -133,7 +140,7 @@ namespace eicrecon {
 
             if (result.ok()) {
                 // Get the track finding output object
-                const auto &trackFindingOutput = result.value();
+                auto &trackFindingOutput = result.value();
                 // Create a SimMultiTrajectory
                 trajectories.push_back(new eicrecon::TrackingResultTrajectory(std::move(trackFindingOutput.fittedStates),
                                                                               std::move(trackFindingOutput.lastMeasurementIndices),

--- a/src/algorithms/tracking/CKFTracking.h
+++ b/src/algorithms/tracking/CKFTracking.h
@@ -48,8 +48,11 @@ namespace eicrecon {
     public:
         /// Track finder function that takes input measurements, initial trackstate
         /// and track finder options and returns some track-finder-specific result.
-        using TrackFinderOptions = Acts::CombinatorialKalmanFilterOptions<eicrecon::IndexSourceLinkAccessor::Iterator>;
-        using TrackFinderResult = std::vector<Acts::Result<Acts::CombinatorialKalmanFilterResult>>;
+        using TrackFinderOptions =
+            Acts::CombinatorialKalmanFilterOptions<IndexSourceLinkAccessor::Iterator,
+                                                   Acts::VectorMultiTrajectory>;
+        using TrackFinderResult = std::vector<Acts::Result<
+            Acts::CombinatorialKalmanFilterResult<Acts::VectorMultiTrajectory>>>;
 
         /// Find function that takes the above parameters
         /// @note This is separated into a virtual interface to keep compilation units

--- a/src/algorithms/tracking/CKFTrackingFunction.cc
+++ b/src/algorithms/tracking/CKFTrackingFunction.cc
@@ -31,7 +31,8 @@ namespace eicrecon{
   using Stepper    = Acts::EigenStepper<>;
   using Navigator  = Acts::Navigator;
   using Propagator = Acts::Propagator<Stepper, Navigator>;
-  using CKF        = Acts::CombinatorialKalmanFilter<Propagator>;
+  using CKF =
+      Acts::CombinatorialKalmanFilter<Propagator, Acts::VectorMultiTrajectory>;
 
   /** Finder implementation .
    *

--- a/src/algorithms/tracking/JugTrack/Measurement.hpp
+++ b/src/algorithms/tracking/JugTrack/Measurement.hpp
@@ -7,6 +7,7 @@
 #include "Acts/EventData/Measurement.hpp"
 #include "Acts/EventData/MultiTrajectory.hpp"
 #include "Acts/EventData/SourceLink.hpp"
+#include "Acts/EventData/VectorMultiTrajectory.hpp"
 #include "IndexSourceLink.hpp"
 
 #include <cassert>
@@ -37,8 +38,10 @@ namespace eicrecon {
     /// @tparam parameters_t Track parameters type
     /// @param gctx The geometry context (unused)
     /// @param trackState The track state to calibrate
-    void calibrate(const Acts::GeometryContext& /*gctx*/,
-                   Acts::MultiTrajectory::TrackStateProxy trackState) const {
+    void calibrate(
+        const Acts::GeometryContext& /*gctx*/,
+        Acts::MultiTrajectory<Acts::VectorMultiTrajectory>::TrackStateProxy
+            trackState) const {
       const auto& sourceLink =
           static_cast<const IndexSourceLink&>(trackState.uncalibrated());
 

--- a/src/algorithms/tracking/TrackProjector.cc
+++ b/src/algorithms/tracking/TrackProjector.cc
@@ -23,7 +23,6 @@
 #include "Acts/Geometry/GeometryIdentifier.hpp"
 #include "Acts/MagneticField/ConstantBField.hpp"
 #include "Acts/MagneticField/InterpolatedBFieldMap.hpp"
-#include "Acts/MagneticField/SharedBField.hpp"
 #include "Acts/Propagator/EigenStepper.hpp"
 #include "Acts/Surfaces/PerigeeSurface.hpp"
 

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -26,7 +26,6 @@
 #include "Acts/Geometry/GeometryIdentifier.hpp"
 #include "Acts/MagneticField/ConstantBField.hpp"
 #include "Acts/MagneticField/InterpolatedBFieldMap.hpp"
-#include "Acts/MagneticField/SharedBField.hpp"
 #include "Acts/Propagator/EigenStepper.hpp"
 #include "Acts/Surfaces/PerigeeSurface.hpp"
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
In order to test the EPIC geometry upgrade to use Acts-20 construction, we need to have a reconstruction framework that is able to work with that Acts version. This upgrades EICrecon tracking algorithms to work with Acts-20.2.0 and beyond.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators: @DraTeots 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
Yes, there is no backwards compatibility for older Acts versions.

### Does this PR change default behavior?
No.