### PR TITLE
fix: forbidden string conversion warning from `reco_particles_track_matching.cc`

### DIFF
--- a/src/examples/track_matching/reco_particles_track_matching.cc
+++ b/src/examples/track_matching/reco_particles_track_matching.cc
@@ -14,7 +14,7 @@
 
 using std::string;
 
-void reco_particles_track_matching(char *file_name) {
+void reco_particles_track_matching(TString file_name) {
     auto file = new TFile(file_name);
     auto tree = (TTree *) file->Get("events");
     TTreeReader tree_reader(tree);       // !the tree reader


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Fixes the following warning:
```
EICrecon/src/examples/track_matching/reco_particles_track_matching.cc: In function ‘int main()’:
EICrecon/src/examples/track_matching/reco_particles_track_matching.cc:59:35: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
   59 |     reco_particles_track_matching("/home/romanov/eic/soft/eicrecon/main/src/examples/test_data_generator/2022-11-15_pgun_pi-_epic_arches_e0.01-30GeV_alldir_4prt_1000evt_reco.tree.edm4eic.root");
      |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```


### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no

### Does this PR change default behavior?
no