### PR TITLE
CalorimeterHitDigi: parametrize energy smearing with respect to 1 GeV scale

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -145,9 +145,9 @@ void CalorimeterHitDigi::single_hits_digi(){
         // apply additional calorimeter noise to corrected energy deposit
         const double eResRel = (eDep > m_threshold)
                                ? m_normDist(generator) * std::sqrt(
-                                    std::pow(eRes[0] / std::sqrt(eDep), 2) +
+                                    std::pow(eRes[0] / std::sqrt(eDep / dd4hep::GeV), 2) +
                                     std::pow(eRes[1], 2) +
-                                    std::pow(eRes[2] / (eDep), 2)
+                                    std::pow(eRes[2] / (eDep / dd4hep::GeV), 2)
                 )
                                : 0;
 //       const double eResRel = (eDep > 1e-6)
@@ -217,14 +217,14 @@ void CalorimeterHitDigi::signal_sum_digi( void ){
 //        double eResRel = 0.;
         // safety check
         const double eResRel = (edep > m_threshold)
-                ? m_normDist(generator) * eRes[0] / std::sqrt(edep) +
+                ? m_normDist(generator) * eRes[0] / std::sqrt(edep / dd4hep::GeV) +
                   m_normDist(generator) * eRes[1] +
-                  m_normDist(generator) * eRes[2] / edep
+                  m_normDist(generator) * eRes[2] / (edep / dd4hep::GeV)
                   : 0;
 //        if (edep > 1e-6) {
-//            eResRel = m_normDist(generator) * eRes[0] / std::sqrt(edep) +
+//            eResRel = m_normDist(generator) * eRes[0] / std::sqrt(edep / dd4hep::GeV) +
 //                      m_normDist(generator) * eRes[1] +
-//                      m_normDist(generator) * eRes[2] / edep;
+//                      m_normDist(generator) * eRes[2] / (edep / dd4hep::GeV);
 //        }
         double    ped     = m_pedMeanADC + m_normDist(generator) * m_pedSigmaADC;
         unsigned long long adc     = std::llround(ped + edep * (m_corrMeanScale + eResRel) / m_dyRangeADC * m_capADC);


### PR DESCRIPTION
This should not change any behavior, but make the intention behind the code more explicit.

See also https://github.com/eic/EICrecon/issues/573

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [x] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No