### PR TITLE
feat: output raw hits and associations from `PhotomultiplierHitDigi`

### DIFF
--- a/src/algorithms/digi/PhotoMultiplierHitDigi.cc
+++ b/src/algorithms/digi/PhotoMultiplierHitDigi.cc
@@ -177,7 +177,7 @@ eicrecon::PhotoMultiplierHitDigiResult eicrecon::PhotoMultiplierHitDigi::Algorit
                   hit_assoc.addToSimHits(sim_hits->at(i));
             }
         }
-        return std::move(result);
+        return result;
 }
 
 void  eicrecon::PhotoMultiplierHitDigi::qe_init()

--- a/src/algorithms/digi/PhotoMultiplierHitDigi.cc
+++ b/src/algorithms/digi/PhotoMultiplierHitDigi.cc
@@ -64,8 +64,8 @@ void eicrecon::PhotoMultiplierHitDigi::AlgorithmChangeRun() {
 //------------------------
 // AlgorithmProcess
 //------------------------
-std::vector<edm4eic::MCRecoTrackerHitAssociation*> eicrecon::PhotoMultiplierHitDigi::AlgorithmProcess(
-    const std::vector<const edm4hep::SimTrackerHit*>& sim_hits
+eicrecon::PhotoMultiplierHitDigiResult eicrecon::PhotoMultiplierHitDigi::AlgorithmProcess(
+    const edm4hep::SimTrackerHitCollection* sim_hits
     )
 {
         m_log->trace("{:=^70}"," call PhotoMultiplierHitDigi::AlgorithmProcess ");
@@ -74,36 +74,41 @@ std::vector<edm4eic::MCRecoTrackerHitAssociation*> eicrecon::PhotoMultiplierHitD
           double signal;
           decltype(edm4hep::SimTrackerHitData::time) time;
           dd4hep::Position pos;
-          std::vector<const edm4hep::SimTrackerHit*> mc_hits;
+          std::vector<size_t> sim_hit_indices;
         };
         std::unordered_map<decltype(edm4eic::RawTrackerHitData::cellID), std::vector<HitData>> hit_groups;
         // collect the photon hit in the same cell
         // calculate signal
-        for(const auto& ahit : sim_hits) {
-            auto edep_eV = ahit->getEDep() * 1e9; // [GeV] -> [eV] // FIXME: use common unit converters, when available
-            auto id      = ahit->getCellID();
+        for(size_t sim_hit_index = 0; sim_hit_index < sim_hits->size(); sim_hit_index++) {
+            const auto& sim_hit = sim_hits->at(sim_hit_index);
+            auto edep_eV = sim_hit.getEDep() * 1e9; // [GeV] -> [eV] // FIXME: use common unit converters, when available
+            auto id      = sim_hit.getCellID();
             m_log->trace("hit: pixel id={:#X}  edep = {} eV", id, edep_eV);
 
             // overall safety factor
             if (m_rngUni() > m_cfg.safetyFactor) continue;
+            m_log->critical("debug 1");
 
             // quantum efficiency
             if (!qe_pass(edep_eV, m_rngUni())) continue;
+            m_log->critical("debug 2");
 
             // pixel gap cuts
             // FIXME: generalize; this assumes the segmentation is `CartesianGridXY`
             dd4hep::Position pos_pixel, pos_hit;
             if(m_cfg.enablePixelGaps) {
               pos_pixel = get_sensor_local_position( id, m_cellid_converter->position(id) );
-              pos_hit   = get_sensor_local_position( id, vec2pos(ahit->getPosition())     );
+              pos_hit   = get_sensor_local_position( id, vec2pos(sim_hit.getPosition())     );
               if( std::abs( pos_hit.x()/dd4hep::mm - pos_pixel.x()/dd4hep::mm ) > m_cfg.pixelSize/2 ||
                   std::abs( pos_hit.y()/dd4hep::mm - pos_pixel.y()/dd4hep::mm ) > m_cfg.pixelSize/2
                 ) continue;
             }
+            m_log->critical("debug 3");
 
             // cell time, signal amplitude, truth photon
-            auto   time = ahit->getTime();
+            auto   time = sim_hit.getTime();
             double amp  = m_cfg.speMean + m_rngNorm() * m_cfg.speError;
+            m_log->critical("debug 4");
 
             // group hits
             auto it = hit_groups.find(id);
@@ -111,45 +116,57 @@ std::vector<edm4eic::MCRecoTrackerHitAssociation*> eicrecon::PhotoMultiplierHitD
                 size_t i = 0;
                 for (auto ghit = it->second.begin(); ghit != it->second.end(); ++ghit, ++i) {
                     if (std::abs(time - ghit->time) <= (m_cfg.hitTimeWindow)) {
-                        // hit group found, update npe, signal, and list of mc_hits
+                        // hit group found, update npe, signal, and list of sim_hit_indices
+                        m_log->critical("debug 7");
                         ghit->npe += 1;
                         ghit->signal += amp;
-                        ghit->mc_hits.push_back(ahit);
+                        ghit->sim_hit_indices.push_back(sim_hit_index);
                         m_log->trace(" -> add to group @ {:#X}: signal={}", id, ghit->signal);
                         break;
                     }
                 }
                 // no hits group found
                 if (i >= it->second.size()) {
+                    m_log->critical("debug 6");
                     auto sig = amp + m_cfg.pedMean + m_cfg.pedError * m_rngNorm();
-                    it->second.emplace_back(HitData{1, sig, time, pos_hit, {ahit}});
+                    it->second.push_back(HitData{1, sig, time, pos_hit, {sim_hit_index}});
                     m_log->trace(" -> no group found,");
                     m_log->trace("    so new group @ {:#X}: signal={}", id, sig);
                 }
             } else {
+                m_log->critical("debug 5");
                 auto sig = amp + m_cfg.pedMean + m_cfg.pedError * m_rngNorm();
-                hit_groups[id] = {HitData{1, sig, time, pos_hit, {ahit}}};
+                m_log->critical("debug 5.1");
+                m_log->critical("  amp={}", amp);
+                m_log->critical("  pos={} {} {}", pos_hit.x(), pos_hit.y(), pos_hit.z());
+                it->second.push_back(HitData{1, sig, time, pos_hit, {sim_hit_index}});
+                m_log->critical("debug 5.2");
                 m_log->trace(" -> new group @ {:#X}: signal={}", id, sig);
             }
         }
 
         // print `hit_groups`
+        m_log->critical("debug 8");
         if(m_log->level() <= spdlog::level::trace) {
           for(auto &[id,hitVec] : hit_groups)
             for(auto &hit : hitVec) {
               m_log->trace("hit_group: pixel id={:#X} -> npe={} signal={} time={}", id, hit.npe, hit.signal, hit.time);
-              for(auto &mc_hit : hit.mc_hits)
-                m_log->trace("           - photon: EDep = {}", mc_hit->getEDep());
+              for(auto i : hit.sim_hit_indices)
+                m_log->trace("           - photon: EDep = {}", sim_hits->at(i).getEDep());
             }
         }
 
         // build output `MCRecoTrackerHitAssociation`
-        std::vector<edm4eic::MCRecoTrackerHitAssociation*> hit_assocs;
+        m_log->critical("debug 9");
+        PhotoMultiplierHitDigiResult result;
+        result.raw_hits   = std::make_unique<edm4eic::RawTrackerHitCollection>();
+        result.hit_assocs = std::make_unique<edm4eic::MCRecoTrackerHitAssociationCollection>();
         for (auto &it : hit_groups) {
             for (auto &data : it.second) {
 
                 // build `RawTrackerHit`
-                edm4eic::MutableRawTrackerHit raw_hit;
+                m_log->critical("debug 10");
+                auto raw_hit = result.raw_hits->create();
                 raw_hit.setCellID(it.first);
                 raw_hit.setCharge(    static_cast<decltype(edm4eic::RawTrackerHitData::charge)>    (data.signal)                    );
                 raw_hit.setTimeStamp( static_cast<decltype(edm4eic::RawTrackerHitData::timeStamp)> (data.time/m_cfg.timeResolution) );
@@ -162,15 +179,15 @@ std::vector<edm4eic::MCRecoTrackerHitAssociation*> eicrecon::PhotoMultiplierHitD
                     );
 
                 // build `MCRecoTrackerHitAssociation`
-                edm4eic::MutableMCRecoTrackerHitAssociation hit_assoc;
+                m_log->critical("debug 11");
+                auto hit_assoc = result.hit_assocs->create();
                 hit_assoc.setWeight(1.0); // not used
                 hit_assoc.setRawHit(raw_hit);
-                for(auto &mc_hit : data.mc_hits)
-                  hit_assoc.addToSimHits(*mc_hit);
-                hit_assocs.push_back(new edm4eic::MCRecoTrackerHitAssociation(hit_assoc)); // force immutable
+                for(auto i : data.sim_hit_indices)
+                  hit_assoc.addToSimHits(sim_hits->at(i));
             }
         }
-        return hit_assocs;
+        return std::move(result);
 }
 
 void  eicrecon::PhotoMultiplierHitDigi::qe_init()

