### PR TITLE
fix: avoid m_cfg shadowing

### DIFF
--- a/src/algorithms/tracking/TrackParamTruthInit.h
+++ b/src/algorithms/tracking/TrackParamTruthInit.h
@@ -27,7 +27,6 @@ namespace eicrecon {
 
     private:
         std::shared_ptr<spdlog::logger> m_log;
-        TrackParamTruthInitConfig m_cfg;
         std::shared_ptr<TDatabasePDG> m_pdg_db;
 
         std::default_random_engine generator; // TODO: need something more appropriate here


### PR DESCRIPTION
### Briefly, what does this PR introduce?
`m_cfg` was defined with same type in both CRTP base (protected) and derived (public), but somehow no compiler was warning. This caused the settings for the truth seeding to not take hold.

Fun with godbolt, https://godbolt.org/z/e3W4j41Wv

### What kind of change does this PR introduce?
- [X] Bug fix (issue: cannot change MaxEtaForward)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators: @rahmans1 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.