### PR TITLE
feat: pass time information to track reconstruction

### DIFF
--- a/src/algorithms/tracking/TrackerSourceLinker.cc
+++ b/src/algorithms/tracking/TrackerSourceLinker.cc
@@ -52,9 +52,10 @@ eicrecon::TrackerSourceLinkerResult *eicrecon::TrackerSourceLinker::produce(std:
     int hit_index = 0;
     for (const auto *hit: trk_hits) {
 
-        Acts::SymMatrix2 cov = Acts::SymMatrix2::Zero();
+        Acts::SymMatrix3 cov = Acts::SymMatrix3::Zero();
         cov(0, 0) = hit->getPositionError().xx * mm_acts * mm_acts; // note mm = 1 (Acts)
         cov(1, 1) = hit->getPositionError().yy * mm_acts * mm_acts;
+        cov(2, 2) = hit->getTimeError() * Acts::UnitConstants::ns * Acts::UnitConstants::ns;
 
 
         const auto* vol_ctx = m_cellid_converter->findContext(hit->getCellID());
@@ -80,7 +81,7 @@ eicrecon::TrackerSourceLinkerResult *eicrecon::TrackerSourceLinker::produce(std:
 
         const auto& hit_pos = hit->getPosition();
 
-        Acts::Vector2 loc = Acts::Vector2::Zero();
+        Acts::Vector3 loc = Acts::Vector3::Zero();
         Acts::Vector2 pos;
         auto hit_det = hit->getCellID()&0xFF;
         auto onSurfaceTolerance = 0.1*Acts::UnitConstants::um;      // By default, ACTS uses 0.1 micron as the on surface tolerance
@@ -98,6 +99,7 @@ eicrecon::TrackerSourceLinkerResult *eicrecon::TrackerSourceLinker::produce(std:
 
             loc[Acts::eBoundLoc0] = pos[0];
             loc[Acts::eBoundLoc1] = pos[1];
+            loc[Acts::eBoundTime] = hit->getTime();
         }
         catch(std::exception &ex) {
             m_log->warn("Can't convert globalToLocal for hit: vol_id={} det_id={} CellID={} x={} y={} z={}",
@@ -124,7 +126,7 @@ eicrecon::TrackerSourceLinkerResult *eicrecon::TrackerSourceLinker::produce(std:
         auto sourceLink = std::make_shared<ActsExamples::IndexSourceLink>(surface->geometryId(), hit_index);
         sourceLinks.emplace_back(sourceLink);
 
-        auto measurement = Acts::makeMeasurement(*sourceLink, loc, cov, Acts::eBoundLoc0, Acts::eBoundLoc1);
+        auto measurement = Acts::makeMeasurement(*sourceLink, loc, cov, Acts::eBoundLoc0, Acts::eBoundLoc1, Acts::eBoundTime);
         measurements->emplace_back(std::move(measurement));
 
         hit_index++;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Credit @DraTeots. This fixes #580 and adds the time information for hits into the track reconstruction. Obsoletes #581.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #580)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.