### PR TITLE
feat: rebuild when source files added

### DIFF
--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -107,9 +107,9 @@ endmacro()
 macro(plugin_glob_all _name)
 
     # But... GLOB here makes this file just hot pluggable
-    file(GLOB LIB_SRC_FILES *.cc *.cpp *.c)
-    file(GLOB PLUGIN_SRC_FILES *.cc *.cpp *.c)
-    file(GLOB HEADER_FILES *.h *.hh *.hpp)
+    file(GLOB LIB_SRC_FILES CONFIGURE_DEPENDS *.cc *.cpp *.c)
+    file(GLOB PLUGIN_SRC_FILES CONFIGURE_DEPENDS *.cc *.cpp *.c)
+    file(GLOB HEADER_FILES CONFIGURE_DEPENDS *.h *.hh *.hpp)
 
     # We need plugin relative path for correct headers installation
     string(REPLACE ${EICRECON_SOURCE_DIR}/src "" PLUGIN_RELATIVE_PATH ${PROJECT_SOURCE_DIR})


### PR DESCRIPTION
### Briefly, what does this PR introduce?
When globbing, this is done when cmake is called. When adding `CONFIGURE_DEPENDS`, the globbing is redone when building.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.