### PR TITLE
fix: clang-tidy readability-container-size-empty

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterClusterMerger.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterMerger.cc
@@ -40,7 +40,7 @@ void CalorimeterClusterMerger::AlgorithmProcess() {
     auto& merged = m_outputClusters;
     auto& assoc2 = m_outputAssociations;
 
-    if (!split.size()) {
+    if (split.empty()) {
       m_log->debug("Nothing to do for this event, returning...");
       return;
     }

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -28,7 +28,7 @@ namespace eicrecon {
     m_detector = detector;
 
     // update depth correction if a name is provided
-    if (m_cfg.moduleDimZName != "") {
+    if (!m_cfg.moduleDimZName.empty()) {
       m_cfg.depthCorrection = m_detector->constantAsDouble(m_cfg.moduleDimZName);
     }
 

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -57,7 +57,7 @@ void CalorimeterHitDigi::AlgorithmInit(std::shared_ptr<spdlog::logger>& logger) 
     // set energy resolution numbers
     m_log=logger;
 
-    if (u_eRes.size() == 0) {
+    if (u_eRes.empty()) {
       u_eRes.resize(3);
     } else if (u_eRes.size() != 3) {
       m_log->error("Invalid u_eRes.size()");

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -99,7 +99,7 @@ void CalorimeterIslandCluster::AlgorithmInit(std::shared_ptr<spdlog::logger>& lo
     bool method_found = false;
 
     // Adjacency matrix methods
-    if (u_adjacencyMatrix != "") {
+    if (!u_adjacencyMatrix.empty()) {
       // sanity checks
       if (!m_geoSvc) {
         m_log->error("Unable to locate Geometry Service. ",

--- a/src/algorithms/digi/PhotoMultiplierHitDigi.cc
+++ b/src/algorithms/digi/PhotoMultiplierHitDigi.cc
@@ -181,7 +181,7 @@ eicrecon::PhotoMultiplierHitDigiResult eicrecon::PhotoMultiplierHitDigi::Algorit
                     );
 
                 // build `MCRecoTrackerHitAssociation` (for non-noise hits only)
-                if(data.sim_hit_indices.size()>0) {
+                if(!data.sim_hit_indices.empty()) {
                   auto hit_assoc = result.hit_assocs->create();
                   hit_assoc.setWeight(1.0); // not used
                   hit_assoc.setRawHit(raw_hit);

--- a/src/algorithms/reco/InclusiveKinematicsDA.cc
+++ b/src/algorithms/reco/InclusiveKinematicsDA.cc
@@ -38,7 +38,7 @@ namespace eicrecon {
     std::vector<edm4eic::InclusiveKinematics *> kinematics;
     // Get incoming electron beam
     const auto ei_coll = find_first_beam_electron(mcparts);
-    if (ei_coll.size() == 0) {
+    if (ei_coll.empty()) {
       m_log->debug("No beam electron found");
       return kinematics;
     }
@@ -52,7 +52,7 @@ namespace eicrecon {
 
     // Get incoming hadron beam
     const auto pi_coll = find_first_beam_hadron(mcparts);
-    if (pi_coll.size() == 0) {
+    if (pi_coll.empty()) {
       m_log->debug("No beam hadron found");
       return kinematics;
     }
@@ -66,7 +66,7 @@ namespace eicrecon {
 
     // Get first scattered electron
     const auto ef_coll = find_first_scattered_electron(mcparts);
-    if (ef_coll.size() == 0) {
+    if (ef_coll.empty()) {
       m_log->debug("No truth scattered electron found");
       return kinematics;
     }

--- a/src/algorithms/reco/InclusiveKinematicsElectron.cc
+++ b/src/algorithms/reco/InclusiveKinematicsElectron.cc
@@ -87,7 +87,7 @@ namespace eicrecon {
 
     // Get incoming electron beam
     const auto ei_coll = find_first_beam_electron(mcparts);
-    if (ei_coll.size() == 0) {
+    if (ei_coll.empty()) {
       m_log->debug("No beam electron found");
       return kinematics;
     }
@@ -101,7 +101,7 @@ namespace eicrecon {
 
     // Get incoming hadron beam
     const auto pi_coll = find_first_beam_hadron(mcparts);
-    if (pi_coll.size() == 0) {
+    if (pi_coll.empty()) {
       m_log->debug("No beam hadron found");
       return kinematics;
     }
@@ -115,7 +115,7 @@ namespace eicrecon {
 
     // Get first scattered electron
     const auto ef_coll = find_first_scattered_electron(mcparts);
-    if (ef_coll.size() == 0) {
+    if (ef_coll.empty()) {
       m_log->debug("No truth scattered electron found");
       return kinematics;
     }
@@ -148,7 +148,7 @@ namespace eicrecon {
     }
 
     // If no scattered electron was found
-    if (electrons.size() == 0) {
+    if (electrons.empty()) {
       m_log->debug("No scattered electron found");
       return kinematics;
     }

--- a/src/algorithms/reco/InclusiveKinematicsJB.cc
+++ b/src/algorithms/reco/InclusiveKinematicsJB.cc
@@ -38,7 +38,7 @@ namespace eicrecon {
     std::vector<edm4eic::InclusiveKinematics *> kinematics;
     // Get incoming electron beam
     const auto ei_coll = find_first_beam_electron(mcparts);
-    if (ei_coll.size() == 0) {
+    if (ei_coll.empty()) {
       m_log->debug("No beam electron found");
       return kinematics;
     }
@@ -52,7 +52,7 @@ namespace eicrecon {
 
     // Get incoming hadron beam
     const auto pi_coll = find_first_beam_hadron(mcparts);
-    if (pi_coll.size() == 0) {
+    if (pi_coll.empty()) {
       m_log->debug("No beam hadron found");
       return kinematics;
     }
@@ -66,7 +66,7 @@ namespace eicrecon {
 
     // Get first scattered electron
     const auto ef_coll = find_first_scattered_electron(mcparts);
-    if (ef_coll.size() == 0) {
+    if (ef_coll.empty()) {
       m_log->debug("No truth scattered electron found");
       return kinematics;
     }

--- a/src/algorithms/reco/InclusiveKinematicsSigma.cc
+++ b/src/algorithms/reco/InclusiveKinematicsSigma.cc
@@ -39,7 +39,7 @@ namespace eicrecon {
 
     // Get incoming electron beam
     const auto ei_coll = find_first_beam_electron(mcparts);
-    if (ei_coll.size() == 0) {
+    if (ei_coll.empty()) {
       m_log->debug("No beam electron found");
       return kinematics;
     }
@@ -53,7 +53,7 @@ namespace eicrecon {
 
     // Get incoming hadron beam
     const auto pi_coll = find_first_beam_hadron(mcparts);
-    if (pi_coll.size() == 0) {
+    if (pi_coll.empty()) {
       m_log->debug("No beam hadron found");
       return kinematics;
     }
@@ -67,7 +67,7 @@ namespace eicrecon {
 
     // Get first scattered electron
     const auto ef_coll = find_first_scattered_electron(mcparts);
-    if (ef_coll.size() == 0) {
+    if (ef_coll.empty()) {
       m_log->debug("No truth scattered electron found");
       return kinematics;
     }

--- a/src/algorithms/reco/InclusiveKinematicsTruth.cc
+++ b/src/algorithms/reco/InclusiveKinematicsTruth.cc
@@ -46,7 +46,7 @@ namespace eicrecon {
 
     // Get incoming electron beam
     const auto ei_coll = find_first_beam_electron(mcparts);
-    if (ei_coll.size() == 0) {
+    if (ei_coll.empty()) {
       m_log->debug("No beam electron found");
       return kinematics;
     }
@@ -57,7 +57,7 @@ namespace eicrecon {
 
     // Get incoming hadron beam
     const auto pi_coll = find_first_beam_hadron(mcparts);
-    if (pi_coll.size() == 0) {
+    if (pi_coll.empty()) {
       m_log->debug("No beam hadron found");
       return kinematics;
     }
@@ -72,7 +72,7 @@ namespace eicrecon {
     // it may be better to trace back each final-state electron and see which one originates from
     // the beam.
     const auto ef_coll = find_first_scattered_electron(mcparts);
-    if (ef_coll.size() == 0) {
+    if (ef_coll.empty()) {
       m_log->debug("No truth scattered electron found");
       return kinematics;
     }

--- a/src/algorithms/reco/InclusiveKinematicseSigma.cc
+++ b/src/algorithms/reco/InclusiveKinematicseSigma.cc
@@ -39,7 +39,7 @@ namespace eicrecon {
 
     // Get incoming electron beam
     const auto ei_coll = find_first_beam_electron(mcparts);
-    if (ei_coll.size() == 0) {
+    if (ei_coll.empty()) {
       m_log->debug("No beam electron found");
       return kinematics;
     }
@@ -53,7 +53,7 @@ namespace eicrecon {
 
     // Get incoming hadron beam
     const auto pi_coll = find_first_beam_hadron(mcparts);
-    if (pi_coll.size() == 0) {
+    if (pi_coll.empty()) {
       m_log->debug("No beam hadron found");
       return kinematics;
     }
@@ -67,7 +67,7 @@ namespace eicrecon {
 
     // Get first scattered electron
     const auto ef_coll = find_first_scattered_electron(mcparts);
-    if (ef_coll.size() == 0) {
+    if (ef_coll.empty()) {
       m_log->debug("No truth scattered electron found");
       return kinematics;
     }

--- a/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.cc
@@ -445,7 +445,7 @@ void femc_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event) 
   float minAggE     = 0.001;
   float seedE       = 0.20;
 
-  if (input_tower_rec.size()> 0){
+  if (!input_tower_rec.empty()){
 
     // clean up rec array for clusterization
     while (input_tower_rec.at(input_tower_rec.size()-1).energy < minAggE ){

--- a/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
@@ -530,7 +530,7 @@ void lfhcal_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event
   float minAggE     = 0.001;
   float seedE       = 0.100;
 
-  if (input_tower_rec.size()> 0){
+  if (!input_tower_rec.empty()){
 
     // clean up rec array for clusterization
     while (input_tower_rec.at(input_tower_rec.size()-1).energy < minAggE ){


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This propagates a number of suggested clang-tidy changes related to testing whether a container is empty. Containers may implement `size()` differently from `empty()`, and `size()` may run in O(n) instead of constant time. This means that `empty()` is preferred by clang-tidy for performance reasons. Moreover, `empty()` improves readability, and avoids implicit bool conversion (as in `if (!split.size())`).

See https://clang.llvm.org/extra/clang-tidy/checks/readability/container-size-empty.html for details

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: code style changes only

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.