### PR TITLE
fix: propagate adjacency matrix to B0ECAL and ZDC island clustering

### DIFF
--- a/src/detectors/B0ECAL/ProtoCluster_factory_B0ECalIslandProtoClusters.h
+++ b/src/detectors/B0ECAL/ProtoCluster_factory_B0ECalIslandProtoClusters.h
@@ -32,6 +32,11 @@ public:
         m_minClusterHitEdep=1.0 * dd4hep::MeV;    // from ATHENA reconstruction.py
         m_minClusterCenterEdep=30.0 * dd4hep::MeV; // from ATHENA reconstruction.py
 
+        // adjacency matrix
+        m_geoSvcName = "GeoSvc";
+        u_adjacencyMatrix = "";
+        m_readout = "";
+
         // neighbour checking distances
         m_sectorDist=5.0 * dd4hep::cm;             // from ATHENA reconstruction.py
         u_localDistXY={};     //{this, "localDistXY", {}};
@@ -52,6 +57,9 @@ public:
         app->SetDefaultParameter("B0ECAL:B0ECalIslandProtoClusters:globalDistRPhi",    u_globalDistRPhi);
         app->SetDefaultParameter("B0ECAL:B0ECalIslandProtoClusters:globalDistEtaPhi",    u_globalDistEtaPhi);
         app->SetDefaultParameter("B0ECAL:B0ECalIslandProtoClusters:dimScaledLocalDistXY",    u_dimScaledLocalDistXY);
+        app->SetDefaultParameter("B0ECAL:B0ECalIslandProtoClusters:adjacencyMatrix", u_adjacencyMatrix);
+        app->SetDefaultParameter("B0ECAL:B0ECalIslandProtoClusters:geoServiceName", m_geoSvcName);
+        app->SetDefaultParameter("B0ECAL:B0ECalIslandProtoClusters:readoutClass", m_readout);
         m_geoSvc = app->template GetService<JDD4hep_service>();
 
         AlgorithmInit(m_log);

--- a/src/detectors/ZDC/ProtoCluster_factory_ZDCEcalIslandProtoClusters.h
+++ b/src/detectors/ZDC/ProtoCluster_factory_ZDCEcalIslandProtoClusters.h
@@ -32,6 +32,11 @@ public:
         m_minClusterHitEdep=0.1 * dd4hep::MeV;    // from https://eicweb.phy.anl.gov/EIC/detectors/athena/-/blob/master/calibrations/ffi_zdc.json
         m_minClusterCenterEdep=3.0 * dd4hep::MeV; // from https://eicweb.phy.anl.gov/EIC/detectors/athena/-/blob/master/calibrations/ffi_zdc.json
 
+        // adjacency matrix
+        m_geoSvcName = "GeoSvc";
+        u_adjacencyMatrix = "";
+        m_readout = "";
+
         // neighbour checking distances
         m_sectorDist=5.0 * dd4hep::cm;             // from ATHENA reconstruction.py
         u_localDistXY={50 * dd4hep::cm, 50 * dd4hep::cm};     //{this, "localDistXY", {}};
@@ -54,6 +59,9 @@ public:
         app->SetDefaultParameter("ZDC:ZDCEcalIslandProtoClusters:globalDistRPhi",    u_globalDistRPhi);
         app->SetDefaultParameter("ZDC:ZDCEcalIslandProtoClusters:globalDistEtaPhi",    u_globalDistEtaPhi);
         app->SetDefaultParameter("ZDC:ZDCEcalIslandProtoClusters:dimScaledLocalDistXY",    u_dimScaledLocalDistXY);
+        app->SetDefaultParameter("ZDC:ZDCIslandProtoClusters:adjacencyMatrix", u_adjacencyMatrix);
+        app->SetDefaultParameter("ZDC:ZDCIslandProtoClusters:geoServiceName", m_geoSvcName);
+        app->SetDefaultParameter("ZDC:ZDCIslandProtoClusters:readoutClass", m_readout);
         m_geoSvc = app->template GetService<JDD4hep_service>();
 
         AlgorithmInit(m_log);
@@ -79,4 +87,3 @@ public:
         protoClusters.clear(); // not really needed, but better to not leave dangling pointers around
     }
 };
-


### PR DESCRIPTION
### Briefly, what does this PR introduce?
We hadn't propagated the adjacency matrix addition to the B0ECAL and ZDC island clustering factories.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: adjacency matrix parameters missing for B0ECAL and ZDC island clustering factories)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.