### PR TITLE
EcalEndcapP{,Insert}RawHits: revert back to unitless definitions

### DIFF
--- a/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapPInsertRawHits.h
+++ b/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapPInsertRawHits.h
@@ -36,7 +36,7 @@ public:
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
         m_input_tag = "EcalEndcapPInsertHits";
-        u_eRes = {3.16 * dd4hep::MeV, 1.5 * dd4hep::MeV, 0.0 * dd4hep::MeV};
+        u_eRes = {0.00316, 0.0015, 0.0}; // (0.316% / sqrt(E)) \oplus 0.15%
         m_tRes = 0.0 * dd4hep::ns;
         m_capADC = 16384;
         m_dyRangeADC = 3 * dd4hep::GeV;

--- a/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapPRawHits.h
+++ b/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapPRawHits.h
@@ -36,7 +36,7 @@ public:
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
         m_input_tag = "EcalEndcapPHits";
-        u_eRes = {3.16 * dd4hep::MeV, 1.5 * dd4hep::MeV, 0.0 * dd4hep::MeV};
+        u_eRes = {0.00316, 0.0015, 0.0}; // (0.316% / sqrt(E)) \oplus 0.15%
         m_tRes = 0.0 * dd4hep::ns;
         m_capADC = 16384;
         m_dyRangeADC = 3 * dd4hep::GeV;


### PR DESCRIPTION
The MeV multipliers were introduced in #408, but they don't make sense from the dimensional analysis point (terms are divided by sqrt(E), 1 and E respectively). Each element of the array would need to have its own unit, but the commonly accepted convention is to use fractions and assume GeV. This commit restores that convention. The actual behavior in reconstruction is not changed by this PR, because the values stay the same.

See also https://github.com/eic/EICrecon/issues/573

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
