### PR TITLE
fix: MatchClusters.cc, use before delete (asan)

### DIFF
--- a/src/algorithms/reco/MatchClusters.cc
+++ b/src/algorithms/reco/MatchClusters.cc
@@ -82,9 +82,9 @@ namespace eicrecon {
             if (clusterMap.count(mcID)) {
                 const auto &clus = clusterMap[mcID];
                 m_log->debug("    --> found matching cluster with energy: {}", clus->getEnergy());
-                clusterMap.erase(mcID);
                 m_log->debug("    --> adding cluster to reconstructed particle");
                 outpart.addToClusters(*clus);
+                clusterMap.erase(mcID);
             }
 
             // create truth associations


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This shifts the cluster map erase after the use of the cluster. Erase before use is an error in the address sanitizer branch.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @veprbl 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.