### PR TITLE
fix: print cell dimensions as debug in CalorimeterHitReco

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -214,7 +214,7 @@ void CalorimeterHitReco::AlgorithmProcess() {
             cdim.resize(3);
             cdim[0] = cell_dim[0];
             cdim[1] = cell_dim[1];
-            m_log->error("Using segmentation for cell dimensions: {}", fmt::join(cdim, ", "));
+            m_log->debug("Using segmentation for cell dimensions: {}", fmt::join(cdim, ", "));
         } else {
             if (segmentation_type != "NoSegmentation") {
                 m_log->warn("Usupported segmentation type \"{}\"", segmentation_type);
@@ -224,7 +224,7 @@ void CalorimeterHitReco::AlgorithmProcess() {
             cdim = converter->findContext(cellID)->volumePlacement().volume().boundingBox().dimensions();
             std::transform(cdim.begin(), cdim.end(), cdim.begin(),
                            std::bind(std::multiplies<double>(), std::placeholders::_1, 2));
-            m_log->error("Using bounding box for cell dimensions: {}", fmt::join(cdim, ", "));
+            m_log->debug("Using bounding box for cell dimensions: {}", fmt::join(cdim, ", "));
         }
 
         //create constant vectors for passing to hit initializer list


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Reduces the level of output in the CalorimeterHitReco by not printing the cell dimensions as an `error` for each hit in each event.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #698)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.