### PR TITLE
CalorimeterHitReco: warn about unsupported segementation only once

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -216,8 +216,9 @@ void CalorimeterHitReco::AlgorithmProcess() {
             cdim[1] = cell_dim[1];
             m_log->debug("Using segmentation for cell dimensions: {}", fmt::join(cdim, ", "));
         } else {
-            if (segmentation_type != "NoSegmentation") {
-                m_log->warn("Usupported segmentation type \"{}\"", segmentation_type);
+            if ((segmentation_type != "NoSegmentation") && (!warned_unsupported_segmentation)) {
+                m_log->warn("Unsupported segmentation type \"{}\"", segmentation_type);
+                warned_unsupported_segmentation = true;
             }
 
             // Using bounding box instead of actual solid so the dimensions are always in dim_x, dim_y, dim_z

--- a/src/algorithms/calorimetry/CalorimeterHitReco.h
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.h
@@ -74,6 +74,8 @@ public:
 
   size_t sector_idx{0}, layer_idx{0};
 
+  bool warned_unsupported_segmentation = false;
+
   // name of detelment or fields to find the local detector (for global->local transform)
   // if nothing is provided, the lowest level DetElement (from cellID) will be used
   std::string m_localDetElement="", m_maskPos="";


### PR DESCRIPTION
There doesn't seem to be a warn_once facility in spdlog and algorithms are not supposed to rely on common services, so the flag is implemented inline.

Resolves: #700
Closes: #701