### PR TITLE
Changing default smearing to 10%

### DIFF
--- a/src/algorithms/tracking/TrackParamTruthInitConfig.h
+++ b/src/algorithms/tracking/TrackParamTruthInitConfig.h
@@ -14,8 +14,7 @@ struct TrackParamTruthInitConfig {
     double m_minMomentum      = 100 * Acts::UnitConstants::MeV;
     double m_maxEtaForward    = 4.0;
     double m_maxEtaBackward   = 4.1;
-    double m_momentumSplit    = 0.0;
-    double m_momentumSmear    = 0.0;
+    double m_momentumSmear    = 0.1;
 
 };
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
I removed the momentum split and changed the default momentum smearing to 10%.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, I removed the momentum split and changed the default momentum smearing to 10%.