### PR TITLE
Re-enable MatchClusters algorithm

### DIFF
--- a/docs/design/naming_conventions.md
+++ b/docs/design/naming_conventions.md
@@ -1,0 +1,30 @@
+
+# Naming conventions
+
+## Collection names
+
+- Should generally end with the type they contain.
+  Example: `EcalEndcapPClusters` contains type `edm4eic::Cluster`
+
+- If the type name is too long and unwieldy to be used as a suffix, it can be shortened, but should be done so consistently.
+  Example: `ReconstructedParticleAssociations` contains type `edm4eic::MCRecoParticleAssociation`
+
+- The prefix describes what the collection is used for. As these names become more specific, they should append to the _front_.
+
+- Collection names should be pluralized, but only at the very end.
+  Example: `EcalEndcapPClusterAssociations`, NOT `EcalEndcapPClustersAssociations`.
+  Note: `MatchClusters_factory` relies on the convention that all of its input collections names end in `Clusters` 
+    and have a corresponding `ClusterAssociations` collection.
+
+
+## Factory names
+
+- JFactoryT's and JFactoryPodioT's should follow the pattern `OutputTypeName_factory_CollectionName`.
+  Example: `Cluster_factory_EcalEndcapPClusters`
+ 
+- Multifactories, ChainFactories, and ChainMultifactories (where there are multiple output types, parameterized   
+  collection names, or both, respectively) should follow the pattern `AlgorithmName_factory`.
+  Example: `MatchClusters_factory`
+ 
+- If a Multifactory produces predominantly one collection (e.g. if the other output collections are just associations.
+  or debugging data), it is okay for them to follow the pattern `OutputTypeName_factory_CollectionName`.

--- a/docs/design/naming_conventions.md
+++ b/docs/design/naming_conventions.md
@@ -13,7 +13,7 @@
 
 - Collection names should be pluralized, but only at the very end.
   Example: `EcalEndcapPClusterAssociations`, NOT `EcalEndcapPClustersAssociations`.
-  Note: `MatchClusters_factory` relies on the convention that all of its input collections names end in `Clusters` 
+  Note: `MatchClusters_factory` relies on the convention that all of its input collections names end in `Clusters`
     and have a corresponding `ClusterAssociations` collection.
 
 
@@ -21,10 +21,10 @@
 
 - JFactoryT's and JFactoryPodioT's should follow the pattern `OutputTypeName_factory_CollectionName`.
   Example: `Cluster_factory_EcalEndcapPClusters`
