### PR TITLE
fix: remove memory leaks in calorimetry algorithms

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterClusterMerger.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterMerger.cc
@@ -76,6 +76,7 @@ void CalorimeterClusterMerger::AlgorithmProcess() {
         ca->setWeight(1.0);
         ca->setRec(*new_clus);
         edm4eic::MCRecoClusterParticleAssociation* toadd = new edm4eic::MCRecoClusterParticleAssociation(*ca);
+        delete ca;
         assoc2.push_back(toadd);
         //ca.setSim(//FIXME);
       } else {

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -167,6 +167,7 @@ void CalorimeterClusterRecoCoG::AlgorithmProcess() {
         //clusterassoc.setSim(mcp);
         edm4eic::MCRecoClusterParticleAssociation* cassoc = new edm4eic::MCRecoClusterParticleAssociation(*clusterassoc);
         m_outputAssociations.push_back(cassoc);
+        delete clusterassoc;
       } else {
         if (m_log->level() <= spdlog::level::debug) {
           //LOG_INFO(default_cout_logger) << "No mcHitCollection was provided, so no truth association will be performed." << LOG_END;

--- a/src/algorithms/calorimetry/CalorimeterTruthClustering.cc
+++ b/src/algorithms/calorimetry/CalorimeterTruthClustering.cc
@@ -95,5 +95,8 @@ void CalorimeterTruthClustering::AlgorithmProcess() {
       m_outputProtoClusters.push_back(to_add);
     }
 
-    return;
+    // free allocated memory
+    for (auto& p : proto) {
+        delete p;
+    }
 }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This removes some of the memory leaks, in particular in the calorimetry algorithms. This does **not** address #414 since that requires a but if a different approach than simply matching a `delete` to each `new`.

Fixes #412. Fixes #413.

### What kind of change does this PR introduce?
- [X] Bug fix (issue #412, #413)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.