### PR TITLE
fix: use HcalEndcapPInsertMergedHits tag in factory

### DIFF
--- a/src/detectors/HCAL/CalorimeterHit_factory_HcalEndcapPInsertMergedHits.h
+++ b/src/detectors/HCAL/CalorimeterHit_factory_HcalEndcapPInsertMergedHits.h
@@ -31,9 +31,9 @@ public:
 
         m_geoSvc= app->GetService<JDD4hep_service>();
 
-        app->SetDefaultParameter("HCAL:HcalBarrelMergedHits:input_tag", m_input_tag);
-        app->SetDefaultParameter("HCAL:HcalBarrelMergedHits:fields", u_fields);
-        app->SetDefaultParameter("HCAL:HcalBarrelMergedHits:refs",  u_refs);
+        app->SetDefaultParameter("HCAL:HcalEndcapPInsertMergedHits:input_tag", m_input_tag);
+        app->SetDefaultParameter("HCAL:HcalEndcapPInsertMergedHits:fields", u_fields);
+        app->SetDefaultParameter("HCAL:HcalEndcapPInsertMergedHits:refs",  u_refs);
 
         initialize();
     }


### PR DESCRIPTION
Issue #410 is resolved by replacing the tag name with the correct name instead of defining it twice in different factories.