### PR TITLE
Add GitHub action for PR backporting

### DIFF
--- a/.github/workflows/pr-backport.yml
+++ b/.github/workflows/pr-backport.yml
@@ -1,0 +1,17 @@
+name: Backport merged pull request
+on:
+  pull_request_target:
+    types: [closed]
+permissions:
+  contents: write # so it can comment
+  pull-requests: write # so it can create pull requests
+jobs:
+  backport:
+    name: Backport pull request
+    runs-on: ubuntu-latest
+    # Don't run on closed unmerged pull requests
+    if: github.event.pull_request.merged
+    steps:
+      - uses: actions/checkout@v3
+      - name: Create backport pull requests
+        uses: korthout/backport-action@v1


### PR DESCRIPTION
This allows one to create labels with special name like `backport v1.2` that would automatically create a PR to duplicate change into a maintenance branch.