### PR TITLE
IrtGeo: mark destructor as virtual

### DIFF
--- a/src/services/geometry/rich/richgeo/IrtGeo.h
+++ b/src/services/geometry/rich/richgeo/IrtGeo.h
@@ -32,7 +32,7 @@ namespace rich {
       IrtGeo(std::string detName_, dd4hep::Detector *det_, bool verbose_=false);
       // alternate constructor: use compact file for DD4hep geometry (backward compatibility)
       IrtGeo(std::string detName_, std::string compactFile_="", bool verbose_=false);
-      ~IrtGeo(); 
+      virtual ~IrtGeo();
 
       // access the full IRT geometry
       CherenkovDetectorCollection *GetIrtDetectorCollection() { return m_irtDetectorCollection; }


### PR DESCRIPTION
```
src/services/geometry/rich/RichGeo_service.cc:73:18: warning: delete called on 'rich::IrtGeo' that is abstract but has non-virtual destructor [-Wdelete-abstract-non-virtual-dtor]
    if(m_irtGeo) delete m_irtGeo;
                 ^
```

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No