### PR TITLE
Updated a calculation in seeder configuration to ACTS units

### DIFF
--- a/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
+++ b/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
@@ -81,10 +81,10 @@ namespace eicrecon {
 	m_seedFinderConfig.highland / m_seedFinderConfig.minPt;
       m_seedFinderConfig.maxScatteringAngle2 =
 	maxScatteringAngle * maxScatteringAngle;
-      // helix radius in homogeneous magnetic field. Units are Kilotesla, MeV and
-      // millimeter
-      m_seedFinderConfig.pTPerHelixRadius =
-	300. * m_seedFinderConfig.bFieldInZ;
+
+      // Helix radius in homogeneous magnetic field
+      // in ACTS Units are GeV, mm, and GeV/(e*mm)
+      m_seedFinderConfig.pTPerHelixRadius = m_seedFinderConfig.bFieldInZ;
       m_seedFinderConfig.minHelixDiameter2 =
 	std::pow(m_seedFinderConfig.minPt * 2 /
 		 m_seedFinderConfig.pTPerHelixRadius,


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR modifies the calculation of the transverse momentum per unit radius so that it is now in ACTS units. The original equation seems to have been copied from here:

https://github.com/acts-project/acts/blob/main/Core/include/Acts/Seeding/SeedFinderConfig.hpp#L258

It is mentioned there that the calculation should be updated to ACTS units.

In any event, this change seems to have a negligible effect on the output of the seed finder.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No
