### PR TITLE
Removing momentum split part.

### DIFF
--- a/src/algorithms/tracking/TrackParamTruthInit.cc
+++ b/src/algorithms/tracking/TrackParamTruthInit.cc
@@ -73,10 +73,7 @@ eicrecon::TrackParameters *eicrecon::TrackParamTruthInit::produce(const edm4hep:
     }
 
     // modify initial momentum to avoid bleeding truth to results when fit fails
-    // this picks uniformly between [1-eps,1,1+eps] times true momentum, then smeared
-    const auto pinit = pmag
-                     * (1.0 + m_cfg.m_momentumSplit * m_uniformIntDist(generator))
-                     * (1.0 + m_cfg.m_momentumSmear * m_normDist(generator));
+    const auto pinit = pmag*(1.0 + m_cfg.m_momentumSmear * m_normDist(generator));
 
     // build some track cov matrix
     Acts::BoundSymMatrix cov                    = Acts::BoundSymMatrix::Zero();


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Removing momentum split part from the true momentum smearing as discussed.
### What kind of change does this PR introduce?
- [x ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __


### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
It will be the correct way to smear the momentum as Gaussian.