--- a/src/algorithms/digi/PhotoMultiplierHitDigi.h
+++ b/src/algorithms/digi/PhotoMultiplierHitDigi.h
@@ -28,6 +28,11 @@
 
 namespace eicrecon {
 
+struct PhotoMultiplierHitDigiResult {
+  std::unique_ptr<edm4eic::RawTrackerHitCollection> raw_hits;
+  std::unique_ptr<edm4eic::MCRecoTrackerHitAssociationCollection> hit_assocs;
+};
+
 class PhotoMultiplierHitDigi : public WithPodConfig<PhotoMultiplierHitDigiConfig> {
 
 public:
@@ -35,8 +40,8 @@ public:
     ~PhotoMultiplierHitDigi(){}
     void AlgorithmInit(dd4hep::Detector *detector, std::shared_ptr<spdlog::logger>& logger);
     void AlgorithmChangeRun();
-    std::vector<edm4eic::MCRecoTrackerHitAssociation*> AlgorithmProcess(
-        const std::vector<const edm4hep::SimTrackerHit*>& sim_hits
+    PhotoMultiplierHitDigiResult AlgorithmProcess(
+        const edm4hep::SimTrackerHitCollection* sim_hits
         );
 
     // transform global position `pos` to sensor `id` frame position

--- a/src/detectors/DRICH/DRICH.cc
+++ b/src/detectors/DRICH/DRICH.cc
@@ -6,6 +6,7 @@
 #include <JANA/JApplication.h>
 #include <JANA/JFactoryGenerator.h>
 #include <extensions/jana/JChainFactoryGeneratorT.h>
+#include <extensions/jana/JChainMultifactoryGeneratorT.h>
 
 // factories
 #include <global/digi/PhotoMultiplierHitDigi_factory.h>
@@ -58,10 +59,12 @@ extern "C" {
     // clang-format off
 
     // digitization
-    app->Add(new JChainFactoryGeneratorT<PhotoMultiplierHitDigi_factory>(
+    app->Add(new JChainMultifactoryGeneratorT<PhotoMultiplierHitDigi_factory>(
+          "DRICHRawHits",
           {"DRICHHits"},
-          "DRICHRawHitsAssociations",
-          digi_cfg
+          {"DRICHRawHits", "DRICHRawHitsAssociations"},
+          digi_cfg,
+          app
           ));
 
     // charged particle tracks

--- a/src/detectors/DRICH/DRICH.cc
+++ b/src/detectors/DRICH/DRICH.cc
@@ -10,7 +10,6 @@
 // factories
 #include <global/digi/PhotoMultiplierHitDigi_factory.h>
 #include <global/pid/RichTrack_factory.h>
-// #include <global/pid/IrtParticleID_factory.h>
 
 // algorithm configurations
 #include <algorithms/digi/PhotoMultiplierHitDigiConfig.h>
@@ -22,7 +21,9 @@ extern "C" {
 
     using namespace eicrecon;
 
-    // Digitization
+    // configuration parameters ///////////////////////////////////////////////
+
+    // digitization
     PhotoMultiplierHitDigiConfig digi_cfg;
     digi_cfg.seed            = 5; // FIXME: set to 0 for a 'unique' seed, but
                                   // that seems to delay the RNG from actually randomizing
@@ -51,18 +52,28 @@ extern "C" {
     digi_cfg.quantumEfficiency.push_back({800, 0.08});
     digi_cfg.quantumEfficiency.push_back({850, 0.06});
     digi_cfg.quantumEfficiency.push_back({900, 0.04});
-    app->Add(new JChainFactoryGeneratorT<PhotoMultiplierHitDigi_factory>({"DRICHHits"}, "DRICHRawHitsAssociations", digi_cfg));
 
-    // Track Propagation to each radiator
-    // FIXME: algorithm configuration currently set in RichTrack factory; need to write independent RichTrack algorithm
-    app->Add(new JChainFactoryGeneratorT<RichTrack_factory>({"CentralCKFTrajectories"}, "DRICHAerogelTracks"));
-    app->Add(new JChainFactoryGeneratorT<RichTrack_factory>({"CentralCKFTrajectories"}, "DRICHGasTracks"));
 
-    /* TODO: transform PhotoElectrons to Cherenkov Particle Identification
-     * - Run the Indirect Ray Tracing (IRT) algorithm
-     * - Cherenkov angle measurement
-     * - PID hypotheses
-     */
-    // app->Add(new JFactoryGeneratorT<IrtParticleID_factory>());
+    // wiring between factories and data ///////////////////////////////////////
+    // clang-format off
+
+    // digitization
+    app->Add(new JChainFactoryGeneratorT<PhotoMultiplierHitDigi_factory>(
+          {"DRICHHits"},
+          "DRICHRawHitsAssociations",
+          digi_cfg
+          ));
+
+    // charged particle tracks
+    app->Add(new JChainFactoryGeneratorT<RichTrack_factory>(
+          {"CentralCKFTrajectories"},
+          "DRICHAerogelTracks"
+          ));
+    app->Add(new JChainFactoryGeneratorT<RichTrack_factory>(
+          {"CentralCKFTrajectories"},
+          "DRICHGasTracks"
+          ));
+
+    // clang-format on
   }
 }

--- a/src/global/digi/PhotoMultiplierHitDigi_factory.h
+++ b/src/global/digi/PhotoMultiplierHitDigi_factory.h
@@ -4,11 +4,12 @@
 #pragma once
 
 // JANA
-#include <extensions/jana/JChainFactoryT.h>
+#include <extensions/jana/JChainMultifactoryT.h>
 #include <JANA/JEvent.h>
 
 // data model
 #include <edm4hep/SimTrackerHit.h>
+#include <edm4eic/RawTrackerHit.h>
 #include <edm4eic/MCRecoTrackerHitAssociation.h>
 
 // algorithms
@@ -27,26 +28,33 @@ namespace eicrecon {
     class PhotoMultiplierHitDigi;
 
     class PhotoMultiplierHitDigi_factory :
-            public JChainFactoryT<edm4eic::MCRecoTrackerHitAssociation, PhotoMultiplierHitDigiConfig>,
+            public JChainMultifactoryT<PhotoMultiplierHitDigiConfig>,
             public SpdlogMixin<PhotoMultiplierHitDigi_factory> {
 
     public:
 
-        explicit PhotoMultiplierHitDigi_factory(std::vector<std::string> default_input_tags, PhotoMultiplierHitDigiConfig cfg) :
-            JChainFactoryT<edm4eic::MCRecoTrackerHitAssociation, PhotoMultiplierHitDigiConfig>(std::move(default_input_tags), cfg) {}
+        explicit PhotoMultiplierHitDigi_factory(
+            std::string tag,
+            const std::vector<std::string>& input_tags,
+            const std::vector<std::string>& output_tags,
+            PhotoMultiplierHitDigiConfig cfg
+            ):
+          JChainMultifactoryT<PhotoMultiplierHitDigiConfig>(std::move(tag), input_tags, output_tags, cfg) {
+            DeclarePodioOutput<edm4eic::RawTrackerHit>(GetOutputTags()[0]);
+            DeclarePodioOutput<edm4eic::MCRecoTrackerHitAssociation>(GetOutputTags()[1]);
+          }
 
         /** One time initialization **/
         void Init() override;
 
         /** On run change preparations **/
-        void ChangeRun(const std::shared_ptr<const JEvent> &event) override;
+        void BeginRun(const std::shared_ptr<const JEvent> &event) override;
 
         /** Event by event processing **/
         void Process(const std::shared_ptr<const JEvent> &event) override;
 
     private:
 
-        std::string                      m_plugin_name;
         eicrecon::PhotoMultiplierHitDigi m_digi_algo;       /// Actual digitisation algorithm
     };
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?

**NOTE**: This PR targets the branch associated with https://github.com/eic/EICrecon/pull/599, and therefore adds on to it.

- output both the raw hits and associations, using the new `JMultifactory` feature
  - new `struct PhotoMultiplierHitDigiResult` is used as the return value of `AlgorithmProcess` (rather than a `std::pair`, for better flexibility and readability)
- switch from `std::vector`s of raw pointers to PODIO collections
- unrelated: style changes to `DRICH.cc` to be more consistent with #393 (we are factorizing that giant PR into smaller PRs, and these changes will make this process a bit easier)

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no

### Does this PR change default behavior?
no