### PR TITLE
fix: clang-tidy modernize-use-emplace

### DIFF
--- a/src/algorithms/digi/PhotoMultiplierHitDigi.cc
+++ b/src/algorithms/digi/PhotoMultiplierHitDigi.cc
@@ -198,8 +198,9 @@ void  eicrecon::PhotoMultiplierHitDigi::qe_init()
         // get quantum efficiency table
         qeff.clear();
         auto hc = dd4hep::h_Planck * dd4hep::c_light / (dd4hep::eV * dd4hep::nm); // [eV*nm]
-        for(const auto &[wl,qe] : m_cfg.quantumEfficiency)
-          qeff.push_back({ hc / wl, qe }); // convert wavelength [nm] -> energy [eV]
+        for(const auto &[wl,qe] : m_cfg.quantumEfficiency) {
+          qeff.emplace_back( hc / wl, qe ); // convert wavelength [nm] -> energy [eV]
+}
 
         // sort quantum efficiency data first
         std::sort(qeff.begin(), qeff.end(),

--- a/src/algorithms/digi/PhotoMultiplierHitDigi.cc
+++ b/src/algorithms/digi/PhotoMultiplierHitDigi.cc
@@ -200,7 +200,7 @@ void  eicrecon::PhotoMultiplierHitDigi::qe_init()
         auto hc = dd4hep::h_Planck * dd4hep::c_light / (dd4hep::eV * dd4hep::nm); // [eV*nm]
         for(const auto &[wl,qe] : m_cfg.quantumEfficiency) {
           qeff.emplace_back( hc / wl, qe ); // convert wavelength [nm] -> energy [eV]
-}
+        }
 
         // sort quantum efficiency data first
         std::sort(qeff.begin(), qeff.end(),

--- a/src/algorithms/pid/IrtCherenkovParticleID.cc
+++ b/src/algorithms/pid/IrtCherenkovParticleID.cc
@@ -330,7 +330,7 @@ std::map<std::string, std::unique_ptr<edm4eic::CherenkovParticleIDCollection>> e
 
         // add to the total
         npe++;
-        phot_theta_phi.push_back({ phot_theta, phot_phi });
+        phot_theta_phi.emplace_back( phot_theta, phot_phi );
         if(m_cfg.cheatPhotonVertex) {
           rindex_ave += irt_photon->GetVertexRefractiveIndex();
           energy_ave += irt_photon->GetVertexMomentum().Mag();

--- a/src/algorithms/reco/JetReconstruction.cc
+++ b/src/algorithms/reco/JetReconstruction.cc
@@ -42,7 +42,7 @@ namespace eicrecon {
     for (const auto &mom : momenta) {
       // Only cluster particles within the given pt Range
       if ((mom->pt() > m_minCstPt) && (mom->pt() < m_maxCstPt)) {
-        particles.push_back( PseudoJet(mom->px(), mom->py(), mom->pz(), mom->e()) );
+        particles.emplace_back(mom->px(), mom->py(), mom->pz(), mom->e() );
       }
     }
 

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -78,8 +78,8 @@ std::vector<edm4eic::TrackParameters*> eicrecon::TrackSeeding::makeTrackParams(S
       std::vector<std::pair<float,float>> rzHitPositions;
       for(auto& spptr : seed.sp())
 	{
-	  xyHitPositions.push_back(std::make_pair(spptr->x(), spptr->y()));
-	  rzHitPositions.push_back(std::make_pair(spptr->r(), spptr->z()));
+	  xyHitPositions.emplace_back(spptr->x(), spptr->y());
+	  rzHitPositions.emplace_back(spptr->r(), spptr->z());
 	}
 
       auto RX0Y0 = circleFit(xyHitPositions);

--- a/src/services/geometry/richgeo/IrtGeo.cc
+++ b/src/services/geometry/richgeo/IrtGeo.cc
@@ -81,7 +81,7 @@ void richgeo::IrtGeo::SetRefractiveIndexTable() {
       auto energy = rindex_matrix->Get(row,0) / dd4hep::eV;
       auto rindex = rindex_matrix->Get(row,1);
       m_log->debug("  {:>5} eV   {:<}", energy, rindex);
-      rad->m_ri_lookup_table.push_back({energy,rindex});
+      rad->m_ri_lookup_table.emplace_back(energy,rindex);
     }
   }
 }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Constructing an element at the end of a container doesn't require a temporary copy followed by `push_back`, but can be done with `emplace_back`.

See https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-emplace.html.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: code style changes only

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.