### PR TITLE
RawCalorimeterHit_factory_: specify u_eRes with units

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -56,8 +56,12 @@ void CalorimeterHitDigi::AlgorithmInit(std::shared_ptr<spdlog::logger>& logger) 
 
     // set energy resolution numbers
     m_log=logger;
-    for (size_t i = 0; i < u_eRes.size() && i < 3; ++i) {
-        eRes[i] = u_eRes[i];
+
+    if (u_eRes.size() == 0) {
+      u_eRes.resize(3);
+    } else if (u_eRes.size() != 3) {
+      m_log->error("Invalid u_eRes.size()");
+      throw std::runtime_error("Invalid u_eRes.size()");
     }
 
     // using juggler internal units (GeV, mm, radian, ns)
@@ -145,14 +149,14 @@ void CalorimeterHitDigi::single_hits_digi(){
         // apply additional calorimeter noise to corrected energy deposit
         const double eResRel = (eDep > m_threshold)
                                ? m_normDist(generator) * std::sqrt(
-                                    std::pow(eRes[0] / std::sqrt(eDep), 2) +
-                                    std::pow(eRes[1], 2) +
-                                    std::pow(eRes[2] / (eDep), 2)
+                                    std::pow(u_eRes[0] / std::sqrt(eDep), 2) +
+                                    std::pow(u_eRes[1], 2) +
+                                    std::pow(u_eRes[2] / (eDep), 2)
                 )
                                : 0;
 //       const double eResRel = (eDep > 1e-6)
-//                               ? m_normDist(generator) * std::sqrt(std::pow(eRes[0] / std::sqrt(eDep), 2) +
-//                                                          std::pow(eRes[1], 2) + std::pow(eRes[2] / (eDep), 2))
+//                               ? m_normDist(generator) * std::sqrt(std::pow(u_eRes[0] / std::sqrt(eDep), 2) +
+//                                                          std::pow(u_eRes[1], 2) + std::pow(u_eRes[2] / (eDep), 2))
 //                               : 0;
 
         const double ped    = m_pedMeanADC + m_normDist(generator) * m_pedSigmaADC;
@@ -217,14 +221,14 @@ void CalorimeterHitDigi::signal_sum_digi( void ){
 //        double eResRel = 0.;
         // safety check
         const double eResRel = (edep > m_threshold)
-                ? m_normDist(generator) * eRes[0] / std::sqrt(edep) +
-                  m_normDist(generator) * eRes[1] +
-                  m_normDist(generator) * eRes[2] / edep
+                ? m_normDist(generator) * u_eRes[0] / std::sqrt(edep) +
+                  m_normDist(generator) * u_eRes[1] +
+                  m_normDist(generator) * u_eRes[2] / edep
                   : 0;
 //        if (edep > 1e-6) {
-//            eResRel = m_normDist(generator) * eRes[0] / std::sqrt(edep) +
-//                      m_normDist(generator) * eRes[1] +
-//                      m_normDist(generator) * eRes[2] / edep;
+//            eResRel = m_normDist(generator) * u_eRes[0] / std::sqrt(edep) +
+//                      m_normDist(generator) * u_eRes[1] +
+//                      m_normDist(generator) * u_eRes[2] / edep;
 //        }
         double    ped     = m_pedMeanADC + m_normDist(generator) * m_pedSigmaADC;
         unsigned long long adc     = std::llround(ped + edep * (m_corrMeanScale + eResRel) / m_dyRangeADC * m_capADC);

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.h
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.h
@@ -72,7 +72,7 @@ public:
     //-----------------------------------------------
 
     // unitless counterparts of inputs
-    double           dyRangeADC{0}, stepTDC{0}, tRes{0}, eRes[3] = {0., 0., 0.};
+    double           dyRangeADC{0}, stepTDC{0}, tRes{0};
     // variables for merging at digitization step
     bool             merge_hits = false;
     std::shared_ptr<JDD4hep_service> m_geoSvc;

--- a/src/detectors/B0ECAL/RawCalorimeterHit_factory_B0ECalRawHits.h
+++ b/src/detectors/B0ECAL/RawCalorimeterHit_factory_B0ECalRawHits.h
@@ -36,7 +36,7 @@ public:
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
         m_input_tag = "B0ECalHits";
-        u_eRes = {0.0,0.02,0.0};
+        u_eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV};
         m_tRes = 0.0 * dd4hep::ns;
         m_capADC = 16384;
         m_dyRangeADC = 20 * dd4hep::GeV;

--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelImagingRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelImagingRawHits.h
@@ -36,7 +36,7 @@ public:
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
         m_input_tag = "EcalBarrelImagingHits";
-        u_eRes = {0.0, 0.02, 0.0};
+        u_eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV};
         m_tRes = 0.0 * dd4hep::ns;
         m_capADC = 8192;
         m_dyRangeADC = 3 * dd4hep::MeV;

--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelScFiRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelScFiRawHits.h
@@ -36,7 +36,7 @@ public:
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
         m_input_tag = "EcalBarrelScFiHits";
-        u_eRes = {0.0, 0.0, 0.0};
+        u_eRes = {0.0 * sqrt(dd4hep::GeV), 0.0, 0.0 * dd4hep::GeV};
         m_tRes = 0.0 * dd4hep::ns;
         m_capADC = 16384;
         m_dyRangeADC = 750 * dd4hep::MeV;

--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelSciGlassRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelSciGlassRawHits.h
@@ -36,7 +36,7 @@ public:
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
         m_input_tag = "EcalBarrelSciGlassHits";
-        u_eRes =  {0.0, 0.0, 0.0};
+        u_eRes =  {0.0 * sqrt(dd4hep::GeV), 0.0, 0.0 * dd4hep::GeV};
         m_tRes = 0.0 * dd4hep::ns;
         m_capADC = 16384;
         m_dyRangeADC = 20 * dd4hep::GeV;

--- a/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapNRawHits.h
+++ b/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapNRawHits.h
@@ -36,7 +36,7 @@ public:
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
         m_input_tag = "EcalEndcapNHits";
-        u_eRes = {0.0, 0.02, 0.0}; // flat 2%
+        u_eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV}; // flat 2%
         m_tRes = 0.0 * dd4hep::ns;
         m_capADC = 16384;
         m_dyRangeADC = 20 * dd4hep::GeV;

