### PR TITLE
Fix a warning in JDD4hep_service.h

### DIFF
--- a/src/services/geometry/dd4hep/JDD4hep_service.h
+++ b/src/services/geometry/dd4hep/JDD4hep_service.h
@@ -37,7 +37,7 @@ class JDD4hep_service : public JService
 {
 public:
     JDD4hep_service( JApplication *app ) : app(app) {}
-    virtual ~JDD4hep_service();
+    virtual ~JDD4hep_service() override;
 
     virtual dd4hep::Detector* detector();
     virtual std::shared_ptr<const dd4hep::rec::CellIDPositionConverter> cellIDPositionConverter() {


### PR DESCRIPTION
```
src/services/geometry/dd4hep/JDD4hep_service.h:40:13: warning: '~JDD4hep_service' overrides a destructor but is not marked 'override' [-Wsuggest-destructor-override]
    virtual ~JDD4hep_service();
            ^
prefix/include/JANA/Services/JServiceLocator.h:38:13: note: overridden virtual function is here
    virtual ~JService() = default;
            ^
```