### PR TITLE
BUGFIX: ProtoCluster_factory_EcalBarrelSciGlassProtoClusters: fix adjacencyMatrix

### DIFF
--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
@@ -37,8 +37,17 @@ public:
         // Magic constants:
         //  24 - number of sectors
         //  5  - number of towers per sector
-        u_adjacencyMatrix = "(abs(tower_1 - tower_2) + min(abs((sector_1 - sector_2) * 5 + row_1 - row_2), 24 * 5 - abs((sector_1 - sector_2) * 5 + row_1 - row_2))) == 1";
-        std::remove(u_adjacencyMatrix.begin(), u_adjacencyMatrix.end(), ' ');
+        u_adjacencyMatrix = "
+        (
+          abs(tower_1 - tower_2)
+        + min(
+              abs((sector_1 - sector_2) * 5 + row_1 - row_2),
+              24 * 5 - abs((sector_1 - sector_2) * 5 + row_1 - row_2)
+          )
+        ) == 1";
+        u_adjacencyMatrix.erase(
+          std::remove_if(u_adjacencyMatrix.begin(), u_adjacencyMatrix.end(), ::isspace),
+          u_adjacencyMatrix.end());
         m_readout = "EcalBarrelSciGlassHits";
 
         // neighbour checking distances

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
@@ -37,6 +37,7 @@ public:
         // Magic constants:
         //  24 - number of sectors
         //  5  - number of towers per sector
+        // The following compares distance of 1 to a taxicab metric on a cylinder that is our calorimeter:
         u_adjacencyMatrix = "
         (
           abs(tower_1 - tower_2)

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
@@ -37,7 +37,7 @@ public:
         // Magic constants:
         //  24 - number of sectors
         //  5  - number of towers per sector
-        u_adjacencyMatrix = "(abs(tower_1 - tower_2) + (abs((sector_1 - sector_2) * 5 + row_1 - row_2) == 1) + (abs((sector_1 - sector_2) * 5 + row_1 - row_2) == (24 * 5 - 1))) == 1";
+        u_adjacencyMatrix = "(abs(tower_1 - tower_2) + min(abs((sector_1 - sector_2) * 5 + row_1 - row_2), 24 * 5 - abs((sector_1 - sector_2) * 5 + row_1 - row_2))) == 1";
         std::remove(u_adjacencyMatrix.begin(), u_adjacencyMatrix.end(), ' ');
         m_readout = "EcalBarrelSciGlassHits";
 

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
@@ -38,14 +38,14 @@ public:
         //  24 - number of sectors
         //  5  - number of towers per sector
         // The following compares distance of 1 to a taxicab metric on a cylinder that is our calorimeter:
-        u_adjacencyMatrix = "
-        (
-          abs(tower_1 - tower_2)
-        + min(
-              abs((sector_1 - sector_2) * 5 + row_1 - row_2),
-              24 * 5 - abs((sector_1 - sector_2) * 5 + row_1 - row_2)
-          )
-        ) == 1";
+        u_adjacencyMatrix =
+          "("
+          "  abs(tower_1 - tower_2)"
+          "  + min("
+          "      abs((sector_1 - sector_2) * 5 + row_1 - row_2),"
+          "      24 * 5 - abs((sector_1 - sector_2) * 5 + row_1 - row_2)"
+          "  )"
+          ") == 1";
         u_adjacencyMatrix.erase(
           std::remove_if(u_adjacencyMatrix.begin(), u_adjacencyMatrix.end(), ::isspace),
           u_adjacencyMatrix.end());


### PR DESCRIPTION
A critical bug is present in the original expression:

`(abs(dx) + (abs(dy) == 1) + (abs(dy) = 1234)) == 1`

Allows for arbitrary `dy` in range `[2, 1233]` as long as `abs(dx) == 1`. That caused merging of the clusters in across the azimuthal direction.

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No