### PR TITLE
fix: use dd4hep::long64 instead of size_t for field indices

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -57,7 +57,7 @@ jobs:
         platform-release: "jug_xl:nightly"
         run: |
           # install this repo
-          CC=${{ matrix.CC }} CXX=${{ matrix.CXX }} cmake -B build -S . -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }} -DUSE_ASAN=ON -DUSE_TSAN=ON
+          CC=${{ matrix.CC }} CXX=${{ matrix.CXX }} cmake -B build -S . -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }} -DUSE_ASAN=ON -DUSE_TSAN=OFF
           cmake --build build -- -j 2 install
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -219,7 +219,7 @@ jobs:
         particle: [pi, e]
         detector_config: [arches, brycecanyon]
     env:
-      ASAN_OPTIONS: malloc_context_size=20:verify_asan_link_order=0:detect_stack_use_after_return=true:halt_on_error=false
+      ASAN_OPTIONS: malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:detect_stack_use_after_return=true:halt_on_error=false
     steps:
     - uses: actions/download-artifact@v3
       with:
@@ -268,7 +268,7 @@ jobs:
         - beam: 5x41
           minq2: 1000
     env:
-      ASAN_OPTIONS: malloc_context_size=20:verify_asan_link_order=0:detect_stack_use_after_return=true:halt_on_error=false
+      ASAN_OPTIONS: malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:detect_stack_use_after_return=true:halt_on_error=false
     steps:
     - uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -57,7 +57,7 @@ jobs:
         platform-release: "jug_xl:nightly"
         run: |
           # install this repo
-          CC=${{ matrix.CC }} CXX=${{ matrix.CXX }} cmake -B build -S . -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }}
+          CC=${{ matrix.CC }} CXX=${{ matrix.CXX }} cmake -B build -S . -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }} -DUSE_ASAN=ON -DUSE_TSAN=ON
           cmake --build build -- -j 2 install
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -25,9 +25,6 @@ jobs:
           - CC: clang
             CXX: clang++
             CMAKE_BUILD_TYPE: Release
-          - CC: gcc
-            CXX: g++
-            CMAKE_BUILD_TYPE: Debug
     steps:
     - uses: actions/checkout@v3
     - name: Prepare ccache timestamp
@@ -174,39 +171,6 @@ jobs:
       with:
         name: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
         path: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
