### PR TITLE
fix: remove spaces in adjacency matrix expression

### DIFF
--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
@@ -38,6 +38,7 @@ public:
         //  24 - number of sectors
         //  5  - number of towers per sector
         u_adjacencyMatrix = "(abs(tower_1 - tower_2) + (abs((sector_1 - sector_2) * 5 + row_1 - row_2) == 1) + (abs((sector_1 - sector_2) * 5 + row_1 - row_2) == (24 * 5 - 1))) == 1";
+        std::remove(u_adjacencyMatrix.begin(), u_adjacencyMatrix.end(), ' ');
         m_readout = "EcalBarrelSciGlassHits";
 
         // neighbour checking distances


### PR DESCRIPTION
### Briefly, what does this PR introduce?
When there are spaces in the adjacency matrix string expression's default value, JANA2 chops at the first space. This results in many warnings, i.e. https://github.com/eic/EICrecon/actions/runs/4121127389/jobs/7116665443.

The issue seems to be in the `SetDefaultParameter` call, since modifying `u_adjacencyMatrix` in the algorithm didn't have any impact. At that point the string has already been chopped.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.