### PR TITLE
doc(dRICH): remove dRICH spec from reconstructed particle collections

### DIFF
--- a/src/detectors/DRICH/README.md
+++ b/src/detectors/DRICH/README.md
@@ -248,8 +248,8 @@ flowchart TB
   classDef comp fill:#8888ff,color:black
 
   %% nodes
-  ReconPart(<strong>ReconstructedChargedParticlesWithDRICHPID</strong><br/>edm4eic::ReconstructedParticle):::col
-  ReconAssoc(<strong>ReconstructedChargedParticleAssociationsWithDRICHPID</strong><br/>edm4eic::MCRecoParticleAssociation):::col
+  ReconPart(<strong>ReconstructedChargedParticles</strong><br/>edm4eic::ReconstructedParticle):::col
+  ReconAssoc(<strong>ReconstructedChargedParticleAssociations</strong><br/>edm4eic::MCRecoParticleAssociation):::col
   MCPart(<strong>MCParticles</strong><br/>MC True Particles<br/>edm4hep::MCParticles):::col
   RecFn[rec]:::fn
   SimFn[sim]:::fn


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Final reconstructed particle and association collections do not include the suffix `WithDRICHPID` (this is a remnant of an older design).

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [x] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
no