### PR TITLE
fix: `#include <string>` in CalorimeterClusterRecoCoGConfig

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoGConfig.h
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoGConfig.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <string>
+
 namespace eicrecon {
 
     struct CalorimeterClusterRecoCoGConfig {


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Adds required `#include <string>` header where it is not transitively included.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: IWYU

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added: in progress...
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.