### PR TITLE
ci: clarify version check failure, and make it its own job

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -60,7 +60,7 @@ jobs:
           CC=${{ matrix.CC }} CXX=${{ matrix.CXX }} cmake -B build -S . -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }}
           cmake --build build -- -j 2 install
           echo "Installed EICrecon version: $(eicrecon --version)"
-          if [[ $(eicrecon --version) =~ unknown ]] ; then echo "ERROR: unknown version" ; false ; fi
+          if [[ $(eicrecon --version) =~ unknown ]] ; then echo "ERROR: unknown version" ; true ; fi # test forcing this to pass; switch to false afterward
     - uses: actions/upload-artifact@v3
       with:
         name: install-${{ matrix.CC }}-eic-shell-${{ matrix.CMAKE_BUILD_TYPE }}

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -92,10 +92,9 @@ jobs:
         platform-release: "jug_xl:nightly"
         run: |
           chmod u+x bin/eicrecon
-          version=$(bin/eicrecon --version)
-          echo "Installed EICrecon version: ${version}"
-          # if [[ ${version} =~ unknown ]] ; then echo "ERROR: unknown version" ; false ; fi
-          if [[ ${version} =~ unknown ]] ; then echo "ERROR: unknown version" ; true ; fi # testing force pass
+          echo "Installed EICrecon version: $(bin/eicrecon --version)"
+          # if [[ $(bin/eicrecon --version) =~ unknown ]] ; then echo "ERROR: unknown version" ; false ; fi
+          if [[ $(bin/eicrecon --version) =~ unknown ]] ; then echo "ERROR: unknown version" ; true ; fi # testing force pass
 
   clang-tidy:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -93,8 +93,7 @@ jobs:
         run: |
           chmod u+x bin/eicrecon
           echo "Installed EICrecon version: $(bin/eicrecon --version)"
-          # if [[ $(bin/eicrecon --version) =~ unknown ]] ; then echo "ERROR: unknown version" ; false ; fi
-          if [[ $(bin/eicrecon --version) =~ unknown ]] ; then echo "ERROR: unknown version" ; true ; fi # testing force pass
+          if [[ $(bin/eicrecon --version) =~ unknown ]] ; then echo "ERROR: unknown version" ; false ; fi
 
   clang-tidy:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -59,7 +59,8 @@ jobs:
           # install this repo
           CC=${{ matrix.CC }} CXX=${{ matrix.CXX }} cmake -B build -S . -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }}
           cmake --build build -- -j 2 install
-          if [[ $(eicrecon --version) =~ unknown ]] ; then false ; fi
+          echo "Installed EICrecon version: $(eicrecon --version)"
+          if [[ $(eicrecon --version) =~ unknown ]] ; then echo "ERROR: unknown version" ; false ; fi
     - uses: actions/upload-artifact@v3
       with:
         name: install-${{ matrix.CC }}-eic-shell-${{ matrix.CMAKE_BUILD_TYPE }}

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -60,7 +60,7 @@ jobs:
           CC=${{ matrix.CC }} CXX=${{ matrix.CXX }} cmake -B build -S . -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }}
           cmake --build build -- -j 2 install
           echo "Installed EICrecon version: $(eicrecon --version)"
-          if [[ $(eicrecon --version) =~ unknown ]] ; then echo "ERROR: unknown version" ; true ; fi # test forcing this to pass; switch to false afterward
+          if [[ $(eicrecon --version) =~ unknown ]] ; then echo "ERROR: unknown version" ; false ; fi
     - uses: actions/upload-artifact@v3
       with:
         name: install-${{ matrix.CC }}-eic-shell-${{ matrix.CMAKE_BUILD_TYPE }}

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -59,8 +59,6 @@ jobs:
           # install this repo
           CC=${{ matrix.CC }} CXX=${{ matrix.CXX }} cmake -B build -S . -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }}
           cmake --build build -- -j 2 install
-          echo "Installed EICrecon version: $(eicrecon --version)"
-          if [[ $(eicrecon --version) =~ unknown ]] ; then echo "ERROR: unknown version" ; false ; fi
     - uses: actions/upload-artifact@v3
       with:
         name: install-${{ matrix.CC }}-eic-shell-${{ matrix.CMAKE_BUILD_TYPE }}
@@ -78,6 +76,26 @@ jobs:
         path: |
           build/
         if-no-files-found: error
+
+  version-check:
+    runs-on: ubuntu-latest
+    needs:
+    - build
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: install-gcc-eic-shell-Release
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - name: Version check
+      uses: eic/run-cvmfs-osg-eic-shell@main
+      with:
+        platform-release: "jug_xl:nightly"
+        run: |
+          chmod u+x bin/eicrecon
+          version=$(bin/eicrecon --version)
+          echo "Installed EICrecon version: ${version}"
+          # if [[ ${version} =~ unknown ]] ; then echo "ERROR: unknown version" ; false ; fi
+          if [[ ${version} =~ unknown ]] ; then echo "ERROR: unknown version" ; true ; fi # testing force pass
 
   clang-tidy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Along with #567, we are starting to see version check failures even on PRs from this primary fork, so let's clarify this with an error message and a printout of the version number.

Let's also make this version checking its own job, so it does not prevent subsequent jobs from being cancelled.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no

### Does this PR change default behavior?
no