### PR TITLE
fix: CKF makes tracks instead of particles

### DIFF
--- a/src/algorithms/tracking/ParticlesFromTrackFit.cc
+++ b/src/algorithms/tracking/ParticlesFromTrackFit.cc
@@ -32,7 +32,7 @@ void eicrecon::Reco::ParticlesFromTrackFit::init(std::shared_ptr<spdlog::logger>
 ParticlesFromTrackFitResultNew eicrecon::Reco::ParticlesFromTrackFit::execute(const std::vector<const eicrecon::TrackingResultTrajectory *> &trajectories) {
 
     // create output collections
-    auto rec_parts = std::make_unique<edm4eic::ReconstructedParticleCollection >();
+    auto rec_tracks = std::make_unique<edm4eic::TrackCollection>();
     auto track_pars = std::make_unique<edm4eic::TrackParametersCollection>();
 
     m_log->debug("Trajectories size: {}", std::size(trajectories));
@@ -126,16 +126,16 @@ ParticlesFromTrackFitResultNew eicrecon::Reco::ParticlesFromTrackFit::execute(co
                 return;
             }
 
-            auto rec_part = rec_parts->create();
-            rec_part.setMomentum(
+            auto rec_track = rec_tracks->create();
+            rec_track.setMomentum(
                     edm4eic::sphericalToVector(
                             1.0 / std::abs(params[Acts::eBoundQOverP]),
                             params[Acts::eBoundTheta],
                             params[Acts::eBoundPhi])
             );
-            rec_part.setCharge(static_cast<int16_t>(std::copysign(1., params[Acts::eBoundQOverP])));
+            rec_track.setCharge(static_cast<int16_t>(std::copysign(1., params[Acts::eBoundQOverP])));
         });
     }
 
-    return std::make_pair(std::move(rec_parts), std::move(track_pars));
+    return std::make_pair(std::move(rec_tracks), std::move(track_pars));
 }

--- a/src/algorithms/tracking/ParticlesFromTrackFit.cc
+++ b/src/algorithms/tracking/ParticlesFromTrackFit.cc
@@ -6,8 +6,6 @@
 #include "DDRec/SurfaceManager.h"
 #include "DDRec/Surface.h"
 
-
-
 #include "Acts/EventData/MultiTrajectory.hpp"
 #include "Acts/EventData/MultiTrajectoryHelpers.hpp"
 

--- a/src/algorithms/tracking/ParticlesFromTrackFit.h
+++ b/src/algorithms/tracking/ParticlesFromTrackFit.h
@@ -9,8 +9,9 @@
 #include "JugTrack/TrackingResultTrajectory.hpp"
 #include <algorithms/tracking/ParticlesFromTrackFitResult.h>
 
+#include "edm4eic/TrackCollection.h"
 
