### PR TITLE
JetReconstruction: apply pT constraints before running jet algorithm

### DIFF
--- a/src/algorithms/reco/JetReconstruction.cc
+++ b/src/algorithms/reco/JetReconstruction.cc
@@ -72,7 +72,7 @@ namespace eicrecon {
       for (unsigned j = 0; j < csts.size(); j++) {
         const double cst_pt = csts[j].pt();
         m_log->trace("    constituent {}'s pt: {}", j, cst_pt);
-        
+
         edm4eic::MutableReconstructedParticle cst_edm;
         // Type = 0 for jets, Type = 1 for constituents
         // Use PDG values to match jets and constituents

--- a/src/algorithms/reco/JetReconstruction.cc
+++ b/src/algorithms/reco/JetReconstruction.cc
@@ -40,9 +40,10 @@ namespace eicrecon {
     // Particles for jet reconstrution
     std::vector<PseudoJet> particles;
     for (const auto &mom : momenta) {
-      double partPt = std::sqrt(mom->px()*mom->px() + mom->py()*mom->py());
-      if(partPt > m_minCstPt && partPt < m_maxCstPt) // Only cluster particles within the given pt Range
+      // Only cluster particles within the given pt Range
+      if ((mom->pt() > m_minCstPt) && (mom->pt() < m_maxCstPt)) {
         particles.push_back( PseudoJet(mom->px(), mom->py(), mom->pz(), mom->e()) );
+      }
     }
 
     // Choose jet and area definitions


### PR DESCRIPTION

### Briefly, what does this PR introduce?

Move constraint on particle transverse momentum from the recording of constituents to restricting what particles are included in the clustering.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: Fixes algorithm behavior

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No
