### PR TITLE
feat: support PolarGridRPhi2 segmentation in CalorimeterHitReco

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -215,9 +215,14 @@ void CalorimeterHitReco::AlgorithmProcess() {
             cdim[0] = cell_dim[0];
             cdim[1] = cell_dim[1];
             m_log->error("Using segmentation for cell dimensions: {}", fmt::join(cdim, ", "));
+        } else if (segmentation_type == "PolarGridRPhi2") {
+            cdim.resize(3);
+            cdim[0] = cell_dim[0];
+            cdim[1] = cell_dim[1];
+            m_log->error("Using segmentation for cell dimensions: {}", fmt::join(cdim, ", "));
         } else {
             if (segmentation_type != "NoSegmentation") {
-                m_log->warn("Usupported segmentation type \"{}\"", segmentation_type);
+                m_log->warn("Unsupported segmentation type \"{}\"", segmentation_type);
             }
 
             // Using bounding box instead of actual solid so the dimensions are always in dim_x, dim_y, dim_z


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This supports PolarGridRPhi2 segmentations in CalorimeterHitReco, similar to the CartesianGridXY. [As far as I know](https://github.com/search?q=repo%3Aeic%2Fepic%20PolarGridRPhi2&type=code), only used by HcalEndcapN so impact needs to be assessed by that group.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #700)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
Maybe, cell dimension not written as bounding box but as actual cell dimensions, may affect clustering downstream.

### Does this PR change default behavior?
Yes, cell dimension not written as bounding box but as actual cell dimensions, may affect clustering downstream.