### PR TITLE
MPGD: Update digi threshold value based on digitization table

### DIFF
--- a/src/detectors/MPGD/MPGD.cc
+++ b/src/detectors/MPGD/MPGD.cc
@@ -22,7 +22,7 @@ void InitPlugin(JApplication *app) {
 
     // Digitization
     SiliconTrackerDigiConfig barrel_digi_default_cfg;
-    barrel_digi_default_cfg.threshold = 0 * dd4hep::keV;
+    barrel_digi_default_cfg.threshold = 0.25 * dd4hep::keV;
     barrel_digi_default_cfg.timeResolution = 8;
     app->Add(new JChainFactoryGeneratorT<SiliconTrackerDigi_factory>({"MPGDBarrelHits"}, "MPGDBarrelDigiHits", barrel_digi_default_cfg));
 
@@ -36,7 +36,7 @@ void InitPlugin(JApplication *app) {
 
     // Digitization
     SiliconTrackerDigiConfig dirc_digi_default_cfg;
-    barrel_digi_default_cfg.threshold = 0 * dd4hep::keV;
+    barrel_digi_default_cfg.threshold = 0.25 * dd4hep::keV;
     barrel_digi_default_cfg.timeResolution = 8;
     app->Add(new JChainFactoryGeneratorT<SiliconTrackerDigi_factory>({"MPGDDIRCHits"}, "MPGDDIRCDigiHits", dirc_digi_default_cfg));
 


### PR DESCRIPTION

### Briefly, what does this PR introduce?
Update MPGD digi threshold value based on digitization table: https://docs.google.com/spreadsheets/d/1s8oXj36SqIh7TJeHFH89gQ_ayU1_SVEpWQNkx6sETKs/edit#gid=238482234

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, 0.25 keV threshold is applied for MPGD hit digitization. Prior code used 0 keV threshold for digitization.