### PR TITLE
feat: add theta/phi debug output to truth seeder

### DIFF
--- a/src/global/tracking/TrackParamTruthInit_factory.cc
+++ b/src/global/tracking/TrackParamTruthInit_factory.cc
@@ -70,9 +70,15 @@ void eicrecon::TrackParamTruthInit_factory::Process(const std::shared_ptr<const 
             if (m_log->level() <= spdlog::level::debug) {
                 const auto p = std::hypot(mc_particle->getMomentum().x, mc_particle->getMomentum().y,
                                           mc_particle->getMomentum().z);
+                const auto theta = std::atan2(std::hypot(mc_particle->getMomentum().x,
+                                                         mc_particle->getMomentum().y),
+                                              mc_particle->getMomentum().z);
+                const auto phi = std::atan2(mc_particle->getMomentum().y, mc_particle->getMomentum().x);
                 const auto charge = result->charge();
                 m_log->debug("Invoke track finding seeded by truth particle with:");
-                m_log->debug("   p =  {} GeV\"", p);
+                m_log->debug("   p =  {} GeV", p);
+                m_log->debug("   theta = {}", theta);
+                m_log->debug("   phi = {}", phi);
                 m_log->debug("   charge = {}", charge);
                 m_log->debug("   q/p =  {}", charge / p);
             }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This adds theta/phi debug output to truth seeder, which was useful when running the seeder in debug mode for matching studies.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: minor additional output)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.