### PR TITLE
EcalBarrelScFiRawHits: revert back to unitless definitions

### DIFF
--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelScFiRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelScFiRawHits.h
@@ -36,7 +36,7 @@ public:
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
         m_input_tag = "EcalBarrelScFiHits";
-        u_eRes = {0.0 * dd4hep::MeV};
+        u_eRes = {0.0, 0.0, 0.0};
         m_tRes = 0.0 * dd4hep::ns;
         m_capADC = 16384;
         m_dyRangeADC = 750 * dd4hep::MeV;


### PR DESCRIPTION
The current value was introduced in 13b9c92188d9cacedc5c4b9ca0c80404c21f1c3e. There should have been three values, and using units for those doesn't make sense from the dimensional analysis point (terms are divided by sqrt(E), 1 and E respectively). Each element of the array would need to have its own unit, but the commonly accepted convention is to use fractions and assume GeV. The actual behavior in reconstruction is not changed by this PR, because the values stay the same.

See also https://github.com/eic/EICrecon/issues/573

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
