### PR TITLE
WIP: Calo clustering factories now use JMultifactory

### DIFF
--- a/src/detectors/B0ECAL/Cluster_factory_B0ECalClusters.h
+++ b/src/detectors/B0ECAL/Cluster_factory_B0ECalClusters.h
@@ -7,7 +7,7 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <JANA/JMultifactory.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterClusterRecoCoG.h>
 #include <services/log/Log_service.h>
@@ -15,20 +15,22 @@
 
 
 
-class Cluster_factory_B0ECalClusters : public eicrecon::JFactoryPodioT<edm4eic::Cluster>, CalorimeterClusterRecoCoG {
+class Cluster_factory_B0ECalClusters : public JMultifactory, CalorimeterClusterRecoCoG {
 
 public:
     //------------------------------------------
     // Constructor
     Cluster_factory_B0ECalClusters(){
-        SetTag("B0ECalClusters");
-        m_log = japp->GetService<Log_service>()->logger(GetTag());
+        DeclarePodioOutput<edm4eic::Cluster>("B0ECalClusters");
+        DeclarePodioOutput<edm4eic::MCRecoClusterParticleAssociation>("B0ECalClusterAssociations");
     }
 
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        auto app = japp; // GetApplication(); // TODO: NWB: FIXME after JANA2 v2.1.1
+        m_log = app->GetService<Log_service>()->logger("B0ECalClusters");
+
         //-------- Configuration Parameters ------------
         m_input_simhit_tag="B0ECalHits";
         m_input_protoclust_tag="B0ECalIslandProtoClusters";
@@ -59,14 +61,13 @@ public:
 
     //------------------------------------------
     // ChangeRun
-    void ChangeRun(const std::shared_ptr<const JEvent> &event) override{
+    void BeginRun(const std::shared_ptr<const JEvent> &event) override{
         AlgorithmChangeRun();
     }
 
     //------------------------------------------
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
-
 
         // Prefill inputs
         m_inputSimhits=event->Get<edm4hep::SimCalorimeterHit>(m_input_simhit_tag);
@@ -75,12 +76,10 @@ public:
         // Call Process for generic algorithm
         AlgorithmProcess();
 
-
-        //outputs
-
         // Hand owner of algorithm objects over to JANA
-        Set(m_outputClusters);
-        event->Insert(m_outputAssociations, "B0ECalClusterAssociations");
+        SetData("B0ECalClusters", m_outputClusters);
+        SetData("B0ECalClusterAssociations", m_outputAssociations);
+
         m_outputClusters.clear(); // not really needed, but better to not leave dangling pointers around
         m_outputAssociations.clear();
     }

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelImagingClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelImagingClusters.h
@@ -6,7 +6,7 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <JANA/JMultifactory.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/ImagingClusterReco.h>
 #include <services/log/Log_service.h>
@@ -14,7 +14,7 @@
 
 
 
-class Cluster_factory_EcalBarrelImagingClusters : public eicrecon::JFactoryPodioT<edm4eic::Cluster>, ImagingClusterReco {
+class Cluster_factory_EcalBarrelImagingClusters : public JMultifactory, ImagingClusterReco {
 
 public:
 
@@ -24,14 +24,17 @@ public:
     //------------------------------------------
     // Constructor
     Cluster_factory_EcalBarrelImagingClusters(){
-        SetTag("EcalBarrelImagingClusters");
-        m_log = japp->GetService<Log_service>()->logger(GetTag());
+        DeclarePodioOutput<edm4eic::Cluster>("EcalBarrelImagingClusters");
+        DeclarePodioOutput<edm4eic::MCRecoClusterParticleAssociation>("EcalBarrelImagingClusterAssociations");
+        DeclarePodioOutput<edm4eic::Cluster>("EcalBarrelImagingLayers");
     }
 
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        auto app = japp; // GetApplication(); // TODO: NWB: FIXME after JANA2 v2.1.1
+        m_log = app->GetService<Log_service>()->logger("EcalBarrelImagingClusters");
+
         //-------- Configuration Parameters ------------
         m_input_simhit_tag="EcalBarrelImagingHits";
         m_input_protoclust_tag="EcalBarrelImagingProtoClusters";
@@ -47,7 +50,6 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
 
-
         // Prefill inputs
         m_mcHits=event->Get<edm4hep::SimCalorimeterHit>(m_input_simhit_tag);
         m_inputProtoClusters=event->Get<edm4eic::ProtoCluster>(m_input_protoclust_tag);
@@ -56,9 +58,10 @@ public:
         execute();
 
         // Hand owner of algorithm objects over to JANA
-        Set(m_outputClusters);
-        event->Insert(m_outputAssociations, "EcalBarrelImagingClusterAssociations");
-        event->Insert(m_outputLayers, "EcalBarrelImagingLayers");
+        SetData("EcalBarrelImagingClusters", m_outputClusters);
+        SetData("EcalBarrelImagingClusterAssociations", m_outputAssociations);
+        SetData("EcalBarrelImagingLayers", m_outputLayers);
+
         m_outputClusters.clear(); // not really needed, but better to not leave dangling pointers around
         m_outputAssociations.clear();
         m_outputLayers.clear();

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelScFiClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelScFiClusters.h
@@ -6,7 +6,7 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <JANA/JMultifactory.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterClusterRecoCoG.h>
 #include <services/log/Log_service.h>
@@ -14,20 +14,22 @@
 
 
 
-class Cluster_factory_EcalBarrelScFiClusters : public eicrecon::JFactoryPodioT<edm4eic::Cluster>, CalorimeterClusterRecoCoG {
+class Cluster_factory_EcalBarrelScFiClusters : public JMultifactory, CalorimeterClusterRecoCoG {
 
 public:
     //------------------------------------------
     // Constructor
     Cluster_factory_EcalBarrelScFiClusters(){
-        SetTag("EcalBarrelScFiClusters");
-        m_log = japp->GetService<Log_service>()->logger(GetTag());
+        DeclarePodioOutput<edm4eic::Cluster>("EcalBarrelScFiClusters");
+        DeclarePodioOutput<edm4eic::MCRecoClusterParticleAssociation>("EcalBarrelScFiClusterAssociations");
     }
 
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        auto app = japp; // GetApplication(); // TODO: NWB: FIXME after JANA2 v2.1.1
+        m_log = app->GetService<Log_service>()->logger("EcalBarrelScFiClusters");
+
         //-------- Configuration Parameters ------------
         m_input_simhit_tag="EcalBarrelScFiHits";
         m_input_protoclust_tag="EcalBarrelScFiProtoClusters";
@@ -58,7 +60,7 @@ public:
 
     //------------------------------------------
     // ChangeRun
-    void ChangeRun(const std::shared_ptr<const JEvent> &event) override{
+    void BeginRun(const std::shared_ptr<const JEvent> &event) override{
         AlgorithmChangeRun();
     }
 
@@ -75,8 +77,9 @@ public:
         AlgorithmProcess();
 
         // Hand owner of algorithm objects over to JANA
-        Set(m_outputClusters);
-        event->Insert(m_outputAssociations, "EcalBarrelScFiClusterAssociations");
+        SetData("EcalBarrelScFiClusters", m_outputClusters);
+        SetData("EcalBarrelScFiClusterAssociations", m_outputAssociations);
+
         m_outputClusters.clear(); // not really needed, but better to not leave dangling pointers around
         m_outputAssociations.clear();
     }

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelSciGlassClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelSciGlassClusters.h
@@ -6,7 +6,7 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <JANA/JMultifactory.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterClusterRecoCoG.h>
 #include <services/log/Log_service.h>
@@ -14,20 +14,23 @@
 
 
 
-class Cluster_factory_EcalBarrelSciGlassClusters : public eicrecon::JFactoryPodioT<edm4eic::Cluster>, CalorimeterClusterRecoCoG {
+class Cluster_factory_EcalBarrelSciGlassClusters : public JMultifactory, CalorimeterClusterRecoCoG {
 
 public:
     //------------------------------------------
     // Constructor
     Cluster_factory_EcalBarrelSciGlassClusters(){
-        SetTag("EcalBarrelSciGlassClusters");
-        m_log = japp->GetService<Log_service>()->logger(GetTag());
+        DeclarePodioOutput<edm4eic::Cluster>("EcalBarrelSciGlassClusters");
+        DeclarePodioOutput<edm4eic::MCRecoClusterParticleAssociation>("EcalBarrelClusterAssociations");
+        // TODO: NWB: Collection naming convention not followed here
     }
 
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        auto app = japp; // GetApplication(); // TODO: NWB: FIXME after JANA2 v2.1.1
+        m_log = app->GetService<Log_service>()->logger("EcalBarrelSciGlassClusters");
+
         //-------- Configuration Parameters ------------
         m_input_simhit_tag="EcalBarrelSciGlassHits";
         m_input_protoclust_tag="EcalBarrelSciGlassProtoClusters";
@@ -60,14 +63,13 @@ public:
 
     //------------------------------------------
     // ChangeRun
-    void ChangeRun(const std::shared_ptr<const JEvent> &event) override{
+    void BeginRun(const std::shared_ptr<const JEvent> &event) override{
         AlgorithmChangeRun();
     }
 
     //------------------------------------------
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
-
 
         // Prefill inputs
         m_inputSimhits=event->Get<edm4hep::SimCalorimeterHit>(m_input_simhit_tag);
@@ -76,12 +78,10 @@ public:
         // Call Process for generic algorithm
         AlgorithmProcess();
 
-
-        //outputs
-
         // Hand owner of algorithm objects over to JANA
-        Set(m_outputClusters);
-        event->Insert(m_outputAssociations, "EcalBarrelClusterAssociations");
+        SetData("EcalBarrelSciGlassClusters", m_outputClusters);
+        SetData("EcalBarrelClusterAssociations", m_outputAssociations);
+
         m_outputClusters.clear(); // not really needed, but better to not leave dangling pointers around
         m_outputAssociations.clear();
     }

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelSciGlassTruthClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelSciGlassTruthClusters.h
@@ -5,7 +5,7 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <JANA/JMultifactory.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterClusterRecoCoG.h>
 #include <services/log/Log_service.h>
@@ -13,20 +13,22 @@
 
 
 
-class Cluster_factory_EcalBarrelSciGlassTruthClusters : public eicrecon::JFactoryPodioT<edm4eic::Cluster>, CalorimeterClusterRecoCoG {
+class Cluster_factory_EcalBarrelSciGlassTruthClusters : public JMultifactory, CalorimeterClusterRecoCoG {
 
 public:
     //------------------------------------------
     // Constructor
     Cluster_factory_EcalBarrelSciGlassTruthClusters(){
-        SetTag("EcalBarrelSciGlassTruthClusters");
-        m_log = japp->GetService<Log_service>()->logger(GetTag());
+        DeclarePodioOutput<edm4eic::Cluster>("EcalBarrelSciGlassTruthClusters");
+        DeclarePodioOutput<edm4eic::MCRecoClusterParticleAssociation>("EcalBarrelTruthClusterAssociations");
     }
 
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        auto app = japp; // GetApplication(); // TODO: NWB: FIXME after JANA2 v2.1.1
+        m_log = app->GetService<Log_service>()->logger("EcalBarrelSciGlassTruthClusters");
+
         //-------- Configuration Parameters ------------
         m_input_simhit_tag="EcalBarrelSciGlassHits";
         m_input_protoclust_tag="EcalBarrelSciGlassTruthProtoClusters";
@@ -57,7 +59,7 @@ public:
 
     //------------------------------------------
     // ChangeRun
-    void ChangeRun(const std::shared_ptr<const JEvent> &event) override{
+    void BeginRun(const std::shared_ptr<const JEvent> &event) override{
         AlgorithmChangeRun();
     }
 
@@ -73,12 +75,10 @@ public:
         // Call Process for generic algorithm
         AlgorithmProcess();
 
-
-        //outputs
-
         // Hand owner of algorithm objects over to JANA
-        Set(m_outputClusters);
-        event->Insert(m_outputAssociations, "EcalBarrelTruthClusterAssociations");
+        SetData("EcalBarrelSciGlassTruthClusters", m_outputClusters);
+        SetData("EcalBarrelTruthClusterAssociations", m_outputAssociations);
+
         m_outputClusters.clear(); // not really needed, but better to not leave dangling pointers around
         m_outputAssociations.clear();
     }

--- a/src/detectors/BHCAL/Cluster_factory_HcalBarrelClusters.h
+++ b/src/detectors/BHCAL/Cluster_factory_HcalBarrelClusters.h
@@ -6,7 +6,7 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <JANA/JMultifactory.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterClusterRecoCoG.h>
 #include <services/log/Log_service.h>
@@ -14,20 +14,22 @@
 
 
 
-class Cluster_factory_HcalBarrelClusters : public eicrecon::JFactoryPodioT<edm4eic::Cluster>, CalorimeterClusterRecoCoG {
+class Cluster_factory_HcalBarrelClusters : public JMultifactory, CalorimeterClusterRecoCoG {
 
 public:
     //------------------------------------------
     // Constructor
     Cluster_factory_HcalBarrelClusters(){
-        SetTag("HcalBarrelClusters");
-        m_log = japp->GetService<Log_service>()->logger(GetTag());
+        DeclarePodioOutput<edm4eic::Cluster>("HcalBarrelClusters");
+        DeclarePodioOutput<edm4eic::MCRecoClusterParticleAssociation>("HcalBarrelClusterAssociations");
     }
 
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        auto app = japp; // GetApplication(); // TODO: NWB: FIXME after JANA2 v2.1.1
+        m_log = app->GetService<Log_service>()->logger("HcalBarrelClusters");
+
         //-------- Configuration Parameters ------------
         m_input_simhit_tag="HcalBarrelHits";
         m_input_protoclust_tag="HcalBarrelIslandProtoClusters";
@@ -59,14 +61,13 @@ public:
 
     //------------------------------------------
     // ChangeRun
-    void ChangeRun(const std::shared_ptr<const JEvent> &event) override{
+    void BeginRun(const std::shared_ptr<const JEvent> &event) override{
         AlgorithmChangeRun();
     }
 
     //------------------------------------------
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
-
 
         // Prefill inputs
         m_inputSimhits=event->Get<edm4hep::SimCalorimeterHit>(m_input_simhit_tag);
@@ -76,11 +77,10 @@ public:
         AlgorithmProcess();
 
 
-        //outputs
-
         // Hand owner of algorithm objects over to JANA
-        Set(m_outputClusters);
-        event->Insert(m_outputAssociations, "HcalBarrelClusterAssociations");
+        SetData("HcalBarrelClusters", m_outputClusters);
+        SetData("HcalBarrelClusterAssociations", m_outputAssociations);
+
         m_outputClusters.clear(); // not really needed, but better to not leave dangling pointers around
         m_outputAssociations.clear();
     }

--- a/src/detectors/BHCAL/Cluster_factory_HcalBarrelTruthClusters.h
+++ b/src/detectors/BHCAL/Cluster_factory_HcalBarrelTruthClusters.h
@@ -5,7 +5,7 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <JANA/JMultifactory.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterClusterRecoCoG.h>
 #include <services/log/Log_service.h>
@@ -13,20 +13,22 @@
 
 
 
-class Cluster_factory_HcalBarrelTruthClusters : public eicrecon::JFactoryPodioT<edm4eic::Cluster>, CalorimeterClusterRecoCoG {
+class Cluster_factory_HcalBarrelTruthClusters : public JMultifactory, CalorimeterClusterRecoCoG {
 
 public:
     //------------------------------------------
     // Constructor
     Cluster_factory_HcalBarrelTruthClusters(){
-        SetTag("HcalBarrelTruthClusters");
-        m_log = japp->GetService<Log_service>()->logger(GetTag());
+        DeclarePodioOutput<edm4eic::Cluster>("HcalBarrelTruthClusters");
+        DeclarePodioOutput<edm4eic::MCRecoClusterParticleAssociation>("HcalBarrelTruthClusterAssociations");
     }
 
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        auto app = japp; // GetApplication(); // TODO: NWB: FIXME after JANA2 v2.1.1
+        m_log = app->GetService<Log_service>()->logger("HcalBarrelTruthClusters");
+
         //-------- Configuration Parameters ------------
         m_input_simhit_tag="HcalBarrelHits";
         m_input_protoclust_tag="HcalBarrelTruthProtoClusters";
@@ -58,14 +60,13 @@ public:
 
     //------------------------------------------
     // ChangeRun
-    void ChangeRun(const std::shared_ptr<const JEvent> &event) override{
+    void BeginRun(const std::shared_ptr<const JEvent> &event) override{
         AlgorithmChangeRun();
     }
 
     //------------------------------------------
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
-
 
         // Prefill inputs
         m_inputSimhits=event->Get<edm4hep::SimCalorimeterHit>(m_input_simhit_tag);
@@ -74,12 +75,10 @@ public:
         // Call Process for generic algorithm
         AlgorithmProcess();
 
-
-        //outputs
-
         // Hand owner of algorithm objects over to JANA
-        Set(m_outputClusters);
-        event->Insert(m_outputAssociations, "HcalBarrelTruthClusterAssociations");
+        SetData("HcalBarrelTruthClusters", m_outputClusters);
+        SetData("HcalBarrelTruthClusterAssociations", m_outputAssociations);
+
         m_outputClusters.clear(); // not really needed, but better to not leave dangling pointers around
         m_outputAssociations.clear();
     }

--- a/src/detectors/EEMC/Cluster_factory_EcalEndcapNClusters.h
+++ b/src/detectors/EEMC/Cluster_factory_EcalEndcapNClusters.h
@@ -7,7 +7,7 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <JANA/JMultifactory.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterClusterRecoCoG.h>
 #include <services/log/Log_service.h>
@@ -15,33 +15,23 @@
 
 
 
-// Dummy factory for JFactoryGeneratorT
-class Association_factory_EcalEndcapNClusterAssociations : public eicrecon::JFactoryPodioT<edm4eic::MCRecoClusterParticleAssociation> {
 
-public:
-    //------------------------------------------
-    // Constructor
-    Association_factory_EcalEndcapNClusterAssociations(){
-        SetTag("EcalEndcapNClusterAssociations");
-    }
-};
-
-
-
-class Cluster_factory_EcalEndcapNClusters : public eicrecon::JFactoryPodioT<edm4eic::Cluster>, CalorimeterClusterRecoCoG {
+class Cluster_factory_EcalEndcapNClusters : public JMultifactory, CalorimeterClusterRecoCoG {
 
 public:
     //------------------------------------------
     // Constructor
     Cluster_factory_EcalEndcapNClusters(){
-        SetTag("EcalEndcapNClusters");
-        m_log = japp->GetService<Log_service>()->logger(GetTag());
+        DeclarePodioOutput<edm4eic::Cluster>("EcalEndcapNClusters");
+        DeclarePodioOutput<edm4eic::MCRecoClusterParticleAssociation>("EcalEndcapNClusterAssociations");
     }
 
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        auto app = japp; // GetApplication(); // TODO: NWB: FIXME after JANA2 v2.1.1
+        m_log = app->GetService<Log_service>()->logger("EcalEndcapNClusters");
+
         //-------- Configuration Parameters ------------
         m_input_simhit_tag="EcalEndcapNHits";
         m_input_protoclust_tag="EcalEndcapNIslandProtoClusters";
@@ -72,14 +62,13 @@ public:
 
     //------------------------------------------
     // ChangeRun
-    void ChangeRun(const std::shared_ptr<const JEvent> &event) override{
+    void BeginRun(const std::shared_ptr<const JEvent> &event) override{
         AlgorithmChangeRun();
     }
 
     //------------------------------------------
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
-
 
         // Prefill inputs
         m_inputSimhits=event->Get<edm4hep::SimCalorimeterHit>(m_input_simhit_tag);
@@ -88,12 +77,10 @@ public:
         // Call Process for generic algorithm
         AlgorithmProcess();
 
-
-        //outputs
-
         // Hand owner of algorithm objects over to JANA
-        Set(m_outputClusters);
-        event->Insert(m_outputAssociations, "EcalEndcapNClusterAssociations");
+        SetData("EcalEndcapNClusters", m_outputClusters);
+        SetData("EcalEndcapNClusterAssociations", m_outputAssociations);
+
         m_outputClusters.clear(); // not really needed, but better to not leave dangling pointers around
         m_outputAssociations.clear();
     }

--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -23,7 +23,5 @@ extern "C" {
         app->Add(new JFactoryGeneratorT<ProtoCluster_factory_EcalEndcapNIslandProtoClusters>());
         app->Add(new JFactoryGeneratorT<Cluster_factory_EcalEndcapNTruthClusters>());
         app->Add(new JFactoryGeneratorT<Cluster_factory_EcalEndcapNClusters>());
-        app->Add(new JFactoryGeneratorT<Association_factory_EcalEndcapNTruthClusterAssociations>());
-        app->Add(new JFactoryGeneratorT<Association_factory_EcalEndcapNClusterAssociations>());
     }
 }

--- a/src/detectors/FEMC/Cluster_factory_EcalEndcapPInsertClusters.h
+++ b/src/detectors/FEMC/Cluster_factory_EcalEndcapPInsertClusters.h
@@ -6,7 +6,7 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <JANA/JMultifactory.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterClusterRecoCoG.h>
 #include <services/log/Log_service.h>
@@ -14,33 +14,22 @@
 
 
 
-// Dummy factory for JFactoryGeneratorT
-class Association_factory_EcalEndcapPInsertClusterAssociations : public eicrecon::JFactoryPodioT<edm4eic::MCRecoClusterParticleAssociation> {
-
-public:
-    //------------------------------------------
-    // Constructor
-    Association_factory_EcalEndcapPInsertClusterAssociations(){
-        SetTag("EcalEndcapPInsertClusterAssociations");
-    }
-};
-
-
-
-class Cluster_factory_EcalEndcapPInsertClusters : public eicrecon::JFactoryPodioT<edm4eic::Cluster>, CalorimeterClusterRecoCoG {
+class Cluster_factory_EcalEndcapPInsertClusters : public JMultifactory, CalorimeterClusterRecoCoG {
 
 public:
     //------------------------------------------
     // Constructor
     Cluster_factory_EcalEndcapPInsertClusters(){
-        SetTag("EcalEndcapPInsertClusters");
-        m_log = japp->GetService<Log_service>()->logger(GetTag());
+        DeclarePodioOutput<edm4eic::Cluster>("EcalEndcapPInsertClusters");
+        DeclarePodioOutput<edm4eic::MCRecoClusterParticleAssociation>("EcalEndcapPInsertClusterAssociations");
     }
 
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        auto app = japp; // GetApplication(); // TODO: NWB: FIXME
+        m_log = japp->GetService<Log_service>()->logger("EcalEndcapPInsertClusters");
+
         //-------- Configuration Parameters ------------
         m_input_simhit_tag="EcalEndcapPInsertHits";
         m_input_protoclust_tag="EcalEndcapPInsertIslandProtoClusters";
@@ -71,14 +60,13 @@ public:
 
     //------------------------------------------
     // ChangeRun
-    void ChangeRun(const std::shared_ptr<const JEvent> &event) override{
+    void BeginRun(const std::shared_ptr<const JEvent> &event) override{
         AlgorithmChangeRun();
     }
 
     //------------------------------------------
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
-
 
         // Prefill inputs
         m_inputSimhits=event->Get<edm4hep::SimCalorimeterHit>(m_input_simhit_tag);
@@ -87,12 +75,10 @@ public:
         // Call Process for generic algorithm
         AlgorithmProcess();
 
-
-        //outputs
-
         // Hand owner of algorithm objects over to JANA
-        Set(m_outputClusters);
-        event->Insert(m_outputAssociations, "EcalEndcapPInsertClusterAssociations");
+        SetData("EcalEndcapPInsertClusters", m_outputClusters);
+        SetData("EcalEndcapPInsertClusterAssociations", m_outputAssociations);
+
         m_outputClusters.clear(); // not really needed, but better to not leave dangling pointers around
         m_outputAssociations.clear();
     }

--- a/src/detectors/FEMC/Cluster_factory_EcalEndcapPInsertTruthClusters.h
+++ b/src/detectors/FEMC/Cluster_factory_EcalEndcapPInsertTruthClusters.h
@@ -6,7 +6,7 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <JANA/JMultifactory.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterClusterRecoCoG.h>
 #include <services/log/Log_service.h>
@@ -14,33 +14,22 @@
 
 
 
-// Dummy factory for JFactoryGeneratorT
-class Association_factory_EcalEndcapPInsertTruthClusterAssociations : public eicrecon::JFactoryPodioT<edm4eic::MCRecoClusterParticleAssociation> {
-
-public:
-    //------------------------------------------
-    // Constructor
-    Association_factory_EcalEndcapPInsertTruthClusterAssociations(){
-        SetTag("EcalEndcapPInsertTruthClusterAssociations");
-    }
-};
-
-
-
-class Cluster_factory_EcalEndcapPInsertTruthClusters : public eicrecon::JFactoryPodioT<edm4eic::Cluster>, CalorimeterClusterRecoCoG {
+class Cluster_factory_EcalEndcapPInsertTruthClusters : public JMultifactory, CalorimeterClusterRecoCoG {
 
 public:
     //------------------------------------------
     // Constructor
     Cluster_factory_EcalEndcapPInsertTruthClusters(){
-        SetTag("EcalEndcapPInsertTruthClusters");
-        m_log = japp->GetService<Log_service>()->logger(GetTag());
+        DeclarePodioOutput<edm4eic::Cluster>("EcalEndcapPInsertTruthClusters");
+        DeclarePodioOutput<edm4eic::MCRecoClusterParticleAssociation>("EcalEndcapPInsertTruthClusterAssociations");
     }
 
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        auto app = japp; // GetApplication(); // TODO: NWB: FIXME after JANA2 v2.1.1
+        m_log = app->GetService<Log_service>()->logger("EcalEndcapPInsertTruthClusters");
+
         //-------- Configuration Parameters ------------
         m_input_simhit_tag="EcalEndcapPInsertHits";
         m_input_protoclust_tag="EcalEndcapPInsertTruthProtoClusters";
@@ -71,14 +60,13 @@ public:
 
     //------------------------------------------
     // ChangeRun
-    void ChangeRun(const std::shared_ptr<const JEvent> &event) override{
+    void BeginRun(const std::shared_ptr<const JEvent> &event) override{
         AlgorithmChangeRun();
     }
 
     //------------------------------------------
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
-
 
         // Prefill inputs
         m_inputSimhits=event->Get<edm4hep::SimCalorimeterHit>(m_input_simhit_tag);
@@ -87,12 +75,10 @@ public:
         // Call Process for generic algorithm
         AlgorithmProcess();
 
-
-        //outputs
-
         // Hand owner of algorithm objects over to JANA
-        Set(m_outputClusters);
-        event->Insert(m_outputAssociations, "EcalEndcapPInsertTruthClusterAssociations");
+        SetData("EcalEndcapPInsertTruthClusters", m_outputClusters);
+        SetData("EcalEndcapPInsertTruthClusterAssociations", m_outputAssociations);
+
         m_outputClusters.clear(); // not really needed, but better to not leave dangling pointers around
         m_outputAssociations.clear();
     }

--- a/src/detectors/FEMC/Cluster_factory_EcalEndcapPTruthClusters.h
+++ b/src/detectors/FEMC/Cluster_factory_EcalEndcapPTruthClusters.h
@@ -6,7 +6,7 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <JANA/JMultifactory.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterClusterRecoCoG.h>
 #include <services/log/Log_service.h>
@@ -14,33 +14,22 @@
 
 
 
-// Dummy factory for JFactoryGeneratorT
-class Association_factory_EcalEndcapPTruthClusterAssociations : public eicrecon::JFactoryPodioT<edm4eic::MCRecoClusterParticleAssociation> {
-
-public:
-    //------------------------------------------
-    // Constructor
-    Association_factory_EcalEndcapPTruthClusterAssociations(){
-        SetTag("EcalEndcapPTruthClusterAssociations");
-    }
-};
-
-
-
-class Cluster_factory_EcalEndcapPTruthClusters : public eicrecon::JFactoryPodioT<edm4eic::Cluster>, CalorimeterClusterRecoCoG {
+class Cluster_factory_EcalEndcapPTruthClusters : public JMultifactory, CalorimeterClusterRecoCoG {
 
 public:
     //------------------------------------------
     // Constructor
     Cluster_factory_EcalEndcapPTruthClusters(){
-        SetTag("EcalEndcapPTruthClusters");
-        m_log = japp->GetService<Log_service>()->logger(GetTag());
+        DeclarePodioOutput<edm4eic::Cluster>("EcalEndcapPTruthClusters");
+        DeclarePodioOutput<edm4eic::MCRecoClusterParticleAssociation>("EcalEndcapPTruthClusterAssociations");
     }
 
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        auto app = japp; // GetApplication(); // TODO: NWB: FIXME after JANA2 v2.1.1
+        m_log = app->GetService<Log_service>()->logger("EcalEndcapPTruthClusters");
+
         //-------- Configuration Parameters ------------
         m_input_simhit_tag="EcalEndcapPHits";
         m_input_protoclust_tag="EcalEndcapPTruthProtoClusters";
@@ -71,14 +60,13 @@ public:
 
     //------------------------------------------
     // ChangeRun
-    void ChangeRun(const std::shared_ptr<const JEvent> &event) override{
+    void BeginRun(const std::shared_ptr<const JEvent> &event) override{
         AlgorithmChangeRun();
     }
 
     //------------------------------------------
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
-
 
         // Prefill inputs
         m_inputSimhits=event->Get<edm4hep::SimCalorimeterHit>(m_input_simhit_tag);
@@ -87,12 +75,10 @@ public:
         // Call Process for generic algorithm
         AlgorithmProcess();
 
-
-        //outputs
-
         // Hand owner of algorithm objects over to JANA
-        Set(m_outputClusters);
-        event->Insert(m_outputAssociations, "EcalEndcapPTruthClusterAssociations");
+        SetData("EcalEndcapPTruthClusters", m_outputClusters);
+        SetData("EcalEndcapPTruthClusterAssociations", m_outputAssociations);
+
         m_outputClusters.clear(); // not really needed, but better to not leave dangling pointers around
         m_outputAssociations.clear();
     }

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -29,8 +29,6 @@ extern "C" {
         app->Add(new JFactoryGeneratorT<ProtoCluster_factory_EcalEndcapPIslandProtoClusters>());
         app->Add(new JFactoryGeneratorT<Cluster_factory_EcalEndcapPTruthClusters>());
         app->Add(new JFactoryGeneratorT<Cluster_factory_EcalEndcapPClusters>());
-        app->Add(new JFactoryGeneratorT<Association_factory_EcalEndcapPTruthClusterAssociations>());
-        app->Add(new JFactoryGeneratorT<Association_factory_EcalEndcapPClusterAssociations>());
 
         app->Add(new JFactoryGeneratorT<RawCalorimeterHit_factory_EcalEndcapPInsertRawHits>());
         app->Add(new JFactoryGeneratorT<CalorimeterHit_factory_EcalEndcapPInsertRecHits>());
@@ -38,7 +36,5 @@ extern "C" {
         app->Add(new JFactoryGeneratorT<ProtoCluster_factory_EcalEndcapPInsertIslandProtoClusters>());
         app->Add(new JFactoryGeneratorT<Cluster_factory_EcalEndcapPInsertTruthClusters>());
         app->Add(new JFactoryGeneratorT<Cluster_factory_EcalEndcapPInsertClusters>());
-        app->Add(new JFactoryGeneratorT<Association_factory_EcalEndcapPInsertTruthClusterAssociations>());
-        app->Add(new JFactoryGeneratorT<Association_factory_EcalEndcapPInsertClusterAssociations>());
     }
 }

--- a/src/detectors/FHCAL/Cluster_factory_HcalEndcapPInsertClusters.h
+++ b/src/detectors/FHCAL/Cluster_factory_HcalEndcapPInsertClusters.h
@@ -6,7 +6,7 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <JANA/JMultifactory.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterClusterRecoCoG.h>
 #include <services/log/Log_service.h>
@@ -14,20 +14,22 @@
 
 
 
-class Cluster_factory_HcalEndcapPInsertClusters : public eicrecon::JFactoryPodioT<edm4eic::Cluster>, CalorimeterClusterRecoCoG {
+class Cluster_factory_HcalEndcapPInsertClusters : public JMultifactory, CalorimeterClusterRecoCoG {
 
 public:
     //------------------------------------------
     // Constructor
     Cluster_factory_HcalEndcapPInsertClusters(){
-        SetTag("HcalEndcapPInsertClusters");
-        m_log = japp->GetService<Log_service>()->logger(GetTag());
+        DeclarePodioOutput<edm4eic::Cluster>("HcalEndcapPInsertClusters");
+        DeclarePodioOutput<edm4eic::MCRecoClusterParticleAssociation>("HcalEndcapPInsertClusterAssociations");
     }
 
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        auto app = japp; // GetApplication(); // TODO: NWB: FIXME after JANA2 v2.1.1
+        m_log = app->GetService<Log_service>()->logger("HcalEndcapPInsertClusters");
+
         //-------- Configuration Parameters ------------
         m_input_simhit_tag="HcalEndcapPInsertHits";
         m_input_protoclust_tag="HcalEndcapPInsertIslandProtoClusters";
@@ -59,14 +61,13 @@ public:
 
     //------------------------------------------
     // ChangeRun
-    void ChangeRun(const std::shared_ptr<const JEvent> &event) override{
+    void BeginRun(const std::shared_ptr<const JEvent> &event) override{
         AlgorithmChangeRun();
     }
 
     //------------------------------------------
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
-
 
         // Prefill inputs
         m_inputSimhits=event->Get<edm4hep::SimCalorimeterHit>(m_input_simhit_tag);
@@ -75,12 +76,10 @@ public:
         // Call Process for generic algorithm
         AlgorithmProcess();
 
-
-        //outputs
-
         // Hand owner of algorithm objects over to JANA
-        Set(m_outputClusters);
-        event->Insert(m_outputAssociations, "HcalEndcapPInsertClusterAssociations");
+        SetData("HcalEndcapPInsertClusters", m_outputClusters);
+        SetData("HcalEndcapPInsertClusterAssociations", m_outputAssociations);
+
         m_outputClusters.clear(); // not really needed, but better to not leave dangling pointers around
         m_outputAssociations.clear();
     }

--- a/src/detectors/FHCAL/Cluster_factory_HcalEndcapPInsertTruthClusters.h
+++ b/src/detectors/FHCAL/Cluster_factory_HcalEndcapPInsertTruthClusters.h
@@ -5,7 +5,7 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <JANA/JMultifactory.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterClusterRecoCoG.h>
 #include <services/log/Log_service.h>
@@ -13,20 +13,22 @@
 
 
 
-class Cluster_factory_HcalEndcapPInsertTruthClusters : public eicrecon::JFactoryPodioT<edm4eic::Cluster>, CalorimeterClusterRecoCoG {
+class Cluster_factory_HcalEndcapPInsertTruthClusters : public JMultifactory, CalorimeterClusterRecoCoG {
 
 public:
     //------------------------------------------
     // Constructor
     Cluster_factory_HcalEndcapPInsertTruthClusters(){
-        SetTag("HcalEndcapPInsertTruthClusters");
-        m_log = japp->GetService<Log_service>()->logger(GetTag());
+        DeclarePodioOutput<edm4eic::Cluster>("HcalEndcapPInsertTruthClusters");
+        DeclarePodioOutput<edm4eic::MCRecoClusterParticleAssociation>("HcalEndcapPInsertTruthClusterAssociations");
     }
 
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        auto app = japp; // GetApplication(); // TODO: NWB: FIXME after JANA2 v2.1.1
+        m_log = app->GetService<Log_service>()->logger("HcalEndcapPInsertTruthClusters");
+
         //-------- Configuration Parameters ------------
         m_input_simhit_tag="HcalEndcapPInsertHits";
         m_input_protoclust_tag="HcalEndcapPInsertTruthProtoClusters";
@@ -58,7 +60,7 @@ public:
 
     //------------------------------------------
     // ChangeRun
-    void ChangeRun(const std::shared_ptr<const JEvent> &event) override{
+    void BeginRun(const std::shared_ptr<const JEvent> &event) override{
         AlgorithmChangeRun();
     }
 
@@ -75,11 +77,10 @@ public:
         AlgorithmProcess();
 
 
-        //outputs
-
         // Hand owner of algorithm objects over to JANA
-        Set(m_outputClusters);
-        event->Insert(m_outputAssociations, "HcalEndcapPInsertTruthClusterAssociations");
+        SetData("HcalEndcapPInsertTruthClusters", m_outputClusters);
+        SetData("HcalEndcapPInsertTruthClusterAssociations", m_outputAssociations);
+
         m_outputClusters.clear(); // not really needed, but better to not leave dangling pointers around
         m_outputAssociations.clear();
     }

--- a/src/detectors/FHCAL/Cluster_factory_HcalEndcapPTruthClusters.h
+++ b/src/detectors/FHCAL/Cluster_factory_HcalEndcapPTruthClusters.h
@@ -5,38 +5,30 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <JANA/JMultifactory.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterClusterRecoCoG.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
 
-// Dummy factory for JFactoryGeneratorT
-class Association_factory_HcalEndcapPTruthClusterAssociations : public eicrecon::JFactoryPodioT<edm4eic::MCRecoClusterParticleAssociation> {
 
-public:
-    //------------------------------------------
-    // Constructor
-    Association_factory_HcalEndcapPTruthClusterAssociations(){
-        SetTag("HcalEndcapPTruthClusterAssociations");
-    }
-};
-
-class Cluster_factory_HcalEndcapPTruthClusters : public eicrecon::JFactoryPodioT<edm4eic::Cluster>, CalorimeterClusterRecoCoG {
+class Cluster_factory_HcalEndcapPTruthClusters : public JMultifactory, CalorimeterClusterRecoCoG {
 
 public:
     //------------------------------------------
     // Constructor
     Cluster_factory_HcalEndcapPTruthClusters(){
-        SetTag("HcalEndcapPTruthClusters");
-        m_log = japp->GetService<Log_service>()->logger(GetTag());
+        DeclarePodioOutput<edm4eic::Cluster>("HcalEndcapPTruthClusters");
+        DeclarePodioOutput<edm4eic::MCRecoClusterParticleAssociation>("HcalEndcapPTruthClusterAssociations");
     }
 
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        auto app = japp; // GetApplication(); // TODO: NWB: FIXME after JANA2 v2.1.1
+        m_log = app->GetService<Log_service>()->logger("HcalEndcapPTruthClusters");
+
         //-------- Configuration Parameters ------------
         m_input_simhit_tag="HcalEndcapPHits";
         m_input_protoclust_tag="HcalEndcapPTruthProtoClusters";
@@ -68,14 +60,13 @@ public:
 
     //------------------------------------------
     // ChangeRun
-    void ChangeRun(const std::shared_ptr<const JEvent> &event) override{
+    void BeginRun(const std::shared_ptr<const JEvent> &event) override{
         AlgorithmChangeRun();
     }
 
     //------------------------------------------
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
-
 
         // Prefill inputs
         m_inputSimhits=event->Get<edm4hep::SimCalorimeterHit>(m_input_simhit_tag);
@@ -84,12 +75,10 @@ public:
         // Call Process for generic algorithm
         AlgorithmProcess();
 
-
-        //outputs
-
         // Hand owner of algorithm objects over to JANA
-        Set(m_outputClusters);
-        event->Insert(m_outputAssociations, "HcalEndcapPTruthClusterAssociations");
+        SetData("HcalEndcapPTruthClusters", m_outputClusters);
+        SetData("HcalEndcapPTruthClusterAssociations", m_outputAssociations);
+
         m_outputClusters.clear(); // not really needed, but better to not leave dangling pointers around
         m_outputAssociations.clear();
     }

--- a/src/detectors/FHCAL/Cluster_factory_LFHCALClusters.h
+++ b/src/detectors/FHCAL/Cluster_factory_LFHCALClusters.h
@@ -6,39 +6,30 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <JANA/JMultifactory.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterClusterRecoCoG.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
 
-// Dummy factory for JFactoryGeneratorT
-class Association_factory_LFHCALClustersAssociations : public eicrecon::JFactoryPodioT<edm4eic::MCRecoClusterParticleAssociation> {
 
-public:
-    //------------------------------------------
-    // Constructor
-    Association_factory_LFHCALClustersAssociations(){
-        SetTag("LFHCALClustersAssociations");
-    }
-};
-
-
-class Cluster_factory_LFHCALClusters : public JFactoryT<edm4eic::Cluster>, CalorimeterClusterRecoCoG {
+class Cluster_factory_LFHCALClusters : public JMultifactory, CalorimeterClusterRecoCoG {
 
 public:
     //------------------------------------------
     // Constructor
     Cluster_factory_LFHCALClusters(){
-        SetTag("LFHCALClusters");
-        m_log = japp->GetService<Log_service>()->logger(GetTag());
+        DeclarePodioOutput<edm4eic::Cluster>("LFHCALClusters");
+        DeclarePodioOutput<edm4eic::MCRecoClusterParticleAssociation>("LFHCALClusterAssociations");
     }
 
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        auto app = japp; // GetApplication(); // TODO: NWB: FIXME after JANA2 v2.1.1
+        m_log = app->GetService<Log_service>()->logger("LFHCALClusters");
+
         //-------- Configuration Parameters ------------
         m_input_simhit_tag="LFHCALHits";
         m_input_protoclust_tag="LFHCALIslandProtoClusters";
@@ -69,14 +60,13 @@ public:
 
     //------------------------------------------
     // ChangeRun
-    void ChangeRun(const std::shared_ptr<const JEvent> &event) override{
+    void BeginRun(const std::shared_ptr<const JEvent> &event) override{
         AlgorithmChangeRun();
     }
 
     //------------------------------------------
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
-
 
         // Prefill inputs
         m_inputSimhits=event->Get<edm4hep::SimCalorimeterHit>(m_input_simhit_tag);
@@ -85,12 +75,10 @@ public:
         // Call Process for generic algorithm
         AlgorithmProcess();
 
-
-        //outputs
-
         // Hand owner of algorithm objects over to JANA
-        Set(m_outputClusters);
-        event->Insert(m_outputAssociations, "LFHCALClusterAssociations");
+        SetData("LFHCALClusters", m_outputClusters);
+        SetData("LFHCALClusterAssociations", m_outputAssociations);
+
         m_outputClusters.clear(); // not really needed, but better to not leave dangling pointers around
         m_outputAssociations.clear();
     }

--- a/src/detectors/FHCAL/Cluster_factory_LFHCALTruthClusters.h
+++ b/src/detectors/FHCAL/Cluster_factory_LFHCALTruthClusters.h
@@ -5,38 +5,29 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <JANA/JMultifactory.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterClusterRecoCoG.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
 
-// Dummy factory for JFactoryGeneratorT
-class Association_factory_LFHCALTruthClustersAssociations : public eicrecon::JFactoryPodioT<edm4eic::MCRecoClusterParticleAssociation> {
-
-public:
-    //------------------------------------------
-    // Constructor
-    Association_factory_LFHCALTruthClustersAssociations(){
-        SetTag("LFHCALTruthClustersAssociations");
-    }
-};
-
-class Cluster_factory_LFHCALTruthClusters : public JFactoryT<edm4eic::Cluster>, CalorimeterClusterRecoCoG {
+class Cluster_factory_LFHCALTruthClusters : public JMultifactory, CalorimeterClusterRecoCoG {
 
 public:
     //------------------------------------------
     // Constructor
     Cluster_factory_LFHCALTruthClusters(){
-        SetTag("LFHCALTruthClusters");
-        m_log = japp->GetService<Log_service>()->logger(GetTag());
+        DeclarePodioOutput<edm4eic::Cluster>("LFHCALTruthClusters");
+        DeclarePodioOutput<edm4eic::MCRecoClusterParticleAssociation>("LFHCALTruthClusterAssociations");
     }
 
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        auto app = japp; // GetApplication(); // TODO: NWB: FIXME after JANA2 v2.1.1
+        m_log = app->GetService<Log_service>()->logger("LFHCALTruthClusters");
+
         //-------- Configuration Parameters ------------
         m_input_simhit_tag="LFHCALHits";
         m_input_protoclust_tag="LFHCALTruthProtoClusters";
@@ -68,14 +59,13 @@ public:
 
     //------------------------------------------
     // ChangeRun
-    void ChangeRun(const std::shared_ptr<const JEvent> &event) override{
+    void BeginRun(const std::shared_ptr<const JEvent> &event) override{
         AlgorithmChangeRun();
     }
 
     //------------------------------------------
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
-
 
         // Prefill inputs
         m_inputSimhits=event->Get<edm4hep::SimCalorimeterHit>(m_input_simhit_tag);
@@ -84,12 +74,10 @@ public:
         // Call Process for generic algorithm
         AlgorithmProcess();
 
-
-        //outputs
-
         // Hand owner of algorithm objects over to JANA
-        Set(m_outputClusters);
-        event->Insert(m_outputAssociations, "LFHCALTruthClusterAssociations");
+        SetData("LFHCALTruthClusters", m_outputClusters);
+        SetData("LFHCALTruthClusterAssociations", m_outputAssociations);
+
         m_outputClusters.clear(); // not really needed, but better to not leave dangling pointers around
         m_outputAssociations.clear();
     }

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -40,8 +40,6 @@ extern "C" {
         app->Add(new JFactoryGeneratorT<ProtoCluster_factory_HcalEndcapPIslandProtoClusters>());
         app->Add(new JFactoryGeneratorT<Cluster_factory_HcalEndcapPClusters>());
         app->Add(new JFactoryGeneratorT<Cluster_factory_HcalEndcapPTruthClusters>());
-        app->Add(new JFactoryGeneratorT<Association_factory_HcalEndcapPTruthClusterAssociations>());
-        app->Add(new JFactoryGeneratorT<Association_factory_HcalEndcapPClusterAssociations>());
 
         app->Add(new JFactoryGeneratorT<RawCalorimeterHit_factory_HcalEndcapPInsertRawHits>());
         app->Add(new JFactoryGeneratorT<CalorimeterHit_factory_HcalEndcapPInsertRecHits>());

--- a/src/detectors/ZDC/Cluster_factory_ZDCEcalClusters.h
+++ b/src/detectors/ZDC/Cluster_factory_ZDCEcalClusters.h
@@ -6,7 +6,7 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <JANA/JMultifactory.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterClusterRecoCoG.h>
 #include <services/log/Log_service.h>
@@ -14,20 +14,22 @@
 
 
 
-class Cluster_factory_ZDCEcalClusters : public eicrecon::JFactoryPodioT<edm4eic::Cluster>, CalorimeterClusterRecoCoG {
+class Cluster_factory_ZDCEcalClusters : public JMultifactory, CalorimeterClusterRecoCoG {
 
 public:
     //------------------------------------------
     // Constructor
     Cluster_factory_ZDCEcalClusters(){
-        SetTag("ZDCEcalClusters");
-        m_log = japp->GetService<Log_service>()->logger(GetTag());
+        DeclarePodioOutput<edm4eic::Cluster>("ZDCEcalClusters");
+        DeclarePodioOutput<edm4eic::MCRecoClusterParticleAssociation>("ZDCEcalClusterAssociations");
     }
 
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        auto app = japp; // GetApplication(); // TODO: NWB: FIXME after JANA2 v2.1.1
+        m_log = app->GetService<Log_service>()->logger("ZDCEcalClusters");
+
         //-------- Configuration Parameters ------------
         m_input_simhit_tag="ZDCEcalHits";
         m_input_protoclust_tag="ZDCEcalIslandProtoClusters";
@@ -59,7 +61,7 @@ public:
 
     //------------------------------------------
     // ChangeRun
-    void ChangeRun(const std::shared_ptr<const JEvent> &event) override{
+    void BeginRun(const std::shared_ptr<const JEvent> &event) override{
         AlgorithmChangeRun();
     }
 
@@ -75,12 +77,10 @@ public:
         // Call Process for generic algorithm
         AlgorithmProcess();
 
-
-        //outputs
-
         // Hand owner of algorithm objects over to JANA
-        Set(m_outputClusters);
-        event->Insert(m_outputAssociations, "ZDCEcalClusterAssociations");
+        SetData("ZDCEcalClusters", m_outputClusters);
+        SetData("ZDCEcalClusterAssociations", m_outputAssociations);
+
         m_outputClusters.clear(); // not really needed, but better to not leave dangling pointers around
         m_outputAssociations.clear();
     }

--- a/src/detectors/ZDC/Cluster_factory_ZDCEcalTruthClusters.h
+++ b/src/detectors/ZDC/Cluster_factory_ZDCEcalTruthClusters.h
@@ -5,7 +5,7 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <JANA/JMultifactory.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterClusterRecoCoG.h>
 #include <services/log/Log_service.h>
@@ -13,20 +13,22 @@
 
 
 
-class Cluster_factory_ZDCEcalTruthClusters : public eicrecon::JFactoryPodioT<edm4eic::Cluster>, CalorimeterClusterRecoCoG {
+class Cluster_factory_ZDCEcalTruthClusters : public JMultifactory, CalorimeterClusterRecoCoG {
 
 public:
     //------------------------------------------
     // Constructor
     Cluster_factory_ZDCEcalTruthClusters(){
-        SetTag("ZDCEcalTruthClusters");
-        m_log = japp->GetService<Log_service>()->logger(GetTag());
+        DeclarePodioOutput<edm4eic::Cluster>("ZDCEcalTruthClusters");
+        DeclarePodioOutput<edm4eic::MCRecoClusterParticleAssociation>("ZDCEcalTruthClusterAssociations");
     }
 
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        auto app = japp; // GetApplication(); // TODO: NWB: FIXME after JANA2 v2.1.1
+        m_log = app->GetService<Log_service>()->logger("ZDCEcalTruthClusters");
+
         //-------- Configuration Parameters ------------
         m_input_simhit_tag="ZDCEcalHits";
         m_input_protoclust_tag="ZDCEcalTruthProtoClusters";
@@ -58,7 +60,7 @@ public:
 
     //------------------------------------------
     // ChangeRun
-    void ChangeRun(const std::shared_ptr<const JEvent> &event) override{
+    void BeginRun(const std::shared_ptr<const JEvent> &event) override{
         AlgorithmChangeRun();
     }
 
@@ -75,11 +77,10 @@ public:
         AlgorithmProcess();
 
 
-        //outputs
-
         // Hand owner of algorithm objects over to JANA
-        Set(m_outputClusters);
-        event->Insert(m_outputAssociations, "ZDCEcalTruthClusterAssociations");
+        SetData("ZDCEcalTruthClusters", m_outputClusters);
+        SetData("ZDCEcalTruthClusterAssociations", m_outputAssociations);
+
         m_outputClusters.clear(); // not really needed, but better to not leave dangling pointers around
         m_outputAssociations.clear();
     }


### PR DESCRIPTION
### Briefly, what does this PR introduce?

The calorimeter clustering factories need to produce associations alongside clusters, and the current approach is hacky and bug-prone. JANA 2.1.0 introduces multifactories to solve this problem cleanly. This PR migrates all of the calorimeter clustering factories that produce associations to use multifactories. 

### What kind of change does this PR introduce?
- [x] Bug fix (issue #631)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