- 
-- Multifactories, ChainFactories, and ChainMultifactories (where there are multiple output types, parameterized   
+
+- Multifactories, ChainFactories, and ChainMultifactories (where there are multiple output types, parameterized
   collection names, or both, respectively) should follow the pattern `AlgorithmName_factory`.
   Example: `MatchClusters_factory`
- 
+
 - If a Multifactory produces predominantly one collection (e.g. if the other output collections are just associations.
   or debugging data), it is okay for them to follow the pattern `OutputTypeName_factory_CollectionName`.

--- a/src/algorithms/reco/MatchClusters.cc
+++ b/src/algorithms/reco/MatchClusters.cc
@@ -35,8 +35,8 @@ namespace eicrecon {
 
     std::tuple<edm4eic::ReconstructedParticleCollection*, edm4eic::MCRecoParticleAssociationCollection*> MatchClusters::execute(
             std::vector<const edm4hep::MCParticle *> mcparticles,
-            std::vector<edm4eic::ReconstructedParticle *> inparts,
-            std::vector<edm4eic::MCRecoParticleAssociation *> inpartsassoc,
+            std::vector<const edm4eic::ReconstructedParticle *> inparts,
+            std::vector<const edm4eic::MCRecoParticleAssociation *> inpartsassoc,
             const std::vector<std::vector<const edm4eic::Cluster*>> &cluster_collections,
             const std::vector<std::vector<const edm4eic::MCRecoClusterParticleAssociation*>> &cluster_assoc_collections) {
 

--- a/src/algorithms/reco/MatchClusters.h
+++ b/src/algorithms/reco/MatchClusters.h
@@ -38,8 +38,8 @@ namespace eicrecon {
 
         MatchingResults execute(
             std::vector<const edm4hep::MCParticle *> mcparticles,
-            std::vector<edm4eic::ReconstructedParticle *> inparts,            // TODO fix const
-            std::vector<edm4eic::MCRecoParticleAssociation *> inpartsassoc,   // TODO fix const
+            std::vector<const edm4eic::ReconstructedParticle *> inparts,
+            std::vector<const edm4eic::MCRecoParticleAssociation *> inpartsassoc,
             const std::vector<std::vector<const edm4eic::Cluster*>> &cluster_collections,
             const std::vector<std::vector<const edm4eic::MCRecoClusterParticleAssociation*>> &cluster_assoc_collections);
 

--- a/src/detectors/FHCAL/Cluster_factory_LFHCALClusters.h
+++ b/src/detectors/FHCAL/Cluster_factory_LFHCALClusters.h
@@ -20,7 +20,7 @@ public:
     //------------------------------------------
     // Constructor
     Association_factory_LFHCALClustersAssociations(){
-        SetTag("LFHCALClustersAssociations");
+        SetTag("LFHCALClusterAssociations");
     }
 };
 

--- a/src/detectors/FHCAL/Cluster_factory_LFHCALTruthClusters.h
+++ b/src/detectors/FHCAL/Cluster_factory_LFHCALTruthClusters.h
@@ -19,7 +19,7 @@ public:
     //------------------------------------------
     // Constructor
     Association_factory_LFHCALTruthClustersAssociations(){
-        SetTag("LFHCALTruthClustersAssociations");
+        SetTag("LFHCALTruthClusterAssociations");
     }
 };
 

--- a/src/examples/track_matching/reco_particles_track_matching.cc
+++ b/src/examples/track_matching/reco_particles_track_matching.cc
@@ -28,8 +28,8 @@ void reco_particles_track_matching(const std::string &file_name) {
 
     // Next arrays correspond to particle associations
     // Each association has 2 ids - indexes in corresponding reco and MC arrays
-    TTreeReaderArray<unsigned int> rec_id = {tree_reader, "ReconstructedChargedParticlesAssociations.recID"};
-    TTreeReaderArray<unsigned int> sim_id = {tree_reader, "ReconstructedChargedParticlesAssociations.simID"};
+    TTreeReaderArray<unsigned int> rec_id = {tree_reader, "ReconstructedChargedParticleAssociations.recID"};
+    TTreeReaderArray<unsigned int> sim_id = {tree_reader, "ReconstructedChargedParticleAssociations.simID"};
 
 
     // Read 100 events

--- a/src/global/reco/MatchClusters_factory.cc
+++ b/src/global/reco/MatchClusters_factory.cc
@@ -30,8 +30,16 @@ namespace eicrecon {
 
         // Set up association tags
         for (const std::string& input_tag : GetInputTags()) {
-            // "EcalEndcapNClusters" => "EcalEndcapNClusterAssociations". Sadly we need to strip the 's' at the end
-            m_input_assoc_tags.push_back(input_tag.substr(0, input_tag.size()-1) + "Associations");
+            // "EcalEndcapNClusters" => "EcalEndcapNClusterAssociations"
+            auto pos = input_tag.find("Clusters");
+
+            // Validate that our input collection names conform to this convention
+            if (pos == std::string::npos) {
+                throw std::runtime_error(fmt::format("input_tag=\"{}\" doesn't end with \"Clusters\"", input_tag));
+            }
+            std::string output_tag = input_tag;
+            output_tag.replace(pos, 8, "ClusterAssociations");
+            m_input_assoc_tags.push_back(output_tag);
         }
     }
 

--- a/src/global/reco/MatchClusters_factory.cc
+++ b/src/global/reco/MatchClusters_factory.cc
@@ -52,8 +52,7 @@ namespace eicrecon {
         // TODO make input tags changable
         auto mc_particles = event->Get<edm4hep::MCParticle>("MCParticles");
         auto charged_particles = event->Get<edm4eic::ReconstructedParticle>("ReconstructedChargedParticles");
-        auto charged_particle_assocs = event->Get<edm4eic::MCRecoParticleAssociation>("ReconstructedChargedParticlesAssociations");
-        // TODO: NWB: Inconsistent plurals in collection names: "ReconstructedChargedParticlesAssociations" vs "EcalEndcapNClusterAssociations"
+        auto charged_particle_assocs = event->Get<edm4eic::MCRecoParticleAssociation>("ReconstructedChargedParticleAssociations");
 
         using ClustersVector = std::vector<const edm4eic::Cluster*>;
         using ClustersAssocVector = std::vector<const edm4eic::MCRecoClusterParticleAssociation*>;

--- a/src/global/reco/MatchClusters_factory.cc
+++ b/src/global/reco/MatchClusters_factory.cc
@@ -27,6 +27,12 @@ namespace eicrecon {
         InitLogger(GetPrefix(), "info");
 
         m_match_algo.init(m_log);
+
+        // Set up association tags
+        for (const std::string& input_tag : GetInputTags()) {
+            // "EcalEndcapNClusters" => "EcalEndcapNClusterAssociations". Sadly we need to strip the 's' at the end
+            m_input_assoc_tags.push_back(input_tag.substr(0, input_tag.size()-1) + "Associations");
+        }
     }
 
     void MatchClusters_factory::BeginRun(const std::shared_ptr<const JEvent> &event) {
@@ -34,70 +40,48 @@ namespace eicrecon {
     }
 
     void MatchClusters_factory::Process(const std::shared_ptr<const JEvent> &event) {
-        using ClustersVector = std::vector<const edm4eic::Cluster*>;
-        using ClustersAssocVector = std::vector<const edm4eic::MCRecoClusterParticleAssociation*>;
-
-        m_log->debug("------- Process start -------");
 
         // TODO make input tags changable
         auto mc_particles = event->Get<edm4hep::MCParticle>("MCParticles");
+        auto charged_particles = event->Get<edm4eic::ReconstructedParticle>("ReconstructedChargedParticles");
+        auto charged_particle_assocs = event->Get<edm4eic::MCRecoParticleAssociation>("ReconstructedChargedParticlesAssociations");
+        // TODO: NWB: Inconsistent plurals in collection names: "ReconstructedChargedParticlesAssociations" vs "EcalEndcapNClusterAssociations"
 
-        auto charged_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase("ReconstructedChargedParticles"));
-        auto charged_particle_assocs = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase("ReconstructedChargedParticlesAssociations"));
-        // TODO: NWB: Switch to GetCollection<T> once JANA v2.1.1 is in
+        using ClustersVector = std::vector<const edm4eic::Cluster*>;
+        using ClustersAssocVector = std::vector<const edm4eic::MCRecoClusterParticleAssociation*>;
 
-        // TODO: NWB: tracking_data is going away. Also it is redundant with charged_particles, charged_particle_assocs.
-        // auto tracking_data = event->GetSingle<eicrecon::ParticlesWithAssociation>("ChargedParticlesWithAssociations");
         std::vector<ClustersVector> input_cluster_vectors;//{"OutputClusters", Gaudi::DataHandle::Writer, this};
         std::vector<ClustersAssocVector> input_cluster_assoc;//{"OutputAssociations", Gaudi::DataHandle::Writer, this};
 
         for(auto &input_tag: GetInputTags()) {
             auto clusters = event->Get<edm4eic::Cluster>(input_tag);
             input_cluster_vectors.push_back(clusters);
-//            m_log->debug("Clusters '{}' len: {}", input_tag,  clusters.size());
-//            for(auto cluster: clusters) {
-//                m_log->debug("  {} {}", cluster->getObjectID().collectionID, cluster->getEnergy());
-//            }
+
+            m_log->debug("Clusters '{}' len: {}", input_tag,  clusters.size());
+            for(auto cluster: clusters) {
+                m_log->debug("  {} {}", cluster->getObjectID().collectionID, cluster->getEnergy());
+            }
         }
 
         for(auto &input_tag: m_input_assoc_tags) {
             auto assocs = event->Get<edm4eic::MCRecoClusterParticleAssociation>(input_tag);
             input_cluster_assoc.push_back(assocs);
 
-//            m_log->debug("Associations '{}' len: {}", input_tag, assocs.size());
-//            for(auto assoc: assocs) {
-//                m_log->debug("  {} {} {} {}", assoc->getRecID(), assoc->getSimID(), assoc->getRec().getEnergy(), assoc->getSim().getEnergy());
-//            }
+            m_log->debug("Associations '{}' len: {}", input_tag, assocs.size());
+            for(auto assoc: assocs) {
+                m_log->debug("  {} {} {} {}", assoc->getRecID(), assoc->getSimID(), assoc->getRec().getEnergy(), assoc->getSim().getEnergy());
+            }
         }
 
 
+        auto [matched_particles, matched_assocs] = m_match_algo.execute(mc_particles,
+                                                                              charged_particles,
+                                                                              charged_particle_assocs,
+                                                                              input_cluster_vectors,
+                                                                              input_cluster_assoc);
 
+        SetCollection<edm4eic::ReconstructedParticle>(GetOutputTags()[0], std::unique_ptr<edm4eic::ReconstructedParticleCollection>(matched_particles));
+        SetCollection<edm4eic::MCRecoParticleAssociation>(GetOutputTags()[1], std::unique_ptr<edm4eic::MCRecoParticleAssociationCollection>(matched_assocs));
 
-//        auto result = m_match_algo.execute(mc_particles,
-//                                           charged_particles,
-//                                           charged_particle_assocs,
-//                                           input_cluster_vectors,
-//                                           input_cluster_assoc);
-
-        //std::vector<edm4eic::ReconstructedParticle*> result;
-//        for(size_t i=0; i < tracking_data->particles()->size(); i++) {
-//            auto particle = (*tracking_data->particles())[i];
-//            result.push_back(new edm4eic::ReconstructedParticle(particle));
-//        }
-
-        edm4eic::ReconstructedParticleCollection reconstructed_particles;
-        reconstructed_particles.setSubsetCollection(true);
-        for (auto part : *charged_particles) {
-            reconstructed_particles.push_back(part);
-        }
-
-        edm4eic::MCRecoParticleAssociationCollection reconstructed_particle_assocs;
-        reconstructed_particle_assocs.setSubsetCollection(true);
-        for (auto assoc : *charged_particle_assocs) {
-            reconstructed_particle_assocs.push_back(assoc);
-        }
-
-        SetCollection<edm4eic::ReconstructedParticle>(GetOutputTags()[0], std::move(reconstructed_particles));
-        SetCollection<edm4eic::MCRecoParticleAssociation>(GetOutputTags()[1], std::move(reconstructed_particle_assocs));
     }
 } // eicrecon

--- a/src/global/reco/MatchClusters_factory.h
+++ b/src/global/reco/MatchClusters_factory.h
@@ -24,9 +24,8 @@ namespace eicrecon {
                                        const std::vector<std::string>& output_tags):
                 JChainMultifactoryT<NoConfig>(std::move(tag), input_tags, output_tags) {
 
-            // TODO: NWB: object ownership is set to false because right now we populate the collections without doing any matching
-            DeclarePodioOutput<edm4eic::ReconstructedParticle>(GetOutputTags()[0], false);
-            DeclarePodioOutput<edm4eic::MCRecoParticleAssociation>(GetOutputTags()[1], false);
+            DeclarePodioOutput<edm4eic::ReconstructedParticle>(GetOutputTags()[0]);
+            DeclarePodioOutput<edm4eic::MCRecoParticleAssociation>(GetOutputTags()[1]);
         }
 
         /** One time initialization **/

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -43,9 +43,6 @@ void InitPlugin(JApplication *app) {
         },
         app
     ));