--- a/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapPInsertRawHits.h
+++ b/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapPInsertRawHits.h
@@ -36,7 +36,7 @@ public:
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
         m_input_tag = "EcalEndcapPInsertHits";
-        u_eRes = {0.00316, 0.0015, 0.0}; // (0.316% / sqrt(E)) \oplus 0.15%
+        u_eRes = {0.00316 * sqrt(dd4hep::GeV), 0.0015, 0.0 * dd4hep::GeV}; // (0.316% / sqrt(E)) \oplus 0.15%
         m_tRes = 0.0 * dd4hep::ns;
         m_capADC = 16384;
         m_dyRangeADC = 3 * dd4hep::GeV;

--- a/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapPRawHits.h
+++ b/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapPRawHits.h
@@ -36,7 +36,7 @@ public:
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
         m_input_tag = "EcalEndcapPHits";
-        u_eRes = {0.00316, 0.0015, 0.0}; // (0.316% / sqrt(E)) \oplus 0.15%
+        u_eRes = {0.00316 * sqrt(dd4hep::GeV), 0.0015, 0.0 * dd4hep::GeV}; // (0.316% / sqrt(E)) \oplus 0.15%
         m_tRes = 0.0 * dd4hep::ns;
         m_capADC = 16384;
         m_dyRangeADC = 3 * dd4hep::GeV;


### PR DESCRIPTION
The purpose of this change is to provide explicit units for different smearing terms.

This removes CalorimeterHitDigi::eRes that is declared as unitless.

This is as suggested by @wdconinc in https://github.com/eic/EICrecon/pull/582#issuecomment-1498337700

Closes: #585
Fixes: #573

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
