### PR TITLE
fix: only use reconstructed charged particles in inclusive kinematics, until cluster matching works

### DIFF
--- a/src/global/reco/InclusiveKinematicsDA_factory.cc
+++ b/src/global/reco/InclusiveKinematicsDA_factory.cc
@@ -39,8 +39,8 @@ namespace eicrecon {
 
     void InclusiveKinematicsDA_factory::Process(const std::shared_ptr<const JEvent> &event) {
         auto mc_particles = event->Get<edm4hep::MCParticle>("MCParticles");
-        auto rc_particles = event->Get<edm4eic::ReconstructedParticle>("ReconstructedParticles");
-        auto rc_particles_assoc = event->Get<edm4eic::MCRecoParticleAssociation>("ReconstructedParticleAssociations");
+        auto rc_particles = event->Get<edm4eic::ReconstructedParticle>("ReconstructedChargedParticles");
+        auto rc_particles_assoc = event->Get<edm4eic::MCRecoParticleAssociation>("ReconstructedChargedParticleAssociations");
 
         auto inclusive_kinematics = m_inclusive_kinematics_algo.execute(
             mc_particles,

--- a/src/global/reco/InclusiveKinematicsElectron_factory.cc
+++ b/src/global/reco/InclusiveKinematicsElectron_factory.cc
@@ -39,8 +39,8 @@ namespace eicrecon {
 
     void InclusiveKinematicsElectron_factory::Process(const std::shared_ptr<const JEvent> &event) {
         auto mc_particles = event->Get<edm4hep::MCParticle>("MCParticles");
-        auto rc_particles = event->Get<edm4eic::ReconstructedParticle>("ReconstructedParticles");
-        auto rc_particles_assoc = event->Get<edm4eic::MCRecoParticleAssociation>("ReconstructedParticleAssociations");
+        auto rc_particles = event->Get<edm4eic::ReconstructedParticle>("ReconstructedChargedParticles");
+        auto rc_particles_assoc = event->Get<edm4eic::MCRecoParticleAssociation>("ReconstructedChargedParticleAssociations");
 
         auto inclusive_kinematics = m_inclusive_kinematics_algo.execute(
             mc_particles,

--- a/src/global/reco/InclusiveKinematicsJB_factory.cc
+++ b/src/global/reco/InclusiveKinematicsJB_factory.cc
@@ -39,8 +39,8 @@ namespace eicrecon {
 
     void InclusiveKinematicsJB_factory::Process(const std::shared_ptr<const JEvent> &event) {
         auto mc_particles = event->Get<edm4hep::MCParticle>("MCParticles");
-        auto rc_particles = event->Get<edm4eic::ReconstructedParticle>("ReconstructedParticles");
-        auto rc_particles_assoc = event->Get<edm4eic::MCRecoParticleAssociation>("ReconstructedParticleAssociations");
+        auto rc_particles = event->Get<edm4eic::ReconstructedParticle>("ReconstructedChargedParticles");
+        auto rc_particles_assoc = event->Get<edm4eic::MCRecoParticleAssociation>("ReconstructedChargedParticleAssociations");
 
         auto inclusive_kinematics = m_inclusive_kinematics_algo.execute(
             mc_particles,

--- a/src/global/reco/InclusiveKinematicsSigma_factory.cc
+++ b/src/global/reco/InclusiveKinematicsSigma_factory.cc
@@ -39,8 +39,8 @@ namespace eicrecon {
 
     void InclusiveKinematicsSigma_factory::Process(const std::shared_ptr<const JEvent> &event) {
         auto mc_particles = event->Get<edm4hep::MCParticle>("MCParticles");
-        auto rc_particles = event->Get<edm4eic::ReconstructedParticle>("ReconstructedParticles");
-        auto rc_particles_assoc = event->Get<edm4eic::MCRecoParticleAssociation>("ReconstructedParticleAssociations");
+        auto rc_particles = event->Get<edm4eic::ReconstructedParticle>("ReconstructedChargedParticles");
+        auto rc_particles_assoc = event->Get<edm4eic::MCRecoParticleAssociation>("ReconstructedChargedParticleAssociations");
 
         auto inclusive_kinematics = m_inclusive_kinematics_algo.execute(
             mc_particles,

--- a/src/global/reco/InclusiveKinematicseSigma_factory.cc
+++ b/src/global/reco/InclusiveKinematicseSigma_factory.cc
@@ -39,8 +39,8 @@ namespace eicrecon {
 
     void InclusiveKinematicseSigma_factory::Process(const std::shared_ptr<const JEvent> &event) {
         auto mc_particles = event->Get<edm4hep::MCParticle>("MCParticles");
-        auto rc_particles = event->Get<edm4eic::ReconstructedParticle>("ReconstructedParticles");
-        auto rc_particles_assoc = event->Get<edm4eic::MCRecoParticleAssociation>("ReconstructedParticleAssociations");
+        auto rc_particles = event->Get<edm4eic::ReconstructedParticle>("ReconstructedChargedParticles");
+        auto rc_particles_assoc = event->Get<edm4eic::MCRecoParticleAssociation>("ReconstructedChargedParticleAssociations");
 
         auto inclusive_kinematics = m_inclusive_kinematics_algo.execute(
             mc_particles,

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -46,22 +46,22 @@ void InitPlugin(JApplication *app) {
 
 
     app->Add(new JChainFactoryGeneratorT<InclusiveKinematicsElectron_factory>(
-            {"MCParticles", "ReconstructedParticles", "ReconstructedParticleAssociations"}, "InclusiveKinematicsElectron"));
+            {"MCParticles", "ReconstructedChargedParticles", "ReconstructedChargedParticleAssociations"}, "InclusiveKinematicsElectron"));
 
     app->Add(new JChainFactoryGeneratorT<InclusiveKinematicsTruth_factory>(
-            {"MCParticles", "ReconstructedParticles", "ReconstructedParticleAssociations"}, "InclusiveKinematicsTruth"));
+            {"MCParticles", "ReconstructedChargedParticles", "ReconstructedChargedParticleAssociations"}, "InclusiveKinematicsTruth"));
 
     app->Add(new JChainFactoryGeneratorT<InclusiveKinematicsJB_factory>(
-            {"MCParticles", "ReconstructedParticles", "ReconstructedParticleAssociations"}, "InclusiveKinematicsJB"));
+            {"MCParticles", "ReconstructedChargedParticles", "ReconstructedChargedParticleAssociations"}, "InclusiveKinematicsJB"));
 
     app->Add(new JChainFactoryGeneratorT<InclusiveKinematicsDA_factory>(
-            {"MCParticles", "ReconstructedParticles", "ReconstructedParticleAssociations"}, "InclusiveKinematicsDA"));
+            {"MCParticles", "ReconstructedChargedParticles", "ReconstructedChargedParticleAssociations"}, "InclusiveKinematicsDA"));
 
     app->Add(new JChainFactoryGeneratorT<InclusiveKinematicseSigma_factory>(
-            {"MCParticles", "ReconstructedParticles", "ReconstructedParticleAssociations"}, "InclusiveKinematicseSigma"));
+            {"MCParticles", "ReconstructedChargedParticles", "ReconstructedChargedParticleAssociations"}, "InclusiveKinematicseSigma"));
 
     app->Add(new JChainFactoryGeneratorT<InclusiveKinematicsSigma_factory>(
-            {"MCParticles", "ReconstructedParticles", "ReconstructedParticleAssociations"}, "InclusiveKinematicsSigma"));
+            {"MCParticles", "ReconstructedChargedParticles", "ReconstructedChargedParticleAssociations"}, "InclusiveKinematicsSigma"));
 
     app->Add(new JChainFactoryGeneratorT<GeneratedJets_factory>(
             {"MCParticles"}, "GeneratedJets"));


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Track/cluster matching in MatchClusters is now active and doesn't just return the reconstructed charged particles and their associations. However, until the clusters themselves get converted to multifactories and get associations, this doesn't result in any matched results, not even the reconstructed charged particles.

Rather than living without any x and Q2 in the campaign (a quick way to check overall performance since it relies on everything going right), this reverts the inclusive kinematics explicitly to using reconstructed charged particles without information from the cluster matching.

Woud like to backport into the v1.1 branch and include in a v1.1.1 bugfix release to use in the 23.05 campaign.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: inclusive kinematics not filled)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.