### PR TITLE
fix(dRICH): extrapolate quantum efficiency endpoints

### DIFF
--- a/src/algorithms/digi/PhotoMultiplierHitDigiConfig.h
+++ b/src/algorithms/digi/PhotoMultiplierHitDigiConfig.h
@@ -40,21 +40,23 @@ namespace eicrecon {
       // - wavelength units are [nm]
       // FIXME: figure out how users can override this, maybe an external `yaml` file
       std::vector<std::pair<double, double> > quantumEfficiency = {
-        {325, 0.04},
-        {340, 0.10},
-        {350, 0.20},
-        {370, 0.30},
-        {400, 0.35},
-        {450, 0.40},
-        {500, 0.38},
-        {550, 0.35},
-        {600, 0.27},
-        {650, 0.20},
-        {700, 0.15},
-        {750, 0.12},
-        {800, 0.08},
-        {850, 0.06},
-        {900, 0.04}
+        {315,  0.00},
+        {325,  0.04},
+        {340,  0.10},
+        {350,  0.20},
+        {370,  0.30},
+        {400,  0.35},
+        {450,  0.40},
+        {500,  0.38},
+        {550,  0.35},
+        {600,  0.27},
+        {650,  0.20},
+        {700,  0.15},
+        {750,  0.12},
+        {800,  0.08},
+        {850,  0.06},
+        {900,  0.04},
+        {1000, 0.00}
       };
       /*
          std::vector<std::pair<double, double> > quantumEfficiency = { // test unit QE

--- a/src/detectors/DRICH/DRICH.cc
+++ b/src/detectors/DRICH/DRICH.cc
@@ -40,21 +40,25 @@ extern "C" {
     digi_cfg.pixelSize       = 3.0; // [mm]
     digi_cfg.safetyFactor    = 0.7;
     digi_cfg.quantumEfficiency.clear();
-    digi_cfg.quantumEfficiency.push_back({325, 0.04}); // wavelength units are [nm]
-    digi_cfg.quantumEfficiency.push_back({340, 0.10});
-    digi_cfg.quantumEfficiency.push_back({350, 0.20});
-    digi_cfg.quantumEfficiency.push_back({370, 0.30});
-    digi_cfg.quantumEfficiency.push_back({400, 0.35});
-    digi_cfg.quantumEfficiency.push_back({450, 0.40});
-    digi_cfg.quantumEfficiency.push_back({500, 0.38});
-    digi_cfg.quantumEfficiency.push_back({550, 0.35});
-    digi_cfg.quantumEfficiency.push_back({600, 0.27});
-    digi_cfg.quantumEfficiency.push_back({650, 0.20});
-    digi_cfg.quantumEfficiency.push_back({700, 0.15});
-    digi_cfg.quantumEfficiency.push_back({750, 0.12});
-    digi_cfg.quantumEfficiency.push_back({800, 0.08});
-    digi_cfg.quantumEfficiency.push_back({850, 0.06});
-    digi_cfg.quantumEfficiency.push_back({900, 0.04});
+    digi_cfg.quantumEfficiency = { // wavelength units are [nm]
+      {315,  0.00},
+      {325,  0.04},
+      {340,  0.10},
+      {350,  0.20},
+      {370,  0.30},
+      {400,  0.35},
+      {450,  0.40},
+      {500,  0.38},
+      {550,  0.35},
+      {600,  0.27},
+      {650,  0.20},
+      {700,  0.15},
+      {750,  0.12},
+      {800,  0.08},
+      {850,  0.06},
+      {900,  0.04},
+      {1000, 0.00}
+    };
 
     // track propagation to each radiator
     RichTrackConfig track_cfg;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Extrapolate endpoints of the quantum efficiency curve down to zero. Two points are added:
| wavelength | quantum efficiency |
| --- | --- |
| 315 nm | 0.0 |
| 1000 nm | 0.0 |

This is a minor change, applied to both the default config `PhotoMultiplierHitDigiConfig`  and the dRICH-specific config in `DRICH.cc` (along with a syntax simplification).

This goes along with other material property extrapolations from https://github.com/eic/epic/pull/445

### What kind of change does this PR introduce?
- [x] Bug fix: this is a part of https://github.com/eic/epic/issues/439
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators
  - @chchatte92 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
no, but `<NPE>` will increase slightly