### PR TITLE
refactor+fix: use collections and multi-factory in `RichTrack_factory`; fix potential leaks in `TrackPropagation`

### DIFF
--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2022 Wenqing Fan, Barak Schmookler, Whitney Armstrong, Sylvester Joosten, Dmitry Romanov
+// Copyright (C) 2022, 2023 Wenqing Fan, Barak Schmookler, Whitney Armstrong, Sylvester Joosten, Dmitry Romanov, Christopher Dilks
 
 #include <cmath>
 #include <algorithm>
@@ -75,53 +75,69 @@ namespace eicrecon {
 
 
 
-    edm4eic::TrackSegment* TrackPropagation::propagateToSurfaceList(const eicrecon::TrackingResultTrajectory *traj,
-                                                                    std::vector<std::shared_ptr<Acts::Surface>> targetSurfaces) {
-      // start a mutable TrackSegment
-      edm4eic::MutableTrackSegment track_segment;
-      decltype(edm4eic::TrackSegmentData::length)      length       = 0;
-      decltype(edm4eic::TrackSegmentData::lengthError) length_error = 0;
+    std::unique_ptr<edm4eic::TrackSegmentCollection> TrackPropagation::propagateToSurfaceList(
+        std::vector<const eicrecon::TrackingResultTrajectory*> trajectories,
+        std::vector<std::shared_ptr<Acts::Surface>> targetSurfaces
+        )
+    {
+      // logging
+      m_log->trace("Propagate trajectories: --------------------");
+      m_log->trace("number of trajectories: {}",trajectories.size());
 
-      // loop over projection-target surfaces
-      for(const auto& targetSurf : targetSurfaces) {
+      // start output collection
+      auto track_segments = std::make_unique<edm4eic::TrackSegmentCollection>();
 
-        // project the trajectory `traj` to this surface
-        edm4eic::TrackPoint *point;
-        try {
-          point = propagate(traj, targetSurf);
-        } catch(std::exception &e) {
-          m_log->warn("<> Exception in TrackPropagation::propagateToSurfaceList: {}; skip this TrackPoint and surface", e.what());
-        }
-        if(!point) {
-          m_log->trace("<> Failed to propagate trajectory to this plane");
-          continue;
-        }
+      // loop over input trajectories
+      for(const auto& traj : trajectories) {
 
-        // logging
-        m_log->trace("<> trajectory: x=( {:>10.2f} {:>10.2f} {:>10.2f} )",
-            point->position.x, point->position.y, point->position.z);
-        m_log->trace("               p=( {:>10.2f} {:>10.2f} {:>10.2f} )",
-            point->momentum.x, point->momentum.y, point->momentum.z);
+        // start a mutable TrackSegment
+        auto track_segment = track_segments->create();
+        decltype(edm4eic::TrackSegmentData::length)      length       = 0;
+        decltype(edm4eic::TrackSegmentData::lengthError) length_error = 0;
 
-        // update the `TrackSegment` length
-        // FIXME: `length` and `length_error` are currently not used by any callers, and may not be correctly calculated here
-        if(track_segment.points_size()>0) {
-          auto pos0 = point->position;
-          auto pos1 = std::prev(track_segment.points_end())->position;
-          auto dist = edm4eic::magnitude(pos0-pos1);
-          length += dist;
-          m_log->trace("               dist to previous point: {}", dist);
-        }
+        // loop over projection-target surfaces
+        for(const auto& targetSurf : targetSurfaces) {
 
-        // add the `TrackPoint` to the `TrackSegment`
-        track_segment.addToPoints(*point);
+          // project the trajectory `traj` to this surface
+          edm4eic::TrackPoint *point;
+          try {
+            point = propagate(traj, targetSurf);
+          } catch(std::exception &e) {
+            m_log->warn("<> Exception in TrackPropagation::propagateToSurfaceList: {}; skip this TrackPoint and surface", e.what());
+          }
+          if(!point) {
+            m_log->trace("<> Failed to propagate trajectory to this plane");
+            continue;
+          }
 
-      } // end `targetSurfaces` loop
+          // logging
+          m_log->trace("<> trajectory: x=( {:>10.2f} {:>10.2f} {:>10.2f} )",
+              point->position.x, point->position.y, point->position.z);
+          m_log->trace("               p=( {:>10.2f} {:>10.2f} {:>10.2f} )",
+              point->momentum.x, point->momentum.y, point->momentum.z);
 
-      // output
-      track_segment.setLength(length);
-      track_segment.setLengthError(length_error);
-      return new edm4eic::TrackSegment(track_segment);
+          // update the `TrackSegment` length
+          // FIXME: `length` and `length_error` are currently not used by any callers, and may not be correctly calculated here
+          if(track_segment.points_size()>0) {
+            auto pos0 = point->position;
+            auto pos1 = std::prev(track_segment.points_end())->position;
+            auto dist = edm4eic::magnitude(pos0-pos1);
+            length += dist;
+            m_log->trace("               dist to previous point: {}", dist);
+          }
+
+          // add the `TrackPoint` to the `TrackSegment`
+          track_segment.addToPoints(*point);
+
+        } // end `targetSurfaces` loop
+
+        // set final length and length error
+        track_segment.setLength(length);
+        track_segment.setLengthError(length_error);
+
+      } // end loop over input trajectories
+
+      return track_segments;
     }
 
 

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -51,11 +51,11 @@ namespace eicrecon {
 
 
 
-    std::vector<edm4eic::TrackPoint *>
+    std::vector<std::unique_ptr<edm4eic::TrackPoint>>
     TrackPropagation::propagateMany(std::vector<const eicrecon::TrackingResultTrajectory *> trajectories,
                                     const std::shared_ptr<const Acts::Surface> &targetSurf) {
         // output collection
-        std::vector<edm4eic::TrackPoint *> track_points;
+        std::vector<std::unique_ptr<edm4eic::TrackPoint>> track_points;
         m_log->trace("Track propagation evnet process. Num of input trajectories: {}", std::size(trajectories));
 
         // Loop over the trajectories
@@ -67,7 +67,7 @@ namespace eicrecon {
             if(!result) continue;
 
             // Add to output collection
-            track_points.push_back(result);
+            track_points.push_back(std::move(result));
         }
 
         return track_points;
@@ -99,7 +99,7 @@ namespace eicrecon {
         for(const auto& targetSurf : targetSurfaces) {
 
           // project the trajectory `traj` to this surface
-          edm4eic::TrackPoint *point;
+          std::unique_ptr<edm4eic::TrackPoint> point;
           try {
             point = propagate(traj, targetSurf);
           } catch(std::exception &e) {
@@ -142,7 +142,7 @@ namespace eicrecon {
 
 
 
-    edm4eic::TrackPoint *TrackPropagation::propagate(const eicrecon::TrackingResultTrajectory *traj,
+    std::unique_ptr<edm4eic::TrackPoint> TrackPropagation::propagate(const eicrecon::TrackingResultTrajectory *traj,
                                                      const std::shared_ptr<const Acts::Surface> &targetSurf) {
         // Get the entry index for the single trajectory
         // The trajectory entry indices and the multiTrajectory
@@ -279,7 +279,7 @@ namespace eicrecon {
           float pathlength{}; ///< Pathlength from the origin to this point
           float pathlengthError{}; ///< Error on the pathlenght
          */
-        return new edm4eic::TrackPoint({
+        return std::make_unique<edm4eic::TrackPoint>(edm4eic::TrackPoint{
                                                position,
                                                positionError,
                                                momentum,

--- a/src/algorithms/tracking/TrackPropagation.h
+++ b/src/algorithms/tracking/TrackPropagation.h
@@ -46,10 +46,12 @@ namespace eicrecon {
         std::vector<edm4eic::TrackPoint *> propagateMany(std::vector<const eicrecon::TrackingResultTrajectory *> trajectories,
                                                          const std::shared_ptr<const Acts::Surface> &targetSurf);
 
-        /** Propagates a trajectory to a list of surfaces, and returns the full `TrackSegment`
+        /** Propagates a collection of trajectories to a list of surfaces, and returns the full `TrackSegment`
          * @remark: being a simple wrapper of propagate(...) this method is more sutable for factories */
-        edm4eic::TrackSegment* propagateToSurfaceList(const eicrecon::TrackingResultTrajectory *traj,
-                                                      std::vector<std::shared_ptr<Acts::Surface>> targetSurfaces);
+        std::unique_ptr<edm4eic::TrackSegmentCollection> propagateToSurfaceList(
+            std::vector<const eicrecon::TrackingResultTrajectory*> trajectories,
+            std::vector<std::shared_ptr<Acts::Surface>> targetSurfaces
+            );
 
     private:
 

--- a/src/algorithms/tracking/TrackPropagation.h
+++ b/src/algorithms/tracking/TrackPropagation.h
@@ -39,11 +39,11 @@ namespace eicrecon {
         void init(std::shared_ptr<const ActsGeometryProvider> geo_svc, std::shared_ptr<spdlog::logger> logger);
 
         /** Propagates a single trajectory to a given surface */
-        edm4eic::TrackPoint * propagate(const eicrecon::TrackingResultTrajectory *, const std::shared_ptr<const Acts::Surface>& targetSurf);
+        std::unique_ptr<edm4eic::TrackPoint> propagate(const eicrecon::TrackingResultTrajectory *, const std::shared_ptr<const Acts::Surface>& targetSurf);
 
         /** Propagates a collection of trajectories to a given surface
          * @remark: being a simple wrapper of propagate(...) this method is more sutable for factories */
-        std::vector<edm4eic::TrackPoint *> propagateMany(std::vector<const eicrecon::TrackingResultTrajectory *> trajectories,
+        std::vector<std::unique_ptr<edm4eic::TrackPoint>> propagateMany(std::vector<const eicrecon::TrackingResultTrajectory *> trajectories,
                                                          const std::shared_ptr<const Acts::Surface> &targetSurf);
 
         /** Propagates a collection of trajectories to a list of surfaces, and returns the full `TrackSegment`

--- a/src/detectors/DRICH/DRICH.cc
+++ b/src/detectors/DRICH/DRICH.cc
@@ -14,6 +14,7 @@
 
 // algorithm configurations
 #include <algorithms/digi/PhotoMultiplierHitDigiConfig.h>
+#include <global/pid/RichTrackConfig.h>
 
 
 extern "C" {
@@ -54,6 +55,11 @@ extern "C" {
     digi_cfg.quantumEfficiency.push_back({850, 0.06});
     digi_cfg.quantumEfficiency.push_back({900, 0.04});
 
+    // track propagation to each radiator
+    RichTrackConfig track_cfg;
+    track_cfg.numPlanes.insert({ "Aerogel", 5  });
+    track_cfg.numPlanes.insert({ "Gas",     10 });
+
 
     // wiring between factories and data ///////////////////////////////////////
     // clang-format off
@@ -68,13 +74,12 @@ extern "C" {
           ));
 
     // charged particle tracks
-    app->Add(new JChainFactoryGeneratorT<RichTrack_factory>(
+    app->Add(new JChainMultifactoryGeneratorT<RichTrack_factory>(
+          "DRICHTracks",
           {"CentralCKFTrajectories"},
-          "DRICHAerogelTracks"
-          ));
-    app->Add(new JChainFactoryGeneratorT<RichTrack_factory>(
-          {"CentralCKFTrajectories"},
-          "DRICHGasTracks"
+          {"DRICHAerogelTracks", "DRICHGasTracks"},
+          track_cfg,
+          app
           ));
 
     // clang-format on

--- a/src/global/pid/RichTrackConfig.h
+++ b/src/global/pid/RichTrackConfig.h
@@ -1,0 +1,36 @@
+// Copyright 2023, Christopher Dilks
+// Subject to the terms in the LICENSE file found in the top-level directory.
+
+#pragma once
+
+#include <spdlog/spdlog.h>
+
+namespace eicrecon {
+
+  class RichTrackConfig {
+    public:
+
+      /////////////////////////////////////////////////////
+      // CONFIGURATION PARAMETERS
+      //   NOTE: some defaults are hard-coded here; override externally
+
+      std::map <std::string,unsigned> numPlanes; // number of xy-planes for track projections (for each radiator)
+
+      //
+      /////////////////////////////////////////////////////
+
+
+      // print all parameters
+      void Print(
+          std::shared_ptr<spdlog::logger> m_log,
+          spdlog::level::level_enum lvl=spdlog::level::debug
+          )
+      {
+        m_log->log(lvl, "{:=^60}"," RichTrackConfig Settings ");
+        for(const auto& [rad,val] : numPlanes)
+          m_log->log(lvl, "  {:>20} = {:<}", fmt::format("{} numPlanes", rad), val);
+        m_log->log(lvl, "{:=^60}","");
+      }
+
+  };
+}

--- a/src/global/pid/RichTrack_factory.cc
+++ b/src/global/pid/RichTrack_factory.cc
@@ -21,10 +21,10 @@ void eicrecon::RichTrack_factory::Init() {
   // get list of radiators
   std::map<int,std::string> radiator_list;
   for(auto& output_tag : GetOutputTags()) {
-    auto radiator_id = richgeo::ParseRadiatorName(output_tag/*, m_log*/); // FIXME: m_log argument requires PR #608
+    auto radiator_id = richgeo::ParseRadiatorName(output_tag, m_log);
     radiator_list.insert({
         radiator_id,
-        richgeo::RadiatorName(radiator_id/*, m_log*/) // FIXME: m_log argument requires PR #608
+        richgeo::RadiatorName(radiator_id, m_log)
         });
   }
 

--- a/src/global/pid/RichTrack_factory.cc
+++ b/src/global/pid/RichTrack_factory.cc
@@ -21,10 +21,10 @@ void eicrecon::RichTrack_factory::Init() {
   // get list of radiators
   std::map<int,std::string> radiator_list;
   for(auto& output_tag : GetOutputTags()) {
-    auto radiator_id = richgeo::ParseRadiatorName(output_tag, m_log);
+    auto radiator_id = richgeo::ParseRadiatorName(output_tag/*, m_log*/); // FIXME: m_log argument requires PR #608
     radiator_list.insert({
         radiator_id,
-        richgeo::RadiatorName(radiator_id, m_log)
+        richgeo::RadiatorName(radiator_id/*, m_log*/) // FIXME: m_log argument requires PR #608
         });
   }
 

--- a/src/global/pid/RichTrack_factory.h
+++ b/src/global/pid/RichTrack_factory.h
@@ -1,10 +1,10 @@
-// Copyright 2022, Christopher Dilks
+// Copyright (C) 2022, 2023 Christopher Dilks
 // Subject to the terms in the LICENSE file found in the top-level directory.
 
 #pragma once
 
 // JANA
-#include <extensions/jana/JChainFactoryT.h>
+#include <extensions/jana/JChainMultifactoryT.h>
 #include <JANA/JEvent.h>
 
 // data model
@@ -12,6 +12,9 @@
 
 // algorithms
 #include <algorithms/tracking/TrackPropagation.h>
+
+// configuration
+#include <global/pid/RichTrackConfig.h>
 
 // services
 #include <services/geometry/richgeo/RichGeo_service.h>
@@ -23,19 +26,27 @@
 
 namespace eicrecon {
   class RichTrack_factory :
-    public JChainFactoryT<edm4eic::TrackSegment>,
+    public JChainMultifactoryT<RichTrackConfig>,
     public SpdlogMixin<RichTrack_factory>
   {
     public:
 
-      explicit RichTrack_factory(std::vector<std::string> default_input_tags) :
-          JChainFactoryT<edm4eic::TrackSegment>(std::move(default_input_tags)) {}
+      explicit RichTrack_factory(
+          std::string tag,
+          const std::vector<std::string>& input_tags,
+          const std::vector<std::string>& output_tags,
+          RichTrackConfig cfg
+          ):
+        JChainMultifactoryT<RichTrackConfig>(std::move(tag), input_tags, output_tags, cfg) {
+          for(auto& output_tag : GetOutputTags())
+            DeclarePodioOutput<edm4eic::TrackSegment>(output_tag);
+        }
 
       /** One time initialization **/
       void Init() override;
 
       /** On run change preparations **/
-      void ChangeRun(const std::shared_ptr<const JEvent> &event) override;
+      void BeginRun(const std::shared_ptr<const JEvent> &event) override;
 
       /** Event by event processing **/
       void Process(const std::shared_ptr<const JEvent> &event) override;
@@ -45,9 +56,11 @@ namespace eicrecon {
       std::shared_ptr<RichGeo_service> m_richGeoSvc;
       std::shared_ptr<ACTSGeo_service> m_actsSvc;
       richgeo::ActsGeo *m_actsGeo;
-      std::vector<std::shared_ptr<Acts::Surface>> m_trackingPlanes;
-      int m_numPlanes;
-      int m_radiatorID;
+
+      // vector of radiators, each with a vector of xy-planes to project to
+      std::vector< std::vector<std::shared_ptr<Acts::Surface>> > m_tracking_planes;
+
+      // underlying algorithm
       eicrecon::TrackPropagation m_propagation_algo;
   };
 }

--- a/src/tests/track_propagation_test/TrackPropagationTest_processor.cc
+++ b/src/tests/track_propagation_test/TrackPropagationTest_processor.cc
@@ -85,7 +85,7 @@ void TrackPropagationTest_processor::Process(const std::shared_ptr<const JEvent>
         auto &trajectory = trajectories[traj_index];
         m_log->trace(" -- trajectory {} --", traj_index);
 
-        edm4eic::TrackPoint* projection_point;
+        std::unique_ptr<edm4eic::TrackPoint> projection_point;
         try {
             // >>> try to propagate to surface <<<
             projection_point = m_propagation_algo.propagate(trajectory, m_hcal_surface);

--- a/src/tests/track_seeding_test/TrackSeedingTest_processor.cc
+++ b/src/tests/track_seeding_test/TrackSeedingTest_processor.cc
@@ -88,7 +88,7 @@ void TrackSeedingTest_processor::Process(const std::shared_ptr<const JEvent>& ev
         auto &trajectory = trajectories[traj_index];
         m_log->trace(" -- trajectory {} --", traj_index);
 
-        edm4eic::TrackPoint* projection_point;
+        std::unique_ptr<edm4eic::TrackPoint> projection_point;
         try {
             // >>> try to propagate to surface <<<
             projection_point = m_propagation_algo.propagate(trajectory, m_hcal_surface);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
- return `Collection` of `TrackSegments` in `TrackPropagation::propagateToSurfaceList`, rather than a (potentially leaky) new `TrackSegment` pointer
  - the loop over input trajectories is moved from `RichTrack_factory` to `TrackPropagation::propagateToSurfaceList`, which makes the PR diff appear to be more complex than it actually is
  - fix additional possible memory leaks by replacing any `return new raw_pointer` calls with `return std::make_unique<...>(...)`, and update any code which depends on this change
- improve the configuration with `RichTrackConfig`, which configures the _factory_, not the algorithm, since the factory is used to connect to the `richgeo` service (and not the more general `TrackPropagation` algorithm)


### What kind of change does this PR introduce?
- [x] Bug fix (memory leaks)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added: tested in `irt-algo` branch
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no, unless the `TrackPropagation` algorithm is called by anything external of EICrecon

### Does this PR change default behavior?
no