### PR TITLE
feat(dRICH): merge track propagations

### DIFF
--- a/src/algorithms/CMakeLists.txt
+++ b/src/algorithms/CMakeLists.txt
@@ -2,5 +2,6 @@ cmake_minimum_required(VERSION 3.16)
 
 add_subdirectory( calorimetry )
 add_subdirectory( tracking )
+add_subdirectory( pid )
 add_subdirectory( digi )
 add_subdirectory( reco )

--- a/src/algorithms/pid/CMakeLists.txt
+++ b/src/algorithms/pid/CMakeLists.txt
@@ -1,12 +1,10 @@
 cmake_minimum_required(VERSION 3.16)
 
-# Automatically set plugin name the same as the directory name
-# Don't forget string(REPLACE " " "_" PLUGIN_NAME ${PLUGIN_NAME}) if this dir has spaces in its name
-get_filename_component(PLUGIN_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
+set(PLUGIN_NAME "algorithms_pid")
 
 # Function creates ${PLUGIN_NAME}_plugin and ${PLUGIN_NAME}_library targets
 # Setting default includes, libraries and installation paths
-plugin_add(${PLUGIN_NAME})
+plugin_add(${PLUGIN_NAME} WITH_STATIC_LIBRARY)
 
 # The macro grabs sources as *.cc *.cpp *.c and headers as *.h *.hh *.hpp
 # Then correctly sets sources for ${_name}_plugin and ${_name}_library targets
@@ -15,11 +13,6 @@ plugin_glob_all(${PLUGIN_NAME})
 
 # Find dependencies
 plugin_add_dd4hep(${PLUGIN_NAME})
-plugin_add_acts(${PLUGIN_NAME})
 plugin_add_irt(${PLUGIN_NAME})
-plugin_add_cern_root(${PLUGIN_NAME})
 plugin_add_event_model(${PLUGIN_NAME})
-
-# Add libraries
-# (same as target_include_directories but for both plugin and library)
-plugin_link_libraries(${PLUGIN_NAME} algorithms_tracking_library algorithms_pid_library)
+plugin_add_cern_root(${PLUGIN_NAME})

--- a/src/algorithms/pid/MergeTracks.cc
+++ b/src/algorithms/pid/MergeTracks.cc
@@ -1,0 +1,75 @@
+// Copyright 2023, Christopher Dilks
+// Subject to the terms in the LICENSE file found in the top-level directory.
+
+#include "MergeTracks.h"
+
+// AlgorithmInit
+//---------------------------------------------------------------------------
+void eicrecon::MergeTracks::AlgorithmInit(std::shared_ptr<spdlog::logger>& logger)
+{
+  m_log = logger;
+}
+
+
+// AlgorithmChangeRun
+//---------------------------------------------------------------------------
+void eicrecon::MergeTracks::AlgorithmChangeRun() {
+}
+
+
+// AlgorithmProcess
+//---------------------------------------------------------------------------
+std::unique_ptr<edm4eic::TrackSegmentCollection> eicrecon::MergeTracks::AlgorithmProcess(
+    std::vector<const edm4eic::TrackSegmentCollection*> in_track_collections
+    )
+{
+  // logging
+  m_log->trace("{:=^70}"," call MergeTracks::AlgorithmProcess ");
+
+  // start output collection
+  auto out_tracks = std::make_unique<edm4eic::TrackSegmentCollection>();
+
+  // check that all input collections have the same size
+  std::size_t n_tracks = -1;
+  for(const auto& in_track_collection : in_track_collections) {
+    if(n_tracks == -1)
+      n_tracks = in_track_collection->size();
+    else if(n_tracks != in_track_collection->size()) {
+      m_log->error("input track collections do not have the same size; cannot merge");
+      return out_tracks;
+    }
+  }
+
+  // loop over track collection elements
+  for(std::size_t i_track=0; i_track<n_tracks; i_track++) {
+
+    // create a new output track, and a local container to hold its track points
+    auto out_track = out_tracks->create();
+    std::vector<edm4eic::TrackPoint> out_track_points;
+
+    // loop over collections for this track, and add each track's points to `out_track_points`
+    for(const auto& in_track_collection : in_track_collections) {
+      const auto& in_track = in_track_collection->at(i_track);
+      for(const auto& point : in_track.getPoints())
+        out_track_points.push_back(point);
+    }
+
+    // sort all `out_track_points` by time
+    std::sort(
+        out_track_points.begin(),
+        out_track_points.end(),
+        [] (edm4eic::TrackPoint& a, edm4eic::TrackPoint& b) { return a.time < b.time; }
+        );
+
+    // add these sorted points to `out_track`
+    for(const auto& point : out_track_points)
+      out_track.addToPoints(point);
+
+    /* FIXME: merge other members, such as `length` and `lengthError`;
+     * currently not needed for RICH tracks, so such members are left as default
+     */
+
+  } // end loop over tracks
+
+  return out_tracks;
+}

--- a/src/algorithms/pid/MergeTracks.h
+++ b/src/algorithms/pid/MergeTracks.h
@@ -1,0 +1,43 @@
+// Copyright 2023, Christopher Dilks
+// Subject to the terms in the LICENSE file found in the top-level directory.
+
+// merge together TrackSegments, sorting their TrackPoints by time
+/* FIXME: only VectorMember `points` is combined, which is all that is needed
+ * for the RICH detectors. If using this algorithm for any other purpose, you
+ * may want to combine the other members and relations in `TrackSegment`.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <algorithm>
+
+// data model
+#include <edm4eic/TrackSegmentCollection.h>
+
+// EICrecon
+#include <spdlog/spdlog.h>
+
+namespace eicrecon {
+
+  class MergeTracks {
+
+    public:
+      MergeTracks() = default;
+      ~MergeTracks() {}
+
+      void AlgorithmInit(std::shared_ptr<spdlog::logger>& logger);
+      void AlgorithmChangeRun();
+
+      // AlgorithmProcess
+      // - input: a list of TrackSegment collections
+      // - output: the merged TrackSegment collections, effectively the "zip" of the input collections
+      std::unique_ptr<edm4eic::TrackSegmentCollection> AlgorithmProcess(
+          std::vector<const edm4eic::TrackSegmentCollection*> in_track_collections
+          );
+
+    private:
+      std::shared_ptr<spdlog::logger> m_log;
+
+  };
+}

--- a/src/detectors/DRICH/DRICH.cc
+++ b/src/detectors/DRICH/DRICH.cc
@@ -11,6 +11,7 @@
 // factories
 #include <global/digi/PhotoMultiplierHitDigi_factory.h>
 #include <global/pid/RichTrack_factory.h>
+#include <global/pid/MergeTrack_factory.h>
 
 // algorithm configurations
 #include <algorithms/digi/PhotoMultiplierHitDigiConfig.h>
@@ -80,6 +81,10 @@ extern "C" {
           {"DRICHAerogelTracks", "DRICHGasTracks"},
           track_cfg,
           app
+          ));
+    app->Add(new JChainFactoryGeneratorT<MergeTrack_factory>(
+          {"DRICHAerogelTracks", "DRICHGasTracks"},
+          "DRICHMergedTracks"
           ));
 
     // clang-format on

--- a/src/global/pid/MergeTrack_factory.cc
+++ b/src/global/pid/MergeTrack_factory.cc
@@ -1,0 +1,45 @@
+// Copyright (C) 2022, 2023, Christopher Dilks
+// Subject to the terms in the LICENSE file found in the top-level directory.
+
+#include "MergeTrack_factory.h"
+
+//-----------------------------------------------------------------------------
+void eicrecon::MergeTrack_factory::Init() {
+
+  // get plugin name and tag
+  auto app = GetApplication();
+  auto detector_name = eicrecon::str::ReplaceAll(GetPluginName(), ".so", "");
+  auto param_prefix = detector_name + ":" + GetTag();
+  InitDataTags(param_prefix);
+
+  // services
+  InitLogger(param_prefix, "info");
+  m_algo.AlgorithmInit(m_log);
+  m_log->debug("detector_name='{}'  param_prefix='{}'", detector_name, param_prefix);
+
+}
+
+//-----------------------------------------------------------------------------
+void eicrecon::MergeTrack_factory::BeginRun(const std::shared_ptr<const JEvent> &event) {
+}
+
+//-----------------------------------------------------------------------------
+void eicrecon::MergeTrack_factory::Process(const std::shared_ptr<const JEvent> &event) {
+
+  // get input collections
+  std::vector<const edm4eic::TrackSegmentCollection*> in_track_collections;
+  for(auto& input_tag : GetInputTags())
+    in_track_collections.push_back(
+        static_cast<const edm4eic::TrackSegmentCollection*>(event->GetCollectionBase(input_tag))
+        );
+
+  // call the MergeTracks algorithm
+  try {
+    auto out_track_collection = m_algo.AlgorithmProcess(in_track_collections);
+    SetCollection(std::move(out_track_collection));
+  }
+  catch(std::exception &e) {
+    m_log->warn("Exception in underlying algorithm: {}. Event data will be skipped", e.what());
+  }
+
+}

--- a/src/global/pid/MergeTrack_factory.cc
+++ b/src/global/pid/MergeTrack_factory.cc
@@ -39,7 +39,7 @@ void eicrecon::MergeTrack_factory::Process(const std::shared_ptr<const JEvent> &
     SetCollection(std::move(out_track_collection));
   }
   catch(std::exception &e) {
-    m_log->warn("Exception in underlying algorithm: {}. Event data will be skipped", e.what());
+    throw JException(e.what());
   }
 
 }

--- a/src/global/pid/MergeTrack_factory.h
+++ b/src/global/pid/MergeTrack_factory.h
@@ -1,0 +1,50 @@
+// Copyright (C) 2022, 2023 Christopher Dilks
+// Subject to the terms in the LICENSE file found in the top-level directory.
+
+#pragma once
+
+// JANA
+#include <extensions/jana/JChainFactoryT.h>
+#include <JANA/JEvent.h>
+
+// data model
+#include <edm4eic/TrackSegmentCollection.h>
+
+// algorithms
+#include <algorithms/pid/MergeTracks.h>
+
+// services
+#include <services/log/Log_service.h>
+#include <extensions/spdlog/SpdlogExtensions.h>
+#include <extensions/spdlog/SpdlogMixin.h>
+#include <extensions/string/StringHelpers.h>
+
+namespace eicrecon {
+
+  class MergeTracks;
+
+  class MergeTrack_factory :
+    public JChainFactoryT<edm4eic::TrackSegment>,
+    public SpdlogMixin<MergeTrack_factory>
+  {
+
+    public:
+
+      explicit MergeTrack_factory(std::vector<std::string> default_input_tags) :
+        JChainFactoryT<edm4eic::TrackSegment>(std::move(default_input_tags)) {}
+
+      /** One time initialization **/
+      void Init() override;
+
+      /** On run change preparations **/
+      void BeginRun(const std::shared_ptr<const JEvent> &event) override;
+
+      /** Event by event processing **/
+      void Process(const std::shared_ptr<const JEvent> &event) override;
+
+    private:
+
+      // underlying algorithm
+      eicrecon::MergeTracks m_algo;
+  };
+}

