### PR TITLE
CalorimeterIslandCluster: autotune transverse shower profile parameter

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -65,6 +65,7 @@ void CalorimeterIslandCluster::AlgorithmInit(std::shared_ptr<spdlog::logger>& lo
         {"globalDistRPhi", {globalDistRPhi, {dd4hep::mm, dd4hep::rad}}}, {"globalDistEtaPhi", {globalDistEtaPhi, {1., dd4hep::rad}}}
     };
 
+        hitsDist = globalDistEtaPhi; // FIXME
 
     // set coordinate system
     auto set_dist_method = [this](std::pair<std::string, std::vector<double>> uprop) {


### PR DESCRIPTION
The current implementation uses calorimeter cell size for value of shower width parameter. This approach probably doesn't work for calorimeters other than the Imaging. The width should be related to the Moli`ere radius for the material, but possibly also the geometry (even location of the cluster in the calorimeter). This commit implements a parameter scan that should help users to get get cluster splitting working, while we are trying to figure out a better way to handle this.

Example reconstruction for epic_sciglass_only:
![eicrecon_clustering_autotune](https://user-images.githubusercontent.com/245573/226755295-3154b857-8b11-4221-9ea5-6615f0743959.png)

Can be tested using an option like: `-PEcalBarrelSciGlassProtoClusters:splitCluster=1` (`-PEcalBarrelSciGlassProtoClusters:LogLevel=debug` will show the values of "lambda")

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
Only for users had splitting manually enabled

### Does this PR change default behavior?
No