### PR TITLE
CalorimeterIslandCluster: wrap around azimuthal distance

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.h
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.h
@@ -23,6 +23,10 @@
 
 using CaloHit = edm4eic::CalorimeterHit;
 
+static double Phi_mpi_pi(double phi) {
+  return std::remainder(phi, 2 * M_PI);
+}
+
 //TODO:Reconcile edm4hep::Vector2f and edm4eic::Vector3f especially with regards to the operators and sign convention
 static edm4hep::Vector2f localDistXY(const CaloHit *h1, const CaloHit *h2) {
   //edm4eic::Vector3f h1_pos=geo_converter->position(h1.getCellID());
@@ -64,7 +68,7 @@ static edm4hep::Vector2f globalDistRPhi(const CaloHit *h1, const CaloHit *h2) {
       edm4eic::magnitude(h1->getPosition()) - edm4eic::magnitude(h2->getPosition())
     ),
     static_cast<vector_type>(
-      edm4eic::angleAzimuthal(h1->getPosition()) - edm4eic::angleAzimuthal(h2->getPosition())
+      Phi_mpi_pi(edm4eic::angleAzimuthal(h1->getPosition()) - edm4eic::angleAzimuthal(h2->getPosition()))
     )
   };
 }
@@ -76,7 +80,7 @@ static edm4hep::Vector2f globalDistEtaPhi(const CaloHit *h1,
       edm4eic::eta(h1->getPosition()) - edm4eic::eta(h2->getPosition())
     ),
     static_cast<vector_type>(
-      edm4eic::angleAzimuthal(h1->getPosition()) - edm4eic::angleAzimuthal(h2->getPosition())
+      Phi_mpi_pi(edm4eic::angleAzimuthal(h1->getPosition()) - edm4eic::angleAzimuthal(h2->getPosition()))
     )
   };
 }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Wrap around for when |delta phi| >= pi (helps to not miss cases when delta phi \approx \pm 2pi)

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No