### PR TITLE
feat: write ReconstructedParticleAssociations into output file

### DIFF
--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -67,6 +67,7 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             // Reconstructed data
             "GeneratedParticles",
             "ReconstructedParticles",
+            "ReconstructedParticleAssociations",
             "ReconstructedChargedParticles",
             "ReconstructedChargedParticleAssociations",
             "CentralTrackSegments",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
We have a working (somewhat) MatchClusters, but don't write the ReconstructedParticleAssociations collection. This adds that to the output.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: associations are found but not written)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Adds new output collection ReconstructedParticleAssociations.