### PR TITLE
feat: cluster matching is not actually implemented, so don't make sciglass a requirement

### DIFF
--- a/src/global/reco/MatchClusters_factory.h
+++ b/src/global/reco/MatchClusters_factory.h
@@ -34,7 +34,7 @@ namespace eicrecon {
         void Process(const std::shared_ptr<const JEvent> &event) override;
     protected:
 
-        std::vector<std::string> m_input_assoc_tags = {"EcalBarrelClusterAssociations"};
+        std::vector<std::string> m_input_assoc_tags;
         MatchClusters m_match_algo;
 
     };

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -34,12 +34,8 @@ void InitPlugin(JApplication *app) {
 
     app->Add(new JChainFactoryGeneratorT<MatchClusters_factory>(
         {
-            "EcalEndcapNInsertClusters",
             "EcalEndcapNClusters",
-            "EcalBarrelSciGlassClusters",
-            "EcalBarrelImagingClusters",
             "EcalEndcapPClusters",
-            "EcalEndcapPInsertClusters"
          },
         "ReconstructedParticlesWithAssoc"
     ));

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -33,7 +33,16 @@ void InitPlugin(JApplication *app) {
             {"MCParticles"}, "GeneratedParticles", smearing_default_config));
 
     app->Add(new JChainFactoryGeneratorT<MatchClusters_factory>(
-            {"EcalEndcapNClusters", "EcalBarrelSciGlassClusters"}, "ReconstructedParticlesWithAssoc"));
+        {
+            "EcalEndcapNInsertClusters",
+            "EcalEndcapNClusters",
+            "EcalBarrelSciGlassClusters",
+            "EcalBarrelImagingClusters",
+            "EcalEndcapPClusters",
+            "EcalEndcapPInsertClusters"
+         },
+        "ReconstructedParticlesWithAssoc"
+    ));
 
     app->Add(new JChainFactoryGeneratorT<ReconstructedParticles_factory>(
             {"ReconstructedParticlesWithAssoc"}, "ReconstructedParticles"));


### PR DESCRIPTION
### Briefly, what does this PR introduce?
~~This enables cluster matching with tracks in all calorimeters, not just the negative endcap and sciglass. This should allow the kinematics determination to work for brycecanyon too, since it requires the output of the cluster matching to find the electron track.~~

Cluster matching is not actually implemented or run at all. The only thing the MatchCluster factory does is pass the charged particles and associations. But because it requires sciglass clusters as input, it fails to complete even this minimal task for brycecanyon.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes. Brycecanyon should get some more kinematics output.