### PR TITLE
add position masks for hit reco

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -11,6 +11,7 @@
 #include <JANA/JEvent.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <fmt/format.h>
+#include <cctype>
 
 using namespace dd4hep;
 
@@ -37,7 +38,7 @@ void CalorimeterHitReco::AlgorithmInit(std::shared_ptr<spdlog::logger>& logger) 
     // First, try and get the IDDescriptor. This will throw an exception if it fails.
     try{
         auto id_spec = m_geoSvc->detector()->readout(m_readout).idSpec();
-    }catch(...){
+    } catch(...) {
         m_log->warn("Failed to get idSpec for {}", m_readout);
         return;
     }
@@ -61,7 +62,7 @@ void CalorimeterHitReco::AlgorithmInit(std::shared_ptr<spdlog::logger>& logger) 
             std::stringstream readouts;
             for (auto r: m_geoSvc->detector()->readouts()) readouts << "\"" << r.first << "\", ";
             m_log->warn("Available readouts: {}", readouts.str() );
-        }else {
+        } else {
             m_log->warn("Failed to find field index for {}.", m_readout);
             if (!m_sectorField.empty()) { m_log->warn(" -- looking for sector field \"{}\".", m_sectorField); }
             if (!m_layerField.empty()) { m_log->warn(" -- looking for layer field  \"{}\".", m_layerField); }
@@ -123,7 +124,7 @@ void CalorimeterHitReco::AlgorithmProcess() {
     // number is encountered disable this algorithm. A useful message
     // indicating what is going on is printed below where the
     // error is detector.
-    if( NcellIDerrors >= MaxCellIDerrors) return;
+    if (NcellIDerrors >= MaxCellIDerrors) return;
 
     auto converter = m_geoSvc->cellIDPositionConverter();
     for (const auto rh: rawhits) {
@@ -153,6 +154,26 @@ void CalorimeterHitReco::AlgorithmProcess() {
             // global positions
             gpos = converter->position(cellID);
 
+            // masked position (look for a mother volume)
+            if (gpos_mask != 0) {
+                auto mpos = converter->position(cellID & ~gpos_mask);
+                for (const char &c : m_mask_position) {
+                    switch (std::tolower(c)) {
+                    case 'x':
+                        gpos.SetX(mpos.X());
+                        break;
+                    case 'y':
+                        gpos.SetY(mpos.Y());
+                        break;
+                    case 'z':
+                        gpos.SetZ(mpos.Z());
+                        break;
+                    default:
+                        break;
+                    }
+                }
+            }
+
             // local positions
             if (m_localDetElement.empty()) {
                 auto volman = m_geoSvc->detector()->volumeManager();
@@ -161,7 +182,7 @@ void CalorimeterHitReco::AlgorithmProcess() {
         } catch (...) {
             // Error looking up cellID. Messages should already have been printed.
             // Also, see comment at top of this method.
-            if( ++NcellIDerrors >= MaxCellIDerrors ){
+            if (++NcellIDerrors >= MaxCellIDerrors) {
                 m_log->error("Maximum number of errors reached: {}", MaxCellIDerrors);
                 m_log->error("This is likely an issue with the cellID being unknown.");
                 m_log->error("Note: local_mask={:X} example cellID={:x}", local_mask, cellID);

--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -56,8 +56,16 @@ void CalorimeterHitReco::AlgorithmInit(std::shared_ptr<spdlog::logger>& logger) 
             layer_idx = id_dec->index(m_layerField);
             m_log->info("Find layer field {}, index = {}", m_layerField, sector_idx);
         }
+        if (!u_maskPosFields.empty()) {
+            size_t tmp_mask = 0;
+            for (auto &field : u_maskPosFields) {
+                tmp_mask |= id_spec.field(field)->mask();
+            }
+            // assign this mask if all fields succeed
+            gpos_mask = tmp_mask;
+        }
     } catch (...) {
-        if( !id_dec ) {
+        if (!id_dec) {
             m_log->warn("Failed to load ID decoder for {}", m_readout);
             std::stringstream readouts;
             for (auto r: m_geoSvc->detector()->readouts()) readouts << "\"" << r.first << "\", ";
@@ -66,10 +74,14 @@ void CalorimeterHitReco::AlgorithmInit(std::shared_ptr<spdlog::logger>& logger) 
             m_log->warn("Failed to find field index for {}.", m_readout);
             if (!m_sectorField.empty()) { m_log->warn(" -- looking for sector field \"{}\".", m_sectorField); }
             if (!m_layerField.empty()) { m_log->warn(" -- looking for layer field  \"{}\".", m_layerField); }
+            if (!u_maskPosFields.empty()) {
+                m_log->warn(" -- looking for masking fields  \"{}\".", fmt::join(u_maskPosFields, ", "));
+            }
             std::stringstream fields;
             for (auto field: id_spec.decoder()->fields()) fields << "\"" << field.name() << "\", ";
             m_log->warn("Available fields: {}", fields.str() );
             m_log->warn("n.b. The local position, sector id and layer id will not be correct for this.");
+            m_log->warn("Position masking may not be applied.");
             m_log->warn("however, the position, energy, and time values should still be good.");
         }
 
@@ -157,7 +169,8 @@ void CalorimeterHitReco::AlgorithmProcess() {
             // masked position (look for a mother volume)
             if (gpos_mask != 0) {
                 auto mpos = converter->position(cellID & ~gpos_mask);
-                for (const char &c : m_mask_position) {
+                // replace corresponding coords
+                for (const char &c : m_maskPos) {
                     switch (std::tolower(c)) {
                     case 'x':
                         gpos.SetX(mpos.X());

--- a/src/algorithms/calorimetry/CalorimeterHitReco.h
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.h
@@ -74,10 +74,10 @@ public:
 
   // name of detelment or fields to find the local detector (for global->local transform)
   // if nothing is provided, the lowest level DetElement (from cellID) will be used
-  std::string m_localDetElement="";
-  std::vector<std::string> u_localDetFields={};
+  std::string m_localDetElement="", m_mask_position="";
+  std::vector<std::string> u_localDetFields={}, u_posMaskFields;
   dd4hep::DetElement local;
-  size_t local_mask = ~0;
+  size_t local_mask = ~0, gpos_mask = 0;
 
     std::vector<edm4eic::CalorimeterHit*> hits;
     std::vector<const edm4hep::RawCalorimeterHit*> rawhits;

--- a/src/algorithms/calorimetry/CalorimeterHitReco.h
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.h
@@ -74,8 +74,8 @@ public:
 
   // name of detelment or fields to find the local detector (for global->local transform)
   // if nothing is provided, the lowest level DetElement (from cellID) will be used
-  std::string m_localDetElement="", m_mask_position="";
-  std::vector<std::string> u_localDetFields={}, u_posMaskFields;
+  std::string m_localDetElement="", m_maskPos="";
+  std::vector<std::string> u_localDetFields={}, u_maskPosFields={};
   dd4hep::DetElement local;
   size_t local_mask = ~0, gpos_mask = 0;
 

--- a/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelScFiRecHits.h
+++ b/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelScFiRecHits.h
@@ -44,8 +44,14 @@ public:
         m_layerField="layer";            // from ATHENA's reconstruction.py (i.e. not defined there)
         m_sectorField="module";          // from ATHENA's reconstruction.py
 
-        m_localDetElement="";         // from ATHENA's reconstruction.py (i.e. not defined there)
-        u_localDetFields={"system"};          // from ATHENA's reconstruction.py (i.e. not defined there)
+        m_localDetElement="";            // from ATHENA's reconstruction.py (i.e. not defined there)
+        u_localDetFields={"system"};     // from ATHENA's reconstruction.py (i.e. not defined there)
+
+        // here we want to use grid center position (XY) but keeps the z information from fiber-segment
+        // TODO: a more realistic way to get z is to reconstruct it from timing
+        m_maskPos = "xy";
+        u_maskPosFields = {"fiber", "z"};
+
 
 //        app->SetDefaultParameter("BEMC:tag",              m_input_tag);
         app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:input_tag",        m_input_tag, "Name of input collection to use");
@@ -60,6 +66,7 @@ public:
         app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:thresholdFactor",  m_thresholdFactor);
         app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:thresholdValue",   m_thresholdValue);
         app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:samplingFraction", m_sampFrac);
+        app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:maskPosition",     m_maskPos);
         m_geoSvc = app->template GetService<JDD4hep_service>(); // TODO: implement named geometry service?
 
         AlgorithmInit(m_log);

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelScFiProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelScFiProtoClusters.h
@@ -38,9 +38,9 @@ public:
         m_readout = "";
 
         // neighbour checking distances
-        m_sectorDist=5.0 * dd4hep::cm;             // ?
+        m_sectorDist=50. * dd4hep::mm;             // connects hits from different sectors
         u_localDistXY={};     //{this, "localDistXY", {}};
-        u_localDistXZ={30 * dd4hep::mm, 30 * dd4hep::mm};     //{this, "localDistXZ", {}};  n.b. 30 * dd4hep::mm, 30 * dd4hep::mm came from comment Maria Z. put into PR.
+        u_localDistXZ={40 * dd4hep::mm, 40 * dd4hep::mm};     //{this, "localDistXZ", {}};  n.b. 30 * dd4hep::mm, 30 * dd4hep::mm came from comment Maria Z. put into PR.
         u_localDistYZ={};     //{this, "localDistYZ", {}};
         u_globalDistRPhi={};  //{this, "globalDistRPhi", {}};
         u_globalDistEtaPhi={};//{this, "globalDistEtaPhi", {}};


### PR DESCRIPTION
### Briefly, what does this PR introduce?
It's part of the solution to #499 
related to https://github.com/eic/epic/pull/370

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No, it adds an option to use the mother volume's position of a hit

### Does this PR change default behavior?
No, by default this option is turned off.