### PR TITLE
fix: ensure sectorDist is compared with hit distance in right units.

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.h
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.h
@@ -141,7 +141,7 @@ private:
           // different sector, local coordinates do not work, using global coordinates
         } else {
           // sector may have rotation (barrel), so z is included
-          return (edm4eic::magnitude(h1->getPosition() - h2->getPosition()) <= m_sectorDist / dd4hep::mm); # EDM4hep units are mm, so convert sectorDist to mm
+          return (edm4eic::magnitude(h1->getPosition() - h2->getPosition()) <= m_sectorDist / dd4hep::mm); // EDM4hep units are mm, so convert sectorDist to mm
         }
    }
 

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.h
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.h
@@ -141,7 +141,7 @@ private:
           // different sector, local coordinates do not work, using global coordinates
         } else {
           // sector may have rotation (barrel), so z is included
-          return (edm4eic::magnitude(h1->getPosition() - h2->getPosition()) <= m_sectorDist);
+          return (edm4eic::magnitude(h1->getPosition() - h2->getPosition()) <= m_sectorDist / dd4hep::mm); # EDM4hep units are mm, so convert sectorDist to mm
         }
    }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
In CalorimeterIslandClustering, we compare the hit distances with the sector distance `sectorDist`. The EDM4hep units (hits) are mm = 1 while the dd4hep units (sectorDist parameter) are cm = 1. We need an explicit conversion.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators @mariakzurek 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, some other calorimeter parameters would need changing if they are determined only on the basis of observed clusters.