### PR TITLE
fix: throw exceptions for algorithm failures, instead of warning printouts

### DIFF
--- a/src/global/digi/PhotoMultiplierHitDigi_factory.cc
+++ b/src/global/digi/PhotoMultiplierHitDigi_factory.cc
@@ -50,7 +50,7 @@ void eicrecon::PhotoMultiplierHitDigi_factory::Process(const std::shared_ptr<con
     SetCollection<edm4eic::MCRecoTrackerHitAssociation>(GetOutputTags()[1], std::move(result.hit_assocs));
   }
   catch(std::exception &e) {
-    m_log->warn("Exception in underlying algorithm: {}. Event data will be skipped", e.what());
+    throw JException(e.what());
   }
 
 }

--- a/src/global/pid/RichTrack_factory.cc
+++ b/src/global/pid/RichTrack_factory.cc
@@ -74,7 +74,7 @@ void eicrecon::RichTrack_factory::Process(const std::shared_ptr<const JEvent> &e
       SetCollection<edm4eic::TrackSegment>(out_collection_name, std::move(result));
     }
     catch(std::exception &e) {
-      m_log->warn("Exception in underlying algorithm: {}. Event data will be skipped", e.what());
+      throw JException(e.what());
     }
   }
 }

--- a/src/global/tracking/CKFTracking_factory.cc
+++ b/src/global/tracking/CKFTracking_factory.cc
@@ -101,7 +101,7 @@ void eicrecon::CKFTracking_factory::Process(const std::shared_ptr<const JEvent> 
         Set(trajectories);
     }
     catch(std::exception &e) {
-        m_log->warn("Exception in underlying algorithm: {}. Event data will be skipped", e.what());
+        throw JException(e.what());
     }
 
     // Enable ticker back

--- a/src/global/tracking/IterativeVertexFinder_factory.cc
+++ b/src/global/tracking/IterativeVertexFinder_factory.cc
@@ -59,6 +59,6 @@ void eicrecon::IterativeVertexFinder_factory::Process(const std::shared_ptr<cons
     auto result = m_vertexing_algo.produce(trajectories);
     Set(result); // Set() - is what factory produced
   } catch (std::exception& e) {
-    m_log->warn("Exception in underlying algorithm: {}. Event data will be skipped", e.what());
+    throw JException(e.what());
   }
 }

--- a/src/global/tracking/ParticlesWithTruthPID_factory.cc
+++ b/src/global/tracking/ParticlesWithTruthPID_factory.cc
@@ -33,6 +33,6 @@ void eicrecon::ParticlesWithTruthPID_factory::Process(const std::shared_ptr<cons
         SetCollection<edm4eic::MCRecoParticleAssociation>(GetOutputTags()[1], std::move(prt_with_assoc.second));
     }
     catch(std::exception &e) {
-        m_log->warn("Exception in underlying algorithm: {}. Event data will be skipped", e.what());
+        throw JException(e.what());
     }
 }

--- a/src/global/tracking/TrackParamTruthInit_factory.cc
+++ b/src/global/tracking/TrackParamTruthInit_factory.cc
@@ -80,6 +80,6 @@ void eicrecon::TrackParamTruthInit_factory::Process(const std::shared_ptr<const 
         Set(results);
     }
     catch(std::exception &e) {
-        m_log->warn("Exception in underlying algorithm: {}. Event data will be skipped", e.what());
+        throw JException(e.what());
     }
 }

--- a/src/global/tracking/TrackProjector_factory.cc
+++ b/src/global/tracking/TrackProjector_factory.cc
@@ -41,7 +41,7 @@ namespace eicrecon {
             Set(result);
         }
         catch(std::exception &e) {
-            m_log->warn("Exception in underlying algorithm: {}. Event data will be skipped", e.what());
+            throw JException(e.what());
         }
     }
 

--- a/src/global/tracking/TrackSeeding_factory.cc
+++ b/src/global/tracking/TrackSeeding_factory.cc
@@ -85,6 +85,6 @@ void eicrecon::TrackSeeding_factory::Process(const std::shared_ptr<const JEvent>
         Set(result);    // Set() - is what factory produced
     }
     catch(std::exception &e) {
-        m_log->warn("Exception in underlying algorithm: {}. Event data will be skipped", e.what());
+        throw JException(e.what());
     }
 }

--- a/src/global/tracking/TrackerHitReconstruction_factory.cc
+++ b/src/global/tracking/TrackerHitReconstruction_factory.cc
@@ -55,6 +55,6 @@ void TrackerHitReconstruction_factory::Process(const std::shared_ptr<const JEven
         m_log->debug("End of process. Hits count: {}", hits.size());
     }
     catch(std::exception &e) {
-        m_log->warn("Exception in underlying algorithm: {}. Event data will be skipped", e.what());
+        throw JException(e.what());
     }
 }

--- a/src/global/tracking/TrackerSourceLinker_factory.cc
+++ b/src/global/tracking/TrackerSourceLinker_factory.cc
@@ -73,7 +73,7 @@ namespace eicrecon {
             Insert(result);
         }
         catch(std::exception &e) {
-            m_log->warn("Exception in underlying algorithm: {}. Event data will be skipped", e.what());
+            throw JException(e.what());
         }
     }
 } // eicrecon

--- a/src/global/tracking/TrackingResult_factory.cc
+++ b/src/global/tracking/TrackingResult_factory.cc
@@ -32,6 +32,6 @@ void TrackingResult_factory::Process(const std::shared_ptr<const JEvent> &event)
         SetCollection<edm4eic::TrackParameters>(GetOutputTags()[1], std::move(result.second));
     }
     catch(std::exception &e) {
-        m_log->warn("Exception in underlying algorithm: {}. Event data will be skipped", e.what());
+        throw JException(e.what());
     }
 }

--- a/src/tests/track_propagation_test/TrackPropagationTest_processor.cc
+++ b/src/tests/track_propagation_test/TrackPropagationTest_processor.cc
@@ -91,7 +91,7 @@ void TrackPropagationTest_processor::Process(const std::shared_ptr<const JEvent>
             projection_point = m_propagation_algo.propagate(trajectory, m_hcal_surface);
         }
         catch(std::exception &e) {
-            m_log->warn("Exception in underlying algorithm: {}. Trajectory is skipped", e.what());
+            throw JException(e.what());
         }
 
         if(!projection_point) {

--- a/src/tests/track_seeding_test/TrackSeedingTest_processor.cc
+++ b/src/tests/track_seeding_test/TrackSeedingTest_processor.cc
@@ -94,7 +94,7 @@ void TrackSeedingTest_processor::Process(const std::shared_ptr<const JEvent>& ev
             projection_point = m_propagation_algo.propagate(trajectory, m_hcal_surface);
         }
         catch(std::exception &e) {
-            m_log->warn("Exception in underlying algorithm: {}. Trajectory is skipped", e.what());
+            throw JException(e.what());
         }
 
         if(!projection_point) {


### PR DESCRIPTION
### Briefly, what does this PR introduce?
There are several factories that `catch` exceptions in underlying algorithms and just print a warning. We should try to `throw` these exceptions instead, however:
- there may still be some algorithms where this is not a good idea, in other words, there may be a reason just printing a warning message is preferred; IMO this should be fixed in the algorithm and we shouldn't just be warning on exceptions
- this PR likely does not address all of the cases

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no, but there may be "regular" warning messages that are now thrown exceptions

### Does this PR change default behavior?
maybe (see bullet points above)