### PR TITLE
fix: missing comma in tracking.cc

### DIFF
--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -40,7 +40,7 @@ void InitPlugin(JApplication *app) {
                          "TOFBarrelRecHit",             // TOF hits
                          "TOFEndcapRecHits",
 			 "MPGDBarrelRecHits",           // MPGD
-                         "MPGDDIRCRecHits"
+                         "MPGDDIRCRecHits",
                          "OuterMPGDBarrelRecHits",
                          "BackwardMPGDEndcapRecHits",
                          "ForwardMPGDEndcapRecHits",


### PR DESCRIPTION
This fixes the tracking for me locally. Presumably this failed before (likely not silently but without an error return code because EICrecon depends on failing without error codes).