### PR TITLE
feat: add adjacency matrix in calorimeter clustering

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -127,7 +127,6 @@ void CalorimeterIslandCluster::AlgorithmInit(std::shared_ptr<spdlog::logger>& lo
         }
         dd4hep::tools::Evaluator::Object::EvalStatus eval = evaluator.evaluate(u_adjacencyMatrix.c_str());
         if (eval.status()) {
-          // no known conversion from 'MsgStream' to 'std::ostream &'
           std::stringstream sstr;
           eval.print_error(sstr);
           m_log->error(sstr.str());

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -9,6 +9,10 @@
 #include <edm4hep/Vector2f.h>
 #include <edm4hep/Vector3f.h>
 
+// Expression evaluator from DD4hep
+#include <Evaluator/Evaluator.h>
+#include <Evaluator/detail/Evaluator.h>
+
 #include <JANA/JEvent.h>
 #include <edm4hep/SimCalorimeterHit.h>
 #include <Evaluator/DD4hepUnits.h>
@@ -106,10 +110,61 @@ void CalorimeterIslandCluster::AlgorithmInit(std::shared_ptr<spdlog::logger>& lo
 //    };
 
     bool method_found = false;
-    for (auto& uprop : uprops) {
-      if (set_dist_method(uprop)) {
-        method_found = true;
-        break;
+    if (u_adjacencyMatrix.value() != "") {
+      m_geoSvc = service(m_geoSvcName);
+      // sanity checks
+      if (!m_geoSvc) {
+        m_log->error("Unable to locate Geometry Service. "
+                  + "Make sure you have GeoSvc and SimSvc in the right order in the configuration.");
+        return;
+      }
+      if (m_readout.value().empty()) {
+        m_log->error("readoutClass is not provided, it is needed to know the fields in readout ids");
+      }
+      m_idSpec = m_geoSvc->detector()->readout(m_readout).idSpec();
+
+      is_neighbour = [this](const CaloHit& h1, const CaloHit& h2) {
+        dd4hep::tools::Evaluator::Object evaluator;
+        for(const auto &p : m_idSpec.fields()) {
+          const std::string &name = p.first;
+          const dd4hep::IDDescriptor::Field* field = p.second;
+          evaluator.setVariable((name + "_1").c_str(), field->value(h1.getCellID()));
+          evaluator.setVariable((name + "_2").c_str(), field->value(h2.getCellID()));
+          m_log->debug("setVariable(\"" << name  << "_1\", " << field->value(h1.getCellID()) << ");" << endmsg;
+          m_log->debug("setVariable(\"" << name  << "_2\", " << field->value(h2.getCellID()) << ");" << endmsg;
+        }
+        dd4hep::tools::Evaluator::Object::EvalStatus eval = evaluator.evaluate(u_adjacencyMatrix.value().c_str());
+        if (eval.status()) {
+          // no known conversion from 'MsgStream' to 'std::ostream &'
+          std::stringstream sstr;
+          eval.print_error(sstr);
+          m_log->error(sstr.str());
+        }
+        m_log->debug("result = {}", eval.result());
+        return eval.result();
+      };
+      method_found = true;
+    }
+    if (!method_found)
+    {
+      for (auto& uprop : uprops) {
+        if (set_dist_method(uprop)) {
+          method_found = true;
+
+          is_neighbour = [this](const CaloHit& h1, const CaloHit& h2) {
+            // in the same sector
+            if (h1.getSector() == h2.getSector()) {
+              auto dist = hitsDist(h1, h2);
+              return (dist.a <= neighbourDist[0]) && (dist.b <= neighbourDist[1]);
+              // different sector, local coordinates do not work, using global coordinates
+            } else {
+              // sector may have rotation (barrel), so z is included
+              return (edm4eic::magnitude(h1.getPosition() - h2.getPosition()) <= sectorDist);
+            }
+          };
+
+          break;
+        }
       }
     }
     if (not method_found) {

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -1,7 +1,7 @@
 // Copyright 2022, David Lawrence
 // Subject to the terms in the LICENSE file found in the top-level directory.
 //
-//  Sections Copyright (C) 2022 Chao Peng, Wouter Deconinck, Sylvester Joosten
+//  Sections Copyright (C) 2023 Chao Peng, Wouter Deconinck, Sylvester Joosten, Dmitry Kalinkin
 //  under SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "CalorimeterIslandCluster.h"

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.h
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.h
@@ -102,6 +102,11 @@ public:
     double m_minClusterHitEdep;//{this, "minClusterHitEdep", 0.};
     double m_minClusterCenterEdep;//{this, "minClusterCenterEdep", 50.0 * dd4hep::MeV};
 
+    // geometry service to get ids
+    std::string m_geoSvcName; //{this, "geoServiceName", "GeoSvc"};
+    std::string m_readout; //{this, "readoutClass", ""};
+    std::string u_adjacencyMatrix; //{this, "adjacencyMatrix", ""};
+
     // neighbour checking distances
     double m_sectorDist;//{this, "sectorDist", 5.0 * dd4hep::cm};
     std::vector<double> u_localDistXY;//{this, "localDistXY", {}};
@@ -114,17 +119,20 @@ public:
     std::function<edm4hep::Vector2f(const CaloHit*, const CaloHit*)> hitsDist;
 
     // helper function to group hits
-    std::function<bool(const CaloHit& h1, const CaloHit& h2)> is_neighbour;
+    std::function<bool(const CaloHit* h1, const CaloHit* h2)> is_neighbour;
 
     // unitless counterparts of the input parameters
     std::array<double, 2> neighbourDist;
+
+    // Pointer to the geometry service
+    std::shared_ptr<JDD4hep_service> m_geoSvc;
+    dd4hep::IDDescriptor m_idSpec;
 
     //-----------------------------------------------
 
     // unitless counterparts of inputs
     double           stepTDC, tRes, eRes[3];
     //Rndm::Numbers    m_normDist;
-    std::shared_ptr<JDD4hep_service> m_geoSvc;
     uint64_t         id_mask, ref_mask;
 
     // inputs/outputs

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.h
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.h
@@ -110,10 +110,13 @@ public:
     std::vector<double> u_globalDistRPhi;//{this, "globalDistRPhi", {}};
     std::vector<double> u_globalDistEtaPhi;//{this, "globalDistEtaPhi", {}};
     std::vector<double> u_dimScaledLocalDistXY;//{this, "dimScaledLocalDistXY", {1.8, 1.8}};
-  // neighbor checking function
+    // neighbor checking function
     std::function<edm4hep::Vector2f(const CaloHit*, const CaloHit*)> hitsDist;
 
-  // unitless counterparts of the input parameters
+    // helper function to group hits
+    std::function<bool(const CaloHit& h1, const CaloHit& h2)> is_neighbour;
+
+    // unitless counterparts of the input parameters
     std::array<double, 2> neighbourDist;
 
     //-----------------------------------------------
@@ -131,19 +134,6 @@ public:
 private:
     std::default_random_engine generator; // TODO: need something more appropriate here
     std::normal_distribution<double> m_normDist; // defaults to mean=0, sigma=1
-
-    // helper function to group hits
-    inline bool is_neighbour(const CaloHit *h1, const CaloHit *h2) const {
-        // in the same sector
-        if (h1->getSector() == h2->getSector()) {
-          auto dist = hitsDist(h1, h2);
-          return (dist.a <= neighbourDist[0]) && (dist.b <= neighbourDist[1]);
-          // different sector, local coordinates do not work, using global coordinates
-        } else {
-          // sector may have rotation (barrel), so z is included
-          return (edm4eic::magnitude(h1->getPosition() - h2->getPosition()) <= m_sectorDist / dd4hep::mm); // EDM4hep units are mm, so convert sectorDist to mm
-        }
-   }
 
    // grouping function with Depth-First Search
    //TODO: confirm grouping without calohitcollection

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelScFiProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelScFiProtoClusters.h
@@ -33,6 +33,11 @@ public:
         m_minClusterHitEdep=1.0 * dd4hep::MeV;    // from ATHENA reconstruction.py
         m_minClusterCenterEdep=10.0 * dd4hep::MeV; // from ATHENA reconstruction.py
 
+        // adjacency matrix
+        m_geoSvcName = "GeoSvc";
+        u_adjacencyMatrix = "";
+        m_readout = "";
+
         // neighbour checking distances
         m_sectorDist=5.0 * dd4hep::cm;             // ?
         u_localDistXY={};     //{this, "localDistXY", {}};
@@ -53,6 +58,9 @@ public:
         app->SetDefaultParameter("BEMC:EcalBarrelScFiProtoClusters:globalDistRPhi",    u_globalDistRPhi);
         app->SetDefaultParameter("BEMC:EcalBarrelScFiProtoClusters:globalDistEtaPhi",    u_globalDistEtaPhi);
         app->SetDefaultParameter("BEMC:EcalBarrelScFiProtoClusters:dimScaledLocalDistXY",    u_dimScaledLocalDistXY);
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiProtoClusters:adjacencyMatrix", u_dimScaledLocalDistXY);
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiProtoClusters:geoServiceName", m_geoSvcName);
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiProtoClusters:readoutClass", m_readout);
         m_geoSvc = app->template GetService<JDD4hep_service>();
 
         AlgorithmInit(m_log);

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
@@ -39,13 +39,13 @@ public:
         m_readout = "EcalBarrelSciGlassHits";
 
         // neighbour checking distances
-        m_sectorDist=5.0 * dd4hep::cm;             // from ATHENA reconstruction.py
+        m_sectorDist=0.0 * dd4hep::cm;             // not applicable
         u_localDistXY={};     //{this, "localDistXY", {}};
         u_localDistXZ={};     //{this, "localDistXZ", {}};
         u_localDistYZ={};     //{this, "localDistYZ", {}};
         u_globalDistRPhi={};  //{this, "globalDistRPhi", {}};
-        u_globalDistEtaPhi={};//{this, "globalDistEtaPhi", {}};
-        u_dimScaledLocalDistXY={1.8,1.8};// from ATHENA reconstruction.py
+        u_globalDistEtaPhi={}; //{this, "globalDistEtaPhi", {}};
+        u_dimScaledLocalDistXY={}; // not used
 
         app->SetDefaultParameter("BEMC:EcalBarrelSciGlassProtoClusters:input_tag", m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelSciGlassProtoClusters:splitCluster",             m_splitCluster);

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
@@ -35,7 +35,10 @@ public:
 
         // adjacency matrix
         m_geoSvcName = "GeoSvc";
-        u_adjacencyMatrix = "(abs(tower_1 - tower_2) + abs((sector_1 - sector_2) * 5 + row_1 - row_2)) == 1";
+        // Magic constants:
+        //  24 - number of sectors
+        //  5  - number of towers per sector
+        u_adjacencyMatrix = "(abs(tower_1 - tower_2) + (abs((sector_1 - sector_2) * 5 + row_1 - row_2) == 1) + (abs((sector_1 - sector_2) * 5 + row_1 - row_2) == (24 * 5 - 1))) == 1";
         m_readout = "EcalBarrelSciGlassHits";
 
         // neighbour checking distances

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
@@ -36,7 +36,7 @@ public:
         // adjacency matrix
         m_geoSvcName = "GeoSvc";
         u_adjacencyMatrix = "(abs(tower_1 - tower_2) + abs((sector_1 - sector2) * 5 + row_1 - row2)) == 1";
-        m_readout = "";
+        m_readout = "EcalBarrelSciGlassHits";
 
         // neighbour checking distances
         m_sectorDist=5.0 * dd4hep::cm;             // from ATHENA reconstruction.py

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
@@ -33,6 +33,11 @@ public:
         m_minClusterHitEdep=1.0 * dd4hep::MeV;    // from ATHENA reconstruction.py
         m_minClusterCenterEdep=30.0 * dd4hep::MeV; // from ATHENA reconstruction.py
 
+        // adjacency matrix
+        m_geoSvcName = "GeoSvc";
+        u_adjacencyMatrix = "";
+        m_readout = "";
+
         // neighbour checking distances
         m_sectorDist=5.0 * dd4hep::cm;             // from ATHENA reconstruction.py
         u_localDistXY={};     //{this, "localDistXY", {}};
@@ -53,6 +58,9 @@ public:
         app->SetDefaultParameter("BEMC:EcalBarrelSciGlassProtoClusters:globalDistRPhi",    u_globalDistRPhi);
         app->SetDefaultParameter("BEMC:EcalBarrelSciGlassProtoClusters:globalDistEtaPhi",    u_globalDistEtaPhi);
         app->SetDefaultParameter("BEMC:EcalBarrelSciGlassProtoClusters:dimScaledLocalDistXY",    u_dimScaledLocalDistXY);
+        app->SetDefaultParameter("BEMC:EcalBarrelSciGlassProtoClusters:adjacencyMatrix", u_dimScaledLocalDistXY);
+        app->SetDefaultParameter("BEMC:EcalBarrelSciGlassProtoClusters:geoServiceName", m_geoSvcName);
+        app->SetDefaultParameter("BEMC:EcalBarrelSciGlassProtoClusters:readoutClass", m_readout);
         m_geoSvc = app->template GetService<JDD4hep_service>();
 
         AlgorithmInit(m_log);

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
@@ -35,7 +35,7 @@ public:
 
         // adjacency matrix
         m_geoSvcName = "GeoSvc";
-        u_adjacencyMatrix = "";
+        u_adjacencyMatrix = "(abs(tower_1 - tower_2) + abs((sector_1 - sector2) * 5 + row_1 - row2)) == 1";
         m_readout = "";
 
         // neighbour checking distances

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
@@ -35,7 +35,7 @@ public:
 
         // adjacency matrix
         m_geoSvcName = "GeoSvc";
-        u_adjacencyMatrix = "(abs(tower_1 - tower_2) + abs((sector_1 - sector2) * 5 + row_1 - row2)) == 1";
+        u_adjacencyMatrix = "(abs(tower_1 - tower_2) + abs((sector_1 - sector_2) * 5 + row_1 - row_2)) == 1";
         m_readout = "EcalBarrelSciGlassHits";
 
         // neighbour checking distances

--- a/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapNIslandProtoClusters.h
+++ b/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapNIslandProtoClusters.h
@@ -32,6 +32,11 @@ public:
         m_minClusterHitEdep=1.0 * dd4hep::MeV;    // from ATHENA reconstruction.py
         m_minClusterCenterEdep=30.0 * dd4hep::MeV; // from ATHENA reconstruction.py
 
+        // adjacency matrix
+        m_geoSvcName = "GeoSvc";
+        u_adjacencyMatrix = "";
+        m_readout = "";
+
         // neighbour checking distances
         m_sectorDist=5.0 * dd4hep::cm;             // from ATHENA reconstruction.py
         u_localDistXY={};     //{this, "localDistXY", {}};
@@ -53,6 +58,9 @@ public:
         app->SetDefaultParameter("EEMC:EcalEndcapNIslandProtoClusters:globalDistRPhi",    u_globalDistRPhi);
         app->SetDefaultParameter("EEMC:EcalEndcapNIslandProtoClusters:globalDistEtaPhi",    u_globalDistEtaPhi);
         app->SetDefaultParameter("EEMC:EcalEndcapNIslandProtoClusters:dimScaledLocalDistXY",    u_dimScaledLocalDistXY);
+        app->SetDefaultParameter("EEMC:EcalEndcapNIslandProtoClusters:adjacencyMatrix", u_dimScaledLocalDistXY);
+        app->SetDefaultParameter("EEMC:EcalEndcapNIslandProtoClusters:geoServiceName", m_geoSvcName);
+        app->SetDefaultParameter("EEMC:EcalEndcapNIslandProtoClusters:readoutClass", m_readout);
         m_geoSvc = app->template GetService<JDD4hep_service>();
 
         AlgorithmInit(m_log);

--- a/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapPInsertIslandProtoClusters.h
+++ b/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapPInsertIslandProtoClusters.h
@@ -32,6 +32,11 @@ public:
         m_minClusterHitEdep=0.0 * dd4hep::MeV;    // from ATHENA reconstruction.py
         m_minClusterCenterEdep=10.0 * dd4hep::MeV; // from ATHENA reconstruction.py
 
+        // adjacency matrix
+        m_geoSvcName = "GeoSvc";
+        u_adjacencyMatrix = "";
+        m_readout = "";
+
         // neighbour checking distances
         m_sectorDist=5.0 * dd4hep::cm;             // from ATHENA reconstruction.py
         u_localDistXY={10.0 * dd4hep::cm, 10.0 * dd4hep::cm};     //{this, "localDistXY", {}};
@@ -53,6 +58,9 @@ public:
         app->SetDefaultParameter("EEMC:EcalEndcapPInsertIslandProtoClusters:globalDistRPhi",    u_globalDistRPhi);
         app->SetDefaultParameter("EEMC:EcalEndcapPInsertIslandProtoClusters:globalDistEtaPhi",    u_globalDistEtaPhi);
         app->SetDefaultParameter("EEMC:EcalEndcapPInsertIslandProtoClusters:dimScaledLocalDistXY",    u_dimScaledLocalDistXY);
+        app->SetDefaultParameter("EEMC:EcalEndcapPInsertIslandProtoClusters:adjacencyMatrix", u_dimScaledLocalDistXY);
+        app->SetDefaultParameter("EEMC:EcalEndcapPInsertIslandProtoClusters:geoServiceName", m_geoSvcName);
+        app->SetDefaultParameter("EEMC:EcalEndcapPInsertIslandProtoClusters:readoutClass", m_readout);
         m_geoSvc = app->template GetService<JDD4hep_service>();
 
         AlgorithmInit(m_log);

--- a/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapPIslandProtoClusters.h
+++ b/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapPIslandProtoClusters.h
@@ -32,6 +32,11 @@ public:
         m_minClusterHitEdep=0.0 * dd4hep::MeV;    // from ATHENA reconstruction.py
         m_minClusterCenterEdep=10.0 * dd4hep::MeV; // from ATHENA reconstruction.py
 
+        // adjacency matrix
+        m_geoSvcName = "GeoSvc";
+        u_adjacencyMatrix = "";
+        m_readout = "";
+
         // neighbour checking distances
         m_sectorDist=5.0 * dd4hep::cm;             // from ATHENA reconstruction.py
         u_localDistXY={10.0 * dd4hep::cm, 10.0 * dd4hep::cm};     //{this, "localDistXY", {}};
@@ -53,6 +58,9 @@ public:
         app->SetDefaultParameter("EEMC:EcalEndcapPIslandProtoClusters:globalDistRPhi",    u_globalDistRPhi);
         app->SetDefaultParameter("EEMC:EcalEndcapPIslandProtoClusters:globalDistEtaPhi",    u_globalDistEtaPhi);
         app->SetDefaultParameter("EEMC:EcalEndcapPIslandProtoClusters:dimScaledLocalDistXY",    u_dimScaledLocalDistXY);
+        app->SetDefaultParameter("EEMC:EcalEndcapPIslandProtoClusters:adjacencyMatrix", u_dimScaledLocalDistXY);
+        app->SetDefaultParameter("EEMC:EcalEndcapPIslandProtoClusters:geoServiceName", m_geoSvcName);
+        app->SetDefaultParameter("EEMC:EcalEndcapPIslandProtoClusters:readoutClass", m_readout);
         m_geoSvc = app->template GetService<JDD4hep_service>();
 
         AlgorithmInit(m_log);

--- a/src/detectors/HCAL/ProtoCluster_factory_HcalBarrelIslandProtoClusters.h
+++ b/src/detectors/HCAL/ProtoCluster_factory_HcalBarrelIslandProtoClusters.h
@@ -32,6 +32,11 @@ public:
         m_minClusterHitEdep=3.0 * dd4hep::MeV;    // from https://eicweb.phy.anl.gov/EIC/detectors/athena/-/blob/master/calibrations/ffi_zdc.json
         m_minClusterCenterEdep=30.0 * dd4hep::MeV; // from https://eicweb.phy.anl.gov/EIC/detectors/athena/-/blob/master/calibrations/ffi_zdc.json
 
+        // adjacency matrix
+        m_geoSvcName = "GeoSvc";
+        u_adjacencyMatrix = "";
+        m_readout = "";
+
         // neighbour checking distances
         m_sectorDist=5.0 * dd4hep::cm;             // from ATHENA reconstruction.py
         u_localDistXY={15*dd4hep::mm, 15*dd4hep::mm};     //{this, "localDistXY", {}};
@@ -52,6 +57,9 @@ public:
         app->SetDefaultParameter("HCAL:HcalBarrelIslandProtoClusters:globalDistRPhi",    u_globalDistRPhi);
         app->SetDefaultParameter("HCAL:HcalBarrelIslandProtoClusters:globalDistEtaPhi",    u_globalDistEtaPhi);
         app->SetDefaultParameter("HCAL:HcalBarrelIslandProtoClusters:dimScaledLocalDistXY",    u_dimScaledLocalDistXY);
+        app->SetDefaultParameter("HCAL:HcalBarrelIslandProtoClusters:adjacencyMatrix", u_dimScaledLocalDistXY);
+        app->SetDefaultParameter("HCAL:HcalBarrelIslandProtoClusters:geoServiceName", m_geoSvcName);
+        app->SetDefaultParameter("HCAL:HcalBarrelIslandProtoClusters:readoutClass", m_readout);
         m_geoSvc = app->template GetService<JDD4hep_service>();
 
         AlgorithmInit(m_log);

--- a/src/detectors/HCAL/ProtoCluster_factory_HcalEndcapNIslandProtoClusters.h
+++ b/src/detectors/HCAL/ProtoCluster_factory_HcalEndcapNIslandProtoClusters.h
@@ -33,6 +33,11 @@ public:
         m_minClusterHitEdep=0.0 * dd4hep::MeV;    // https://eicweb.phy.anl.gov/EIC/juggler/-/blob/main/JugReco/src/components/CalorimeterIslandCluster.cpp
         m_minClusterCenterEdep=30.0 * dd4hep::MeV; // from ATHENA's reconstruction.py
 
+        // adjacency matrix
+        m_geoSvcName = "GeoSvc";
+        u_adjacencyMatrix = "";
+        m_readout = "";
+
         // neighbour checking distances
         m_sectorDist=5.0 * dd4hep::cm;             // https://eicweb.phy.anl.gov/EIC/juggler/-/blob/main/JugReco/src/components/CalorimeterIslandCluster.cpp
         u_localDistXY={15*dd4hep::mm, 15*dd4hep::mm};     //{this, "localDistXY", {}};
@@ -53,6 +58,9 @@ public:
         app->SetDefaultParameter("HCAL:HcalEndcapNIslandProtoClusters:globalDistRPhi",    u_globalDistRPhi);
         app->SetDefaultParameter("HCAL:HcalEndcapNIslandProtoClusters:globalDistEtaPhi",    u_globalDistEtaPhi);
         app->SetDefaultParameter("HCAL:HcalEndcapNIslandProtoClusters:dimScaledLocalDistXY",    u_dimScaledLocalDistXY);
+        app->SetDefaultParameter("HCAL:HcalEndcapNIslandProtoClusters:adjacencyMatrix", u_dimScaledLocalDistXY);
+        app->SetDefaultParameter("HCAL:HcalEndcapNIslandProtoClusters:geoServiceName", m_geoSvcName);
+        app->SetDefaultParameter("HCAL:HcalEndcapNIslandProtoClusters:readoutClass", m_readout);
         m_geoSvc = app->template GetService<JDD4hep_service>();
 
         AlgorithmInit(m_log);

--- a/src/detectors/HCAL/ProtoCluster_factory_HcalEndcapPInsertIslandProtoClusters.h
+++ b/src/detectors/HCAL/ProtoCluster_factory_HcalEndcapPInsertIslandProtoClusters.h
@@ -32,6 +32,11 @@ public:
         m_minClusterHitEdep=0.0 * dd4hep::MeV;    // https://eicweb.phy.anl.gov/EIC/juggler/-/blob/main/JugReco/src/components/CalorimeterIslandCluster.cpp
         m_minClusterCenterEdep=30.0 * dd4hep::MeV; // from ATHENA's reconstruction.py
 
+        // adjacency matrix
+        m_geoSvcName = "GeoSvc";
+        u_adjacencyMatrix = "";
+        m_readout = "";
+
         // neighbour checking distances
         m_sectorDist=5.0 * dd4hep::cm;             // https://eicweb.phy.anl.gov/EIC/juggler/-/blob/main/JugReco/src/components/CalorimeterIslandCluster.cpp
         u_localDistXY={15*dd4hep::mm, 15*dd4hep::mm};     //{this, "localDistXY", {}};
@@ -52,6 +57,9 @@ public:
         app->SetDefaultParameter("HCAL:HcalEndcapPInsertIslandProtoClusters:globalDistRPhi",    u_globalDistRPhi);
         app->SetDefaultParameter("HCAL:HcalEndcapPInsertIslandProtoClusters:globalDistEtaPhi",    u_globalDistEtaPhi);
         app->SetDefaultParameter("HCAL:HcalEndcapPInsertIslandProtoClusters:dimScaledLocalDistXY",    u_dimScaledLocalDistXY);
+        app->SetDefaultParameter("HCAL:HcalEndcapPInsertIslandProtoClusters:adjacencyMatrix", u_dimScaledLocalDistXY);
+        app->SetDefaultParameter("HCAL:HcalEndcapPInsertIslandProtoClusters:geoServiceName", m_geoSvcName);
+        app->SetDefaultParameter("HCAL:HcalEndcapPInsertIslandProtoClusters:readoutClass", m_readout);
         m_geoSvc = app->template GetService<JDD4hep_service>();
 
         AlgorithmInit(m_log);

--- a/src/detectors/HCAL/ProtoCluster_factory_HcalEndcapPIslandProtoClusters.h
+++ b/src/detectors/HCAL/ProtoCluster_factory_HcalEndcapPIslandProtoClusters.h
@@ -33,6 +33,11 @@ public:
         m_minClusterHitEdep=0.0 * dd4hep::MeV;    // https://eicweb.phy.anl.gov/EIC/juggler/-/blob/main/JugReco/src/components/CalorimeterIslandCluster.cpp
         m_minClusterCenterEdep=30.0 * dd4hep::MeV; // from ATHENA's reconstruction.py
 
+        // adjacency matrix
+        m_geoSvcName = "GeoSvc";
+        u_adjacencyMatrix = "";
+        m_readout = "";
+
         // neighbour checking distances
         m_sectorDist=5.0 * dd4hep::cm;             // https://eicweb.phy.anl.gov/EIC/juggler/-/blob/main/JugReco/src/components/CalorimeterIslandCluster.cpp
         u_localDistXY={15.0*dd4hep::mm, 15.0*dd4hep::mm};     //{this, "localDistXY", {}};
@@ -53,6 +58,9 @@ public:
         app->SetDefaultParameter("HCAL:HcalEndcapPIslandProtoClusters:globalDistRPhi",    u_globalDistRPhi);
         app->SetDefaultParameter("HCAL:HcalEndcapPIslandProtoClusters:globalDistEtaPhi",    u_globalDistEtaPhi);
         app->SetDefaultParameter("HCAL:HcalEndcapPIslandProtoClusters:dimScaledLocalDistXY",    u_dimScaledLocalDistXY);
+        app->SetDefaultParameter("HCAL:HcalEndcapPIslandProtoClusters:adjacencyMatrix", u_dimScaledLocalDistXY);
+        app->SetDefaultParameter("HCAL:HcalEndcapPIslandProtoClusters:geoServiceName", m_geoSvcName);
+        app->SetDefaultParameter("HCAL:HcalEndcapPIslandProtoClusters:readoutClass", m_readout);
         m_geoSvc = app->template GetService<JDD4hep_service>();
 
         AlgorithmInit(m_log);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This introduces the adjacency matrix into calorimeter island clustering and is a port of https://github.com/eic/juggler/pull/2 into eicrecon. Copying the comments from original author @veprbl into this PR.

The issue with the current implementation is that `is_neighbour()` relies on geometrical dimensions of a calorimeter being used. This makes it cumbersome and error-prone to enable clustering for different detectors. The goal is to instead use readout cellID fields.

This PR suggests a following interface for doing that: A new parameter `adjacencyMatrix` is added to describe the adjacency of the sensitive elements. It can be used replace the existing settings like `localDistXY`. The value specified must be a string expression (to be evaluated by DD4hep evaluator) that returns a "boolean" value which is non-zero for adjacent cells. An example predicate for a calorimeter with a readout ID spec like `system:8,row:8,column:8` could look like

```python
cl = IslandCluster("cl",
  readoutClass="EcalBarrelSciGlassHits",
  adjacencyMatrix="(abs(row_1 - row_2) + abs(column_1 - column_2)) == 1",
  # ...
)
```

A calorimeter that has sectors might require a more sophisticated predicate like:
```
(
  abs(tower_1 - tower_2)
  + abs((sector_1 - sector2) * 5 + row_1 - row2)
) == 1
```

There are few minor issues with the current implementation:
1. The `5` is a magical constant for number of rows per sector. It is possible to scan the geometry and define some sort of `row_max` constant to be used in place.
2. Expressions are evaluated for every tower. This may be slow, but those values can be precomputed if needed.
3. The DD4hep evaluator is designed to work with doubles, there might be some floating points caveats. Should not affect us unless we get into large numbers?

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @veprbl

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.