### PR TITLE
Fixed RP code to use local coordinates for matrix reconstruction. 

### DIFF
--- a/src/detectors/RPOTS/RomanPotsReconstruction_factory.h
+++ b/src/detectors/RPOTS/RomanPotsReconstruction_factory.h
@@ -9,10 +9,11 @@
 #include <fmt/format.h>
 #include <spdlog/spdlog.h>
 
+#include "DD4hep/Detector.h"
 #include <DDRec/CellIDPositionConverter.h>
 #include <DDRec/Surface.h>
 #include <DDRec/SurfaceManager.h>
-
+#include <services/geometry/dd4hep/JDD4hep_service.h>
 
 // Event Model related classes
 #include <edm4eic/MutableReconstructedParticle.h>
@@ -44,8 +45,8 @@ namespace eicrecon {
 
 	//----- Define constants here ------
 
-	const double local_x_offset_station_1 = -833.3878326;
-	const double local_x_offset_station_2 = -924.342804;
+	//const double local_x_offset_station_1 = -833.3878326;
+	//const double local_x_offset_station_2 = -924.342804;
 	const double local_x_slope_offset = -0.00622147;
 	const double local_y_slope_offset = -0.0451035;
 	const double crossingAngle = -0.025;
@@ -54,17 +55,18 @@ namespace eicrecon {
 	std::string m_readout;
 	std::string m_layerField;
 	std::string m_sectorField;
+	std::string m_geoSvcName;
 
 	dd4hep::BitFieldCoder *id_dec = nullptr;
 	size_t sector_idx{0}, layer_idx{0};
 
+	std::shared_ptr<JDD4hep_service> m_geoSvc;
 	std::string m_localDetElement;
 	std::vector<std::string> u_localDetFields;
 
 	dd4hep::DetElement local;
 	size_t local_mask = ~0;
 	dd4hep::Detector *detector = nullptr;
-	std::shared_ptr<const dd4hep::rec::CellIDPositionConverter> m_cellid_converter = nullptr;
 
 	const double aXRP[2][2] = {{2.102403743, 29.11067626},
 	                           {0.186640381, 0.192604619}};


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This PR uses local coordinates for reconstruction of hits in the Roman Pots - this is a required step since the detectors will have no clue about a global coordinate system.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [x] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No - it's all behind the scenes, and changes nothing about the collections passed to or from the reco code.

### Does this PR change default behavior?

Only in the actual matrix calculation to obtain the momentum.
