### PR TITLE
feat: CMAKE_PROJECT_VERSION as git describe (e.g. v0.6.2-5-g5f598b8-dirty)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,12 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(EICRecon VERSION 0.3.6)
+project(EICRecon)
+
+# Set version based on git
+include(cmake/git_version.cmake)
+set_git_version(VERSION)
+set(CMAKE_PROJECT_VERSION ${VERSION})
 
 # Make C++17 a default
 if(NOT "${CMAKE_CXX_STANDARD}")

--- a/cmake/git_version.cmake
+++ b/cmake/git_version.cmake
@@ -1,0 +1,26 @@
+macro(set_git_version VERSION)
+  if(NOT Git_Found)
+    find_package(Git)
+  endif()
+
+  if(GIT_EXECUTABLE)
+    # Generate a git-describe version string from Git repository tags
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} describe --tags --dirty --match "v*"
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      OUTPUT_VARIABLE GIT_DESCRIBE_VERSION
+      RESULT_VARIABLE GIT_DESCRIBE_ERROR_CODE
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+    if(NOT GIT_DESCRIBE_ERROR_CODE)
+	    set(VERSION ${GIT_DESCRIBE_VERSION})
+    endif()
+  endif()
+
+  # Final fallback: Just use a bogus version string that is semantically older
+  # than anything else and spit out a warning to the developer.
+  if(NOT DEFINED VERSION)
+    set(VERSION v0.0.0-unknown)
+    message(WARNING "Failed to determine VERSION from Git tags. Using default version \"${VERSION}\".")
+  endif()
+endmacro()


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This sets the version number based on the output of `git describe` for installations where git is installed and such output is available. This notably excludes tar balls of releases. We are not currently using those. A release procedure is required that addresses this, e.g. by creating a `VERSION` file before release as part of a release workflow.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #523)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @veprbl 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, automatically update version number.