### PR TITLE
refactor(dRICH): compatibility update for PDU readout

### DIFF
--- a/src/algorithms/digi/PhotoMultiplierHitDigi.cc
+++ b/src/algorithms/digi/PhotoMultiplierHitDigi.cc
@@ -267,6 +267,7 @@ bool  eicrecon::PhotoMultiplierHitDigi::qe_pass(double ev, double rand) const
 
 
 // add a hit to local `hit_groups` data structure
+// NOLINTBEGIN(bugprone-easily-swappable-parameters)
 void eicrecon::PhotoMultiplierHitDigi::InsertHit(
     std::unordered_map<CellIDType, std::vector<HitData>> &hit_groups,
     CellIDType       id,
@@ -274,7 +275,7 @@ void eicrecon::PhotoMultiplierHitDigi::InsertHit(
     TimeType         time,
     std::size_t      sim_hit_index,
     bool             is_noise_hit
-    )
+    ) // NOLINTEND(bugprone-easily-swappable-parameters)
 {
   auto it = hit_groups.find(id);
   if (it != hit_groups.end()) {

--- a/src/algorithms/digi/PhotoMultiplierHitDigiConfig.h
+++ b/src/algorithms/digi/PhotoMultiplierHitDigiConfig.h
@@ -31,7 +31,6 @@ namespace eicrecon {
 
       // SiPM pixels
       bool   enablePixelGaps = false; // enable/disable removal of hits in gaps between pixels
-      double pixelSize       = 3.0;   // pixel (active) size // [mm]
 
       // overall safety factor
       /* simulations assume the detector is ideal and perfect, but reality is
@@ -87,7 +86,6 @@ namespace eicrecon {
         print_param("pedMean",pedMean);
         print_param("pedError",pedError);
         print_param("enablePixelGaps",enablePixelGaps);
-        print_param("pixelSize",pixelSize);
         print_param("safetyFactor",safetyFactor);
         print_param("enableNoise",enableNoise);
         print_param("noiseRate",noiseRate);

--- a/src/algorithms/pid/IrtCherenkovParticleID.cc
+++ b/src/algorithms/pid/IrtCherenkovParticleID.cc
@@ -248,12 +248,14 @@ std::map<std::string, std::unique_ptr<edm4eic::CherenkovParticleIDCollection>> e
         // was used in GEANT, but should be very close
         if(m_cfg.cheatPhotonVertex) {
           double ri;
-          auto ri_set = Tools::GetFinelyBinnedTableEntry(
-              irt_rad->m_ri_lookup_table,
-              1e9 * irt_photon->GetVertexMomentum().Mag(),
-              &ri
-              );
-          if(ri_set) irt_photon->SetVertexRefractiveIndex(ri);
+          auto mom    = 1e9 * irt_photon->GetVertexMomentum().Mag();
+          auto ri_set = Tools::GetFinelyBinnedTableEntry(irt_rad->m_ri_lookup_table, mom, &ri);
+          if(ri_set) {
+            irt_photon->SetVertexRefractiveIndex(ri);
+            m_log->trace("{:>30} = {}", "refractive index", ri);
+          }
+          else
+            m_log->warn("Tools::GetFinelyBinnedTableEntry failed to lookup refractive index for momentum {} eV", mom);
         }
 
         // add each `irt_photon` to the radiator history

--- a/src/detectors/DIRC/DIRC.cc
+++ b/src/detectors/DIRC/DIRC.cc
@@ -33,7 +33,6 @@ extern "C" {
     digi_cfg.pedMean         = 200.0;
     digi_cfg.pedError        = 3.0;
     digi_cfg.enablePixelGaps = false;
-    digi_cfg.pixelSize       = 3.0; // [mm]
     digi_cfg.safetyFactor    = 1.0;
     digi_cfg.quantumEfficiency.clear();
 

--- a/src/detectors/DRICH/DRICH.cc
+++ b/src/detectors/DRICH/DRICH.cc
@@ -38,7 +38,6 @@ extern "C" {
     digi_cfg.pedMean         = 200.0;
     digi_cfg.pedError        = 3.0;
     digi_cfg.enablePixelGaps = true;
-    digi_cfg.pixelSize       = 3.0; // [mm]
     digi_cfg.safetyFactor    = 0.7;
     digi_cfg.enableNoise     = false;
     digi_cfg.noiseRate       = 20000; // [Hz]

--- a/src/global/digi/PhotoMultiplierHitDigi_factory.cc
+++ b/src/global/digi/PhotoMultiplierHitDigi_factory.cc
@@ -36,7 +36,6 @@ void eicrecon::PhotoMultiplierHitDigi_factory::Init() {
   set_param("pedMean",         cfg.pedMean,         "");
   set_param("pedError",        cfg.pedError,        "");
   set_param("enablePixelGaps", cfg.enablePixelGaps, "enable/disable removal of hits in gaps between pixels");
-  set_param("pixelSize",       cfg.pixelSize,       "pixel (active) size");
   set_param("safetyFactor",    cfg.safetyFactor,    "overall safety factor");
   set_param("enableNoise",     cfg.enableNoise,     "");
   set_param("noiseRate",       cfg.noiseRate,       "");
@@ -53,6 +52,10 @@ void eicrecon::PhotoMultiplierHitDigi_factory::Init() {
     m_digi_algo.SetVisitRngCellIDs(
         [readoutGeo = this->m_readoutGeo] (std::function<void(uint64_t)> lambda, float p) { readoutGeo->VisitAllRngPixels(lambda, p); }
         );
+    m_digi_algo.SetPixelGapMask(
+        [readoutGeo = this->m_readoutGeo] (uint64_t cellID, dd4hep::Position pos) { return readoutGeo->PixelGapMask(cellID, pos); }
+        );
+
   }
 }
 

--- a/src/global/digi/PhotoMultiplierHitDigi_factory.cc
+++ b/src/global/digi/PhotoMultiplierHitDigi_factory.cc
@@ -50,10 +50,10 @@ void eicrecon::PhotoMultiplierHitDigi_factory::Init() {
   if(use_richgeo) {
     m_readoutGeo->SetSeed(cfg.seed);
     m_digi_algo.SetVisitRngCellIDs(
-        [readoutGeo = this->m_readoutGeo] (std::function<void(uint64_t)> lambda, float p) { readoutGeo->VisitAllRngPixels(lambda, p); }
+        [readoutGeo = this->m_readoutGeo] (std::function<void(PhotoMultiplierHitDigi::CellIDType)> lambda, float p) { readoutGeo->VisitAllRngPixels(lambda, p); }
         );
     m_digi_algo.SetPixelGapMask(
-        [readoutGeo = this->m_readoutGeo] (uint64_t cellID, dd4hep::Position pos) { return readoutGeo->PixelGapMask(cellID, pos); }
+        [readoutGeo = this->m_readoutGeo] (PhotoMultiplierHitDigi::CellIDType cellID, dd4hep::Position pos) { return readoutGeo->PixelGapMask(cellID, pos); }
         );
 
   }

--- a/src/services/geometry/richgeo/IrtGeo.h
+++ b/src/services/geometry/richgeo/IrtGeo.h
@@ -42,6 +42,11 @@ namespace richgeo {
       virtual void DD4hep_to_IRT() = 0;    // given DD4hep geometry, produce IRT geometry
       void SetReadoutIDToPositionLambda(); // define the `cell ID -> pixel position` converter, correcting to sensor surface
       void SetRefractiveIndexTable();      // fill table of refractive indices
+      // read `VariantParameters` for a vector
+      template<class VecT>
+        VecT GetVectorFromVariantParameters(dd4hep::rec::VariantParameters *pars, std::string key) {
+          return VecT(pars->get<double>(key+"_x"), pars->get<double>(key+"_y"), pars->get<double>(key+"_z"));
+        }
 
       // inputs
       std::string m_detName;

--- a/src/services/geometry/richgeo/IrtGeo.h
+++ b/src/services/geometry/richgeo/IrtGeo.h
@@ -9,6 +9,7 @@
 
 // DD4Hep
 #include <DD4hep/Detector.h>
+#include <DDRec/DetectorData.h>
 #include <DDRec/CellIDPositionConverter.h>
 #include <DD4hep/DD4hepUnits.h>
 

--- a/src/services/geometry/richgeo/IrtGeoDRICH.cc
+++ b/src/services/geometry/richgeo/IrtGeoDRICH.cc
@@ -114,9 +114,9 @@ void richgeo::IrtGeoDRICH::DD4hep_to_IRT() {
 
     // sensor modules: search the detector tree for sensors for this sector
     m_log->trace("  SENSORS:");
-    m_log->trace("--------------------------------------------------------------------------------------"); 
-    m_log->trace("name ID sector   pos_x pos_y pos_z   normX_x normX_y normX_z   normY_x normY_y normY_z"); 
-    m_log->trace("--------------------------------------------------------------------------------------"); 
+    m_log->trace("--------------------------------------------------------------------------------------");
+    m_log->trace("name ID sector   pos_x pos_y pos_z   normX_x normX_y normX_z   normY_x normY_y normY_z");
+    m_log->trace("--------------------------------------------------------------------------------------");
     auto sensorThickness = m_det->constant<double>("DRICH_sensor_thickness") / dd4hep::mm;
     auto sensorSize      = m_det->constant<double>("DRICH_sensor_size") / dd4hep::mm;
     for(auto const& [de_name, detSensor] : m_detRich.children()) {

--- a/src/services/geometry/richgeo/IrtGeoDRICH.cc
+++ b/src/services/geometry/richgeo/IrtGeoDRICH.cc
@@ -130,19 +130,23 @@ void richgeo::IrtGeoDRICH::DD4hep_to_IRT() {
     for(auto const& [de_name, detSensor] : m_detRich.children()) {
       if(de_name.find("sensor_de_"+secName)!=std::string::npos) {
 
-        // sandbox
-        m_log->critical("ID={}", detSensor.id());
-        const auto detSensorPars = detSensor.extension<dd4hep::rec::VariantParameters>(true);
-        if(detSensorPars==nullptr) {
-          m_log->error("this sensor does not have VariantParameters");
-          continue; // FIXME throw runtime error
-        }
-        m_log->critical("  x={}", detSensorPars->get<double>("x"));
-        m_log->critical("  y={}", detSensorPars->get<double>("y"));
-        m_log->critical("  z={}", detSensorPars->get<double>("z"));
-
         // get sensor info
-        auto imodsec = detSensor.id();
+        const auto imodsec       = detSensor.id();
+        /*
+        const auto detSensorPars = detSensor.extension<dd4hep::rec::VariantParameters>(true);
+        if(detSensorPars==nullptr)
+          throw std::runtime_error(fmt::format("sensor '{}' does not have VariantParameters", de_name));
+        // - sensor surface position
+        auto posSensorSurface = GetVectorFromVariantParameters<dd4hep::Position>(detSensorPars, "pos");
+        // - sensor orientation
+        auto normXdir      = GetVectorFromVariantParameters<dd4hep::Direction>(detSensorPars, "normX");
+        auto normYdir      = GetVectorFromVariantParameters<dd4hep::Direction>(detSensorPars, "normY");
+        auto normZdir      = normXdir.Cross(normYdir); // sensor surface normal
+        // - surface offset, used to convert sensor volume centroid to sensor surface centroid
+        auto surfaceOffset = normZDir.Unit() * (0.5*sensorThickness);
+        */
+
+
         // - get sensor centroid position
         auto pvSensor  = detSensor.placement();
         auto posSensor = (1/dd4hep::mm) * (m_posRich + pvSensor.position());

--- a/src/services/geometry/richgeo/IrtGeoDRICH.cc
+++ b/src/services/geometry/richgeo/IrtGeoDRICH.cc
@@ -168,7 +168,7 @@ void richgeo::IrtGeoDRICH::DD4hep_to_IRT() {
             m_sensorFlatSurface  // surface
             );
         m_log->trace(
-            "{} {:#X} {}   {:5.2f} {:5.2f} {:5.2f}   {:5.2f} {:5.2f} {:5.2f}   {:5.2f} {:5.2f} {:5.2f})",
+            "{} {:#X} {}   {:5.2f} {:5.2f} {:5.2f}   {:5.2f} {:5.2f} {:5.2f}   {:5.2f} {:5.2f} {:5.2f}",
             de_name, sensorID, isec,
             posSensor.x(), posSensor.y(), posSensor.z(),
             normXdir.x(),  normXdir.y(),  normXdir.z(),

--- a/src/services/geometry/richgeo/IrtGeoDRICH.cc
+++ b/src/services/geometry/richgeo/IrtGeoDRICH.cc
@@ -112,26 +112,13 @@ void richgeo::IrtGeoDRICH::DD4hep_to_IRT() {
     // complete the radiator volume description; this is the rear side of the container gas volume
     m_irtDetector->GetRadiator(RadiatorName(kGas).c_str())->m_Borders[isec].second = m_mirrorSphericalSurface;
 
-    // sensor sphere (only used for validation of sensor normals)
-    auto sensorSphRadius  = m_det->constant<double>("DRICH_sensor_sph_radius") / dd4hep::mm;
-    auto sensorThickness  = m_det->constant<double>("DRICH_sensor_thickness") / dd4hep::mm;
-    auto sensorSize       = m_det->constant<double>("DRICH_sensor_size") / dd4hep::mm;
-    dd4hep::Position sensorSphCenter(
-      m_det->constant<double>("DRICH_sensor_sph_center_x_"+secName) / dd4hep::mm,
-      m_det->constant<double>("DRICH_sensor_sph_center_y_"+secName) / dd4hep::mm,
-      m_det->constant<double>("DRICH_sensor_sph_center_z_"+secName) / dd4hep::mm
-      );
-    m_log->debug("  SECTOR {:d} SENSOR SPHERE:", isec);
-    m_log->debug("    sphere x = {:f} mm", sensorSphCenter.x());
-    m_log->debug("    sphere y = {:f} mm", sensorSphCenter.y());
-    m_log->debug("    sphere z = {:f} mm", sensorSphCenter.z());
-    m_log->debug("    sphere R = {:f} mm", sensorSphRadius);
-
     // sensor modules: search the detector tree for sensors for this sector
     m_log->trace("  SENSORS:");
     m_log->trace("--------------------------------------------------------------------------------------"); 
     m_log->trace("name ID sector   pos_x pos_y pos_z   normX_x normX_y normX_z   normY_x normY_y normY_z"); 
     m_log->trace("--------------------------------------------------------------------------------------"); 
+    auto sensorThickness = m_det->constant<double>("DRICH_sensor_thickness") / dd4hep::mm;
+    auto sensorSize      = m_det->constant<double>("DRICH_sensor_size") / dd4hep::mm;
     for(auto const& [de_name, detSensor] : m_detRich.children()) {
       if(de_name.find("sensor_de_"+secName)!=std::string::npos) {
 

--- a/src/services/geometry/richgeo/IrtGeoDRICH.cc
+++ b/src/services/geometry/richgeo/IrtGeoDRICH.cc
@@ -130,6 +130,17 @@ void richgeo::IrtGeoDRICH::DD4hep_to_IRT() {
     for(auto const& [de_name, detSensor] : m_detRich.children()) {
       if(de_name.find("sensor_de_"+secName)!=std::string::npos) {
 
+        // sandbox
+        m_log->critical("ID={}", detSensor.id());
+        const auto detSensorPars = detSensor.extension<dd4hep::rec::VariantParameters>(true);
+        if(detSensorPars==nullptr) {
+          m_log->error("this sensor does not have VariantParameters");
+          continue; // FIXME throw runtime error
+        }
+        m_log->critical("  x={}", detSensorPars->get<double>("x"));
+        m_log->critical("  y={}", detSensorPars->get<double>("y"));
+        m_log->critical("  z={}", detSensorPars->get<double>("z"));
+
         // get sensor info
         auto imodsec = detSensor.id();
         // - get sensor centroid position
@@ -195,13 +206,13 @@ void richgeo::IrtGeoDRICH::DD4hep_to_IRT() {
             imodsec,             // copy number
             m_sensorFlatSurface  // surface
             );
-        m_log->trace(
-            "sensor: id={:#X} pos=({:5.2f}, {:5.2f}, {:5.2f}) normX=({:5.2f}, {:5.2f}, {:5.2f}) normY=({:5.2f}, {:5.2f}, {:5.2f})",
-            imodsec,
-            posSensorSurface.x(), posSensorSurface.y(), posSensorSurface.z(),
-            normXdir.x(),  normXdir.y(),  normXdir.z(),
-            normYdir.x(),  normYdir.y(),  normYdir.z()
-            );
+        // m_log->trace(
+        //     "sensor: id={:#X} pos=({:5.2f}, {:5.2f}, {:5.2f}) normX=({:5.2f}, {:5.2f}, {:5.2f}) normY=({:5.2f}, {:5.2f}, {:5.2f})",
+        //     imodsec,
+        //     posSensorSurface.x(), posSensorSurface.y(), posSensorSurface.z(),
+        //     normXdir.x(),  normXdir.y(),  normXdir.z(),
+        //     normYdir.x(),  normYdir.y(),  normYdir.z()
+        //     );
       }
     } // search for sensors
 

--- a/src/services/geometry/richgeo/IrtGeoDRICH.cc
+++ b/src/services/geometry/richgeo/IrtGeoDRICH.cc
@@ -12,12 +12,13 @@ void richgeo::IrtGeoDRICH::DD4hep_to_IRT() {
    * for all radiators will be assigned at the end by hand; FIXME: should assign it on
    * per-photon basis, at birth, like standalone GEANT code does;
    */
-  auto nSectors       = m_det->constant<int>("DRICH_num_sectors");
-  auto vesselZmin     = m_det->constant<double>("DRICH_zmin") / dd4hep::mm;
-  auto gasvolMaterial = m_det->constant<std::string>("DRICH_gasvol_material");
+  auto nSectors              = m_det->constant<int>("DRICH_num_sectors");
+  auto vesselZmin            = m_det->constant<double>("DRICH_zmin") / dd4hep::mm;
+  auto vesselWindowThickness = m_det->constant<double>("DRICH_window_thickness") / dd4hep::mm;
+  auto gasvolMaterial        = m_det->constant<std::string>("DRICH_gasvol_material");
   TVector3 normX(1, 0,  0); // normal vectors
   TVector3 normY(0, -1, 0);
-  m_surfEntrance = new FlatSurface(TVector3(0, 0, vesselZmin), normX, normY);
+  m_surfEntrance = new FlatSurface(TVector3(0, 0, vesselZmin + vesselWindowThickness), normX, normY);
   for (int isec=0; isec<nSectors; isec++) {
     auto cv = m_irtDetectorCollection->SetContainerVolume(
         m_irtDetector,              // Cherenkov detector

--- a/src/services/geometry/richgeo/ReadoutGeo.cc
+++ b/src/services/geometry/richgeo/ReadoutGeo.cc
@@ -161,5 +161,3 @@ dd4hep::Position richgeo::ReadoutGeo::GetSensorLocalPosition(uint64_t cellID, dd
 
   return pos_transformed;
 }
-
-

--- a/src/services/geometry/richgeo/ReadoutGeo.cc
+++ b/src/services/geometry/richgeo/ReadoutGeo.cc
@@ -35,7 +35,7 @@ richgeo::ReadoutGeo::ReadoutGeo(std::string detName_, dd4hep::Detector *det_, st
     m_num_pdus          = m_det->constant<int>("DRICH_num_pdus");
     m_num_sipms_per_pdu = std::pow(m_det->constant<int>("DRICH_pdu_num_sensors"), 2);
     m_num_px            = m_det->constant<int>("DRICH_num_px");
-    m_pixel_size        = m_det->constant<double>("DRICH_pixel_size");
+    m_pixel_size        = m_det->constant<double>("DRICH_pixel_size") / dd4hep::mm;
 
     // define cellID looper
     m_loopCellIDs = [this] (std::function<void(CellIDType)> lambda) {

--- a/src/services/geometry/richgeo/ReadoutGeo.cc
+++ b/src/services/geometry/richgeo/ReadoutGeo.cc
@@ -100,7 +100,7 @@ richgeo::ReadoutGeo::ReadoutGeo(std::string detName_, dd4hep::Detector *det_, st
 
 // pixel gap mask
 // FIXME: generalize; this assumes the segmentation is `CartesianGridXY`
-bool richgeo::ReadoutGeo::PixelGapMask(uint64_t cellID, dd4hep::Position pos_hit_global) {
+bool richgeo::ReadoutGeo::PixelGapMask(CellIDType cellID, dd4hep::Position pos_hit_global) {
   auto pos_pixel_global = m_cellid_converter->position(cellID);
   auto pos_pixel_local  = GetSensorLocalPosition(cellID, pos_pixel_global);
   auto pos_hit_local    = GetSensorLocalPosition(cellID, pos_hit_global);
@@ -113,7 +113,7 @@ bool richgeo::ReadoutGeo::PixelGapMask(uint64_t cellID, dd4hep::Position pos_hit
 
 // transform global position `pos` to sensor `cellID` frame position
 // IMPORTANT NOTE: this has only been tested for the dRICH; if you use it, test it carefully...
-dd4hep::Position richgeo::ReadoutGeo::GetSensorLocalPosition(uint64_t cellID, dd4hep::Position pos) {
+dd4hep::Position richgeo::ReadoutGeo::GetSensorLocalPosition(CellIDType cellID, dd4hep::Position pos) {
 
   // get the VolumeManagerContext for this sensitive detector
   auto context = m_cellid_converter->findContext(cellID);

--- a/src/services/geometry/richgeo/ReadoutGeo.cc
+++ b/src/services/geometry/richgeo/ReadoutGeo.cc
@@ -22,19 +22,20 @@ richgeo::ReadoutGeo::ReadoutGeo(std::string detName_, dd4hep::Detector *det_, st
   m_rngCellIDs = [] (std::function<void(CellIDType)> lambda, float p) { return; };
 
   // common objects
-  m_readoutCoder = m_det->readout(m_detName+"Hits").idSpec().decoder();
-  m_detRich      = m_det->detector(m_detName);
-  m_systemID     = m_detRich.id();
+  m_readoutCoder     = m_det->readout(m_detName+"Hits").idSpec().decoder();
+  m_detRich          = m_det->detector(m_detName);
+  m_systemID         = m_detRich.id();
+  m_cellid_converter = std::make_shared<const dd4hep::rec::CellIDPositionConverter>(*m_det);
 
   // dRICH readout --------------------------------------------------------------------
   if(m_detName=="DRICH") {
 
-    // get number of sectors
-    m_num_sec = m_det->constant<int>("DRICH_num_sectors");
-    // get number of sensors
-    m_num_mod = m_det->constant<int>("DRICH_num_sensors");
-    // get number of pixels along one side of a SiPM
-    m_num_px = m_det->constant<int>("DRICH_num_px");
+    // get constants from geometry
+    m_num_sec           = m_det->constant<int>("DRICH_num_sectors");
+    m_num_pdus          = m_det->constant<int>("DRICH_num_pdus");
+    m_num_sipms_per_pdu = std::pow(m_det->constant<int>("DRICH_pdu_num_sensors"), 2);
+    m_num_px            = m_det->constant<int>("DRICH_num_px");
+    m_pixel_size        = m_det->constant<double>("DRICH_pixel_size");
 
     // define cellID looper
     m_loopCellIDs = [this] (std::function<void(CellIDType)> lambda) {
@@ -44,17 +45,18 @@ richgeo::ReadoutGeo::ReadoutGeo(std::string detName_, dd4hep::Detector *det_, st
       for(auto const& [deName, detSensor] : m_detRich.children()) {
         if(deName.find("sensor_de_sec")!=std::string::npos) {
 
-          // decode `imodsec` to module number and sector number
-          auto imodsec = detSensor.id();
-          auto imod    = m_readoutCoder->get(imodsec, "module");
-          auto isec    = m_readoutCoder->get(imodsec, "sector");
-          // m_log->trace("  module: imodsec={:#018X} => imod={:<6} isec={:<2} name={}", imodsec, imod, isec, deName);
+          // decode `sensorID` to module number and sector number
+          auto sensorID = detSensor.id();
+          auto ipdu     = m_readoutCoder->get(sensorID, "pdu");
+          auto isipm    = m_readoutCoder->get(sensorID, "sipm");
+          auto isec     = m_readoutCoder->get(sensorID, "sector");
+          // m_log->trace("  module: sensorID={:#018X} => ipdu={:<6} isipm={:<6} isec={:<2} name={}", sensorID, ipdu, isipm, isec, deName);
 
           // loop over xy-segmentation
           for (int x = 0; x < m_num_px; x++) {
             for (int y = 0; y < m_num_px; y++) {
 
-              auto cellID = cellIDEncoding(isec, imod, x, y);
+              auto cellID = cellIDEncoding(isec, ipdu, isipm, x, y);
 
               // then execute the user's lambda function
               lambda(cellID);
@@ -68,19 +70,21 @@ richgeo::ReadoutGeo::ReadoutGeo(std::string detName_, dd4hep::Detector *det_, st
     m_rngCellIDs = [this] (std::function<void(CellIDType)> lambda, float p) {
       m_log->trace("call RngReadoutPixels for systemID = {} = {}", m_systemID, m_detName);
 
-      int k = p*m_num_sec*m_num_mod*m_num_px*m_num_px;
+      int k = p * m_num_sec * m_num_pdus * m_num_sipms_per_pdu * m_num_px * m_num_px;
 
       for (int i = 0; i < k; i++) {
 	int isec = m_random.Uniform(0., m_num_sec);
-	int imod = m_random.Uniform(0., m_num_mod);
+	int ipdu = m_random.Uniform(0., m_num_pdus);
+	int isipm = m_random.Uniform(0., m_num_sipms_per_pdu);
 	int x = m_random.Uniform(0., m_num_px);
 	int y = m_random.Uniform(0., m_num_px);
 
-	auto cellID = cellIDEncoding(isec, imod, x, y);
+	auto cellID = cellIDEncoding(isec, ipdu, isipm, x, y);
 
 	lambda(cellID);
       }
     };
+
   }
 
   // pfRICH readout --------------------------------------------------------------------
@@ -92,3 +96,70 @@ richgeo::ReadoutGeo::ReadoutGeo(std::string detName_, dd4hep::Detector *det_, st
   else m_log->error("ReadoutGeo is not defined for detector '{}'",m_detName);
 
 }
+
+
+// pixel gap mask
+// FIXME: generalize; this assumes the segmentation is `CartesianGridXY`
+bool richgeo::ReadoutGeo::PixelGapMask(uint64_t cellID, dd4hep::Position pos_hit_global) {
+  auto pos_pixel_global = m_cellid_converter->position(cellID);
+  auto pos_pixel_local  = GetSensorLocalPosition(cellID, pos_pixel_global);
+  auto pos_hit_local    = GetSensorLocalPosition(cellID, pos_hit_global);
+  return ! (
+      std::abs( pos_hit_local.x()/dd4hep::mm - pos_pixel_local.x()/dd4hep::mm ) > m_pixel_size/2 ||
+      std::abs( pos_hit_local.y()/dd4hep::mm - pos_pixel_local.y()/dd4hep::mm ) > m_pixel_size/2
+      );
+}
+
+
+// transform global position `pos` to sensor `cellID` frame position
+// IMPORTANT NOTE: this has only been tested for the dRICH; if you use it, test it carefully...
+dd4hep::Position richgeo::ReadoutGeo::GetSensorLocalPosition(uint64_t cellID, dd4hep::Position pos) {
+
+  // get the VolumeManagerContext for this sensitive detector
+  auto context = m_cellid_converter->findContext(cellID);
+
+  // transformation vector buffers
+  double xyz_l[3], xyz_e[3], xyz_g[2];
+  double pv_g[3], pv_l[3];
+
+  // get sensor position w.r.t. its parent
+  auto sensor_elem = context->element;
+  sensor_elem.placement().position().GetCoordinates(xyz_l);
+
+  // convert sensor position to global position (cf. `CellIDPositionConverter::positionNominal()`)
+  const auto& volToElement = context->toElement();
+  volToElement.LocalToMaster(xyz_l, xyz_e);
+  const auto& elementToGlobal = sensor_elem.nominal().worldTransformation();
+  elementToGlobal.LocalToMaster(xyz_e, xyz_g);
+  dd4hep::Position pos_sensor;
+  pos_sensor.SetCoordinates(xyz_g);
+
+  // get the position vector of `pos` w.r.t. the sensor position `pos_sensor`
+  dd4hep::Direction pos_pv = pos - pos_sensor;
+
+  // then transform it to the sensor's local frame
+  pos_pv.GetCoordinates(pv_g);
+  volToElement.MasterToLocalVect(pv_g, pv_l);
+  dd4hep::Position pos_transformed;
+  pos_transformed.SetCoordinates(pv_l);
+
+  // trace log
+  /*
+  if(m_log->level() <= spdlog::level::trace) {
+    m_log->trace("pixel hit on cellID={:#018x}",cellID);
+    auto print_pos = [&] (std::string name, dd4hep::Position p) {
+      m_log->trace("  {:>30} x={:.2f} y={:.2f} z={:.2f} [mm]: ", name, p.x()/dd4hep::mm,  p.y()/dd4hep::mm,  p.z()/dd4hep::mm);
+    };
+    print_pos("input position",  pos);
+    print_pos("sensor position", pos_sensor);
+    print_pos("output position", pos_transformed);
+    // auto dim = m_cellid_converter->cellDimensions(cellID);
+    // for (std::size_t j = 0; j < std::size(dim); ++j)
+    //   m_log->trace("   - dimension {:<5} size: {:.2}",  j, dim[j]);
+  }
+  */
+
+  return pos_transformed;
+}
+
+

--- a/src/services/geometry/richgeo/ReadoutGeo.h
+++ b/src/services/geometry/richgeo/ReadoutGeo.h
@@ -30,13 +30,14 @@ namespace richgeo {
       ~ReadoutGeo() {}
 
       // define cellID encoding
-      CellIDType cellIDEncoding(int isec, int imod, int x, int y)
+      CellIDType cellIDEncoding(int isec, int ipdu, int isipm, int x, int y)
       {
 	// encode cellID
 	dd4hep::rec::CellID cellID_dd4hep;
 	m_readoutCoder->set(cellID_dd4hep, "system", m_systemID);
 	m_readoutCoder->set(cellID_dd4hep, "sector", isec);
-	m_readoutCoder->set(cellID_dd4hep, "module", imod);
+	m_readoutCoder->set(cellID_dd4hep, "pdu",    ipdu);
+	m_readoutCoder->set(cellID_dd4hep, "sipm",   isipm);
 	m_readoutCoder->set(cellID_dd4hep, "x",      x);
 	m_readoutCoder->set(cellID_dd4hep, "y",      y);
 	CellIDType cellID(cellID_dd4hep); // in case DD4hep CellID type differs from EDM type
@@ -50,8 +51,15 @@ namespace richgeo {
       // generated k rng cell IDs, executing `lambda(cellID)` on each
       void VisitAllRngPixels(std::function<void(CellIDType)> lambda, float p) { m_rngCellIDs(lambda, p); }
 
-// set RNG seed
-void SetSeed(unsigned long seed) { m_random.SetSeed(seed); }
+      // pixel gap mask
+      bool PixelGapMask(uint64_t cellID, dd4hep::Position pos_hit_global);
+
+      // transform global position `pos` to sensor `id` frame position
+      // IMPORTANT NOTE: this has only been tested for the dRICH; if you use it, test it carefully...
+      dd4hep::Position GetSensorLocalPosition(uint64_t id, dd4hep::Position pos);
+
+      // set RNG seed
+      void SetSeed(unsigned long seed) { m_random.SetSeed(seed); }
 
     protected:
 
@@ -61,10 +69,13 @@ void SetSeed(unsigned long seed) { m_random.SetSeed(seed); }
       dd4hep::Detector*      m_det;
       dd4hep::DetElement     m_detRich;
       dd4hep::BitFieldCoder* m_readoutCoder;
+      std::shared_ptr<const dd4hep::rec::CellIDPositionConverter> m_cellid_converter;
       int                    m_systemID;
       int                    m_num_sec;
-      int                    m_num_mod;
+      int                    m_num_pdus;
+      int                    m_num_sipms_per_pdu;
       int                    m_num_px;
+      double                 m_pixel_size;
 
       // local function to loop over cellIDs; defined in initialization and called by `VisitAllReadoutPixels`
       std::function< void(std::function<void(CellIDType)>) > m_loopCellIDs;

--- a/src/services/geometry/richgeo/ReadoutGeo.h
+++ b/src/services/geometry/richgeo/ReadoutGeo.h
@@ -52,11 +52,11 @@ namespace richgeo {
       void VisitAllRngPixels(std::function<void(CellIDType)> lambda, float p) { m_rngCellIDs(lambda, p); }
 
       // pixel gap mask
-      bool PixelGapMask(uint64_t cellID, dd4hep::Position pos_hit_global);
+      bool PixelGapMask(CellIDType cellID, dd4hep::Position pos_hit_global);
 
       // transform global position `pos` to sensor `id` frame position
       // IMPORTANT NOTE: this has only been tested for the dRICH; if you use it, test it carefully...
-      dd4hep::Position GetSensorLocalPosition(uint64_t id, dd4hep::Position pos);
+      dd4hep::Position GetSensorLocalPosition(CellIDType id, dd4hep::Position pos);
 
       // set RNG seed
       void SetSeed(unsigned long seed) { m_random.SetSeed(seed); }


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Updates respecting https://github.com/eic/epic/pull/331 

- `richgeo`:
  - use DD4hep `VariantParameters` to streamline access to sensor positioning and orientation
  - various updates respecting https://github.com/eic/epic/pull/331 
    - tests of sensor positioning and orientation are moved to `epic` with that PR
  - respect the readout field change: `module` -> `pdu` and `sipm`
  - method `richgeo::ReadoutGeo::PixelGapMask` was cut and pasted from `PhotoMultiplierHitDigi` 
- `PhotoMultiplierHitDigi`:
  - move pixel gap (mask) cuts to `richgeo` service in `ReadoutGeo`
  - delete config parameter `PhotoMultiplierHitDigiConfig::pixelSize`, since it can be obtained from `richgeo`


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [x] Other: refactor

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
yes: this PR should be merged at the same time as
- https://github.com/eic/epic/pull/331
- https://github.com/eic/drich-dev/pull/83

### Does this PR change default behavior?
not really, benchmarks appear to be the same