### PR TITLE
fix(ci): keep .git and .ccache out of artifacts

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -66,6 +66,8 @@ jobs:
           !src/
           !build/
           !apt_cache/
+          !.git/
+          !.ccache/
         if-no-files-found: error
     - uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
I'd been wondering why the artifacts kept increasing in size... Default directory even after checkout is in ~ which is also where .ccache lives.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.