--- a/src/global/pid/RichTrack_factory.cc
+++ b/src/global/pid/RichTrack_factory.cc
@@ -22,11 +22,11 @@ void eicrecon::RichTrack_factory::Init() {
   std::vector<std::tuple<int, std::string, std::string>> radiator_list; // < radiator_id, radiator_name, output_tag >
   for(auto& output_tag : GetOutputTags()) {
     auto radiator_id = richgeo::ParseRadiatorName(output_tag, m_log);
-    radiator_list.push_back({
+    radiator_list.emplace_back(
         radiator_id,
         richgeo::RadiatorName(radiator_id, m_log),
         output_tag
-        });
+        );
   }
 
   // configuration parameters

--- a/src/global/pid/RichTrack_factory.cc
+++ b/src/global/pid/RichTrack_factory.cc
@@ -19,12 +19,13 @@ void eicrecon::RichTrack_factory::Init() {
   m_log->debug("detector_name='{}'  param_prefix='{}'", detector_name, param_prefix);
 
   // get list of radiators
-  std::map<int,std::string> radiator_list;
+  std::vector<std::tuple<int, std::string, std::string>> radiator_list; // < radiator_id, radiator_name, output_tag >
   for(auto& output_tag : GetOutputTags()) {
     auto radiator_id = richgeo::ParseRadiatorName(output_tag, m_log);
-    radiator_list.insert({
+    radiator_list.push_back({
         radiator_id,
-        richgeo::RadiatorName(radiator_id, m_log)
+        richgeo::RadiatorName(radiator_id, m_log),
+        output_tag
         });
   }
 
@@ -34,16 +35,17 @@ void eicrecon::RichTrack_factory::Init() {
     name = param_prefix + ":" + name;
     app->SetDefaultParameter(name, val, description);
   };
-  for(auto& [radiator_id, radiator_name] : radiator_list)
+  for(auto& [radiator_id, radiator_name, output_tag] : radiator_list)
     set_param(radiator_name+":numPlanes", cfg.numPlanes[radiator_name], "");
   cfg.Print(m_log, spdlog::level::debug);
 
-  // get RICH geometry for track projection, for each radiator
+  // get RICH geometry for track propagation, for each radiator
   m_actsGeo = m_richGeoSvc->GetActsGeo(detector_name);
-  for(auto& [radiator_id, radiator_name] : radiator_list)
-    m_tracking_planes.push_back(
+  for(auto& [radiator_id, radiator_name, output_tag] : radiator_list)
+    m_tracking_planes.insert({
+        output_tag,
         m_actsGeo->TrackingPlanes(radiator_id, cfg.numPlanes.at(radiator_name))
-        );
+        });
 }
 
 //-----------------------------------------------------------------------------
@@ -66,12 +68,12 @@ void eicrecon::RichTrack_factory::Process(const std::shared_ptr<const JEvent> &e
   }
 
   // run algorithm, for each radiator
-  for(unsigned i=0; i<m_tracking_planes.size(); i++) {
-    auto& radiator_tracking_planes = m_tracking_planes.at(i);
-    auto& out_collection_name      = GetOutputTags().at(i);
+  for(auto& [output_tag, radiator_tracking_planes] : m_tracking_planes) {
     try {
+      // propagate trajectories to RICH planes (discs)
       auto result = m_propagation_algo.propagateToSurfaceList(trajectories, radiator_tracking_planes);
-      SetCollection<edm4eic::TrackSegment>(out_collection_name, std::move(result));
+      // set factory output propagated tracks
+      SetCollection<edm4eic::TrackSegment>(output_tag, std::move(result));
     }
     catch(std::exception &e) {
       throw JException(e.what());

--- a/src/global/pid/RichTrack_factory.cc
+++ b/src/global/pid/RichTrack_factory.cc
@@ -46,6 +46,7 @@ void eicrecon::RichTrack_factory::Init() {
         output_tag,
         m_actsGeo->TrackingPlanes(radiator_id, cfg.numPlanes.at(radiator_name))
         });
+
 }
 
 //-----------------------------------------------------------------------------
@@ -55,7 +56,7 @@ void eicrecon::RichTrack_factory::BeginRun(const std::shared_ptr<const JEvent> &
 //-----------------------------------------------------------------------------
 void eicrecon::RichTrack_factory::Process(const std::shared_ptr<const JEvent> &event) {
 
-  // collect all trajectories all input tags
+  // collect all trajectories from all input tags
   std::vector<const eicrecon::TrackingResultTrajectory*> trajectories;
   for(const auto& input_tag : GetInputTags()) {
     try {
@@ -67,16 +68,15 @@ void eicrecon::RichTrack_factory::Process(const std::shared_ptr<const JEvent> &e
     }
   }
 
-  // run algorithm, for each radiator
+  // run track propagator algorithm, for each radiator
   for(auto& [output_tag, radiator_tracking_planes] : m_tracking_planes) {
     try {
-      // propagate trajectories to RICH planes (discs)
       auto result = m_propagation_algo.propagateToSurfaceList(trajectories, radiator_tracking_planes);
-      // set factory output propagated tracks
       SetCollection<edm4eic::TrackSegment>(output_tag, std::move(result));
     }
     catch(std::exception &e) {
       throw JException(e.what());
     }
   }
+
 }

--- a/src/global/pid/RichTrack_factory.h
+++ b/src/global/pid/RichTrack_factory.h
@@ -57,8 +57,8 @@ namespace eicrecon {
       std::shared_ptr<ACTSGeo_service> m_actsSvc;
       richgeo::ActsGeo *m_actsGeo;
 
-      // vector of radiators, each with a vector of xy-planes to project to
-      std::vector< std::vector<std::shared_ptr<Acts::Surface>> > m_tracking_planes;
+      // map: output_tag name (for a radiator's track projections) -> a vector of xy-planes to project to
+      std::map< std::string, std::vector<std::shared_ptr<Acts::Surface>> > m_tracking_planes;
 
       // underlying algorithm
       eicrecon::TrackPropagation m_propagation_algo;

--- a/src/tests/algorithms_test/CMakeLists.txt
+++ b/src/tests/algorithms_test/CMakeLists.txt
@@ -3,10 +3,12 @@ get_filename_component(TEST_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
 
 # These tests can use the Catch2-provided main
 add_executable(${TEST_NAME}
-	calorimetry_CalorimeterIslandCluster.cc
-	)
+  calorimetry_CalorimeterIslandCluster.cc
+  pid_MergeTracks.cc
+  )
+
 # Explicit linking to podio::podio is needed due to https://github.com/JeffersonLab/JANA2/issues/151
-target_link_libraries(${TEST_NAME} PRIVATE Catch2::Catch2WithMain algorithms_calorimetry_library podio::podio podio::podioRootIO)
+target_link_libraries(${TEST_NAME} PRIVATE Catch2::Catch2WithMain algorithms_calorimetry_library algorithms_pid_library podio::podio podio::podioRootIO)
 
 # Install executable
 install(TARGETS ${TEST_NAME} DESTINATION bin)

--- a/src/tests/algorithms_test/pid_MergeTracks.cc
+++ b/src/tests/algorithms_test/pid_MergeTracks.cc
@@ -87,9 +87,8 @@ TEST_CASE("the PID MergeTracks algorithm runs", "[MergeTracks]") {
   make_track(collection1, { // empty
       { }
       });
-  make_track(collection2, { // horizontal
-      { {2, 0, 0}, {1, 0, 0}, 3 },
-      { {3, 0, 0}, {1, 0, 0}, 4 }
+  make_track(collection2, { // one point
+      { {2, 0, 0}, {1, 0, 0}, 3 }
       });
 
   // track2
@@ -163,7 +162,7 @@ TEST_CASE("the PID MergeTracks algorithm runs", "[MergeTracks]") {
     REQUIRE(trks->size() == colls.front()->size());
     // track length: from endpoints
     REQUIRE_THAT( track_length(trks->at(0)), Catch::Matchers::WithinAbs(5, EPSILON) );
-    REQUIRE_THAT( track_length(trks->at(1)), Catch::Matchers::WithinAbs(3, EPSILON) );
+    REQUIRE_THAT( track_length(trks->at(1)), Catch::Matchers::WithinAbs(2, EPSILON) );
     REQUIRE_THAT( track_length(trks->at(2)), Catch::Matchers::WithinAbs(std::hypot(1,2), EPSILON) );
     REQUIRE_THAT( track_length(trks->at(3)), Catch::Matchers::WithinAbs(5, EPSILON) );
     // track length: from algorithm // FIXME when implemented in `MergeTracks`

--- a/src/tests/algorithms_test/pid_MergeTracks.cc
+++ b/src/tests/algorithms_test/pid_MergeTracks.cc
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2023, Christopher Dilks
+
+#include <cmath>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <spdlog/logger.h>
+
+#include <algorithms/pid/MergeTracks.cc>
+
+TEST_CASE("the PID MergeTracks algorithm runs", "[MergeTracks]") {
+  eicrecon::MergeTracks algo;
+
+  // initialize algorithm
+  //----------------------------------------------------------
+  std::shared_ptr<spdlog::logger> logger = spdlog::default_logger()->clone("MergeTracks");
+  logger->set_level(spdlog::level::debug);
+  algo.AlgorithmInit(logger);
+
+  // helper functions and objects
+  //----------------------------------------------------------
+  const float EPSILON = 1e-5;
+
+  struct Point {
+    decltype(edm4eic::TrackPoint::position) position;
+    decltype(edm4eic::TrackPoint::momentum) momentum;
+    decltype(edm4eic::TrackPoint::time)     time;
+  };
+
+  auto make_track = [] (auto& coll, std::vector<Point> points) {
+    auto trk = coll->create();
+    for(auto& point : points) {
+      edm4eic::TrackPoint trk_point;
+      trk_point.position = point.position;
+      trk_point.momentum = point.momentum;
+      trk_point.time     = point.time;
+      trk.addToPoints(trk_point);
+    }
+  };
+
+  auto track_length = [] (auto trk) {
+    auto a = trk.getPoints(0);
+    auto b = trk.getPoints(trk.points_size()-1);
+    return std::hypot(
+        a.position.x - b.position.x,
+        a.position.y - b.position.y,
+        a.position.z - b.position.z
+        );
+  };
+
+  // inputs
+  //----------------------------------------------------------
+  /*
+     |        | collection0 | collection1 | collection2 |
+     | ------ | ----------- | ----------- | ----------- |
+     | track0 | horizontal  | horizontal  | horizontal  |
+     | track1 | horizontal  | empty       | one point   |
+     | track2 | vertical    | horizontal  | vertical    |
+     | track3 | horizontal  | horizontal  | horizontal  | // time disordered
+  */
+
+  // collections
+  auto collection0 = std::make_unique<edm4eic::TrackSegmentCollection>();
+  auto collection1 = std::make_unique<edm4eic::TrackSegmentCollection>();
+  auto collection2 = std::make_unique<edm4eic::TrackSegmentCollection>();
+
+  // track0
+  make_track(collection0, { // horizontal
+      { {0, 0, 0}, {1, 0, 0}, 1 }, // { position, momentum, time }
+      { {1, 0, 0}, {1, 0, 0}, 2 }
+      });
+  make_track(collection1, { // horizontal
+      { {2, 0, 0}, {1, 0, 0}, 3 },
+      { {3, 0, 0}, {1, 0, 0}, 4 }
+      });
+  make_track(collection2, { // horizontal
+      { {4, 0, 0}, {1, 0, 0}, 5 },
+      { {5, 0, 0}, {1, 0, 0}, 6 }
+      });
+
+  // track1
+  make_track(collection0, { // horizontal
+      { {0, 0, 0}, {1, 0, 0}, 1 },
+      { {1, 0, 0}, {1, 0, 0}, 2 }
+      });
+  make_track(collection1, { // empty
+      { }
+      });
+  make_track(collection2, { // horizontal
+      { {2, 0, 0}, {1, 0, 0}, 3 },
+      { {3, 0, 0}, {1, 0, 0}, 4 }
+      });
+
+  // track2
+  make_track(collection0, { // vertical
+      { {0, 0, 0}, {0, 1, 0}, 1 },
+      { {0, 1, 0}, {0, 1, 0}, 2 }
+      });
+  make_track(collection1, { // horizontal
+      { {0, 1, 0}, {1, 0, 0}, 3 },
+      { {1, 1, 0}, {1, 0, 0}, 4 }
+      });
+  make_track(collection2, { // vertical
+      { {1, 1, 0}, {0, 1, 0}, 5 },
+      { {1, 2, 0}, {0, 1, 0}, 6 }
+      });
+
+  // track3
+  make_track(collection0, { // horizontal
+      { {1, 0, 0}, {1, 0, 0}, 2 },
+      { {0, 0, 0}, {1, 0, 0}, 1 }
+      });
+  make_track(collection1, { // horizontal
+      { {3, 0, 0}, {1, 0, 0}, 4 },
+      { {4, 0, 0}, {1, 0, 0}, 5 }
+      });
+  make_track(collection2, { // horizontal
+      { {5, 0, 0}, {1, 0, 0}, 6 },
+      { {2, 0, 0}, {1, 0, 0}, 3 }
+      });
+
+  // tests
+  //----------------------------------------------------------
+
+  SECTION("merge tracks from 1 collection") {
+    // run algorithm
+    std::vector<const edm4eic::TrackSegmentCollection*> colls = { collection0.get() };
+    auto trks = algo.AlgorithmProcess(colls);
+    // input collection(s) size == output collection size
+    REQUIRE(trks->size() == colls.front()->size());
+    // track length: from endpoints
+    REQUIRE_THAT( track_length(trks->at(0)), Catch::Matchers::WithinAbs(1, EPSILON) );
+    REQUIRE_THAT( track_length(trks->at(1)), Catch::Matchers::WithinAbs(1, EPSILON) );
+    REQUIRE_THAT( track_length(trks->at(2)), Catch::Matchers::WithinAbs(1, EPSILON) );
+    REQUIRE_THAT( track_length(trks->at(3)), Catch::Matchers::WithinAbs(1, EPSILON) );
+    // track length: from algorithm // FIXME when implemented in `MergeTracks`
+    for(const auto& trk : *trks)
+      REQUIRE_THAT( trk.getLength(), Catch::Matchers::WithinAbs(0, EPSILON) );
+  }
+
+  SECTION("merge tracks from 2 collections") {
+    // run algorithm
+    std::vector<const edm4eic::TrackSegmentCollection*> colls = { collection0.get(), collection1.get() };
+    auto trks = algo.AlgorithmProcess(colls);
+    // input collection(s) size == output collection size
+    REQUIRE(trks->size() == colls.front()->size());
+    // track length: from endpoints
+    REQUIRE_THAT( track_length(trks->at(0)), Catch::Matchers::WithinAbs(3, EPSILON) );
+    REQUIRE_THAT( track_length(trks->at(1)), Catch::Matchers::WithinAbs(1, EPSILON) );
+    REQUIRE_THAT( track_length(trks->at(2)), Catch::Matchers::WithinAbs(std::hypot(1,1), EPSILON) );
+    REQUIRE_THAT( track_length(trks->at(3)), Catch::Matchers::WithinAbs(4, EPSILON) );
+    // track length: from algorithm // FIXME when implemented in `MergeTracks`
+    for(const auto& trk : *trks)
+      REQUIRE_THAT( trk.getLength(), Catch::Matchers::WithinAbs(0, EPSILON) );
+  }
+
+  SECTION("merge tracks from 3 collections") {
+    // run algorithm
+    std::vector<const edm4eic::TrackSegmentCollection*> colls = { collection0.get(), collection1.get(), collection2.get() };
+    auto trks = algo.AlgorithmProcess(colls);
+    // input collection(s) size == output collection size
+    REQUIRE(trks->size() == colls.front()->size());
+    // track length: from endpoints
+    REQUIRE_THAT( track_length(trks->at(0)), Catch::Matchers::WithinAbs(5, EPSILON) );
+    REQUIRE_THAT( track_length(trks->at(1)), Catch::Matchers::WithinAbs(3, EPSILON) );
+    REQUIRE_THAT( track_length(trks->at(2)), Catch::Matchers::WithinAbs(std::hypot(1,2), EPSILON) );
+    REQUIRE_THAT( track_length(trks->at(3)), Catch::Matchers::WithinAbs(5, EPSILON) );
+    // track length: from algorithm // FIXME when implemented in `MergeTracks`
+    for(const auto& trk : *trks)
+      REQUIRE_THAT( trk.getLength(), Catch::Matchers::WithinAbs(0, EPSILON) );
+  }
+
+}


### PR DESCRIPTION
### Briefly, what does this PR introduce?

- Add an algorithm to merge propagated tracks from dRICH aerogel and gas.
- Prefer to keep in `pid` algorithms, since:
  - avoid cluttering `tracking` algorithms
  - this is (currently) only used by PID, though it is a general algorithm for combining `TrackSegments`
  - it's incomplete, only combining the `TrackPoint`s (sorting them by time); we currently don't need the other members downstream for PID
- Add CMake file for `pid` algorithms library
  - there are more `plugin_add_*` calls needed for this PR, however, they will be needed for the full set of `pid` algorithms, so we might as well include them now (see #393)
 

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
no