-        if-no-files-found: error
-
-  valgrind-memcheck-eicrecon-gcc:
-    runs-on: ubuntu-latest
-    needs:
-    - build
-    - ddsim-gun
-    strategy:
-      matrix:
-        particle: [pi]
-        detector_config: [arches, brycecanyon]
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: install-gcc-eic-shell-Debug
-    - uses: actions/download-artifact@v3
-      with:
-        name: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
-    - name: Run EICrecon under valgrind
-      uses: eic/run-cvmfs-osg-eic-shell@main
-      with:
-        platform-release: "jug_xl:nightly"
-        setup: /opt/detector/setup.sh
-        run: |
-          export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
-          export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
-          chmod a+x bin/*
-          valgrind --tool=memcheck --track-origins=yes --leak-check=full --log-file=valgrind-memcheck-eicrecon-${{ matrix.particle }}-${{ matrix.detector_config }}.log --suppressions=/usr/local/etc/root/valgrind-root.supp $PWD/bin/eicrecon -Ppodio:output_file=rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -Pplugins=dump_flags,janadot -Pjana:timeout=0 -Pjana:warmup_timeout=0 -Pdump_flags:json=${{ matrix.detector_config }}_flags.json
-    - uses: actions/upload-artifact@v3
-      with:
-        name: valgrind-memcheck-eicrecon-${{ matrix.particle }}-${{ matrix.detector_config }}.log
-        path: valgrind-memcheck-eicrecon-${{ matrix.particle }}-${{ matrix.detector_config }}.log
         if-no-files-found: error
 
   eicrecon-gcc-gun:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -187,7 +187,7 @@ jobs:
     steps:
     - uses: actions/download-artifact@v3
       with:
-        name: install-gcc-eic-shell-Release
+        name: install-clang-eic-shell-Release
     - uses: actions/download-artifact@v3
       with:
         name: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
@@ -236,7 +236,7 @@ jobs:
     steps:
     - uses: actions/download-artifact@v3
       with:
-        name: install-gcc-eic-shell-Release
+        name: install-clang-eic-shell-Release
     - uses: actions/download-artifact@v3
       with:
         name: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -218,6 +218,8 @@ jobs:
       matrix:
         particle: [pi, e]
         detector_config: [arches, brycecanyon]
+    env:
+      ASAN_OPTIONS: verbosity=1:malloc_context_size=20:verify_asan_link_order=0:detect_stack_use_after_return=true:halt_on_error=false
     steps:
     - uses: actions/download-artifact@v3
       with:
@@ -265,6 +267,8 @@ jobs:
         exclude:
         - beam: 5x41
           minq2: 1000
+    env:
+      ASAN_OPTIONS: verbosity=1:malloc_context_size=20:verify_asan_link_order=0:detect_stack_use_after_return=true:halt_on_error=false
     steps:
     - uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -219,7 +219,7 @@ jobs:
         particle: [pi, e]
         detector_config: [arches, brycecanyon]
     env:
-      ASAN_OPTIONS: verbosity=1:malloc_context_size=20:verify_asan_link_order=0:detect_stack_use_after_return=true:halt_on_error=false
+      ASAN_OPTIONS: malloc_context_size=20:verify_asan_link_order=0:detect_stack_use_after_return=true:halt_on_error=false
     steps:
     - uses: actions/download-artifact@v3
       with:
@@ -268,7 +268,7 @@ jobs:
         - beam: 5x41
           minq2: 1000
     env:
-      ASAN_OPTIONS: verbosity=1:malloc_context_size=20:verify_asan_link_order=0:detect_stack_use_after_return=true:halt_on_error=false
+      ASAN_OPTIONS: malloc_context_size=20:verify_asan_link_order=0:detect_stack_use_after_return=true:halt_on_error=false
     steps:
     - uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -57,7 +57,7 @@ jobs:
         platform-release: "jug_xl:nightly"
         run: |
           # install this repo
-          CC=${{ matrix.CC }} CXX=${{ matrix.CXX }} cmake -B build -S . -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }} -DUSE_ASAN=ON -DUSE_TSAN=OFF
+          CC=${{ matrix.CC }} CXX=${{ matrix.CXX }} cmake -B build -S . -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }} -DUSE_ASAN=ON -DUSE_TSAN=OFF -DUSE_UBSAN=ON
           cmake --build build -- -j 2 install
     - uses: actions/upload-artifact@v3
       with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,13 @@ if (${USE_TSAN})
     add_link_options(-fsanitize=thread)
 endif()
 
+# Undefined behavior sanitizer
+option(USE_UBSAN "Compile with undefined behavior sanitizer" OFF)
+if (${USE_UBSAN})
+    add_compile_options(-fsanitize=undefined -g -O2)
+    add_link_options(-fsanitize=undefined)
+endif()
+
 
 # ------------------------------------------------------------------
 print_grand_header("    B U I L D   E I C R E C O N   P A R T S    ")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,12 +117,25 @@ include(cmake/jana_plugin.cmake)                            # Add common setting
 list (APPEND CMAKE_MODULE_PATH ${EICRECON_SOURCE_DIR}/cmake)   # Find Find<Modules>.cmake
 
 
+# Address sanitizer
+if (${USE_ASAN})
+    add_compile_options(-fsanitize=address -g -O2)
+    add_link_options(-fsanitize=address)
+endif()
+
+# Thread sanitizer 
+if (${USE_TSAN})
+    add_compile_options(-fsanitize=thread -g -O2)
+    add_link_options(-fsanitize=thread)
+endif()
+
+
 # ------------------------------------------------------------------
 print_grand_header("    B U I L D   E I C R E C O N   P A R T S    ")
 # ------------------------------------------------------------------
 add_subdirectory( src/services )
 add_subdirectory( src/algorithms )
-add_subdirectory( src/benchmarks )
+add_subdirectory( src/benchmarks ) 
 add_subdirectory( src/detectors )
 add_subdirectory( src/examples )
 add_subdirectory( src/global )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,8 +134,14 @@ endif()
 # Undefined behavior sanitizer
 option(USE_UBSAN "Compile with undefined behavior sanitizer" OFF)
 if (${USE_UBSAN})
-    add_compile_options(-fsanitize=undefined -fsanitize=implicit-conversion -fsanitize=nullability -g -O1)
-    add_link_options(-fsanitize=undefined -fsanitize=implicit-conversion -fsanitize=nullability)
+    include(CheckCXXCompilerFlag)
+    foreach (sanitizer undefined nullability implicit-conversion)
+        check_cxx_compiler_flag("-fsanitize=${sanitizer}" CXX_COMPILER_HAS_sanitize_${sanitizer})
+        if (CXX_COMPILER_HAS_sanitize_${sanitizer})
+            add_compile_options(-fsanitize=${sanitizer} -g -O1)
+            add_link_options(-fsanitize=${sanitizer})
+        endif()
+    endforeach()
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,12 +118,14 @@ list (APPEND CMAKE_MODULE_PATH ${EICRECON_SOURCE_DIR}/cmake)   # Find Find<Modul
 
 
 # Address sanitizer
+option(USE_ASAN "Compile with address sanitizer" OFF)
 if (${USE_ASAN})
     add_compile_options(-fsanitize=address -g -O2)
     add_link_options(-fsanitize=address)
 endif()
 
 # Thread sanitizer
+option(USE_TSAN "Compile with thread sanitizer" OFF)
 if (${USE_TSAN})
     add_compile_options(-fsanitize=thread -g -O2)
     add_link_options(-fsanitize=thread)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,7 @@ if (${USE_ASAN})
     add_link_options(-fsanitize=address)
 endif()
 
-# Thread sanitizer 
+# Thread sanitizer
 if (${USE_TSAN})
     add_compile_options(-fsanitize=thread -g -O2)
     add_link_options(-fsanitize=thread)
@@ -135,7 +135,7 @@ print_grand_header("    B U I L D   E I C R E C O N   P A R T S    ")
 # ------------------------------------------------------------------
 add_subdirectory( src/services )
 add_subdirectory( src/algorithms )
-add_subdirectory( src/benchmarks ) 
+add_subdirectory( src/benchmarks )
 add_subdirectory( src/detectors )
 add_subdirectory( src/examples )
 add_subdirectory( src/global )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,22 +120,22 @@ list (APPEND CMAKE_MODULE_PATH ${EICRECON_SOURCE_DIR}/cmake)   # Find Find<Modul
 # Address sanitizer
 option(USE_ASAN "Compile with address sanitizer" OFF)
 if (${USE_ASAN})
-    add_compile_options(-fsanitize=address -g -O2)
+    add_compile_options(-fsanitize=address -fno-omit-frame-pointer -g -O1)
     add_link_options(-fsanitize=address)
 endif()
 
 # Thread sanitizer
 option(USE_TSAN "Compile with thread sanitizer" OFF)
 if (${USE_TSAN})
-    add_compile_options(-fsanitize=thread -g -O2)
+    add_compile_options(-fsanitize=thread -g -O1)
     add_link_options(-fsanitize=thread)
 endif()
 
 # Undefined behavior sanitizer
 option(USE_UBSAN "Compile with undefined behavior sanitizer" OFF)
 if (${USE_UBSAN})
-    add_compile_options(-fsanitize=undefined -g -O2)
-    add_link_options(-fsanitize=undefined)
+    add_compile_options(-fsanitize=undefined -fsanitize=implicit-conversion -fsanitize=nullability -g -O1)
+    add_link_options(-fsanitize=undefined -fsanitize=implicit-conversion -fsanitize=nullability)
 endif()
 
 

--- a/src/algorithms/calorimetry/ImagingPixelReco.h
+++ b/src/algorithms/calorimetry/ImagingPixelReco.h
@@ -36,7 +36,7 @@ protected:
     // length unit (from dd4hep geometry service)
     double m_lUnit; // {this, "lengthUnit", dd4hep::mm};
     // digitization parameters
-    unsigned int m_capADC; // {this, "capacitysize_tADC", 8096};
+    unsigned int m_capADC; // {this, "capacityADC", 8096};
     unsigned int m_pedMeanADC; // {this, "pedestalMean", 400};
     double m_dyRangeADC; // {this, "dynamicRangeADC", 100 * dd4hep::MeV};
     double m_pedSigmaADC; // {this, "pedestalSigma", 3.2};

--- a/src/algorithms/calorimetry/ImagingPixelReco.h
+++ b/src/algorithms/calorimetry/ImagingPixelReco.h
@@ -36,7 +36,7 @@ protected:
     // length unit (from dd4hep geometry service)
     double m_lUnit; // {this, "lengthUnit", dd4hep::mm};
     // digitization parameters
-    unsigned int m_capADC; // {this, "capacityADC", 8096};
+    unsigned int m_capADC; // {this, "capacitysize_tADC", 8096};
     unsigned int m_pedMeanADC; // {this, "pedestalMean", 400};
     double m_dyRangeADC; // {this, "dynamicRangeADC", 100 * dd4hep::MeV};
     double m_pedSigmaADC; // {this, "pedestalSigma", 3.2};
@@ -56,7 +56,7 @@ protected:
 
     // visit readout fields
     dd4hep::BitFieldCoder *id_dec;
-    size_t sector_idx{0}, layer_idx{0};
+    dd4hep::long64 sector_idx{0}, layer_idx{0};
 
 public:
     ImagingPixelReco() = default;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The index of fields in the cell ID is a dd4hep::long64 (long long), not a size_t (unsigned long).

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.