### PR TITLE
feat: `auto` podio::getTypeName for both string/string_view support

### DIFF
--- a/src/services/io/podio/JEventSourcePODIO.cc
+++ b/src/services/io/podio/JEventSourcePODIO.cc
@@ -277,10 +277,10 @@ void JEventSourcePODIO::PrintCollectionTypeTable(void) {
     // Record the maximum length of both strings so that we can print nicely aligned columns.
     for (const std::string& name : frame->getAvailableCollections()) {
         const podio::CollectionBase* coll = frame->get(name);
-        const std::string& type = coll->getTypeName();
+        const auto type = coll->getTypeName();
         max_name_len = std::max(max_name_len, name.length());
         max_type_len = std::max(max_type_len, type.length());
-        collectionNames[name] = type;
+        collectionNames[name] = std::string(type);
     }
 
     // Print table

--- a/src/services/io/podio/JEventSourcePODIOLegacy.cc
+++ b/src/services/io/podio/JEventSourcePODIOLegacy.cc
@@ -267,10 +267,10 @@ void JEventSourcePODIOLegacy::PrintCollectionTypeTable(void) {
     // Record the maximum length of both strings so that we can print nicely aligned columns.
     for (const std::string& name : frame->getAvailableCollections()) {
         const podio::CollectionBase* coll = frame->get(name);
-        const std::string& type = coll->getTypeName();
+        const auto type = coll->getTypeName();
         max_name_len = std::max(max_name_len, name.length());
         max_type_len = std::max(max_type_len, type.length());
-        collectionNames[name] = type;
+        collectionNames[name] = std::string(type);
     }
 
     // Print table

--- a/src/services/io/podio/make_datamodel_glue.py
+++ b/src/services/io/podio/make_datamodel_glue.py
@@ -112,7 +112,7 @@ with open('datamodel_glue.h', 'w') as f:
     f.write('\n')
     f.write('\ntemplate <typename Visitor> struct VisitPodioCollection {')
     f.write('\n    void operator()(Visitor& visitor, const podio::CollectionBase& collection) {')
-    f.write('\n        std::string podio_typename = collection.getTypeName();\n')
+    f.write('\n        auto podio_typename = collection.getTypeName();\n')
     f.write('\n'.join(visitor))
     f.write('\n        throw std::runtime_error("Unrecognized podio typename!");')
     f.write('\n    }')


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This adds the required `auto`s to support both current and future `podio::getTypeName` signatures. 

Ref: https://github.com/AIDASoft/podio/pull/402, https://github.com/AIDASoft/podio/pull/404

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.