### PR TITLE
fix: set default dRICH config in `c++`

### DIFF
--- a/src/algorithms/digi/PhotoMultiplierHitDigi.h
+++ b/src/algorithms/digi/PhotoMultiplierHitDigi.h
@@ -19,6 +19,7 @@
 #include <edm4hep/SimTrackerHit.h>
 #include <edm4eic/RawPMTHit.h>
 #include <spdlog/spdlog.h>
+#include <Evaluator/DD4hepUnits.h>
 
 #include "PhotoMultiplierHitDigiConfig.h"
 #include <algorithms/interfaces/WithPodConfig.h>

--- a/src/algorithms/digi/PhotoMultiplierHitDigiConfig.h
+++ b/src/algorithms/digi/PhotoMultiplierHitDigiConfig.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Evaluator/DD4hepUnits.h>
 #include <spdlog/spdlog.h>
 
 namespace eicrecon {
@@ -11,16 +10,16 @@ namespace eicrecon {
       unsigned long seed = 0;
 
       // triggering
-      double hitTimeWindow = 20.0*dd4hep::ns;
-      double timeStep      = 0.0625*dd4hep::ns;
+      double hitTimeWindow = 20.0;   // [ns]
+      double timeStep      = 0.0625; // [ns]
       double speMean       = 80.0;
       double speError      = 16.0;
       double pedMean       = 200.0;
       double pedError      = 3.0;
 
       // SiPM pixels
-      bool   enablePixelGaps = false;          // enable/disable removal of hits in gaps between pixels
-      double pixelSize       = 3.0*dd4hep::mm; // pixel (active) size
+      bool   enablePixelGaps = false; // enable/disable removal of hits in gaps between pixels
+      double pixelSize       = 3.0;   // [mm] // pixel (active) size
 
       // overall safety factor 
       /* simulations assume the detector is ideal and perfect, but reality is
@@ -31,28 +30,29 @@ namespace eicrecon {
       double safetyFactor = 1.0; // allowed range: (0,1]
 
       // quantum efficiency
+      // - wavelength units are [nm]
       // FIXME: figure out how users can override this, maybe an external `yaml` file
       std::vector<std::pair<double, double> > quantumEfficiency = {
-        {325*dd4hep::nm, 0.04},
-        {340*dd4hep::nm, 0.10},
-        {350*dd4hep::nm, 0.20},
-        {370*dd4hep::nm, 0.30},
-        {400*dd4hep::nm, 0.35},
-        {450*dd4hep::nm, 0.40},
-        {500*dd4hep::nm, 0.38},
-        {550*dd4hep::nm, 0.35},
-        {600*dd4hep::nm, 0.27},
-        {650*dd4hep::nm, 0.20},
-        {700*dd4hep::nm, 0.15},
-        {750*dd4hep::nm, 0.12},
-        {800*dd4hep::nm, 0.08},
-        {850*dd4hep::nm, 0.06},
-        {900*dd4hep::nm, 0.04}
+        {325, 0.04},
+        {340, 0.10},
+        {350, 0.20},
+        {370, 0.30},
+        {400, 0.35},
+        {450, 0.40},
+        {500, 0.38},
+        {550, 0.35},
+        {600, 0.27},
+        {650, 0.20},
+        {700, 0.15},
+        {750, 0.12},
+        {800, 0.08},
+        {850, 0.06},
+        {900, 0.04}
       };
       /*
          std::vector<std::pair<double, double> > quantumEfficiency = { // test unit QE
-         {325*dd4hep::nm, 1.00},
-         {900*dd4hep::nm, 1.00}
+         {325, 1.00},
+         {900, 1.00}
          };
          */
 
@@ -76,7 +76,7 @@ namespace eicrecon {
         puts("safetyFactor",safetyFactor);
         m_log->log(lvl, "{:-^60}"," Quantum Efficiency vs. Wavelength ");
         for(auto& [wl,qe] : quantumEfficiency)
-          m_log->log(lvl, "  {:>10} {:<}",wl/dd4hep::nm,qe);
+          m_log->log(lvl, "  {:>10} {:<}",wl,qe);
       }
 
   };

--- a/src/detectors/DRICH/DRICH.cc
+++ b/src/detectors/DRICH/DRICH.cc
@@ -7,9 +7,14 @@
 #include <JANA/JFactoryGenerator.h>
 #include <extensions/jana/JChainFactoryGeneratorT.h>
 
+// factories
 #include <global/digi/PhotoMultiplierHitDigi_factory.h>
 #include <global/pid/RichTrack_factory.h>
 // #include <global/pid/IrtParticleID_factory.h>
+
+// algorithm configurations
+#include <algorithms/digi/PhotoMultiplierHitDigiConfig.h>
+
 
 extern "C" {
   void InitPlugin(JApplication *app) {
@@ -18,9 +23,37 @@ extern "C" {
     using namespace eicrecon;
 
     // Digitization
-    app->Add(new JChainFactoryGeneratorT<PhotoMultiplierHitDigi_factory>({"DRICHHits"}, "DRICHRawHits"));
+    PhotoMultiplierHitDigiConfig digi_cfg;
+    digi_cfg.seed            = 0;
+    digi_cfg.hitTimeWindow   = 20.0; // [ns]
+    digi_cfg.timeStep        = 0.0625; // [ns]
+    digi_cfg.speMean         = 80.0;
+    digi_cfg.speError        = 16.0;
+    digi_cfg.pedMean         = 200.0;
+    digi_cfg.pedError        = 3.0;
+    digi_cfg.enablePixelGaps = true;
+    digi_cfg.pixelSize       = 3.0; // [mm]
+    digi_cfg.safetyFactor    = 0.7;
+    digi_cfg.quantumEfficiency.clear();
+    digi_cfg.quantumEfficiency.push_back({325, 0.04}); // wavelength units are [nm]
+    digi_cfg.quantumEfficiency.push_back({340, 0.10});
+    digi_cfg.quantumEfficiency.push_back({350, 0.20});
+    digi_cfg.quantumEfficiency.push_back({370, 0.30});
+    digi_cfg.quantumEfficiency.push_back({400, 0.35});
+    digi_cfg.quantumEfficiency.push_back({450, 0.40});
+    digi_cfg.quantumEfficiency.push_back({500, 0.38});
+    digi_cfg.quantumEfficiency.push_back({550, 0.35});
+    digi_cfg.quantumEfficiency.push_back({600, 0.27});
+    digi_cfg.quantumEfficiency.push_back({650, 0.20});
+    digi_cfg.quantumEfficiency.push_back({700, 0.15});
+    digi_cfg.quantumEfficiency.push_back({750, 0.12});
+    digi_cfg.quantumEfficiency.push_back({800, 0.08});
+    digi_cfg.quantumEfficiency.push_back({850, 0.06});
+    digi_cfg.quantumEfficiency.push_back({900, 0.04});
+    app->Add(new JChainFactoryGeneratorT<PhotoMultiplierHitDigi_factory>({"DRICHHits"}, "DRICHRawHits", digi_cfg));
 
     // Track Propagation to each radiator
+    // FIXME: algorithm configuration currently set in RichTrack factory; need to write independent RichTrack algorithm
     app->Add(new JChainFactoryGeneratorT<RichTrack_factory>({"CentralCKFTrajectories"}, "DRICHAerogelTracks"));
     app->Add(new JChainFactoryGeneratorT<RichTrack_factory>({"CentralCKFTrajectories"}, "DRICHGasTracks"));
 

--- a/src/global/pid/RichTrack_factory.cc
+++ b/src/global/pid/RichTrack_factory.cc
@@ -30,8 +30,8 @@ void eicrecon::RichTrack_factory::Init() {
    */
   m_numPlanes = 5;
   if(param_prefix.rfind("DRICH")!=std::string::npos || param_prefix.rfind("PFRICH")!=std::string::npos) {
-    if(param_prefix.rfind("Aerogel")) m_numPlanes = 5;
-    else if(param_prefix.rfind("Gas")) m_numPlanes = 10;
+    if(param_prefix.rfind("Aerogel")!=std::string::npos) m_numPlanes = 5;
+    else if(param_prefix.rfind("Gas")!=std::string::npos) m_numPlanes = 10;
   }
 
   // configuration parameters

--- a/src/tools/default_flags_table/reco_flags.py
+++ b/src/tools/default_flags_table/reco_flags.py
@@ -747,7 +747,7 @@ eicrecon_reco_flags = [
     ('DRICH:DRICHRawHits:pedMean',         '200.0',     ''                                                      ),
     ('DRICH:DRICHRawHits:pedError',        '3.0',       ''                                                      ),
     ('DRICH:DRICHRawHits:enablePixelGaps', 'true',      'enable/disable removal of hits in gaps between pixels' ),
-    # ('DRICH:DRICHRawHits:pixelSize',       '3.0*mm',    'pixel (active) size'                                   ), # FIXME: do not use until https://github.com/eic/EICrecon/issues/383 is resolved
+    ('DRICH:DRICHRawHits:pixelSize',       '3.0*mm',    'pixel (active) size'                                   ),
     ('DRICH:DRICHRawHits:safetyFactor',    '0.7',       'overall safety factor'                                 ),
     # ('DRICH:DRICHRawHits:quantumEfficiency', '...', 'quantum efficiency' ), # FIXME cannot define here; instead it is hard coded in src/algorithms/digi/PhotoMultiplierHitDigiConfig.h
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Since we have moved away from `reco_flags.py` and _still_ do not have a simple way to set user parameters (e.g. #346), this PR sets the default parameters for the dRICH by hard-coding them in C++ (in other words, https://github.com/eic/EICrecon/pull/408 for the dRICH)

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no

### Does this PR change default behavior?
no