### PR TITLE
test: run with modified `irt` spack build

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: eicweb/jug_xl:unstable-mr-290-535
+      image: eicweb/jug_xl:unstable-mr-290-539
     strategy:
       matrix:
         include:
@@ -120,7 +120,7 @@ jobs:
   ddsim-gun:
     runs-on: ubuntu-latest
     container:
-      image: eicweb/jug_xl:unstable-mr-290-535
+      image: eicweb/jug_xl:unstable-mr-290-539
     strategy:
       matrix:
         particle: [pi, e]
@@ -155,7 +155,7 @@ jobs:
   # ddsim-dis:
   #   runs-on: ubuntu-latest
   #   container:
-  #     image: eicweb/jug_xl:unstable-mr-290-535
+  #     image: eicweb/jug_xl:unstable-mr-290-539
   #   strategy:
   #     matrix:
   #       beam: [5x41, 10x100, 18x275]
@@ -228,7 +228,7 @@ jobs:
   eicrecon-gcc-gun:
     runs-on: ubuntu-latest
     container:
-      image: eicweb/jug_xl:unstable-mr-290-535
+      image: eicweb/jug_xl:unstable-mr-290-539
     needs:
     - build
     - ddsim-gun
@@ -279,7 +279,7 @@ jobs:
   # eicrecon-gcc-dis:
   #   runs-on: ubuntu-latest
   #   container:
-  #     image: eicweb/jug_xl:unstable-mr-290-535
+  #     image: eicweb/jug_xl:unstable-mr-290-539
   #   needs:
   #   - build
   #   - ddsim-dis

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -62,6 +62,8 @@ jobs:
         head /usr/local/include/IRT/IRT.h
         echo "--- irt libs:"
         ls /usr/local/lib/|grep IRT
+        echo "--- classdef:"
+        grep -C1 'ClassDef' /usr/local/include/IRT/CherenkovDetector.h
     - name: Build and install
       run: |
         # install this repo

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -57,7 +57,11 @@ jobs:
         echo "max_size=500MB" >> ~/.ccache/ccache.conf
         echo "compression=true" >> ~/.ccache/ccache.conf
     - name: Test patch
-      run: head /usr/local/include/IRT/IRT.h
+      run: |
+        echo "--- patch note:"
+        head /usr/local/include/IRT/IRT.h
+        echo "--- irt libs:"
+        ls /usr/local/lib/|grep IRT
     - name: Build and install
       run: |
         # install this repo