-using ParticlesFromTrackFitResultNew = std::pair<std::unique_ptr<edm4eic::ReconstructedParticleCollection>,
+using ParticlesFromTrackFitResultNew = std::pair<std::unique_ptr<edm4eic::TrackCollection>,
                                                  std::unique_ptr<edm4eic::TrackParametersCollection>>;
 
 namespace eicrecon::Reco {

--- a/src/algorithms/tracking/TracksToParticles.cc
+++ b/src/algorithms/tracking/TracksToParticles.cc
@@ -1,0 +1,29 @@
+#include "TracksToParticles.h"
+#include <algorithm>
+
+// Event Model related classes
+#include <edm4eic/ReconstructedParticleCollection.h>
+#include <edm4eic/TrackerHitCollection.h>
+#include <edm4eic/TrackParametersCollection.h>
+#include "JugTrack/IndexSourceLink.hpp"
+#include "JugTrack/Track.hpp"
+
+void eicrecon::Reco::TracksToParticles::init(std::shared_ptr<spdlog::logger> log) 
+{
+  m_log = log;
+}
+
+std::unique_ptr<edm4eic::ReconstructedParticleCollection> 
+eicrecon::Reco::TracksToParticles::execute(const std::vector<const edm4eic::Track*>& tracks)
+{
+  auto rec_particles = std::make_unique<edm4eic::ReconstructedParticleCollection>();
+
+  for(auto& track : tracks)
+    {
+      auto part = rec_particles->create();
+      part.setMomentum(track->getMomentum());
+      part.setCharge(track->getCharge());
+    }
+	
+  return rec_particles;
+}

--- a/src/algorithms/tracking/TracksToParticles.cc
+++ b/src/algorithms/tracking/TracksToParticles.cc
@@ -8,12 +8,12 @@
 #include "JugTrack/IndexSourceLink.hpp"
 #include "JugTrack/Track.hpp"
 
-void eicrecon::Reco::TracksToParticles::init(std::shared_ptr<spdlog::logger> log) 
+void eicrecon::Reco::TracksToParticles::init(std::shared_ptr<spdlog::logger> log)
 {
   m_log = log;
 }
 
-std::unique_ptr<edm4eic::ReconstructedParticleCollection> 
+std::unique_ptr<edm4eic::ReconstructedParticleCollection>
 eicrecon::Reco::TracksToParticles::execute(const std::vector<const edm4eic::Track*>& tracks)
 {
   auto rec_particles = std::make_unique<edm4eic::ReconstructedParticleCollection>();
@@ -24,6 +24,6 @@ eicrecon::Reco::TracksToParticles::execute(const std::vector<const edm4eic::Trac
       part.setMomentum(track->getMomentum());
       part.setCharge(track->getCharge());
     }
-	
+
   return rec_particles;
 }

--- a/src/algorithms/tracking/TracksToParticles.h
+++ b/src/algorithms/tracking/TracksToParticles.h
@@ -1,0 +1,30 @@
+// Original header license: SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2023 Joe Osborn
+//
+
+#pragma once
+
+
+#include <spdlog/logger.h>
+#include <edm4eic/ReconstructedParticleCollection.h>
+#include <edm4eic/TrackParametersCollection.h>
+
+
+
+namespace eicrecon::Reco {
+
+  //! Converts reconstructed tracks to reconstructed particles
+  //! Can add additional detector information when available (e.g. pid, clusters...)
+  class TracksToParticles {
+  public: 
+ 
+    void init(std::shared_ptr<spdlog::logger> log);
+    std::unique_ptr<edm4eic::ReconstructedParticleCollection>
+      execute(const std::vector<const edm4eic::Track*>& tracks);
+
+  private:
+    std::shared_ptr<spdlog::logger> m_log;
+  };
+
+
+}

--- a/src/algorithms/tracking/TracksToParticles.h
+++ b/src/algorithms/tracking/TracksToParticles.h
@@ -16,8 +16,8 @@ namespace eicrecon::Reco {
   //! Converts reconstructed tracks to reconstructed particles
   //! Can add additional detector information when available (e.g. pid, clusters...)
   class TracksToParticles {
-  public: 
- 
+  public:
+
     void init(std::shared_ptr<spdlog::logger> log);
     std::unique_ptr<edm4eic::ReconstructedParticleCollection>
       execute(const std::vector<const edm4eic::Track*>& tracks);

--- a/src/global/tracking/TrackingResult_factory.cc
+++ b/src/global/tracking/TrackingResult_factory.cc
@@ -28,7 +28,7 @@ void TrackingResult_factory::Process(const std::shared_ptr<const JEvent> &event)
         // Collect all hits
         auto trajectories = event->Get<eicrecon::TrackingResultTrajectory>(input_tag);
         auto result = m_particle_maker_algo.execute(trajectories);
-        SetCollection<edm4eic::ReconstructedParticle>(GetOutputTags()[0], std::move(result.first));
+        SetCollection<edm4eic::Track>(GetOutputTags()[0], std::move(result.first));
         SetCollection<edm4eic::TrackParameters>(GetOutputTags()[1], std::move(result.second));
     }
     catch(std::exception &e) {

--- a/src/global/tracking/TrackingResult_factory.h
+++ b/src/global/tracking/TrackingResult_factory.h
@@ -18,7 +18,7 @@ public:
                                     const std::vector<std::string>& output_tags):
     JChainMultifactoryT(std::move(tag), input_tags, output_tags) {
 
-        DeclarePodioOutput<edm4eic::ReconstructedParticle>(GetOutputTags()[0]);
+        DeclarePodioOutput<edm4eic::Track>(GetOutputTags()[0]);
         DeclarePodioOutput<edm4eic::TrackParameters>(GetOutputTags()[1]);
     }
 

--- a/src/global/tracking/TracksToParticles_factory.cc
+++ b/src/global/tracking/TracksToParticles_factory.cc
@@ -29,7 +29,7 @@ void TracksToParticles_factory::Process(const std::shared_ptr<const JEvent> &eve
         auto tracks = event->Get<edm4eic::Track>(input_tag);
         auto result = m_particle_maker_algo.execute(tracks);
         SetCollection<edm4eic::ReconstructedParticle>(GetOutputTags()[0], std::move(result));
-        
+
     }
     catch(std::exception &e) {
         throw JException(e.what());

--- a/src/global/tracking/TracksToParticles_factory.cc
+++ b/src/global/tracking/TracksToParticles_factory.cc
@@ -1,0 +1,37 @@
+// Created by Joe Osborn
+// Subject to the terms in the LICENSE file found in the top-level directory.
+//
+
+#include "TracksToParticles_factory.h"
+#include "services/log/Log_service.h"
+#include "extensions/spdlog/SpdlogExtensions.h"
+#include "extensions/string/StringHelpers.h"
+#include <JANA/JEvent.h>
+
+void TracksToParticles_factory::Init() {
+
+    // SpdlogMixin logger initialization, sets m_log
+    InitLogger(GetPrefix(), "info");
+
+    m_particle_maker_algo.init(m_log);
+}
+
+void TracksToParticles_factory::BeginRun(const std::shared_ptr<const JEvent> &event) {
+
+}
+
+void TracksToParticles_factory::Process(const std::shared_ptr<const JEvent> &event) {
+    // Now we check that user provided an input names
+    std::string input_tag = GetInputTags()[0];
+
+    try {
+        // Collect all hits
+        auto tracks = event->Get<edm4eic::Track>(input_tag);
+        auto result = m_particle_maker_algo.execute(tracks);
+        SetCollection<edm4eic::ReconstructedParticle>(GetOutputTags()[0], std::move(result));
+        
+    }
+    catch(std::exception &e) {
+        throw JException(e.what());
+    }
+}

--- a/src/global/tracking/TracksToParticles_factory.h
+++ b/src/global/tracking/TracksToParticles_factory.h
@@ -1,0 +1,36 @@
+// Created by Joe Osborn
+// Subject to the terms in the LICENSE file found in the top-level directory.
+//
+
+#pragma once
+
+#include <algorithms/tracking/TracksToParticles.h>
+#include <extensions/jana/JChainMultifactoryT.h>
+#include <extensions/spdlog/SpdlogMixin.h>
+
+class TracksToParticles_factory:
+        public JChainMultifactoryT<NoConfig>,
+        public eicrecon::SpdlogMixin<TracksToParticles_factory> {
+public:
+    explicit TracksToParticles_factory(std::string tag,
+                                    const std::vector<std::string>& input_tags,
+                                    const std::vector<std::string>& output_tags):
+    JChainMultifactoryT(std::move(tag), input_tags, output_tags) {
+
+        DeclarePodioOutput<edm4eic::ReconstructedParticle>(GetOutputTags()[0]);
+    }
+
+
+    /** One time initialization **/
+    void Init() override;
+
+    /** On run change preparations **/
+    void BeginRun(const std::shared_ptr<const JEvent> &event) override;
+
+    /** Event by event processing **/
+    void Process(const std::shared_ptr<const JEvent> &event) override;
+
+private:
+
+    eicrecon::Reco::TracksToParticles m_particle_maker_algo;  
+};

--- a/src/global/tracking/TracksToParticles_factory.h
+++ b/src/global/tracking/TracksToParticles_factory.h
@@ -32,5 +32,5 @@ public:
 
 private:
 
-    eicrecon::Reco::TracksToParticles m_particle_maker_algo;  
+    eicrecon::Reco::TracksToParticles m_particle_maker_algo;
 };

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -20,6 +20,7 @@
 #include "TrackProjector_factory.h"
 #include "ParticlesWithTruthPID_factory.h"
 #include "IterativeVertexFinder_factory.h"
+#include "TracksToParticles_factory.h"
 
 //
 extern "C" {
@@ -61,12 +62,16 @@ void InitPlugin(JApplication *app) {
             {"CentralCKFTrajectories"}, "CentralTrackVertices"));
 
     app->Add(new JChainMultifactoryGeneratorT<TrackingResult_factory>(
-            "CentralTrackingParticles",                       // Tag name for multifactory
+            "CentralTrackingTracks",                       // Tag name for multifactory
             {"CentralCKFTrajectories"},                       // eicrecon::TrackingResultTrajectory
-            {"outputParticles",                               // edm4eic::ReconstructedParticle
+            {"outputTracks",                               // edm4eic::ReconstructedParticle
              "outputTrackParameters"},                        // edm4eic::TrackParameters
             app));
-
+    app->Add(new JChainMultifactoryGeneratorT<TracksToParticles_factory>(
+            "CentralTrackingParticles",
+            {"CentralTrackingTracks"},
+            {"outputParticles"}, 
+	    app));
     app->Add(new JChainMultifactoryGeneratorT<ParticlesWithTruthPID_factory>(
             "ChargedParticlesWithAssociations",                // Tag name for multifactory
             {"MCParticles",                                    // edm4hep::MCParticle

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -67,13 +67,13 @@ void InitPlugin(JApplication *app) {
             {"outputTracks",                               // edm4eic::ReconstructedParticle
              "outputTrackParameters"},                        // edm4eic::TrackParameters
             app));
-   
+
     app->Add(new JChainMultifactoryGeneratorT<TracksToParticles_factory>(
             "CentralTrackingParticles",
             {"outputTracks"},
-            {"outputParticles"}, 
+            {"outputParticles"},
 	    app));
- 
+
     app->Add(new JChainMultifactoryGeneratorT<ParticlesWithTruthPID_factory>(
             "ChargedParticlesWithAssociations",                // Tag name for multifactory
             {"MCParticles",                                    // edm4hep::MCParticle

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -67,11 +67,13 @@ void InitPlugin(JApplication *app) {
             {"outputTracks",                               // edm4eic::ReconstructedParticle
              "outputTrackParameters"},                        // edm4eic::TrackParameters
             app));
+   
     app->Add(new JChainMultifactoryGeneratorT<TracksToParticles_factory>(
             "CentralTrackingParticles",
-            {"CentralTrackingTracks"},
+            {"outputTracks"},
             {"outputParticles"}, 
 	    app));
+ 
     app->Add(new JChainMultifactoryGeneratorT<ParticlesWithTruthPID_factory>(
             "ChargedParticlesWithAssociations",                // Tag name for multifactory
             {"MCParticles",                                    // edm4hep::MCParticle

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -66,6 +66,7 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
 
             // Reconstructed data
             "GeneratedParticles",
+	    "ReconstructedTracks",
             "ReconstructedParticles",
             "ReconstructedParticleAssociations",
             "ReconstructedChargedParticles",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR changes the default behavior of the CKF to make `edm4eic::Tracks` instead of `edm4eic::ReconstructedParticles`, where a track would be preferable since we won't necessarily have calo/PID information yet. This prefaces changes to the vertexing EDM which will better accommodate vertex to track relations.

To keep the default behavior the same, there is a new factory added that just converts the tracks to reconstructed particles in the same way that is currently done. This way, there should be no effect to the downstream physics output. At some point down the road this could be modified to e.g. add more detailed information (e.g. calo/PID info), or just removed completely by another module that actually combines all of the subsystem information.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No