### PR TITLE
Add reconstructed electron factory, algorithm utilizing E/p cut 

### DIFF
--- a/src/algorithms/reco/ElectronReconstruction.cc
+++ b/src/algorithms/reco/ElectronReconstruction.cc
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2023 Daniel Brandenburg
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+#include "Beam.h"
+#include "Boost.h"
+#include "ElectronReconstruction.h"
+
+// Event Model related classes
+#include "edm4hep/MCParticleCollection.h"
+#include "edm4eic/MCRecoParticleAssociationCollection.h"
+#include "edm4eic/ReconstructedParticleCollection.h"
+
+namespace eicrecon {
+
+  void ElectronReconstruction::init(std::shared_ptr<spdlog::logger> logger) {
+    m_log = logger;
+  }
+
+  std::vector<edm4eic::ReconstructedParticle*> ElectronReconstruction::execute(
+    std::vector<const edm4hep::MCParticle *> mcparts,
+    std::vector<const edm4eic::ReconstructedParticle *> rcparts,
+    std::vector<const edm4eic::MCRecoParticleAssociation *> rcassoc,
+    std::vector<std::vector<const edm4eic::MCRecoClusterParticleAssociation*>> &in_clu_assoc
+    ) {
+
+        // Step 1. Loop through MCParticle - cluster associations
+        // Step 2. Get Reco particle for the Mc Particle matched to cluster
+        // Step 3. Apply E/p cut using Reco cluster Energy and Reco Particle momentum 
+
+        // Some obvious improvements:
+        // - E/p cut from real study optimized for electron finding and hadron rejection
+        // - use of any HCAL info?
+        // - check for duplicates?
+
+        m_log->debug("ElectronReconstruction::execute");    
+        
+        // output container
+        std::vector<edm4eic::ReconstructedParticle*> electrons_edm;
+
+        for ( auto col : in_clu_assoc ){ // loop on cluster association collections
+          for ( auto clu_assoc : col ){ // loop on MCRecoClusterParticleAssociation in this particular collection
+            auto sim = clu_assoc->getSim(); // McParticle
+            auto clu = clu_assoc->getRec(); // RecoCluster
+            
+            m_log->debug( "SimId={}, CluId={}", clu_assoc->getSimID(), clu_assoc->getRecID() );
+            m_log->debug( "MCParticle: Energy={}, p={}, E/p = {} for PDG: {}", clu.getEnergy(), edm4eic::magnitude(sim.getMomentum()), clu.getEnergy() / edm4eic::magnitude(sim.getMomentum()), sim.getPDG() );
+
+
+            // Find the Reconstructed particle associated to the MC Particle that is matched with this reco cluster
+            // i.e. take (MC Particle <-> RC Cluster) + ( MC Particle <-> RC Particle ) = ( RC Particle <-> RC Cluster )
+            auto reco_part_assoc = rcassoc.begin();
+            bool found_reco_part = false;
+            for (; reco_part_assoc != rcassoc.end(); ++reco_part_assoc) {
+              if ((*reco_part_assoc)->getSimID() == (unsigned) clu_assoc->getSimID()) {
+                found_reco_part = true;
+                break;
+              }
+            }
+
+            // if we found a reco particle then test for electron compatibility
+            if ( found_reco_part ){
+              auto reco_part = (*reco_part_assoc)->getRec();
+              double EoverP = clu.getEnergy() / edm4eic::magnitude(reco_part.getMomentum());
+              m_log->info( "ReconstructedParticle: Energy={}, p={}, E/p = {} for PDG (from truth): {}", clu.getEnergy(), edm4eic::magnitude(reco_part.getMomentum()), EoverP, sim.getPDG() );
+
+              // Apply the E/p cut here to select electons
+              if ( EoverP >= min_energy_over_momentum && EoverP <= max_energy_over_momentum ) {
+                // doing this doesnt cause an error but resulted in an empty podio output collection
+                // electrons_edm.push_back( new edm4eic::ReconstructedParticle( reco_part ) );
+
+                edm4eic::MutableReconstructedParticle electron_edm = reco_part.clone();
+                electron_edm.setMass(m_electron);
+                electrons_edm.push_back(new edm4eic::ReconstructedParticle(electron_edm));
+              }
+
+            } else {
+              m_log->debug( "Could not find reconstructed particle for SimId={}", clu_assoc->getSimID() );
+            }
+
+          } // loop on MC particle to cluster associations in collection
+        } // loop on collections
+
+        m_log->debug( "Found {} electron candidates", electrons_edm.size() );
+        return electrons_edm;
+    }
+
+}

