### PR TITLE
fix: OffMomentumReconstruction_factory should use JFactoryPodioT

### DIFF
--- a/src/detectors/FOFFMTRK/OffMomentumReconstruction_factory.h
+++ b/src/detectors/FOFFMTRK/OffMomentumReconstruction_factory.h
@@ -17,7 +17,7 @@
 
 // Event Model related classes
 #include <edm4eic/MutableReconstructedParticle.h>
-#include <edm4eic/ReconstructedParticle.h>
+#include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4eic/TrackerHit.h>
 #include <edm4eic/vector_utils.h>
 #include <edm4hep/SimTrackerHit.h>
@@ -28,7 +28,7 @@
 
 namespace eicrecon {
 
-    class OffMomentumReconstruction_factory : public JFactoryT<edm4eic::ReconstructedParticle>{
+    class OffMomentumReconstruction_factory : public eicrecon::JFactoryPodioT<edm4eic::ReconstructedParticle>{
 
     public:
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Without `JFactoryPodioT`, eicrecon doesn't produce errors, completes fine, and has no OffMomentum reconstructed particles.

This may also affect:
```console
[2023-07-13 11:50:32.483] [JEventProcessorPODIO] [warning] Explicitly included collection 'EcalBarrelImagingMergedClusterAssociations' not present in factory set, omitting.
```

### What kind of change does this PR introduce?
- [x] Bug fix (issue: OffM doesn't produce tracks)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @ajentsch 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, OffM tracker reconstruction will now work.