### PR TITLE
Fixes associated with forward HCal digitization, clustering and truth associations.

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterClusterMerger.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterMerger.cc
@@ -62,7 +62,7 @@ void CalorimeterClusterMerger::AlgorithmProcess() {
         ca->setRecID(new_clus->getObjectID().index);
         ca->setSimID(mcID);
         ca->setWeight(1.0);
-        ca->setRec(*new_clus);
+        //ca->setRec(*new_clus);
         edm4eic::MCRecoClusterParticleAssociation* toadd = new edm4eic::MCRecoClusterParticleAssociation(*ca);
         delete ca;
         assoc2.push_back(toadd);
@@ -97,7 +97,7 @@ void CalorimeterClusterMerger::AlgorithmProcess() {
         auto ca = new edm4eic::MutableMCRecoClusterParticleAssociation();
         ca->setSimID(mcID);
         ca->setWeight(1.0);
-        ca->setRec(edm4eic::Cluster(new_clus));
+        //ca->setRec(edm4eic::Cluster(new_clus));
         edm4eic::MCRecoClusterParticleAssociation* toadd = new edm4eic::MCRecoClusterParticleAssociation(*ca);
         assoc2.push_back(toadd);
       }

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -143,7 +143,7 @@ void CalorimeterClusterRecoCoG::AlgorithmProcess() {
         m_log->debug("corresponding mc hit energy {} at index {}", (*mchit)->getEnergy(), (*mchit)->getObjectID().index);
         m_log->debug("from MCParticle index {}, PDG {}, {}", mcp.getObjectID().index, mcp.getPDG(), edm4eic::magnitude(mcp.getMomentum()));
 	m_log->debug("creating cluster/particle association  recID={}, simID={}",((uint64_t)cl&0xFFFFFFFF),mcp.getObjectID().index);
-	
+
         // set association
         edm4eic::MutableMCRecoClusterParticleAssociation* clusterassoc = new edm4eic::MutableMCRecoClusterParticleAssociation();
 //        clusterassoc->setRecID(cl->getObjectID().index); // if not using collection, this is always set to -1

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -142,14 +142,15 @@ void CalorimeterClusterRecoCoG::AlgorithmProcess() {
         m_log->debug("pcl hit with highest energy {} at index {}", pclhit->getEnergy(), pclhit->getObjectID().index);
         m_log->debug("corresponding mc hit energy {} at index {}", (*mchit)->getEnergy(), (*mchit)->getObjectID().index);
         m_log->debug("from MCParticle index {}, PDG {}, {}", mcp.getObjectID().index, mcp.getPDG(), edm4eic::magnitude(mcp.getMomentum()));
-
+	m_log->debug("creating cluster/particle association  recID={}, simID={}",((uint64_t)cl&0xFFFFFFFF),mcp.getObjectID().index);
+	
         // set association
         edm4eic::MutableMCRecoClusterParticleAssociation* clusterassoc = new edm4eic::MutableMCRecoClusterParticleAssociation();
 //        clusterassoc->setRecID(cl->getObjectID().index); // if not using collection, this is always set to -1
         clusterassoc->setRecID((uint32_t)((uint64_t)cl&0xFFFFFFFF)); // mask lower 32 bits of cluster pointer as unique ID FIXME:
         clusterassoc->setSimID(mcp.getObjectID().index);
         clusterassoc->setWeight(1.0);
-        clusterassoc->setRec(*cl);
+        //clusterassoc->setRec(*cl);
         //clusterassoc.setSim(mcp);
         edm4eic::MCRecoClusterParticleAssociation* cassoc = new edm4eic::MCRecoClusterParticleAssociation(*clusterassoc);
         m_outputAssociations.push_back(cassoc);

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -161,7 +161,6 @@ void CalorimeterHitDigi::single_hits_digi(){
 
         const double ped    = m_pedMeanADC + m_normDist(generator) * m_pedSigmaADC;
         const long long adc = std::llround(ped + eDep * (m_corrMeanScale + eResRel) / m_dyRangeADC * m_capADC);
-
         double time = std::numeric_limits<double>::max();
         for (const auto& c : ahit->getContributions()) {
             if (c.getTime() <= time) {

--- a/src/detectors/HCAL/CalorimeterHit_factory_HcalEndcapPRecHits.h
+++ b/src/detectors/HCAL/CalorimeterHit_factory_HcalEndcapPRecHits.h
@@ -25,18 +25,18 @@ public:
         m_input_tag = "HcalEndcapPRawHits";
 
         // digitization settings, must be consistent with digi class
-        m_capADC=1024;//{this, "capacityADC", 8096};
-        m_dyRangeADC=3.6 * dd4hep::GeV;//{this, "dynamicRangeADC", 100. * dd4hep::MeV};
-        m_pedMeanADC=20;//{this, "pedestalMean", 400};
-        m_pedSigmaADC=0.8;//{this, "pedestalSigma", 3.2};
+        m_capADC=4096;//{this, "capacityADC", 8096};
+        m_dyRangeADC=50 * dd4hep::MeV;//{this, "dynamicRangeADC", 100. * dd4hep::MeV};
+        m_pedMeanADC=200;//{this, "pedestalMean", 400};
+        m_pedSigmaADC=3.2;//{this, "pedestalSigma", 3.2};
         m_resolutionTDC=10 * dd4hep::picosecond;//{this, "resolutionTDC", 10 * ps};
 
         // zero suppression values
-        m_thresholdFactor=5.0;//{this, "thresholdFactor", 0.0};
-        m_thresholdValue=3.0;//{this, "thresholdValue", 0.0};
+        m_thresholdFactor=4.0;//{this, "thresholdFactor", 0.0};
+        m_thresholdValue=0.0;//{this, "thresholdValue", 0.0};
 
         // energy correction with sampling fraction
-        m_sampFrac=0.025;//{this, "samplingFraction", 1.0};
+        m_sampFrac=1;//0.033;//{this, "samplingFraction", 1.0};
 
         // geometry service to get ids, ignored if no names provided
         m_geoSvcName="geoServiceName";

--- a/src/detectors/HCAL/Cluster_factory_HcalEndcapPClusters.h
+++ b/src/detectors/HCAL/Cluster_factory_HcalEndcapPClusters.h
@@ -11,17 +11,20 @@
 #include <algorithms/calorimetry/CalorimeterClusterRecoCoG.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
-
-
 // Dummy factory for JFactoryGeneratorT
 class Association_factory_HcalEndcapPClusterAssociations : public JFactoryT<edm4eic::MCRecoClusterParticleAssociation> {
 
 public:
-    //------------------------------------------
-    // Constructor
-    Association_factory_HcalEndcapPClusterAssociations(){
-        SetTag("HcalEndcapPClusterAssociations");
-    }
+  //------------------------------------------
+  // Constructor
+  Association_factory_HcalEndcapPClusterAssociations(){
+    SetTag("HcalEndcapPClusterAssociations");
+  }
+
+  // advice from N. Brei to make sure the clusters have been created when this factory is invoked
+  void Process(const std::shared_ptr<const JEvent> &event) override {
+    event->Get<edm4eic::Cluster>("HcalEndcapPClusters");
+  }
 };
 
 

--- a/src/detectors/HCAL/Cluster_factory_HcalEndcapPClusters.h
+++ b/src/detectors/HCAL/Cluster_factory_HcalEndcapPClusters.h
@@ -43,7 +43,7 @@ public:
         m_input_simhit_tag="HcalEndcapPHits";
         m_input_protoclust_tag="HcalEndcapPIslandProtoClusters";
 
-        m_sampFrac=0.025;// https://eicweb.phy.anl.gov/EIC/juggler/-/blob/bf366a35b480cda6c610b0dd6a4d4efcfd9a8e03/JugReco/src/components/ClusterRecoCoG.cpp
+        m_sampFrac=0.033;// https://eicweb.phy.anl.gov/EIC/juggler/-/blob/bf366a35b480cda6c610b0dd6a4d4efcfd9a8e03/JugReco/src/components/ClusterRecoCoG.cpp
         m_logWeightBase=6.2;// from ATHENA's reconstruction.py
         m_depthCorrection=0.0;// https://eicweb.phy.anl.gov/EIC/juggler/-/blob/bf366a35b480cda6c610b0dd6a4d4efcfd9a8e03/JugReco/src/components/ClusterRecoCoG.cpp
         m_energyWeight="log";// https://eicweb.phy.anl.gov/EIC/juggler/-/blob/bf366a35b480cda6c610b0dd6a4d4efcfd9a8e03/JugReco/src/components/ClusterRecoCoG.cpp

--- a/src/detectors/HCAL/Cluster_factory_HcalEndcapPMergedClusters.h
+++ b/src/detectors/HCAL/Cluster_factory_HcalEndcapPMergedClusters.h
@@ -23,6 +23,11 @@ public:
     Association_factory_HcalEndcapPMergedClusterAssociations(){
         SetTag("HcalEndcapPMergedClusterAssociations");
     }
+
+    void Process(const std::shared_ptr<const JEvent> &event) override {
+      event->Get<edm4eic::Cluster>("HcalEndcapPMergedClusters");
+    }
+
 };
 
 

--- a/src/detectors/HCAL/Cluster_factory_HcalEndcapPTruthClusters.h
+++ b/src/detectors/HCAL/Cluster_factory_HcalEndcapPTruthClusters.h
@@ -21,6 +21,12 @@ public:
     Association_factory_HcalEndcapPTruthClusterAssociations(){
         SetTag("HcalEndcapPTruthClusterAssociations");
     }
+
+    // advice from N. Brei to make sure the truth clusters have been created when this factory is invoked
+  void Process(const std::shared_ptr<const JEvent> &event) override {
+    event->Get<edm4eic::Cluster>("HcalEndcapPTruthClusters");
+  }
+  
 };
 
 class Cluster_factory_HcalEndcapPTruthClusters : public JFactoryT<edm4eic::Cluster>, CalorimeterClusterRecoCoG {

--- a/src/detectors/HCAL/Cluster_factory_HcalEndcapPTruthClusters.h
+++ b/src/detectors/HCAL/Cluster_factory_HcalEndcapPTruthClusters.h
@@ -26,7 +26,7 @@ public:
   void Process(const std::shared_ptr<const JEvent> &event) override {
     event->Get<edm4eic::Cluster>("HcalEndcapPTruthClusters");
   }
-  
+
 };
 
 class Cluster_factory_HcalEndcapPTruthClusters : public JFactoryT<edm4eic::Cluster>, CalorimeterClusterRecoCoG {

--- a/src/detectors/HCAL/RawCalorimeterHit_factory_HcalEndcapPRawHits.h
+++ b/src/detectors/HCAL/RawCalorimeterHit_factory_HcalEndcapPRawHits.h
@@ -37,11 +37,11 @@ public:
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
         m_input_tag = "HcalEndcapPHits";
         u_eRes = {};
-        m_tRes = 0.0 * dd4hep::ns;
-        m_capADC = 1024;
-        m_dyRangeADC = 3.6 * dd4hep::GeV ;
-        m_pedMeanADC = 20;
-        m_pedSigmaADC = 0.8;
+        m_tRes = 0.001 * dd4hep::ns;
+        m_capADC = 4096;
+        m_dyRangeADC = 50 * dd4hep::MeV;
+        m_pedMeanADC = 200  ;
+        m_pedSigmaADC = 3.2 ;
         m_resolutionTDC = 10 * dd4hep::picosecond;
         m_corrMeanScale = 1.0;
         u_fields={};


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR addresses issues encountered while trying to understand the EICrecon truth associations
- The units in the calo digi/reco algorithms were inconsistent with the specific HcalEndcapP 
- The dummy algorithms in the src/detectors/HCAL which nominally output the associations were giving empty containers - this needed a dummy request for the parent clusters, as per Nathan's suggestion.  Presumably other detectors will need a similar call, but i haven't tested.
- Finally, the association objects being formed in src/algorithms/calorimetry were inducing segvios when reading back the podio files, presumably since the persistent reference was a nonsense pointer.  At nathan's further suggestion, i removed the "setRec" to at least make the files readable, at the cost of having essentially no meaningful association info in the association objects.  Next I will have a look at #578 

### What kind of change does this PR introduce?
- [X] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [X] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

None - it fixes functionality that was already nominally in place

### Does this PR change default behavior?

It does provide associations that didn't work at all before, but they are still incomplete.