### PR TITLE
CalorimeterHitReco: Fix calo giving no reco hits when using NoSegmentation

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -209,8 +209,8 @@ void CalorimeterHitReco::AlgorithmProcess() {
         std::vector<double> cdim;
         // get segmentation dimensions
         auto segmentation_type = converter->findReadout(local).segmentation().type();
-        auto cell_dim = converter->cellDimensions(cellID);
         if (segmentation_type == "CartesianGridXY") {
+            auto cell_dim = converter->cellDimensions(cellID);
             cdim.resize(3);
             cdim[0] = cell_dim[0];
             cdim[1] = cell_dim[1];


### PR DESCRIPTION
### Briefly, what does this PR introduce?
A calorimeter with NoSegmentation gives no reco hits. This is because cell_dim should be calculated inside the if statement. Otherwise, since a calorimeter such as LFHCAL uses NoSegmentation, the library is terminated when calculating the cell_dim.

### What kind of change does this PR introduce?
- [X] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [X] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No. Users do not need to change their code.

### Does this PR change default behavior?
No.
