### PR TITLE
fix: use `TDatabasePDG` as a singleton

### DIFF
--- a/src/algorithms/tracking/TrackParamTruthInit.cc
+++ b/src/algorithms/tracking/TrackParamTruthInit.cc
@@ -20,7 +20,7 @@ void eicrecon::TrackParamTruthInit::init(const std::shared_ptr<spdlog::logger> &
     m_log = logger;
 
     // TODO make a service?
-    m_pdg_db = std::make_shared<TDatabasePDG>();
+    m_pdg_db = TDatabasePDG::Instance();
 }
 
 eicrecon::TrackParameters *eicrecon::TrackParamTruthInit::produce(const edm4hep::MCParticle *part) {

--- a/src/algorithms/tracking/TrackParamTruthInit.h
+++ b/src/algorithms/tracking/TrackParamTruthInit.h
@@ -25,7 +25,7 @@ namespace eicrecon {
     private:
         std::shared_ptr<spdlog::logger> m_log;
         TrackParamTruthInitConfig m_cfg;
-        std::shared_ptr<TDatabasePDG> m_pdg_db;
+        TDatabasePDG * m_pdg_db;
     };
 }   // namespace eicrecon
 

--- a/src/algorithms/tracking/TruthTrackSeeding.cc
+++ b/src/algorithms/tracking/TruthTrackSeeding.cc
@@ -10,7 +10,7 @@
 void eicrecon::TruthTrackSeeding::init() {
 
     // TODO make a service?
-    m_pdg_db = std::make_shared<TDatabasePDG>();
+    m_pdg_db = TDatabasePDG::Instance();
 
 }
 

--- a/src/algorithms/tracking/TruthTrackSeeding.h
+++ b/src/algorithms/tracking/TruthTrackSeeding.h
@@ -20,7 +20,7 @@ namespace eicrecon {
         edm4eic::TrackParameters * produce(const edm4hep::MCParticle *) override;
 
     private:
-        std::shared_ptr<TDatabasePDG> m_pdg_db;
+        TDatabasePDG * m_pdg_db;
     };
 }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
`TDatabasePDG` should be instantiated with its `Instance()` method, otherwise it will print a warning if you try to instantiate it twice with, e.g., `std::make_shared`.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
no