### PR TITLE
Command line configuration of seeding parameters

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -77,9 +77,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+    - run: echo "FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
     - uses: actions/checkout@v3
       with:
-        fetch-depth: $(( ${{github.event.pull_request.commits}} + 1 ))
+        fetch-depth: ${{ env.FETCH_DEPTH }}
     - uses: cvmfs-contrib/github-action-cvmfs@v3
     - uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -79,7 +79,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        fetch-depth: ${{github.event.pull_request.commits}}
+        fetch-depth: $(( ${{github.event.pull_request.commits}} + 1 ))
     - uses: cvmfs-contrib/github-action-cvmfs@v3
     - uses: actions/download-artifact@v3
       with:

--- a/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
+++ b/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
@@ -17,7 +17,7 @@ namespace eicrecon {
  
   struct OrthogonalTrackSeedingConfig {
     float m_rMax = 500. * Acts::UnitConstants::mm;
-    float m_rMin = 33 * Acts::UnitConstants::mm;
+    float m_rMin = 33. * Acts::UnitConstants::mm;
     float m_deltaRMinTopSP = 1. * Acts::UnitConstants::mm;
     float m_deltaRMaxTopSP = 400. * Acts::UnitConstants::mm;
     float m_deltaRMinBottomSP = 1. * Acts::UnitConstants::mm;

--- a/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
+++ b/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
@@ -17,6 +17,7 @@ namespace eicrecon {
  
   struct OrthogonalTrackSeedingConfig {
     float m_rMax = 500. * Acts::UnitConstants::mm;
+    float m_rMin = 33 * Acts::UnitConstants::mm;
     float m_deltaRMinTopSP = 1. * Acts::UnitConstants::mm;
     float m_deltaRMaxTopSP = 400. * Acts::UnitConstants::mm;
     float m_deltaRMinBottomSP = 1. * Acts::UnitConstants::mm;

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -33,8 +33,7 @@ void eicrecon::TrackSeeding::init(std::shared_ptr<const ActsGeometryProvider> ge
     m_BField = std::dynamic_pointer_cast<const eicrecon::BField::DD4hepBField>(m_geoSvc->getFieldProvider());
     m_fieldctx = eicrecon::BField::BFieldVariant(m_BField);
     
-    m_seederConfig = configureSeeder();
-
+    m_cfg.configure();
 }
 
 std::vector<edm4eic::TrackParameters*> eicrecon::TrackSeeding::produce(std::vector<const edm4eic::TrackerHit*> trk_hits) {
@@ -50,7 +49,7 @@ eicrecon::SeedContainer eicrecon::TrackSeeding::runSeeder(std::vector<const edm4
 {
   std::vector<const eicrecon::SpacePoint*> spacePoints = getSpacePoints(trk_hits);
 
-  Acts::SeedFinderOrthogonal<eicrecon::SpacePoint> finder(m_seederConfig.m_seedFinderConfig);
+  Acts::SeedFinderOrthogonal<eicrecon::SpacePoint> finder(m_cfg.m_seedFinderConfig);
   eicrecon::SeedContainer seeds = finder.createSeeds(spacePoints);
  
   return seeds;
@@ -67,13 +66,6 @@ std::vector<const eicrecon::SpacePoint*> eicrecon::TrackSeeding::getSpacePoints(
     }
 
   return spacepoints;
-}
-
-eicrecon::OrthogonalTrackSeedingConfig eicrecon::TrackSeeding::configureSeeder()
-{
-  eicrecon::OrthogonalTrackSeedingConfig cfg;
-  cfg.configure();
-  return cfg;
 }
 
 std::vector<edm4eic::TrackParameters*> eicrecon::TrackSeeding::makeTrackParams(SeedContainer& seeds)
@@ -102,7 +94,7 @@ std::vector<edm4eic::TrackParameters*> eicrecon::TrackSeeding::makeTrackParams(S
       if(theta < 0)
 	{ theta += M_PI; }
       float eta = -log(tan(theta/2.));
-      float pt = 0.3 * R * (m_seederConfig.m_bFieldInZ * 1000) / 100.;
+      float pt = 0.3 * R * (m_cfg.m_bFieldInZ * 1000) / 100.;
       float p = pt * cosh(eta);
       float qOverP = charge / p;
       

--- a/src/algorithms/tracking/TrackSeeding.h
+++ b/src/algorithms/tracking/TrackSeeding.h
@@ -54,10 +54,7 @@ namespace eicrecon {
         Acts::CalibrationContext m_calibctx;
         Acts::MagneticFieldContext m_fieldctx;
 
-	eicrecon::OrthogonalTrackSeedingConfig m_seederConfig;
-
 	int determineCharge(std::vector<std::pair<float,float>>& positions) const;
-	eicrecon::OrthogonalTrackSeedingConfig configureSeeder();
 	SeedContainer runSeeder(std::vector<const edm4eic::TrackerHit*>& trk_hits);
 	std::pair<float,float> findRoot(std::tuple<float,float,float>& circleParams) const;
 	std::vector<const eicrecon::SpacePoint*> getSpacePoints(std::vector<const edm4eic::TrackerHit*>& trk_hits);

--- a/src/global/tracking/TrackSeeding_factory.cc
+++ b/src/global/tracking/TrackSeeding_factory.cc
@@ -32,10 +32,33 @@ void eicrecon::TrackSeeding_factory::Init() {
 
     // Algorithm configuration
     auto cfg = GetDefaultConfig();
-       
+
+    app->SetDefaultParameter(param_prefix + ":rMax", cfg.m_rMax, "max measurement radius for Acts::OrthogonalSeedFinder");
+    app->SetDefaultParameter(param_prefix + ":rMin", cfg.m_rMin, "min measurement radius for Acts::OrthogonalSeedFinder");
+    app->SetDefaultParameter(param_prefix + ":deltaRMinTopSP", cfg.m_deltaRMinTopSP, "min distance in r between middle and top space point in one seed for Acts::OrthogonalSeedFinder");
+    app->SetDefaultParameter(param_prefix + ":deltaRMaxTopSP", cfg.m_deltaRMaxTopSP, "max distance in r between middle and top space point in one seed for Acts::OrthogonalSeedFinder");
+    app->SetDefaultParameter(param_prefix + ":deltaRMinBottomSP", cfg.m_deltaRMinBottomSP, "min distance in r between bottom and middle space point in one seed for Acts::OrthogonalSeedFinder");
+    app->SetDefaultParameter(param_prefix + ":deltaRMaxBottomSP", cfg.m_deltaRMaxBottomSP, "max distance in r between bottom and middle space point in one seed for Acts::OrthogonalSeedFinder");
+    app->SetDefaultParameter(param_prefix + ":collisionRegionMin", cfg.m_collisionRegionMin, "min location in z for collision region for Acts::OrthogonalSeedFinder");
+    app->SetDefaultParameter(param_prefix + ":collisionRegionMax", cfg.m_collisionRegionMax, "max location in z for collision region for Acts::OrthogonalSeedFinder");
+    app->SetDefaultParameter(param_prefix + ":zMax", cfg.m_zMax, "Max z location for measurements for Acts::OrthogonalSeedFinder");
+    app->SetDefaultParameter(param_prefix + ":zMin", cfg.m_zMin, "Min z location for measurements for Acts::OrthogonalSeedFinder");
+    app->SetDefaultParameter(param_prefix + ":maxSeedsPerSpM", cfg.m_maxSeedsPerSpM, "Maximum number of seeds one space point can be the middle of for Acts::OrthogonalSeedFinder");
+    app->SetDefaultParameter(param_prefix + ":cotThetaMax", cfg.m_cotThetaMax, "cot of maximum theta angle for Acts::OrthogonalSeedFinder");
+    app->SetDefaultParameter(param_prefix + ":sigmaScattering", cfg.m_sigmaScattering, "number of sigmas of scattering angle to consider for Acts::OrthogonalSeedFinder");
+    app->SetDefaultParameter(param_prefix + ":radLengthPerSeed", cfg.m_radLengthPerSeed, "Approximate number of radiation lengths one seed traverses for Acts::OrthogonalSeedFinder");
+    app->SetDefaultParameter(param_prefix + ":minPt", cfg.m_minPt, "Minimum pT to search for for Acts::OrthogonalSeedFinder");
+    app->SetDefaultParameter(param_prefix + ":bFieldInZ", cfg.m_bFieldInZ, "Value of B Field to use in kiloTesla for Acts::OrthogonalSeedFinder");
+    app->SetDefaultParameter(param_prefix + ":beamPosX", cfg.m_beamPosX, "Beam position in x for Acts::OrthogonalSeedFinder");
+    app->SetDefaultParameter(param_prefix + ":beamPosY", cfg.m_beamPosY, "Beam position in y for Acts::OrthogonalSeedFinder");
+    app->SetDefaultParameter(param_prefix + ":impactMax", cfg.m_impactMax, "maximum impact parameter allowed for seeds for Acts::OrthogonalSeedFinder. rMin should be larger than impactMax.");
+    app->SetDefaultParameter(param_prefix + ":rMinMiddle", cfg.m_rMinMiddle, "min radius for middle space point for Acts::OrthogonalSeedFinder");
+    app->SetDefaultParameter(param_prefix + ":rMaxMiddle", cfg.m_rMaxMiddle, "max radius for middle space point for Acts::OrthogonalSeedFinder");
+
     // Initialize algorithm
     m_seeding_algo.applyConfig(cfg);
     m_seeding_algo.init(acts_service->actsGeoProvider(), m_log);
+  
 }
 
 void eicrecon::TrackSeeding_factory::ChangeRun(const std::shared_ptr<const JEvent> &event) {


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR allows users to configure the seeding parameters from the command line when running eicrecon. This should enable easier testing/tuning so that eicrecon doesn't have to be compiled each time someone wants to change one of the seeding algorithm parameters.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No