### PR TITLE
feat(dRICH): link unique `Track` to `TrackSegment`s

### DIFF
--- a/src/detectors/DRICH/DRICH.cc
+++ b/src/detectors/DRICH/DRICH.cc
@@ -77,7 +77,7 @@ extern "C" {
     app->Add(new JChainMultifactoryGeneratorT<RichTrack_factory>(
           "DRICHTracks",
           {"CentralCKFTrajectories"},
-          {"DRICHAerogelTracks", "DRICHGasTracks"},
+          {"DRICHAerogelTracks", "DRICHGasTracks", "DRICHTrackIDs"},
           track_cfg,
           app
           ));

--- a/src/detectors/DRICH/DRICH.cc
+++ b/src/detectors/DRICH/DRICH.cc
@@ -77,7 +77,7 @@ extern "C" {
     app->Add(new JChainMultifactoryGeneratorT<RichTrack_factory>(
           "DRICHTracks",
           {"CentralCKFTrajectories"},
-          {"DRICHAerogelTracks", "DRICHGasTracks", "DRICHTrackIDs"},
+          {"DRICHAerogelTracks", "DRICHGasTracks"},
           track_cfg,
           app
           ));

--- a/src/global/pid/RichTrack_factory.cc
+++ b/src/global/pid/RichTrack_factory.cc
@@ -73,19 +73,20 @@ void eicrecon::RichTrack_factory::Process(const std::shared_ptr<const JEvent> &e
   /* workaround (FIXME)
    * - this factory creates multiple track projections (`edm4eic::TrackSegment`)
    *   for a single input `eicrecon::TrackingResultTrajectory`, but downstream
-   *   needs a way to know which of these `edm4eic::TrackSegments` came from
+   *   code needs a way to know which of these `edm4eic::TrackSegments` came from
    *   the same input `eicrecon::TrackingResultTrajectory`
    * - `eicrecon::TrackingResultTrajectory` is not an `EDM4*` datatype, and
    *   therefore the `edm4eic::TrackSegment` objects this factory creates
    *   cannot link to them
    * - in the data model `edm4eic::TrackSegment` can have a 1-1 relation to
-   *   an `edm4hep::Track`
-   * - therefore, as a workaround, we generate a unique, empty `edm4hep::Track`
-   *   for each `eicrecon::TrackingResultTrajectory`, which can be used in this
+   *   an `edm4eic::Track`
+   * - therefore, as a workaround, we generate a unique, empty `edm4eic::Track`
+   *   for each input `eicrecon::TrackingResultTrajectory`, which can be used in this
    *   1-1 relation from `edm4eic::TrackSegment` as a unique identifier to encode
    *   which `edm4eic::TrackSegment`s came from the same input track
    * - finally, an additional 'TrackID' output tag is needed, to to guarantee
-   *   these related `edm4eic::Track` objects are accessible by downstream readers
+   *   these related `edm4eic::Track` objects have an owner are accessible by
+   *   downstream readers
    */
   auto track_coll = std::make_unique<edm4eic::TrackCollection>();
   for(const auto& traj : trajectories)

--- a/src/global/pid/RichTrack_factory.h
+++ b/src/global/pid/RichTrack_factory.h
@@ -39,12 +39,8 @@ namespace eicrecon {
           RichTrackConfig cfg
           ):
         JChainMultifactoryT<RichTrackConfig>(std::move(tag), input_tags, output_tags, cfg) {
-          for(auto& output_tag : GetOutputTags()) {
-            if(output_tag.find("TrackID") == std::string::npos)
-              DeclarePodioOutput<edm4eic::TrackSegment>(output_tag);
-            else
-              DeclarePodioOutput<edm4eic::Track>(output_tag);
-          }
+          for(auto& output_tag : GetOutputTags())
+            DeclarePodioOutput<edm4eic::TrackSegment>(output_tag);
         }
 
       /** One time initialization **/

--- a/src/global/pid/RichTrack_factory.h
+++ b/src/global/pid/RichTrack_factory.h
@@ -9,6 +9,7 @@
 
 // data model
 #include <edm4eic/TrackSegmentCollection.h>
+#include <edm4eic/TrackCollection.h>
 
 // algorithms
 #include <algorithms/tracking/TrackPropagation.h>
@@ -38,8 +39,12 @@ namespace eicrecon {
           RichTrackConfig cfg
           ):
         JChainMultifactoryT<RichTrackConfig>(std::move(tag), input_tags, output_tags, cfg) {
-          for(auto& output_tag : GetOutputTags())
-            DeclarePodioOutput<edm4eic::TrackSegment>(output_tag);
+          for(auto& output_tag : GetOutputTags()) {
+            if(output_tag.find("TrackID") == std::string::npos)
+              DeclarePodioOutput<edm4eic::TrackSegment>(output_tag);
+            else
+              DeclarePodioOutput<edm4eic::Track>(output_tag);
+          }
         }
 
       /** One time initialization **/
@@ -57,8 +62,11 @@ namespace eicrecon {
       std::shared_ptr<ACTSGeo_service> m_actsSvc;
       richgeo::ActsGeo *m_actsGeo;
 
-      // vector of radiators, each with a vector of xy-planes to project to
-      std::vector< std::vector<std::shared_ptr<Acts::Surface>> > m_tracking_planes;
+      // map: output_tag name (for a radiator's track projections) -> a vector of xy-planes to project to
+      std::map< std::string, std::vector<std::shared_ptr<Acts::Surface>> > m_tracking_planes;
+
+      // name of trackIDs output collection
+      std::string m_trackIDs_tag;
 
       // underlying algorithm
       eicrecon::TrackPropagation m_propagation_algo;


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This is more of a workaround for an uncomfortable design issue:
- the factory `RichTrack_factory` creates multiple track projections (datatype `edm4eic::TrackSegment`) for a single input `eicrecon::TrackingResultTrajectory`, but downstream code needs a way to know which of these `edm4eic::TrackSegments` came from the same input `eicrecon::TrackingResultTrajectory`
- `eicrecon::TrackingResultTrajectory` is not an `EDM4*` datatype, and therefore the `edm4eic::TrackSegment` objects this factory creates cannot link to them
- in the data model `edm4eic::TrackSegment` can have a 1-1 relation to an `edm4eic::Track`
- therefore, as a workaround, we generate a unique, empty `edm4eic::Track` for each input `eicrecon::TrackingResultTrajectory`, which can be used in this 1-1 relation from `edm4eic::TrackSegment` as a unique identifier to encode which `edm4eic::TrackSegment`s came from the same input track
- finally, an additional 'TrackID' output tag is needed, to to guarantee these related `edm4eic::Track` objects have an owner and are accessible by downstream readers

Additional thoughts
1. if `eicrecon::TrackingResultTrajectory` were an `EDM4*` datatype, than that is what `edm4eic::TrackSegment` should link to; alternatively we should be able to run the `TrackPropagator` for `edm4eic::Track` objects
2. if two different PID subsystems use this factory, this workaround will not work, since the created unique `edm4eic::Track` objects will be different; but the hope is that thought (1) above can be addressed, then we can get rid of this workaround and the two PID subsystems will have a way of identifying a unique charged particle track which passed through both of them
3. alternative solution: `RichTrack_factory` for the dRICH creates 2 `edm4eic::TrackSegmentCollection`s: one for aerogel and another for gas. We could combine their `edm4eic::TrackSegment`s to 1 (combining gas and aerogel), but this solution seems to have less flexibility whenever we want to implement another PID algorithm other than IRT, and does not resolve thought (2) above

### What kind of change does this PR introduce?
- [x] Bug fix (a downstream bug on the `irt-algo` branch)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added (running benchmarks locally)
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
Yes, already addressed on the `irt-algo` branch; no breaking changes for `main`

### Does this PR change default behavior?
No