### PR TITLE
OrthogonalTrackSeedingConfig.h: fix invalid include guard

### DIFF
--- a/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
+++ b/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
@@ -2,8 +2,7 @@
 // Subject to the terms in the LICENSE file found in the top-level directory.
 //
 
-#ifndef EICRECON_TRACK_SEEDING_CONFIG_H
-#define EICRECON_ORTHOGONAL_TRACK_SEEDING_CONFIG_H
+#pragma once
 
 #include <vector>
 
@@ -101,6 +100,3 @@ namespace eicrecon {
   };
   
 }
-  
-#endif 
-  


### PR DESCRIPTION
Checked and defined macro names don't match

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
