### PR TITLE
[ci-asan-lsan-suppressions] treewide: avoid leaking memory in users of CalorimeterHitDigi

### DIFF
--- a/src/detectors/B0ECAL/RawCalorimeterHit_factory_B0ECalRawHits.h
+++ b/src/detectors/B0ECAL/RawCalorimeterHit_factory_B0ECalRawHits.h
@@ -88,7 +88,6 @@ public:
 
         // Hand owner of algorithm objects over to JANA
         Set(rawhits);
-        rawhits.clear(); // not really needed, but better to not leave dangling pointers around
     }
 
 };

--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelImagingRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelImagingRawHits.h
@@ -83,7 +83,6 @@ public:
 
         // Hand owner of algorithm objects over to JANA
         Set(rawhits);
-        rawhits.clear(); // not really needed, but better to not leave dangling pointers around
     }
 
 };

--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelScFiRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelScFiRawHits.h
@@ -85,7 +85,6 @@ public:
 
         // Hand owner of algorithm objects over to JANA
         Set(rawhits);
-        rawhits.clear(); // not really needed, but better to not leave dangling pointers around
     }
 
 };

--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelSciGlassRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelSciGlassRawHits.h
@@ -88,7 +88,6 @@ public:
 
         // Hand owner of algorithm objects over to JANA
         Set(rawhits);
-        rawhits.clear(); // not really needed, but better to not leave dangling pointers around
     }
 
 };

--- a/src/detectors/BHCAL/RawCalorimeterHit_factory_HcalBarrelRawHits.h
+++ b/src/detectors/BHCAL/RawCalorimeterHit_factory_HcalBarrelRawHits.h
@@ -87,7 +87,6 @@ public:
 
         // Hand owner of algorithm objects over to JANA
         Set(rawhits);
-        rawhits.clear(); // not really needed, but better to not leave dangling pointers around
     }
 
 };

--- a/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapNRawHits.h
+++ b/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapNRawHits.h
@@ -88,7 +88,6 @@ public:
 
         // Hand owner of algorithm objects over to JANA
         Set(rawhits);
-        rawhits.clear(); // not really needed, but better to not leave dangling pointers around
     }
 
 };

--- a/src/detectors/EHCAL/RawCalorimeterHit_factory_HcalEndcapNRawHits.h
+++ b/src/detectors/EHCAL/RawCalorimeterHit_factory_HcalEndcapNRawHits.h
@@ -86,7 +86,6 @@ public:
 
         // Hand owner of algorithm objects over to JANA
         Set(rawhits);
-        rawhits.clear(); // not really needed, but better to not leave dangling pointers around
     }
 
 };

--- a/src/detectors/FEMC/RawCalorimeterHit_factory_EcalEndcapPInsertRawHits.h
+++ b/src/detectors/FEMC/RawCalorimeterHit_factory_EcalEndcapPInsertRawHits.h
@@ -85,7 +85,6 @@ public:
 
         // Hand owner of algorithm objects over to JANA
         Set(rawhits);
-        rawhits.clear(); // not really needed, but better to not leave dangling pointers around
     }
 
 };

--- a/src/detectors/FEMC/RawCalorimeterHit_factory_EcalEndcapPRawHits.h
+++ b/src/detectors/FEMC/RawCalorimeterHit_factory_EcalEndcapPRawHits.h
@@ -90,7 +90,6 @@ public:
 
         // Hand owner of algorithm objects over to JANA
         Set(rawhits);
-        rawhits.clear(); // not really needed, but better to not leave dangling pointers around
     }
 
 };

--- a/src/detectors/FHCAL/RawCalorimeterHit_factory_HcalEndcapPInsertRawHits.h
+++ b/src/detectors/FHCAL/RawCalorimeterHit_factory_HcalEndcapPInsertRawHits.h
@@ -84,7 +84,6 @@ public:
 
         // Hand owner of algorithm objects over to JANA
         Set(rawhits);
-        rawhits.clear(); // not really needed, but better to not leave dangling pointers around
     }
 
 };

--- a/src/detectors/FHCAL/RawCalorimeterHit_factory_HcalEndcapPRawHits.h
+++ b/src/detectors/FHCAL/RawCalorimeterHit_factory_HcalEndcapPRawHits.h
@@ -86,7 +86,6 @@ public:
 
         // Hand owner of algorithm objects over to JANA
         Set(rawhits);
-        rawhits.clear(); // not really needed, but better to not leave dangling pointers around
     }
 
 };

--- a/src/detectors/FHCAL/RawCalorimeterHit_factory_LFHCALRawHits.h
+++ b/src/detectors/FHCAL/RawCalorimeterHit_factory_LFHCALRawHits.h
@@ -87,7 +87,6 @@ public:
 
         // Hand owner of algorithm objects over to JANA
         Set(rawhits);
-        rawhits.clear(); // not really needed, but better to not leave dangling pointers around
     }
 
 };

--- a/src/detectors/ZDC/RawCalorimeterHit_factory_ZDCEcalRawHits.h
+++ b/src/detectors/ZDC/RawCalorimeterHit_factory_ZDCEcalRawHits.h
@@ -86,7 +86,6 @@ public:
 
         // Hand owner of algorithm objects over to JANA
         Set(rawhits);
-        rawhits.clear(); // not really needed, but better to not leave dangling pointers around
     }
 
 };


### PR DESCRIPTION
Fixes a memory leak as seen in https://github.com/eic/EICrecon/actions/runs/5438209432/jobs/9889373595?pr=722

Clearing the array prevents memory from being released in
https://github.com/eic/EICrecon/blob/6f6abf218abb3ece03b60a4875ba5996777b2274/src/algorithms/calorimetry/CalorimeterHitDigi.cc#L123-L124
This assumes that JANA doesn't release objects pointed to the `rawhits` array.