@@ -247,7 +251,7 @@ jobs:
         export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
         export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
         chmod a+x bin/*
-        $PWD/bin/eicrecon -Ppodio:output_file=rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -Pplugins=dump_flags,janadot -Pdump_flags:json=${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json
+        $PWD/bin/eicrecon -Ppodio:output_file=rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -Pplugins=dump_flags -Pdump_flags:json=${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json
     - uses: actions/upload-artifact@v3
       with:
         name: eicrecon_rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
@@ -258,11 +262,11 @@ jobs:
         name: ${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json
         path: ${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json
         if-no-files-found: error
-    - uses: actions/upload-artifact@v3
-      with:
-        name: eicrecon_rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.dot
-        path: jana.dot
-        if-no-files-found: error
+    # - uses: actions/upload-artifact@v3
+    #   with:
+    #     name: eicrecon_rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.dot
+    #     path: jana.dot
+    #     if-no-files-found: error
 
   eicrecon-gcc-dis:
     runs-on: ubuntu-latest
@@ -296,17 +300,17 @@ jobs:
         export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
         export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
         chmod a+x bin/*
-        $PWD/bin/eicrecon -Ppodio:output_file=rec_dis_${{matrix.beam}}_${{ matrix.detector_config }}.edm4eic.root sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root -Pplugins=janadot
+        $PWD/bin/eicrecon -Ppodio:output_file=rec_dis_${{matrix.beam}}_${{ matrix.detector_config }}.edm4eic.root sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
     - uses: actions/upload-artifact@v3
       with:
         name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root
         path: rec_dis_${{matrix.beam}}_${{ matrix.detector_config }}.edm4eic.root
         if-no-files-found: error
-    - uses: actions/upload-artifact@v3
-      with:
-        name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.dot
-        path: jana.dot
-        if-no-files-found: error
+    # - uses: actions/upload-artifact@v3
+    #   with:
+    #     name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.dot
+    #     path: jana.dot
+    #     if-no-files-found: error
 
   # # build-docs and deploy-docs copy doxygen.yml functionality
   # # the difference is that these jobs use resulting artifacts from EICrecon runs

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: eicweb/jug_xl:unstable-mr-290-522
+      image: eicweb/jug_xl:unstable-mr-290-535
     strategy:
       matrix:
         include:
@@ -120,7 +120,7 @@ jobs:
   ddsim-gun:
     runs-on: ubuntu-latest
     container:
-      image: eicweb/jug_xl:unstable-mr-290-522
+      image: eicweb/jug_xl:unstable-mr-290-535
     strategy:
       matrix:
         particle: [pi, e]
@@ -155,7 +155,7 @@ jobs:
   # ddsim-dis:
   #   runs-on: ubuntu-latest
   #   container:
-  #     image: eicweb/jug_xl:unstable-mr-290-522
+  #     image: eicweb/jug_xl:unstable-mr-290-535
   #   strategy:
   #     matrix:
   #       beam: [5x41, 10x100, 18x275]
@@ -228,7 +228,7 @@ jobs:
   eicrecon-gcc-gun:
     runs-on: ubuntu-latest
     container:
-      image: eicweb/jug_xl:unstable-mr-290-522
+      image: eicweb/jug_xl:unstable-mr-290-535
     needs:
     - build
     - ddsim-gun
@@ -279,7 +279,7 @@ jobs:
   # eicrecon-gcc-dis:
   #   runs-on: ubuntu-latest
   #   container:
-  #     image: eicweb/jug_xl:unstable-mr-290-522
+  #     image: eicweb/jug_xl:unstable-mr-290-535
   #   needs:
   #   - build
   #   - ddsim-dis

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -152,45 +152,45 @@ jobs:
         path: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
         if-no-files-found: error
 
-  ddsim-dis:
-    runs-on: ubuntu-latest
-    container:
-      image: eicweb/jug_xl:unstable-mr-290-522
-    strategy:
-      matrix:
-        beam: [5x41, 10x100, 18x275]
-        minq2: [1, 1000]
-        detector_config: [arches, brycecanyon]
-        exclude:
-        - beam: 5x41
-          minq2: 1000
-    steps:
-    # - uses: cvmfs-contrib/github-action-cvmfs@v3
-    # - name: Get detector info
-    #   id: detector_info
-    #   run: |
-    #     grep epic/nightly /cvmfs/singularity.opensciencegrid.org/eicweb/jug_xl\:nightly/etc/jug_info | sed 's/.*: .*-\(.*\)/hash=\1/g' >> $GITHUB_OUTPUT
-    # - name: Retrieve simulation files
-    #   id: retrieve_simulation_files
-    #   uses: actions/cache@v3
-    #   with:
-    #     path: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
-    #     key: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root-${{ steps.detector_info.outputs.hash }}
-    - name: Produce simulation files
-      # if: steps.retrieve_simulation_files.outputs.cache-hit != 'true'
-      run: |
-        source /usr/local/bin/thisroot.sh
-        source /usr/local/bin/thisdd4hep.sh
-        source /opt/detector/epic-main/setup.sh
-        echo "DETECTOR_PATH = ${DETECTOR_PATH}"
-        echo "DETECTOR      = ${DETECTOR}"
-        url=root://dtn-eic.jlab.org//work/eic2/EPIC/EVGEN/DIS/NC/${{matrix.beam}}/minQ2=${{matrix.minq2}}/pythia8NCDIS_${{matrix.beam}}_minQ2=${{matrix.minq2}}_beamEffects_xAngle=-0.025_hiDiv_1.hepmc3.tree.root
-        ddsim --compactFile ${DETECTOR_PATH}/${DETECTOR}_${{ matrix.detector_config }}.xml -N 100 --inputFiles ${url} --outputFile sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
-    - uses: actions/upload-artifact@v3
-      with:
-        name: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
-        path: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
-        if-no-files-found: error
+  # ddsim-dis:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: eicweb/jug_xl:unstable-mr-290-522
+  #   strategy:
+  #     matrix:
+  #       beam: [5x41, 10x100, 18x275]
+  #       minq2: [1, 1000]
+  #       detector_config: [arches, brycecanyon]
+  #       exclude:
+  #       - beam: 5x41
+  #         minq2: 1000
+  #   steps:
+  #   # - uses: cvmfs-contrib/github-action-cvmfs@v3
+  #   # - name: Get detector info
+  #   #   id: detector_info
+  #   #   run: |
+  #   #     grep epic/nightly /cvmfs/singularity.opensciencegrid.org/eicweb/jug_xl\:nightly/etc/jug_info | sed 's/.*: .*-\(.*\)/hash=\1/g' >> $GITHUB_OUTPUT
+  #   # - name: Retrieve simulation files
+  #   #   id: retrieve_simulation_files
+  #   #   uses: actions/cache@v3
+  #   #   with:
+  #   #     path: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
+  #   #     key: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root-${{ steps.detector_info.outputs.hash }}
+  #   - name: Produce simulation files
+  #     # if: steps.retrieve_simulation_files.outputs.cache-hit != 'true'
+  #     run: |
+  #       source /usr/local/bin/thisroot.sh
+  #       source /usr/local/bin/thisdd4hep.sh
+  #       source /opt/detector/epic-main/setup.sh
+  #       echo "DETECTOR_PATH = ${DETECTOR_PATH}"
+  #       echo "DETECTOR      = ${DETECTOR}"
+  #       url=root://dtn-eic.jlab.org//work/eic2/EPIC/EVGEN/DIS/NC/${{matrix.beam}}/minQ2=${{matrix.minq2}}/pythia8NCDIS_${{matrix.beam}}_minQ2=${{matrix.minq2}}_beamEffects_xAngle=-0.025_hiDiv_1.hepmc3.tree.root
+  #       ddsim --compactFile ${DETECTOR_PATH}/${DETECTOR}_${{ matrix.detector_config }}.xml -N 100 --inputFiles ${url} --outputFile sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
+  #   - uses: actions/upload-artifact@v3
+  #     with:
+  #       name: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
+  #       path: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
+  #       if-no-files-found: error
 
   # valgrind-memcheck-eicrecon-gcc:
   #   runs-on: ubuntu-latest
@@ -250,8 +250,14 @@ jobs:
         source /opt/detector/epic-main/setup.sh
         echo "DETECTOR_PATH = ${DETECTOR_PATH}"
         echo "DETECTOR      = ${DETECTOR}"
+        echo "ls local plugins:"
+        ls $PWD/lib/EICrecon/plugins
         export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
         export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
+        echo "JANA_PLUGIN_PATH = ${JANA_PLUGIN_PATH}"
+        echo "JANA_HOME (before) = ${JANA_HOME}"
+        export JANA_HOME=/usr/local
+        echo "JANA_HOME (after) = ${JANA_HOME}"
         chmod a+x bin/*
         $PWD/bin/eicrecon -Ppodio:output_file=rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -Pplugins=dump_flags -Pdump_flags:json=${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json
     - uses: actions/upload-artifact@v3
@@ -270,49 +276,49 @@ jobs:
     #     path: jana.dot
     #     if-no-files-found: error
 
-  eicrecon-gcc-dis:
-    runs-on: ubuntu-latest
-    container:
-      image: eicweb/jug_xl:unstable-mr-290-522
-    needs:
-    - build
-    - ddsim-dis
-    strategy:
-      matrix:
-        beam: [5x41, 10x100, 18x275]
-        minq2: [1, 1000]
-        detector_config: [arches, brycecanyon]
-        exclude:
-        - beam: 5x41
-          minq2: 1000
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: install-gcc-eic-shell-Release
-    - uses: actions/download-artifact@v3
-      with:
-        name: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
-    - name: Run EICrecon
-      run: |
-        source /usr/local/bin/thisroot.sh
-        source /usr/local/bin/thisdd4hep.sh
-        source /opt/detector/epic-main/setup.sh
-        echo "DETECTOR_PATH = ${DETECTOR_PATH}"
-        echo "DETECTOR      = ${DETECTOR}"
-        export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
-        export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
-        chmod a+x bin/*
-        $PWD/bin/eicrecon -Ppodio:output_file=rec_dis_${{matrix.beam}}_${{ matrix.detector_config }}.edm4eic.root sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
-    - uses: actions/upload-artifact@v3
-      with:
-        name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root
-        path: rec_dis_${{matrix.beam}}_${{ matrix.detector_config }}.edm4eic.root
-        if-no-files-found: error
-    # - uses: actions/upload-artifact@v3
-    #   with:
-    #     name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.dot
-    #     path: jana.dot
-    #     if-no-files-found: error
+  # eicrecon-gcc-dis:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: eicweb/jug_xl:unstable-mr-290-522
+  #   needs:
+  #   - build
+  #   - ddsim-dis
+  #   strategy:
+  #     matrix:
+  #       beam: [5x41, 10x100, 18x275]
+  #       minq2: [1, 1000]
+  #       detector_config: [arches, brycecanyon]
+  #       exclude:
+  #       - beam: 5x41
+  #         minq2: 1000
+  #   steps:
+  #   - uses: actions/download-artifact@v3
+  #     with:
+  #       name: install-gcc-eic-shell-Release
+  #   - uses: actions/download-artifact@v3
+  #     with:
+  #       name: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
+  #   - name: Run EICrecon
+  #     run: |
+  #       source /usr/local/bin/thisroot.sh
+  #       source /usr/local/bin/thisdd4hep.sh
+  #       source /opt/detector/epic-main/setup.sh
+  #       echo "DETECTOR_PATH = ${DETECTOR_PATH}"
+  #       echo "DETECTOR      = ${DETECTOR}"
+  #       export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
+  #       export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
+  #       chmod a+x bin/*
+  #       $PWD/bin/eicrecon -Ppodio:output_file=rec_dis_${{matrix.beam}}_${{ matrix.detector_config }}.edm4eic.root sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
+  #   - uses: actions/upload-artifact@v3
+  #     with:
+  #       name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root
+  #       path: rec_dis_${{matrix.beam}}_${{ matrix.detector_config }}.edm4eic.root
+  #       if-no-files-found: error
+  #   # - uses: actions/upload-artifact@v3
+  #   #   with:
+  #   #     name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.dot
+  #   #     path: jana.dot
+  #   #     if-no-files-found: error
 
   # # build-docs and deploy-docs copy doxygen.yml functionality
   # # the difference is that these jobs use resulting artifacts from EICrecon runs

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -16,18 +16,20 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+      image: eicweb/jug_xl:unstable-mr-290-522
     strategy:
       matrix:
         include:
           - CC: gcc
             CXX: g++
             CMAKE_BUILD_TYPE: Release
-          - CC: clang
-            CXX: clang++
-            CMAKE_BUILD_TYPE: Release
-          - CC: gcc
-            CXX: g++
-            CMAKE_BUILD_TYPE: Debug
+          # - CC: clang
+          #   CXX: clang++
+          #   CMAKE_BUILD_TYPE: Release
+          # - CC: gcc
+          #   CXX: g++
+          #   CMAKE_BUILD_TYPE: Debug
     steps:
     - uses: actions/checkout@v3
     - name: Prepare ccache timestamp
@@ -50,15 +52,13 @@ jobs:
         echo "cache_dir=${{ github.workspace }}/.ccache" > ~/.ccache/ccache.conf
         echo "max_size=500MB" >> ~/.ccache/ccache.conf
         echo "compression=true" >> ~/.ccache/ccache.conf
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - name: Test patch
+      run: head /usr/local/include/IRT/IRT.h
     - name: Build and install
-      uses: eic/run-cvmfs-osg-eic-shell@main
-      with:
-        platform-release: "jug_xl:nightly"
-        run: |
-          # install this repo
-          CC=${{ matrix.CC }} CXX=${{ matrix.CXX }} cmake -B build -S . -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }}
-          cmake --build build -- -j 2 install
+      run: |
+        # install this repo
+        CC=${{ matrix.CC }} CXX=${{ matrix.CXX }} cmake -B build -S . -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }}
+        cmake --build build -- -j 2 install
     - uses: actions/upload-artifact@v3
       with:
         name: install-${{ matrix.CC }}-eic-shell-${{ matrix.CMAKE_BUILD_TYPE }}
@@ -77,38 +77,40 @@ jobs:
           build/
         if-no-files-found: error
 
-  clang-tidy:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-    - run: echo "FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: ${{ env.FETCH_DEPTH }}
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
-    - uses: actions/download-artifact@v3
-      with:
-        name: build-clang-eic-shell-Release
-        path: build/
-    - uses: eic/run-cvmfs-osg-eic-shell@main
-      if: ${{ github.event_name == 'pull_request'}}
-      with:
-        platform-release: "jug_xl:nightly"
-        run: |
-          git diff ${{github.event.pull_request.base.sha}} | clang-tidy-diff -p 1 -path build -quiet -export-fixes clang_tidy_fixes.yml -extra-arg='-std=c++17' -clang-tidy-binary run-clang-tidy
-    - uses: eic/run-cvmfs-osg-eic-shell@main
-      if: ${{ github.event_name == 'push'}}
-      with:
-        platform-release: "jug_xl:nightly"
-        run: |
-          run-clang-tidy -p build -export-fixes clang_tidy_fixes.yml -extra-arg='-std=c++17'
-    - uses: actions/upload-artifact@v3
-      with:
-        name: clang-tidy-fixes.yml
-        path: clang_tidy_fixes.yml
+  # clang-tidy:
+  #   runs-on: ubuntu-latest
+  #   needs: build
+  #   steps:
+  #   - run: echo "FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
+  #   - uses: actions/checkout@v3
+  #     with:
+  #       fetch-depth: ${{ env.FETCH_DEPTH }}
+  #   - uses: cvmfs-contrib/github-action-cvmfs@v3
+  #   - uses: actions/download-artifact@v3
+  #     with:
+  #       name: build-clang-eic-shell-Release
+  #       path: build/
+  #   - uses: eic/run-cvmfs-osg-eic-shell@main
+  #     if: ${{ github.event_name == 'pull_request'}}
+  #     with:
+  #       platform-release: "jug_xl:nightly"
+  #       run: |
+  #         git diff ${{github.event.pull_request.base.sha}} | clang-tidy-diff -p 1 -path build -quiet -export-fixes clang_tidy_fixes.yml -extra-arg='-std=c++17' -clang-tidy-binary run-clang-tidy
+  #   - uses: eic/run-cvmfs-osg-eic-shell@main
+  #     if: ${{ github.event_name == 'push'}}
+  #     with:
+  #       platform-release: "jug_xl:nightly"
+  #       run: |
+  #         run-clang-tidy -p build -export-fixes clang_tidy_fixes.yml -extra-arg='-std=c++17'
+  #   - uses: actions/upload-artifact@v3
+  #     with:
+  #       name: clang-tidy-fixes.yml
+  #       path: clang_tidy_fixes.yml
 
   ddsim-gun:
     runs-on: ubuntu-latest
+    container:
+      image: eicweb/jug_xl:unstable-mr-290-522
     strategy:
       matrix:
         particle: [pi, e]
@@ -117,8 +119,8 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v3
     - name: Get detector info
       id: detector_info
-      run: |
-        grep epic/nightly /cvmfs/singularity.opensciencegrid.org/eicweb/jug_xl\:nightly/etc/jug_info | sed 's/.*: .*-\(.*\)/hash=\1/g' >> $GITHUB_OUTPUT
+      uses: docker://ubuntu:latest
+      args: "grep epic/nightly /cvmfs/singularity.opensciencegrid.org/eicweb/jug_xl\:nightly/etc/jug_info | sed 's/.*: .*-\(.*\)/hash=\1/g' >> $GITHUB_OUTPUT"
     - name: Retrieve simulation files
       id: retrieve_simulation_files
       uses: actions/cache@v3
@@ -126,217 +128,211 @@ jobs:
         path: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
         key: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root-${{ steps.detector_info.outputs.hash }}
     - name: Produce simulation files
-      uses: eic/run-cvmfs-osg-eic-shell@main
       if: steps.retrieve_simulation_files.outputs.cache-hit != 'true'
-      with:
-        platform-release: "jug_xl:nightly"
-        setup: /opt/detector/setup.sh
-        run: |
-          ddsim --compactFile ${DETECTOR_PATH}/${DETECTOR}_${{ matrix.detector_config }}.xml -G --gun.particle "${{ matrix.particle }}-" --gun.momentumMin "1*GeV" --gun.momentumMax "20*GeV" --gun.distribution "uniform" -N 100 --outputFile sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
+      run: |
+        source /opt/detector/setup.sh
+        echo "DETECTOR_PATH = ${DETECTOR_PATH}"
+        echo "DETECTOR      = ${DETECTOR}"
+        ddsim --compactFile ${DETECTOR_PATH}/${DETECTOR}_${{ matrix.detector_config }}.xml -G --gun.particle "${{ matrix.particle }}-" --gun.momentumMin "1*GeV" --gun.momentumMax "20*GeV" --gun.distribution "uniform" -N 100 --outputFile sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
     - uses: actions/upload-artifact@v3
       with:
         name: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
         path: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
         if-no-files-found: error
 
-  ddsim-dis:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        beam: [5x41, 10x100, 18x275]
-        minq2: [1, 1000]
-        detector_config: [arches, brycecanyon]
-        exclude:
-        - beam: 5x41
-          minq2: 1000
-    steps:
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
-    - name: Get detector info
-      id: detector_info
-      run: |
-        grep epic/nightly /cvmfs/singularity.opensciencegrid.org/eicweb/jug_xl\:nightly/etc/jug_info | sed 's/.*: .*-\(.*\)/hash=\1/g' >> $GITHUB_OUTPUT
-    - name: Retrieve simulation files
-      id: retrieve_simulation_files
-      uses: actions/cache@v3
-      with:
-        path: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
-        key: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root-${{ steps.detector_info.outputs.hash }}
-    - name: Produce simulation files
-      uses: eic/run-cvmfs-osg-eic-shell@main
-      if: steps.retrieve_simulation_files.outputs.cache-hit != 'true'
-      with:
-        platform-release: "jug_xl:nightly"
-        setup: /opt/detector/setup.sh
-        run: |
-          url=root://dtn-eic.jlab.org//work/eic2/EPIC/EVGEN/DIS/NC/${{matrix.beam}}/minQ2=${{matrix.minq2}}/pythia8NCDIS_${{matrix.beam}}_minQ2=${{matrix.minq2}}_beamEffects_xAngle=-0.025_hiDiv_1.hepmc3.tree.root
-          ddsim --compactFile ${DETECTOR_PATH}/${DETECTOR}_${{ matrix.detector_config }}.xml -N 100 --inputFiles ${url} --outputFile sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
-    - uses: actions/upload-artifact@v3
-      with:
-        name: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
-        path: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
-        if-no-files-found: error
+  # ddsim-dis:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: eicweb/jug_xl:unstable-mr-290-522
+  #   strategy:
+  #     matrix:
+  #       beam: [5x41, 10x100, 18x275]
+  #       minq2: [1, 1000]
+  #       detector_config: [arches, brycecanyon]
+  #       exclude:
+  #       - beam: 5x41
+  #         minq2: 1000
+  #   steps:
+  #   - uses: cvmfs-contrib/github-action-cvmfs@v3
+  #   - name: Get detector info
+  #     id: detector_info
+  #     run: |
+  #       grep epic/nightly /cvmfs/singularity.opensciencegrid.org/eicweb/jug_xl\:nightly/etc/jug_info | sed 's/.*: .*-\(.*\)/hash=\1/g' >> $GITHUB_OUTPUT
+  #   - name: Retrieve simulation files
+  #     id: retrieve_simulation_files
+  #     uses: actions/cache@v3
+  #     with:
+  #       path: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
+  #       key: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root-${{ steps.detector_info.outputs.hash }}
+  #   - name: Produce simulation files
+  #     if: steps.retrieve_simulation_files.outputs.cache-hit != 'true'
+  #     run: |
+  #       source /opt/detector/setup.sh
+  #       url=root://dtn-eic.jlab.org//work/eic2/EPIC/EVGEN/DIS/NC/${{matrix.beam}}/minQ2=${{matrix.minq2}}/pythia8NCDIS_${{matrix.beam}}_minQ2=${{matrix.minq2}}_beamEffects_xAngle=-0.025_hiDiv_1.hepmc3.tree.root
+  #       ddsim --compactFile ${DETECTOR_PATH}/${DETECTOR}_${{ matrix.detector_config }}.xml -N 100 --inputFiles ${url} --outputFile sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
+  #   - uses: actions/upload-artifact@v3
+  #     with:
+  #       name: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
+  #       path: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
+  #       if-no-files-found: error
 
-  valgrind-memcheck-eicrecon-gcc:
-    runs-on: ubuntu-latest
-    needs:
-    - build
-    - ddsim-gun
-    strategy:
-      matrix:
-        particle: [pi]
-        detector_config: [arches, brycecanyon]
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: install-gcc-eic-shell-Debug
-    - uses: actions/download-artifact@v3
-      with:
-        name: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
-    - name: Run EICrecon under valgrind
-      uses: eic/run-cvmfs-osg-eic-shell@main
-      with:
-        platform-release: "jug_xl:nightly"
-        setup: /opt/detector/setup.sh
-        run: |
-          export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
-          export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
-          chmod a+x bin/*
-          valgrind --tool=memcheck --track-origins=yes --leak-check=full --log-file=valgrind-memcheck-eicrecon-${{ matrix.particle }}-${{ matrix.detector_config }}.log --suppressions=/usr/local/etc/root/valgrind-root.supp $PWD/bin/eicrecon -Ppodio:output_file=rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -Pplugins=dump_flags,janadot -Pjana:timeout=0 -Pjana:warmup_timeout=0 -Pdump_flags:json=${{ matrix.detector_config }}_flags.json
-    - uses: actions/upload-artifact@v3
-      with:
-        name: valgrind-memcheck-eicrecon-${{ matrix.particle }}-${{ matrix.detector_config }}.log
-        path: valgrind-memcheck-eicrecon-${{ matrix.particle }}-${{ matrix.detector_config }}.log
-        if-no-files-found: error
+  # valgrind-memcheck-eicrecon-gcc:
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #   - build
+  #   - ddsim-gun
+  #   strategy:
+  #     matrix:
+  #       particle: [pi]
+  #       detector_config: [arches, brycecanyon]
+  #   steps:
+  #   - uses: actions/download-artifact@v3
+  #     with:
+  #       name: install-gcc-eic-shell-Debug
+  #   - uses: actions/download-artifact@v3
+  #     with:
+  #       name: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
+  #   - uses: cvmfs-contrib/github-action-cvmfs@v3
+  #   - name: Run EICrecon under valgrind
+  #     uses: eic/run-cvmfs-osg-eic-shell@main
+  #     with:
+  #       platform-release: "jug_xl:nightly"
+  #       setup: /opt/detector/setup.sh
+  #       run: |
+  #         export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
+  #         export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
+  #         chmod a+x bin/*
+  #         valgrind --tool=memcheck --track-origins=yes --leak-check=full --log-file=valgrind-memcheck-eicrecon-${{ matrix.particle }}-${{ matrix.detector_config }}.log --suppressions=/usr/local/etc/root/valgrind-root.supp $PWD/bin/eicrecon -Ppodio:output_file=rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -Pplugins=dump_flags,janadot -Pjana:timeout=0 -Pjana:warmup_timeout=0 -Pdump_flags:json=${{ matrix.detector_config }}_flags.json
+  #   - uses: actions/upload-artifact@v3
+  #     with:
+  #       name: valgrind-memcheck-eicrecon-${{ matrix.particle }}-${{ matrix.detector_config }}.log
+  #       path: valgrind-memcheck-eicrecon-${{ matrix.particle }}-${{ matrix.detector_config }}.log
+  #       if-no-files-found: error
 
-  eicrecon-gcc-gun:
-    runs-on: ubuntu-latest
-    needs:
-    - build
-    - ddsim-gun
-    strategy:
-      matrix:
-        particle: [pi, e]
-        detector_config: [arches, brycecanyon]
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: install-gcc-eic-shell-Release
-    - uses: actions/download-artifact@v3
-      with:
-        name: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
-    - name: Run EICrecon
-      uses: eic/run-cvmfs-osg-eic-shell@main
-      with:
-        platform-release: "jug_xl:nightly"
-        setup: /opt/detector/setup.sh
-        run: |
-          export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
-          export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
-          chmod a+x bin/*
-          $PWD/bin/eicrecon -Ppodio:output_file=rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -Pplugins=dump_flags,janadot -Pdump_flags:json=${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json
-    - uses: actions/upload-artifact@v3
-      with:
-        name: eicrecon_rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
-        path: rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
-        if-no-files-found: error
-    - uses: actions/upload-artifact@v3
-      with:
-        name: ${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json
-        path: ${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json
-        if-no-files-found: error
-    - uses: actions/upload-artifact@v3
-      with:
-        name: eicrecon_rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.dot
-        path: jana.dot
-        if-no-files-found: error
+  # eicrecon-gcc-gun:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: eicweb/jug_xl:unstable-mr-290-522
+  #   needs:
+  #   - build
+  #   - ddsim-gun
+  #   strategy:
+  #     matrix:
+  #       particle: [pi, e]
+  #       detector_config: [arches, brycecanyon]
+  #   steps:
+  #   - uses: actions/download-artifact@v3
+  #     with:
+  #       name: install-gcc-eic-shell-Release
+  #   - uses: actions/download-artifact@v3
+  #     with:
+  #       name: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
+  #   - name: Run EICrecon
+  #     run: |
+  #       source /opt/detector/setup.sh
+  #       export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
+  #       export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
+  #       chmod a+x bin/*
+  #       $PWD/bin/eicrecon -Ppodio:output_file=rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -Pplugins=dump_flags,janadot -Pdump_flags:json=${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json
+  #   - uses: actions/upload-artifact@v3
+  #     with:
+  #       name: eicrecon_rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
+  #       path: rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
+  #       if-no-files-found: error
+  #   - uses: actions/upload-artifact@v3
+  #     with:
+  #       name: ${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json
+  #       path: ${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json
+  #       if-no-files-found: error
+  #   - uses: actions/upload-artifact@v3
+  #     with:
+  #       name: eicrecon_rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.dot
+  #       path: jana.dot
+  #       if-no-files-found: error
 
-  eicrecon-gcc-dis:
-    runs-on: ubuntu-latest
-    needs:
-    - build
-    - ddsim-dis
-    strategy:
-      matrix:
-        beam: [5x41, 10x100, 18x275]
-        minq2: [1, 1000]
-        detector_config: [arches, brycecanyon]
-        exclude:
-        - beam: 5x41
-          minq2: 1000
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: install-gcc-eic-shell-Release
-    - uses: actions/download-artifact@v3
-      with:
-        name: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
-    - name: Run EICrecon
-      uses: eic/run-cvmfs-osg-eic-shell@main
-      with:
-        platform-release: "jug_xl:nightly"
-        setup: /opt/detector/setup.sh
-        run: |
-          export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
-          export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
-          chmod a+x bin/*
-          $PWD/bin/eicrecon -Ppodio:output_file=rec_dis_${{matrix.beam}}_${{ matrix.detector_config }}.edm4eic.root sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root -Pplugins=janadot
-    - uses: actions/upload-artifact@v3
-      with:
-        name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root
-        path: rec_dis_${{matrix.beam}}_${{ matrix.detector_config }}.edm4eic.root
-        if-no-files-found: error
-    - uses: actions/upload-artifact@v3
-      with:
-        name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.dot
-        path: jana.dot
-        if-no-files-found: error
+  # eicrecon-gcc-dis:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: eicweb/jug_xl:unstable-mr-290-522
+  #   needs:
+  #   - build
+  #   - ddsim-dis
+  #   strategy:
+  #     matrix:
+  #       beam: [5x41, 10x100, 18x275]
+  #       minq2: [1, 1000]
+  #       detector_config: [arches, brycecanyon]
+  #       exclude:
+  #       - beam: 5x41
+  #         minq2: 1000
+  #   steps:
+  #   - uses: actions/download-artifact@v3
+  #     with:
+  #       name: install-gcc-eic-shell-Release
+  #   - uses: actions/download-artifact@v3
+  #     with:
+  #       name: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
+  #   - name: Run EICrecon
+  #     run: |
+  #       source /opt/detector/setup.sh
+  #       export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
+  #       export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
+  #       chmod a+x bin/*
+  #       $PWD/bin/eicrecon -Ppodio:output_file=rec_dis_${{matrix.beam}}_${{ matrix.detector_config }}.edm4eic.root sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root -Pplugins=janadot
+  #   - uses: actions/upload-artifact@v3
+  #     with:
+  #       name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root
+  #       path: rec_dis_${{matrix.beam}}_${{ matrix.detector_config }}.edm4eic.root
+  #       if-no-files-found: error
+  #   - uses: actions/upload-artifact@v3
+  #     with:
+  #       name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.dot
+  #       path: jana.dot
+  #       if-no-files-found: error
 
-  # build-docs and deploy-docs copy doxygen.yml functionality
-  # the difference is that these jobs use resulting artifacts from EICrecon runs
-  # to embed into docs
-  build-docs-advanced:
-    runs-on: ubuntu-latest
-    container:
-      image: alpine:latest
-      volumes:
-        - /home/runner/work/_temp:/home/runner/work/_temp
-      # FIXME hard-coded: see https://github.com/actions/upload-pages-artifact/pull/14
-    steps:
-      - uses: actions/checkout@v3
-      - name: Run Doxygen
-        run: |
-          apk add doxygen graphviz
-          doxygen Doxyfile
-          cp -r docs publishing_docs
-          mv html publishing_docs/doxygen
-      - uses: actions/upload-artifact@v3
-        with:
-          name: docs
-          path: publishing_docs/
-          if-no-files-found: error
-      - run:
-          apk add tar bash
-        # FIXME bash not really required: see https://github.com/actions/upload-pages-artifact/pull/14
-      - uses: actions/upload-pages-artifact@v1
-        if: github.ref == 'refs/heads/main'
-        with:
-          path: publishing_docs/
-          retention-days: 7
+  # # build-docs and deploy-docs copy doxygen.yml functionality
+  # # the difference is that these jobs use resulting artifacts from EICrecon runs
+  # # to embed into docs
+  # build-docs-advanced:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: alpine:latest
+  #     volumes:
+  #       - /home/runner/work/_temp:/home/runner/work/_temp
+  #     # FIXME hard-coded: see https://github.com/actions/upload-pages-artifact/pull/14
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Run Doxygen
+  #       run: |
+  #         apk add doxygen graphviz
+  #         doxygen Doxyfile
+  #         cp -r docs publishing_docs
+  #         mv html publishing_docs/doxygen
+  #     - uses: actions/upload-artifact@v3
+  #       with:
+  #         name: docs
+  #         path: publishing_docs/
+  #         if-no-files-found: error
+  #     - run:
+  #         apk add tar bash
+  #       # FIXME bash not really required: see https://github.com/actions/upload-pages-artifact/pull/14
+  #     - uses: actions/upload-pages-artifact@v1
+  #       if: github.ref == 'refs/heads/main'
+  #       with:
+  #         path: publishing_docs/
+  #         retention-days: 7
 
-  deploy-docs-advanced:
-    needs: build-docs-advanced
-    if: github.ref == 'refs/heads/main'
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v1
+  # deploy-docs-advanced:
+  #   needs: build-docs-advanced
+  #   if: github.ref == 'refs/heads/main'
+  #   permissions:
+  #     pages: write
+  #     id-token: write
+  #   environment:
+  #     name: github-pages
+  #     url: ${{ steps.deployment.outputs.page_url }}
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Deploy to GitHub Pages
+  #       id: deployment
+  #       uses: actions/deploy-pages@v1

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -116,21 +120,23 @@ jobs:
         particle: [pi, e]
         detector_config: [arches, brycecanyon]
     steps:
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
-    - name: Get detector info
-      id: detector_info
-      uses: docker://ubuntu:latest
-      args: "grep epic/nightly /cvmfs/singularity.opensciencegrid.org/eicweb/jug_xl\:nightly/etc/jug_info | sed 's/.*: .*-\(.*\)/hash=\1/g' >> $GITHUB_OUTPUT"
-    - name: Retrieve simulation files
-      id: retrieve_simulation_files
-      uses: actions/cache@v3
-      with:
-        path: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
-        key: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root-${{ steps.detector_info.outputs.hash }}
+    # - uses: cvmfs-contrib/github-action-cvmfs@v3
+    # - name: Get detector info
+    #   id: detector_info
+    #   run: |
+    #     grep epic/nightly /cvmfs/singularity.opensciencegrid.org/eicweb/jug_xl\:nightly/etc/jug_info | sed 's/.*: .*-\(.*\)/hash=\1/g' >> $GITHUB_OUTPUT
+    # - name: Retrieve simulation files
+    #   id: retrieve_simulation_files
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
+    #     key: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root-${{ steps.detector_info.outputs.hash }}
     - name: Produce simulation files
-      if: steps.retrieve_simulation_files.outputs.cache-hit != 'true'
+      # if: steps.retrieve_simulation_files.outputs.cache-hit != 'true'
       run: |
-        source /opt/detector/setup.sh
+        source /usr/local/bin/thisroot.sh
+        source /usr/local/bin/thisdd4hep.sh
+        source /opt/detector/epic-main/setup.sh
         echo "DETECTOR_PATH = ${DETECTOR_PATH}"
         echo "DETECTOR      = ${DETECTOR}"
         ddsim --compactFile ${DETECTOR_PATH}/${DETECTOR}_${{ matrix.detector_config }}.xml -G --gun.particle "${{ matrix.particle }}-" --gun.momentumMin "1*GeV" --gun.momentumMax "20*GeV" --gun.distribution "uniform" -N 100 --outputFile sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
@@ -140,41 +146,45 @@ jobs:
         path: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
         if-no-files-found: error
 
-  # ddsim-dis:
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: eicweb/jug_xl:unstable-mr-290-522
-  #   strategy:
-  #     matrix:
-  #       beam: [5x41, 10x100, 18x275]
-  #       minq2: [1, 1000]
-  #       detector_config: [arches, brycecanyon]
-  #       exclude:
-  #       - beam: 5x41
-  #         minq2: 1000
-  #   steps:
-  #   - uses: cvmfs-contrib/github-action-cvmfs@v3
-  #   - name: Get detector info
-  #     id: detector_info
-  #     run: |
-  #       grep epic/nightly /cvmfs/singularity.opensciencegrid.org/eicweb/jug_xl\:nightly/etc/jug_info | sed 's/.*: .*-\(.*\)/hash=\1/g' >> $GITHUB_OUTPUT
-  #   - name: Retrieve simulation files
-  #     id: retrieve_simulation_files
-  #     uses: actions/cache@v3
-  #     with:
-  #       path: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
-  #       key: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root-${{ steps.detector_info.outputs.hash }}
-  #   - name: Produce simulation files
-  #     if: steps.retrieve_simulation_files.outputs.cache-hit != 'true'
-  #     run: |
-  #       source /opt/detector/setup.sh
-  #       url=root://dtn-eic.jlab.org//work/eic2/EPIC/EVGEN/DIS/NC/${{matrix.beam}}/minQ2=${{matrix.minq2}}/pythia8NCDIS_${{matrix.beam}}_minQ2=${{matrix.minq2}}_beamEffects_xAngle=-0.025_hiDiv_1.hepmc3.tree.root
-  #       ddsim --compactFile ${DETECTOR_PATH}/${DETECTOR}_${{ matrix.detector_config }}.xml -N 100 --inputFiles ${url} --outputFile sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
-  #   - uses: actions/upload-artifact@v3
-  #     with:
-  #       name: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
-  #       path: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
-  #       if-no-files-found: error
+  ddsim-dis:
+    runs-on: ubuntu-latest
+    container:
+      image: eicweb/jug_xl:unstable-mr-290-522
+    strategy:
+      matrix:
+        beam: [5x41, 10x100, 18x275]
+        minq2: [1, 1000]
+        detector_config: [arches, brycecanyon]
+        exclude:
+        - beam: 5x41
+          minq2: 1000
+    steps:
+    # - uses: cvmfs-contrib/github-action-cvmfs@v3
+    # - name: Get detector info
+    #   id: detector_info
+    #   run: |
+    #     grep epic/nightly /cvmfs/singularity.opensciencegrid.org/eicweb/jug_xl\:nightly/etc/jug_info | sed 's/.*: .*-\(.*\)/hash=\1/g' >> $GITHUB_OUTPUT
+    # - name: Retrieve simulation files
+    #   id: retrieve_simulation_files
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
+    #     key: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root-${{ steps.detector_info.outputs.hash }}
+    - name: Produce simulation files
+      # if: steps.retrieve_simulation_files.outputs.cache-hit != 'true'
+      run: |
+        source /usr/local/bin/thisroot.sh
+        source /usr/local/bin/thisdd4hep.sh
+        source /opt/detector/epic-main/setup.sh
+        echo "DETECTOR_PATH = ${DETECTOR_PATH}"
+        echo "DETECTOR      = ${DETECTOR}"
+        url=root://dtn-eic.jlab.org//work/eic2/EPIC/EVGEN/DIS/NC/${{matrix.beam}}/minQ2=${{matrix.minq2}}/pythia8NCDIS_${{matrix.beam}}_minQ2=${{matrix.minq2}}_beamEffects_xAngle=-0.025_hiDiv_1.hepmc3.tree.root
+        ddsim --compactFile ${DETECTOR_PATH}/${DETECTOR}_${{ matrix.detector_config }}.xml -N 100 --inputFiles ${url} --outputFile sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
+    - uses: actions/upload-artifact@v3
+      with:
+        name: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
+        path: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
+        if-no-files-found: error
 
   # valgrind-memcheck-eicrecon-gcc:
   #   runs-on: ubuntu-latest
@@ -209,86 +219,94 @@ jobs:
   #       path: valgrind-memcheck-eicrecon-${{ matrix.particle }}-${{ matrix.detector_config }}.log
   #       if-no-files-found: error
 
-  # eicrecon-gcc-gun:
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: eicweb/jug_xl:unstable-mr-290-522
-  #   needs:
-  #   - build
-  #   - ddsim-gun
-  #   strategy:
-  #     matrix:
-  #       particle: [pi, e]
-  #       detector_config: [arches, brycecanyon]
-  #   steps:
-  #   - uses: actions/download-artifact@v3
-  #     with:
-  #       name: install-gcc-eic-shell-Release
-  #   - uses: actions/download-artifact@v3
-  #     with:
-  #       name: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
-  #   - name: Run EICrecon
-  #     run: |
-  #       source /opt/detector/setup.sh
-  #       export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
-  #       export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
-  #       chmod a+x bin/*
-  #       $PWD/bin/eicrecon -Ppodio:output_file=rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -Pplugins=dump_flags,janadot -Pdump_flags:json=${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json
-  #   - uses: actions/upload-artifact@v3
-  #     with:
-  #       name: eicrecon_rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
-  #       path: rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
-  #       if-no-files-found: error
-  #   - uses: actions/upload-artifact@v3
-  #     with:
-  #       name: ${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json
-  #       path: ${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json
-  #       if-no-files-found: error
-  #   - uses: actions/upload-artifact@v3
-  #     with:
-  #       name: eicrecon_rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.dot
-  #       path: jana.dot
-  #       if-no-files-found: error
+  eicrecon-gcc-gun:
+    runs-on: ubuntu-latest
+    container:
+      image: eicweb/jug_xl:unstable-mr-290-522
+    needs:
+    - build
+    - ddsim-gun
+    strategy:
+      matrix:
+        particle: [pi, e]
+        detector_config: [arches, brycecanyon]
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: install-gcc-eic-shell-Release
+    - uses: actions/download-artifact@v3
+      with:
+        name: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
+    - name: Run EICrecon
+      run: |
+        source /usr/local/bin/thisroot.sh
+        source /usr/local/bin/thisdd4hep.sh
+        source /opt/detector/epic-main/setup.sh
+        echo "DETECTOR_PATH = ${DETECTOR_PATH}"
+        echo "DETECTOR      = ${DETECTOR}"
+        export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
+        export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
+        chmod a+x bin/*
+        $PWD/bin/eicrecon -Ppodio:output_file=rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -Pplugins=dump_flags,janadot -Pdump_flags:json=${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json
+    - uses: actions/upload-artifact@v3
+      with:
+        name: eicrecon_rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
+        path: rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
+        if-no-files-found: error
+    - uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json
+        path: ${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json
+        if-no-files-found: error
+    - uses: actions/upload-artifact@v3
+      with:
+        name: eicrecon_rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.dot
+        path: jana.dot
+        if-no-files-found: error
 
-  # eicrecon-gcc-dis:
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: eicweb/jug_xl:unstable-mr-290-522
-  #   needs:
-  #   - build
-  #   - ddsim-dis
-  #   strategy:
-  #     matrix:
-  #       beam: [5x41, 10x100, 18x275]
-  #       minq2: [1, 1000]
-  #       detector_config: [arches, brycecanyon]
-  #       exclude:
-  #       - beam: 5x41
-  #         minq2: 1000
-  #   steps:
-  #   - uses: actions/download-artifact@v3
-  #     with:
-  #       name: install-gcc-eic-shell-Release
-  #   - uses: actions/download-artifact@v3
-  #     with:
-  #       name: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
-  #   - name: Run EICrecon
-  #     run: |
-  #       source /opt/detector/setup.sh
-  #       export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
-  #       export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
-  #       chmod a+x bin/*
-  #       $PWD/bin/eicrecon -Ppodio:output_file=rec_dis_${{matrix.beam}}_${{ matrix.detector_config }}.edm4eic.root sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root -Pplugins=janadot
-  #   - uses: actions/upload-artifact@v3
-  #     with:
-  #       name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root
-  #       path: rec_dis_${{matrix.beam}}_${{ matrix.detector_config }}.edm4eic.root
-  #       if-no-files-found: error
-  #   - uses: actions/upload-artifact@v3
-  #     with:
-  #       name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.dot
-  #       path: jana.dot
-  #       if-no-files-found: error
+  eicrecon-gcc-dis:
+    runs-on: ubuntu-latest
+    container:
+      image: eicweb/jug_xl:unstable-mr-290-522
+    needs:
+    - build
+    - ddsim-dis
+    strategy:
+      matrix:
+        beam: [5x41, 10x100, 18x275]
+        minq2: [1, 1000]
+        detector_config: [arches, brycecanyon]
+        exclude:
+        - beam: 5x41
+          minq2: 1000
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: install-gcc-eic-shell-Release
+    - uses: actions/download-artifact@v3
+      with:
+        name: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
+    - name: Run EICrecon
+      run: |
+        source /usr/local/bin/thisroot.sh
+        source /usr/local/bin/thisdd4hep.sh
+        source /opt/detector/epic-main/setup.sh
+        echo "DETECTOR_PATH = ${DETECTOR_PATH}"
+        echo "DETECTOR      = ${DETECTOR}"
+        export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
+        export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
+        chmod a+x bin/*
+        $PWD/bin/eicrecon -Ppodio:output_file=rec_dis_${{matrix.beam}}_${{ matrix.detector_config }}.edm4eic.root sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root -Pplugins=janadot
+    - uses: actions/upload-artifact@v3
+      with:
+        name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root
+        path: rec_dis_${{matrix.beam}}_${{ matrix.detector_config }}.edm4eic.root
+        if-no-files-found: error
+    - uses: actions/upload-artifact@v3
+      with:
+        name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.dot
+        path: jana.dot
+        if-no-files-found: error
 
   # # build-docs and deploy-docs copy doxygen.yml functionality
   # # the difference is that these jobs use resulting artifacts from EICrecon runs


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Testing for #560; do not merge

---
#### Notes: the following changes are needed to test using a `jug_xl:unstable-mr*` container in CI:
- use `bash` shell, so we can `source` setup files
- disable any jobs not needed for the test
- run jobs in the test image
- convert any step that uses `eic/run-cvmfs-osg-eic-shell` to an ordinary step (just use `run`)
- disable cache retrievals of simulated files (e.g., `detector_info` and `retrieve_simulation_files`); this is because `/etc/lsb-release` is not in the test image
- source some environmental setup files:
```
source /usr/local/bin/thisroot.sh
source /usr/local/bin/thisdd4hep.sh
source /opt/detector/epic-main/setup.sh  # NOTE: nightly is not in the unstable-mr image, so just use main instead
```
- do not use `janadot` plugin, since not found (or maybe `JANA` environment also needs to be sourced)
---

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no

### Does this PR change default behavior?
no