### PR TITLE
fix: OOB read of cellDimensions

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -1,4 +1,3 @@
-
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022 Chao Peng, Sylvester Joosten, Wouter Deconinck, Chao, Whitney Armstrong
 
@@ -223,7 +222,7 @@ void CalorimeterHitReco::AlgorithmProcess() {
         const decltype(edm4eic::CalorimeterHitData::position) position(gpos.x() / m_lUnit, gpos.y() / m_lUnit,
                                                                     gpos.z() / m_lUnit);
         const decltype(edm4eic::CalorimeterHitData::dimension) dimension(cdim[0] / m_lUnit, cdim[1] / m_lUnit,
-                                                                      cdim[2] / m_lUnit);
+                                                                      cdim.size() > 2? cdim[2] / m_lUnit: 0);
         const decltype(edm4eic::CalorimeterHitData::local) local_position(pos.x() / m_lUnit, pos.y() / m_lUnit,
                                                                        pos.z() / m_lUnit);
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
As hoc fix for now. We should evaluate this in more detail later: what is the dimension stored for, and why as a 3D bounding box in some cases and as a 2D surface-constrained coordinate in other cases?

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