--- a/src/algorithms/reco/ElectronReconstruction.cc
+++ b/src/algorithms/reco/ElectronReconstruction.cc
@@ -21,10 +21,10 @@ namespace eicrecon {
   }
 
   std::vector<edm4eic::ReconstructedParticle*> ElectronReconstruction::execute(
-    std::vector<const edm4hep::MCParticle *> mcparts,
-    std::vector<const edm4eic::ReconstructedParticle *> rcparts,
-    std::vector<const edm4eic::MCRecoParticleAssociation *> rcassoc,
-    std::vector<std::vector<const edm4eic::MCRecoClusterParticleAssociation*>> &in_clu_assoc
+    const std::vector<const edm4hep::MCParticle *> &mcparts,
+    const std::vector<const edm4eic::ReconstructedParticle *> &rcparts,
+    const std::vector<const edm4eic::MCRecoParticleAssociation *> &rcassoc,
+    const std::vector<std::vector<const edm4eic::MCRecoClusterParticleAssociation*>> &in_clu_assoc
     ) {
 
         // Step 1. Loop through MCParticle - cluster associations

--- a/src/algorithms/reco/ElectronReconstruction.cc
+++ b/src/algorithms/reco/ElectronReconstruction.cc
@@ -1,19 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2023 Daniel Brandenburg
-
-#include <algorithm>
-#include <cmath>
-#include <vector>
-
-#include "Beam.h"
-#include "Boost.h"
 #include "ElectronReconstruction.h"
-
-// Event Model related classes
-#include "edm4hep/MCParticleCollection.h"
-#include "edm4eic/MCRecoParticleAssociationCollection.h"
-#include "edm4eic/ReconstructedParticleCollection.h"
-#include "edm4eic/MCRecoClusterParticleAssociationCollection.h"
 
 namespace eicrecon {
 

--- a/src/algorithms/reco/ElectronReconstruction.cc
+++ b/src/algorithms/reco/ElectronReconstruction.cc
@@ -22,9 +22,9 @@ namespace eicrecon {
   }
 
   std::unique_ptr<edm4eic::ReconstructedParticleCollection> ElectronReconstruction::execute(
-    const std::vector<const edm4hep::MCParticle *> &mcparts,
-    const std::vector<const edm4eic::ReconstructedParticle *> &rcparts,
-    const std::vector<const edm4eic::MCRecoParticleAssociation *> &rcassoc,
+    const edm4hep::MCParticleCollection *mcparts,
+    const edm4eic::ReconstructedParticleCollection *rcparts,
+    const edm4eic::MCRecoParticleAssociationCollection *rcassoc,
     const std::vector<const edm4eic::MCRecoClusterParticleAssociationCollection*> &in_clu_assoc
     ) {
 
@@ -52,10 +52,10 @@ namespace eicrecon {
 
             // Find the Reconstructed particle associated to the MC Particle that is matched with this reco cluster
             // i.e. take (MC Particle <-> RC Cluster) + ( MC Particle <-> RC Particle ) = ( RC Particle <-> RC Cluster )
-            auto reco_part_assoc = rcassoc.begin();
+            auto reco_part_assoc = rcassoc->begin();
             bool found_reco_part = false;
-            for (; reco_part_assoc != rcassoc.end(); ++reco_part_assoc) {
-              if ((*reco_part_assoc)->getSimID() == (unsigned) clu_assoc.getSimID()) {
+            for (; reco_part_assoc != rcassoc->end(); ++reco_part_assoc) {
+              if (reco_part_assoc->getSimID() == (unsigned) clu_assoc.getSimID()) {
                 found_reco_part = true;
                 break;
               }
@@ -63,7 +63,7 @@ namespace eicrecon {
 
             // if we found a reco particle then test for electron compatibility
             if ( found_reco_part ){
-              auto reco_part = (*reco_part_assoc)->getRec();
+              auto reco_part = reco_part_assoc->getRec();
               double EoverP = clu.getEnergy() / edm4eic::magnitude(reco_part.getMomentum());
               m_log->trace( "ReconstructedParticle: Energy={} GeV, p={} GeV, E/p = {} for PDG (from truth): {}", clu.getEnergy(), edm4eic::magnitude(reco_part.getMomentum()), EoverP, sim.getPDG() );
 

--- a/src/algorithms/reco/ElectronReconstruction.cc
+++ b/src/algorithms/reco/ElectronReconstruction.cc
@@ -29,15 +29,15 @@ namespace eicrecon {
 
         // Step 1. Loop through MCParticle - cluster associations
         // Step 2. Get Reco particle for the Mc Particle matched to cluster
-        // Step 3. Apply E/p cut using Reco cluster Energy and Reco Particle momentum 
+        // Step 3. Apply E/p cut using Reco cluster Energy and Reco Particle momentum
 
         // Some obvious improvements:
         // - E/p cut from real study optimized for electron finding and hadron rejection
         // - use of any HCAL info?
         // - check for duplicates?
 
-        m_log->debug("ElectronReconstruction::execute");    
-        
+        m_log->debug("ElectronReconstruction::execute");
+
         // output container
         std::vector<edm4eic::ReconstructedParticle*> electrons_edm;
 
@@ -45,7 +45,7 @@ namespace eicrecon {
           for ( auto clu_assoc : col ){ // loop on MCRecoClusterParticleAssociation in this particular collection
             auto sim = clu_assoc->getSim(); // McParticle
             auto clu = clu_assoc->getRec(); // RecoCluster
-            
+
             m_log->debug( "SimId={}, CluId={}", clu_assoc->getSimID(), clu_assoc->getRecID() );
             m_log->debug( "MCParticle: Energy={}, p={}, E/p = {} for PDG: {}", clu.getEnergy(), edm4eic::magnitude(sim.getMomentum()), clu.getEnergy() / edm4eic::magnitude(sim.getMomentum()), sim.getPDG() );
 

--- a/src/algorithms/reco/ElectronReconstruction.cc
+++ b/src/algorithms/reco/ElectronReconstruction.cc
@@ -36,8 +36,6 @@ namespace eicrecon {
         // - use of any HCAL info?
         // - check for duplicates?
 
-        m_log->debug("ElectronReconstruction::execute");
-
         // output container
         std::vector<edm4eic::ReconstructedParticle*> electrons_edm;
 

--- a/src/algorithms/reco/ElectronReconstruction.cc
+++ b/src/algorithms/reco/ElectronReconstruction.cc
@@ -63,7 +63,7 @@ namespace eicrecon {
             if ( found_reco_part ){
               auto reco_part = (*reco_part_assoc)->getRec();
               double EoverP = clu.getEnergy() / edm4eic::magnitude(reco_part.getMomentum());
-              m_log->info( "ReconstructedParticle: Energy={}, p={}, E/p = {} for PDG (from truth): {}", clu.getEnergy(), edm4eic::magnitude(reco_part.getMomentum()), EoverP, sim.getPDG() );
+              m_log->trace( "ReconstructedParticle: Energy={} GeV, p={} GeV, E/p = {} for PDG (from truth): {}", clu.getEnergy(), edm4eic::magnitude(reco_part.getMomentum()), EoverP, sim.getPDG() );
 
               // Apply the E/p cut here to select electons
               if ( EoverP >= min_energy_over_momentum && EoverP <= max_energy_over_momentum ) {

--- a/src/algorithms/reco/ElectronReconstruction.cc
+++ b/src/algorithms/reco/ElectronReconstruction.cc
@@ -44,8 +44,8 @@ namespace eicrecon {
             auto sim = clu_assoc->getSim(); // McParticle
             auto clu = clu_assoc->getRec(); // RecoCluster
 
-            m_log->debug( "SimId={}, CluId={}", clu_assoc->getSimID(), clu_assoc->getRecID() );
-            m_log->debug( "MCParticle: Energy={}, p={}, E/p = {} for PDG: {}", clu.getEnergy(), edm4eic::magnitude(sim.getMomentum()), clu.getEnergy() / edm4eic::magnitude(sim.getMomentum()), sim.getPDG() );
+            m_log->trace( "SimId={}, CluId={}", clu_assoc->getSimID(), clu_assoc->getRecID() );
+            m_log->trace( "MCParticle: Energy={} GeV, p={} GeV, E/p = {} for PDG: {}", clu.getEnergy(), edm4eic::magnitude(sim.getMomentum()), clu.getEnergy() / edm4eic::magnitude(sim.getMomentum()), sim.getPDG() );
 
 
             // Find the Reconstructed particle associated to the MC Particle that is matched with this reco cluster

--- a/src/algorithms/reco/ElectronReconstruction.cc
+++ b/src/algorithms/reco/ElectronReconstruction.cc
@@ -41,8 +41,7 @@ namespace eicrecon {
         auto out_electrons = std::make_unique<edm4eic::ReconstructedParticleCollection>();
 
         for ( auto col : in_clu_assoc ){ // loop on cluster association collections
-          for ( size_t i = 0; i < col->size(); i++ ){ // loop on MCRecoClusterParticleAssociation in this particular collection
-            const auto& clu_assoc = col->at(i);
+          for ( auto clu_assoc : (*col) ){ // loop on MCRecoClusterParticleAssociation in this particular collection
             auto sim = clu_assoc.getSim(); // McParticle
             auto clu = clu_assoc.getRec(); // RecoCluster
 
@@ -53,16 +52,14 @@ namespace eicrecon {
             // Find the Reconstructed particle associated to the MC Particle that is matched with this reco cluster
             // i.e. take (MC Particle <-> RC Cluster) + ( MC Particle <-> RC Particle ) = ( RC Particle <-> RC Cluster )
             auto reco_part_assoc = rcassoc->begin();
-            bool found_reco_part = false;
             for (; reco_part_assoc != rcassoc->end(); ++reco_part_assoc) {
               if (reco_part_assoc->getSimID() == (unsigned) clu_assoc.getSimID()) {
-                found_reco_part = true;
                 break;
               }
             }
 
             // if we found a reco particle then test for electron compatibility
-            if ( found_reco_part ){
+            if ( reco_part_assoc != rcassoc->end() ){
               auto reco_part = reco_part_assoc->getRec();
               double EoverP = clu.getEnergy() / edm4eic::magnitude(reco_part.getMomentum());
               m_log->trace( "ReconstructedParticle: Energy={} GeV, p={} GeV, E/p = {} for PDG (from truth): {}", clu.getEnergy(), edm4eic::magnitude(reco_part.getMomentum()), EoverP, sim.getPDG() );

--- a/src/algorithms/reco/ElectronReconstruction.h
+++ b/src/algorithms/reco/ElectronReconstruction.h
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2023 Daniel Brandenburg
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+#include <map>
+
+#include <spdlog/spdlog.h>
+
+#include <edm4eic/vector_utils.h>
+
+// Event Model related classes
+#include "edm4hep/MCParticleCollection.h"
+#include "edm4eic/MCRecoParticleAssociationCollection.h"
+#include "edm4eic/ReconstructedParticleCollection.h"
+#include "edm4eic/MCRecoClusterParticleAssociation.h"
+
+
+namespace eicrecon {
+
+    class ElectronReconstruction {
+
+    public:
+
+        void init(std::shared_ptr<spdlog::logger> logger);
+
+        // idea will be to overload this with other version (e.g. reco mode)
+        std::vector<edm4eic::ReconstructedParticle*> execute(
+                std::vector<const edm4hep::MCParticle*> mcparts,
+                std::vector<const edm4eic::ReconstructedParticle*> rcparts,
+                std::vector<const edm4eic::MCRecoParticleAssociation*> rcassoc,
+                std::vector<std::vector<const edm4eic::MCRecoClusterParticleAssociation*>> &in_clu_assoc
+        );
+
+        void setEnergyOverMomentumCut( double minEoP, double maxEoP ) { min_energy_over_momentum = minEoP; max_energy_over_momentum = maxEoP; }
+
+    private:
+        std::shared_ptr<spdlog::logger> m_log;
+        double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
+        double min_energy_over_momentum{0.9}, max_energy_over_momentum{1.2};
+
+    };
+} // namespace eicrecon

--- a/src/algorithms/reco/ElectronReconstruction.h
+++ b/src/algorithms/reco/ElectronReconstruction.h
@@ -13,10 +13,7 @@
 #include <edm4eic/vector_utils.h>
 
 // Event Model related classes
-#include "edm4hep/MCParticleCollection.h"
-#include "edm4eic/ReconstructedParticleCollection.h"
 #include "edm4eic/MCRecoParticleAssociationCollection.h"
-#include "edm4eic/MCRecoClusterParticleAssociation.h"
 #include "edm4eic/MCRecoClusterParticleAssociationCollection.h"
 
 
@@ -30,9 +27,9 @@ namespace eicrecon {
 
         // idea will be to overload this with other version (e.g. reco mode)
         std::unique_ptr<edm4eic::ReconstructedParticleCollection> execute(
-                const std::vector<const edm4hep::MCParticle*> &mcparts,
-                const std::vector<const edm4eic::ReconstructedParticle*> &rcparts,
-                const std::vector<const edm4eic::MCRecoParticleAssociation*> &rcassoc,
+                const edm4hep::MCParticleCollection *mcparts,
+                const edm4eic::ReconstructedParticleCollection *rcparts,
+                const edm4eic::MCRecoParticleAssociationCollection *rcassoc,
                 const std::vector<const edm4eic::MCRecoClusterParticleAssociationCollection*> &in_clu_assoc
         );
 

--- a/src/algorithms/reco/ElectronReconstruction.h
+++ b/src/algorithms/reco/ElectronReconstruction.h
@@ -14,9 +14,10 @@
 
 // Event Model related classes
 #include "edm4hep/MCParticleCollection.h"
-#include "edm4eic/MCRecoParticleAssociationCollection.h"
 #include "edm4eic/ReconstructedParticleCollection.h"
+#include "edm4eic/MCRecoParticleAssociationCollection.h"
 #include "edm4eic/MCRecoClusterParticleAssociation.h"
+#include "edm4eic/MCRecoClusterParticleAssociationCollection.h"
 
 
 namespace eicrecon {
@@ -28,18 +29,18 @@ namespace eicrecon {
         void init(std::shared_ptr<spdlog::logger> logger);
 
         // idea will be to overload this with other version (e.g. reco mode)
-        std::vector<edm4eic::ReconstructedParticle*> execute(
-                std::vector<const edm4hep::MCParticle*> mcparts,
-                std::vector<const edm4eic::ReconstructedParticle*> rcparts,
-                std::vector<const edm4eic::MCRecoParticleAssociation*> rcassoc,
-                std::vector<std::vector<const edm4eic::MCRecoClusterParticleAssociation*>> &in_clu_assoc
+        std::unique_ptr<edm4eic::ReconstructedParticleCollection> execute(
+                const std::vector<const edm4hep::MCParticle*> &mcparts,
+                const std::vector<const edm4eic::ReconstructedParticle*> &rcparts,
+                const std::vector<const edm4eic::MCRecoParticleAssociation*> &rcassoc,
+                const std::vector<const edm4eic::MCRecoClusterParticleAssociationCollection*> &in_clu_assoc
         );
 
         void setEnergyOverMomentumCut( double minEoP, double maxEoP ) { min_energy_over_momentum = minEoP; max_energy_over_momentum = maxEoP; }
 
     private:
         std::shared_ptr<spdlog::logger> m_log;
-        double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
+        double m_electron{0.000510998928};
         double min_energy_over_momentum{0.9}, max_energy_over_momentum{1.2};
 
     };

--- a/src/algorithms/reco/ElectronReconstruction.h
+++ b/src/algorithms/reco/ElectronReconstruction.h
@@ -3,17 +3,16 @@
 
 #pragma once
 
-#include <algorithm>
-#include <cmath>
 #include <vector>
-#include <map>
 
 #include <spdlog/spdlog.h>
 
 #include <edm4eic/vector_utils.h>
 
 // Event Model related classes
+#include "edm4hep/MCParticleCollection.h"
 #include "edm4eic/MCRecoParticleAssociationCollection.h"
+#include "edm4eic/ReconstructedParticleCollection.h"
 #include "edm4eic/MCRecoClusterParticleAssociationCollection.h"
 
 

--- a/src/global/reco/ReconstructedElectrons_factory.h
+++ b/src/global/reco/ReconstructedElectrons_factory.h
@@ -84,7 +84,7 @@ namespace eicrecon {
         );
 
         m_log->info( "We have found {} reconstructed electron candidates this event", output.size() );
-        
+
         // Step 4. Output the collection
         Set( std::move(output) );
       }

--- a/src/global/reco/ReconstructedElectrons_factory.h
+++ b/src/global/reco/ReconstructedElectrons_factory.h
@@ -53,8 +53,6 @@ namespace eicrecon {
 
       /** Event by event processing **/
       void Process(const std::shared_ptr<const JEvent> &event) override{
-        m_log->debug("ReconstructedElectrons_factory: Process");
-
         // Step 1. lets collect the Cluster associations from various detectors
         std::vector<std::vector<const edm4eic::MCRecoClusterParticleAssociation*>> in_clu_assoc;
         for(auto& input_tag : GetInputTags()){

--- a/src/global/reco/ReconstructedElectrons_factory.h
+++ b/src/global/reco/ReconstructedElectrons_factory.h
@@ -47,15 +47,15 @@ namespace eicrecon {
       /** Event by event processing **/
       void Process(const std::shared_ptr<const JEvent> &event) override{
         // Step 1. lets collect the Cluster associations from various detectors
-        std::vector<std::vector<const edm4eic::MCRecoClusterParticleAssociation*>> in_clu_assoc;
+        std::vector<const edm4eic::MCRecoClusterParticleAssociationCollection*> in_clu_assoc;
         for(auto& input_tag : GetInputTags()){
           // only collect from the sources that provide ClusterAssociations
           if ( input_tag.find( "ClusterAssociations" ) == std::string::npos ) {
             continue;
           }
-          m_log->debug( "Adding cluster associations from: {}", input_tag );
+          m_log->trace( "Adding cluster associations from: {}", input_tag );
           in_clu_assoc.push_back(
-            event->Get<edm4eic::MCRecoClusterParticleAssociation>(input_tag)
+            static_cast<const edm4eic::MCRecoClusterParticleAssociationCollection*>(event->GetCollectionBase(input_tag))
           );
         }
 
@@ -74,10 +74,10 @@ namespace eicrecon {
           in_clu_assoc
         );
 
-        m_log->debug( "We have found {} reconstructed electron candidates this event", output.size() );
+        m_log->debug( "We have found {} reconstructed electron candidates this event", output->size() );
 
         // Step 4. Output the collection
-        Set( std::move(output) );
+        SetCollection(std::move(output));
       }
 
     private:

--- a/src/global/reco/ReconstructedElectrons_factory.h
+++ b/src/global/reco/ReconstructedElectrons_factory.h
@@ -7,9 +7,6 @@
 #include <extensions/jana/JChainFactoryT.h>
 #include <JANA/JEvent.h>
 
-// data model
-#include <edm4eic/TrackSegmentCollection.h>
-
 // algorithms
 #include <algorithms/reco/ElectronReconstruction.h>
 

--- a/src/global/reco/ReconstructedElectrons_factory.h
+++ b/src/global/reco/ReconstructedElectrons_factory.h
@@ -61,9 +61,10 @@ namespace eicrecon {
 
         // Step 2. Get MC, RC, and MC-RC association info
         // This is needed as a bridge to get RecoCluster - RC Particle associations
-        auto mc_particles = event->Get<edm4hep::MCParticle>("MCParticles");
-        auto rc_particles = event->Get<edm4eic::ReconstructedParticle>("ReconstructedChargedParticles");
-        auto rc_particles_assoc = event->Get<edm4eic::MCRecoParticleAssociation>("ReconstructedChargedParticleAssociations");
+
+        auto mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase("MCParticles"));
+        auto rc_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase("ReconstructedChargedParticles"));
+        auto rc_particles_assoc = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase("ReconstructedChargedParticleAssociations"));
 
         // Step 3. Pass everything to "the algorithm"
         // in the future, select appropriate algorithm (truth, fully reco, etc.)
@@ -75,7 +76,6 @@ namespace eicrecon {
         );
 
         m_log->debug( "We have found {} reconstructed electron candidates this event", output->size() );
-
         // Step 4. Output the collection
         SetCollection(std::move(output));
       }

--- a/src/global/reco/ReconstructedElectrons_factory.h
+++ b/src/global/reco/ReconstructedElectrons_factory.h
@@ -20,9 +20,6 @@
 
 namespace eicrecon {
 
-// algorithm
-  class ElectronReconstruction;
-
   class ReconstructedElectrons_factory :
     public JChainFactoryT<edm4eic::ReconstructedParticle>,
     public SpdlogMixin<ReconstructedElectrons_factory>

--- a/src/global/reco/ReconstructedElectrons_factory.h
+++ b/src/global/reco/ReconstructedElectrons_factory.h
@@ -45,7 +45,6 @@ namespace eicrecon {
         // services
         InitLogger(prefix, "info");
         m_algo.init(m_log);
-        m_log->debug("ReconstructedElectrons_factory: plugin='{}' prefix='{}'", plugin, prefix);
       }
 
       /** On run change preparations **/

--- a/src/global/reco/ReconstructedElectrons_factory.h
+++ b/src/global/reco/ReconstructedElectrons_factory.h
@@ -1,0 +1,97 @@
+// Copyright (C) 2022, 2023 Daniel Brandenburg
+// Subject to the terms in the LICENSE file found in the top-level directory.
+
+#pragma once
+
+// JANA
+#include <extensions/jana/JChainFactoryT.h>
+#include <JANA/JEvent.h>
+
+// data model
+#include <edm4eic/TrackSegmentCollection.h>
+
+// algorithms
+#include <algorithms/reco/ElectronReconstruction.h>
+
+// services
+#include <services/log/Log_service.h>
+#include <extensions/spdlog/SpdlogExtensions.h>
+#include <extensions/spdlog/SpdlogMixin.h>
+
+namespace eicrecon {
+
+// algorithm
+  class ElectronReconstruction;
+
+  class ReconstructedElectrons_factory :
+    public JChainFactoryT<edm4eic::ReconstructedParticle>,
+    public SpdlogMixin<ReconstructedElectrons_factory>
+  {
+
+    public:
+
+      explicit ReconstructedElectrons_factory(std::vector<std::string> default_input_tags) :
+        JChainFactoryT<edm4eic::ReconstructedParticle>(std::move(default_input_tags)) {
+        }
+
+      /** One time initialization **/
+      void Init() override {
+        // get plugin name and tag
+        auto app    = GetApplication();
+        auto plugin = GetPluginName();
+        auto prefix = plugin + ":" + GetTag();
+        InitDataTags(prefix);
+
+        // services
+        InitLogger(prefix, "info");
+        m_algo.init(m_log);
+        m_log->debug("ReconstructedElectrons_factory: plugin='{}' prefix='{}'", plugin, prefix);
+      }
+
+      /** On run change preparations **/
+      void BeginRun(const std::shared_ptr<const JEvent> &event) override{}
+
+      /** Event by event processing **/
+      void Process(const std::shared_ptr<const JEvent> &event) override{
+        m_log->debug("ReconstructedElectrons_factory: Process");
+
+        // Step 1. lets collect the Cluster associations from various detectors
+        std::vector<std::vector<const edm4eic::MCRecoClusterParticleAssociation*>> in_clu_assoc;
+        for(auto& input_tag : GetInputTags()){
+          // only collect from the sources that provide ClusterAssociations
+          if ( input_tag.find( "ClusterAssociations" ) == std::string::npos ) {
+            continue;
+          }
+          m_log->debug( "Adding cluster associations from: {}", input_tag );
+          in_clu_assoc.push_back(
+            event->Get<edm4eic::MCRecoClusterParticleAssociation>(input_tag)
+          );
+        }
+
+        // Step 2. Get MC, RC, and MC-RC association info
+        // This is needed as a bridge to get RecoCluster - RC Particle associations
+        auto mc_particles = event->Get<edm4hep::MCParticle>("MCParticles");
+        auto rc_particles = event->Get<edm4eic::ReconstructedParticle>("ReconstructedChargedParticles");
+        auto rc_particles_assoc = event->Get<edm4eic::MCRecoParticleAssociation>("ReconstructedChargedParticleAssociations");
+
+        // Step 3. Pass everything to "the algorithm"
+        // in the future, select appropriate algorithm (truth, fully reco, etc.)
+        auto output = m_algo.execute(
+          mc_particles,
+          rc_particles,
+          rc_particles_assoc,
+          in_clu_assoc
+        );
+
+        m_log->info( "We have found {} reconstructed electron candidates this event", output.size() );
+        
+        // Step 4. Output the collection
+        Set( std::move(output) );
+      }
+
+    private:
+
+      // underlying algorithm
+      eicrecon::ElectronReconstruction m_algo;
+  };
+}

--- a/src/global/reco/ReconstructedElectrons_factory.h
+++ b/src/global/reco/ReconstructedElectrons_factory.h
@@ -83,7 +83,7 @@ namespace eicrecon {
           in_clu_assoc
         );
 
-        m_log->info( "We have found {} reconstructed electron candidates this event", output.size() );
+        m_log->debug( "We have found {} reconstructed electron candidates this event", output.size() );
 
         // Step 4. Output the collection
         Set( std::move(output) );

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -73,14 +73,14 @@ void InitPlugin(JApplication *app) {
 
     app->Add(new JChainFactoryGeneratorT<ReconstructedElectrons_factory>(
         {"MCParticles", "ReconstructedChargedParticles", "ReconstructedChargedParticleAssociations",
-        "EcalBarrelScFiClusterAssociations", 
+        "EcalBarrelScFiClusterAssociations",
         // "EcalBarrelSciGlassClusterAssociations",
         "EcalBarrelImagingClusterAssociations",
         "EcalEndcapNClusterAssociations",
-        "EcalEndcapPClusterAssociations", 
-        "EcalEndcapPInsertClusterAssociations", 
+        "EcalEndcapPClusterAssociations",
+        "EcalEndcapPInsertClusterAssociations",
         "EcalLumiSpecClusterAssociations",
-        }, 
+        },
         "ReconstructedElectrons"
     ));
 

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -74,7 +74,6 @@ void InitPlugin(JApplication *app) {
     app->Add(new JChainFactoryGeneratorT<ReconstructedElectrons_factory>(
         {"MCParticles", "ReconstructedChargedParticles", "ReconstructedChargedParticleAssociations",
         "EcalBarrelScFiClusterAssociations",
-        "EcalBarrelImagingClusterAssociations",
         "EcalEndcapNClusterAssociations",
         "EcalEndcapPClusterAssociations",
         "EcalEndcapPInsertClusterAssociations",

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -20,6 +20,7 @@
 #include "InclusiveKinematicsSigma_factory.h"
 #include "GeneratedJets_factory.h"
 #include "ReconstructedJets_factory.h"
+#include "ReconstructedElectrons_factory.h"
 
 //
 extern "C" {
@@ -69,6 +70,19 @@ void InitPlugin(JApplication *app) {
 
     app->Add(new JChainFactoryGeneratorT<ReconstructedJets_factory>(
             {"ReconstructedParticles"}, "ReconstructedJets"));
+
+    app->Add(new JChainFactoryGeneratorT<ReconstructedElectrons_factory>(
+        {"MCParticles", "ReconstructedChargedParticles", "ReconstructedChargedParticleAssociations",
+        "EcalBarrelScFiClusterAssociations", 
+        // "EcalBarrelSciGlassClusterAssociations",
+        "EcalBarrelImagingClusterAssociations",
+        "EcalEndcapNClusterAssociations",
+        "EcalEndcapPClusterAssociations", 
+        "EcalEndcapPInsertClusterAssociations", 
+        "EcalLumiSpecClusterAssociations",
+        }, 
+        "ReconstructedElectrons"
+    ));
 
 }
 } // extern "C"

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -74,7 +74,6 @@ void InitPlugin(JApplication *app) {
     app->Add(new JChainFactoryGeneratorT<ReconstructedElectrons_factory>(
         {"MCParticles", "ReconstructedChargedParticles", "ReconstructedChargedParticleAssociations",
         "EcalBarrelScFiClusterAssociations",
-        // "EcalBarrelSciGlassClusterAssociations",
         "EcalBarrelImagingClusterAssociations",
         "EcalEndcapNClusterAssociations",
         "EcalEndcapPClusterAssociations",

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -81,6 +81,7 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "InclusiveKinematicsTruth",
             "GeneratedJets",
             "ReconstructedJets",
+            "ReconstructedElectrons",
 
             // Ecal stuff
             "EcalEndcapNRawHits",


### PR DESCRIPTION

### Briefly, what does this PR introduce?
Provides electron candidates as a first step towards a DIS electron finder.
This PR uses the recently provided MC particle to Reco cluster associations to produce a `ReconstructedElectrons` collection. Electrons candidates are identified with an E/p cut using Reco particle momentum and Redo cluster energy (only from ECAL detectors for now).

Couple of comments/potential improvements for reviewers:
- I am not sure how best to use the Config objects to allow parameters to be modified (e.g. min/max E/p in this case)
- AFAIK this creates a copy of the reconstructed particles - since this (ReconstructedElectrons) is a strict subset of the ReconstructedParticles collection, is there a way to store as such (without duplicating)
- I am currently pulling from (by name) several locations (see `reco.cc`) to get all possible source of `edm4eic::MCRecoClusterParticleAssociation` - is there a way to instead ask for all sources of a given type?


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added: 
  - Not sure if new tests needed, 
  - "ReconstructedElectrons" added to polio default output (include list) - simply running on a recent sim file should suffice as a test - expected behavior is to produce the "ReconstructedElectrpons" collection. A second level of test is to ensure that the collection is not empty (assuming at least some electrons within acceptance are in the simulated input)
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators: discussion in S&C meeting on June 5

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No
