### PR TITLE
EcalBarrelScFiRecHits: update value of thresholdFactor

### DIFF
--- a/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelScFiRecHits.h
+++ b/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelScFiRecHits.h
@@ -32,7 +32,7 @@ public:
         m_resolutionTDC=10 * dd4hep::picosecond;//{this, "resolutionTDC", 10 * ps};
 
         // zero suppression values
-        m_thresholdFactor=5.0;// from ATHENA's reconstruction.py
+        m_thresholdFactor=36.0488;// from ATHENA's reconstruction.py
         m_thresholdValue=0.0;//{this, "thresholdValue", 0.0};
 
         // energy correction with sampling fraction


### PR DESCRIPTION
Updated the value of the threshold factor from 5 to 36.00488 to have a threshold of 0.5MeV

- [X] Other feature (issue #673 )


### Please check if this PR fulfills the following:
- [X] Tests for the changes have been added
- [X] Documentation has been added / updated
- [X] Changes have been communicated to collaborators


