### PR TITLE
Add writing default JANA config file format.

### DIFF
--- a/src/utilities/dump_flags/DumpFlags_processor.cc
+++ b/src/utilities/dump_flags/DumpFlags_processor.cc
@@ -140,5 +140,16 @@ void DumpFlags_processor::Finish()
             throw JException(ex.what());
         }
     }
+
+    // Save JANA simple key-value file
+    if(!m_janaconfig_file_name.empty()) {
+        try{
+            pm->WriteConfigFile(m_janaconfig_file_name);
+        }
+        catch(std::exception ex) {
+            m_log->error("Can't open file '{}' for write", m_janaconfig_file_name);    // TODO personal logger
+            throw JException(ex.what());
+        }
+    }
 }
 

--- a/src/utilities/dump_flags/DumpFlags_processor.h
+++ b/src/utilities/dump_flags/DumpFlags_processor.h
@@ -53,6 +53,9 @@ private:
     /// If not null, such json file is created
     std::string m_json_file_name = "";
 
+    /// If not null, such jana configuration file is created
+    std::string m_janaconfig_file_name = "jana.conf";
+
     /// Print parameter summary to screen at end of job
     bool m_print_to_screen = true;
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This modifies the dump_flags plugin.
This adds writing of the JANA configuration at the end of a job in the standard format of a JANA config. file. This supplements the existing options of writing JSON, Python and dumping to screen.  

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No