### PR TITLE
CalorimeterHitReco, RomanPotsReconstruction_factory: fix UBSAN error regarding converting -1 to size_t

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitReco.h
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.h
@@ -79,7 +79,7 @@ public:
   std::string m_localDetElement="", m_maskPos="";
   std::vector<std::string> u_localDetFields={}, u_maskPosFields={};
   dd4hep::DetElement local;
-  size_t local_mask = ~0U, gpos_mask = 0U;
+  size_t local_mask = ~0UL, gpos_mask = 0UL;
 
     std::vector<edm4eic::CalorimeterHit*> hits;
     std::vector<const edm4hep::RawCalorimeterHit*> rawhits;

--- a/src/algorithms/calorimetry/CalorimeterHitReco.h
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.h
@@ -79,7 +79,7 @@ public:
   std::string m_localDetElement="", m_maskPos="";
   std::vector<std::string> u_localDetFields={}, u_maskPosFields={};
   dd4hep::DetElement local;
-  size_t local_mask = ~0UL, gpos_mask = 0UL;
+  size_t local_mask = ~static_cast<size_t>(0), gpos_mask = static_cast<size_t>(0);
 
     std::vector<edm4eic::CalorimeterHit*> hits;
     std::vector<const edm4hep::RawCalorimeterHit*> rawhits;

--- a/src/algorithms/calorimetry/CalorimeterHitReco.h
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.h
@@ -79,7 +79,7 @@ public:
   std::string m_localDetElement="", m_maskPos="";
   std::vector<std::string> u_localDetFields={}, u_maskPosFields={};
   dd4hep::DetElement local;
-  size_t local_mask = ~0, gpos_mask = 0;
+  size_t local_mask = ~0U, gpos_mask = 0U;
 
     std::vector<edm4eic::CalorimeterHit*> hits;
     std::vector<const edm4hep::RawCalorimeterHit*> rawhits;

--- a/src/detectors/RPOTS/RomanPotsReconstruction_factory.h
+++ b/src/detectors/RPOTS/RomanPotsReconstruction_factory.h
@@ -65,7 +65,7 @@ namespace eicrecon {
 	std::vector<std::string> u_localDetFields;
 
 	dd4hep::DetElement local;
-	size_t local_mask = ~0UL;
+	size_t local_mask = ~static_cast<size_t>(0);
 	dd4hep::Detector *detector = nullptr;
 
 	const double aXRP[2][2] = {{2.102403743, 29.11067626},

--- a/src/detectors/RPOTS/RomanPotsReconstruction_factory.h
+++ b/src/detectors/RPOTS/RomanPotsReconstruction_factory.h
@@ -65,7 +65,7 @@ namespace eicrecon {
 	std::vector<std::string> u_localDetFields;
 
 	dd4hep::DetElement local;
-	size_t local_mask = ~0U;
+	size_t local_mask = ~0UL;
 	dd4hep::Detector *detector = nullptr;
 
 	const double aXRP[2][2] = {{2.102403743, 29.11067626},

--- a/src/detectors/RPOTS/RomanPotsReconstruction_factory.h
+++ b/src/detectors/RPOTS/RomanPotsReconstruction_factory.h
@@ -65,7 +65,7 @@ namespace eicrecon {
 	std::vector<std::string> u_localDetFields;
 
 	dd4hep::DetElement local;
-	size_t local_mask = ~0;
+	size_t local_mask = ~0U;
 	dd4hep::Detector *detector = nullptr;
 
 	const double aXRP[2][2] = {{2.102403743, 29.11067626},


### PR DESCRIPTION
This is needed to facilitate #514

src/algorithms/calorimetry/CalorimeterHitReco.h:80:23: runtime error: implicit conversion from type 'int' of value -1 (32-bit, signed) to type 'size_t' (aka 'unsigned long') changed the value to 18446744073709551615 (64-bit, unsigned)
src/detectors/RPOTS/RomanPotsReconstruction_factory.h:68:22: runtime error: implicit conversion from type 'int' of value -1 (32-bit, signed) to type 'size_t' (aka 'unsigned long') changed the value to 18446744073709551615 (64-bit, unsigned)