-    // TODO: NWB: "ReconstructedParticleAssociations" used input "ChargedParticlesWithAssociations" instead of
-    //            "ReconstructedParticlesWithAssoc", which I'm pretty sure was wrong, given the mermaid diagrams and
-    //            naming conventions. However, I want someone else to verify this.
 
 
     app->Add(new JChainFactoryGeneratorT<InclusiveKinematicsElectron_factory>(

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -68,7 +68,7 @@ void InitPlugin(JApplication *app) {
             {"MCParticles",                                    // edm4hep::MCParticle
             "outputTrackParameters"},                          // edm4eic::TrackParameters
             {"ReconstructedChargedParticles",                  //
-             "ReconstructedChargedParticlesAssociations"       // edm4eic::MCRecoParticleAssociation
+             "ReconstructedChargedParticleAssociations"       // edm4eic::MCRecoParticleAssociation
             },
             app  // TODO: Remove me once fixed
             ));

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -68,7 +68,7 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "GeneratedParticles",
             "ReconstructedParticles",
             "ReconstructedChargedParticles",
-            "ReconstructedChargedParticlesAssociations",
+            "ReconstructedChargedParticleAssociations",
             "CentralTrackSegments",
             "InclusiveKinematicsDA",
             "InclusiveKinematicsJB",

--- a/src/tests/tracking_test/TrackingTest_processor.cc
+++ b/src/tests/tracking_test/TrackingTest_processor.cc
@@ -132,7 +132,7 @@ void TrackingTest_processor::ProcessTrackingMatching(const std::shared_ptr<const
     // auto prt_with_assoc = event->GetSingle<edm4hep::ReconstructedParticle>("ChargedParticlesWithAssociations");
 
     auto particles = event->GetCollection<edm4eic::ReconstructedParticle>("ReconstructedChargedParticles");
-    auto associations = event->GetCollection<edm4eic::MCRecoParticleAssociation>("ReconstructedChargedParticlesAssociations");
+    auto associations = event->GetCollection<edm4eic::MCRecoParticleAssociation>("ReconstructedChargedParticleAssociations");
 
 
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Re-enables MatchClusters algorithm. 

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [x] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
**Yes**. Some collections have been renamed: 
- "ReconstructedChargedParticlesAssociations" => "ReconstructedChargedParticleAssociations"
- "LFHCALClustersAssociations" => "LFHCALClusterAssociations"
- "LFHCALTruthClustersAssociations" => "LFHCALTruthClusterAssociations"

### Does this PR change default behavior?
No