### PR TITLE
feat!: enable dRICH PID in production

### DIFF
--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -51,6 +51,16 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "TOFBarrelRecHit",
             "TOFEndcapRecHits",
 
+            // DRICH
+            "DRICHRawHits",
+            "DRICHRawHitsAssociations",
+            "DRICHAerogelTracks",
+            "DRICHGasTracks",
+            "DRICHMergedTracks",
+            "DRICHAerogelIrtCherenkovParticleID",
+            "DRICHGasIrtCherenkovParticleID",
+            // "DRICHMergedIrtCherenkovParticleID",
+
             // MPGD
             "MPGDBarrelRecHits",
             "MPGDDIRCRecHits",
@@ -73,6 +83,7 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "ReconstructedChargedParticleAssociations",
             "ReconstructedSeededChargedParticles",
             "ReconstructedSeededChargedParticleAssociations",
+            // "ReconstructedChargedParticleIDs",
             "CentralTrackSegments",
             "CentralTrackVertices",
             "CentralCKFTrajectories",

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -56,10 +56,8 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "DRICHRawHitsAssociations",
             "DRICHAerogelTracks",
             "DRICHGasTracks",
-            "DRICHMergedTracks",
             "DRICHAerogelIrtCherenkovParticleID",
             "DRICHGasIrtCherenkovParticleID",
-            // "DRICHMergedIrtCherenkovParticleID",
 
             // MPGD
             "MPGDBarrelRecHits",

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -81,7 +81,7 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "ReconstructedChargedParticleAssociations",
             "ReconstructedSeededChargedParticles",
             "ReconstructedSeededChargedParticleAssociations",
-            // "ReconstructedChargedParticleIDs",
+            "ReconstructedChargedParticleIDs",
             "CentralTrackSegments",
             "CentralTrackVertices",
             "CentralCKFTrajectories",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Include dRICH output collections in default `eicrecon`.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no

### Does this PR change default behavior?
yes, new output collections