### PR TITLE
linux-eic-shell.yml: fix the apt-get failures

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -138,6 +138,7 @@ jobs:
       with:
         name: build-clang-eic-shell-Debug
         path: build/
+    - run: sudo apt-get update
     - run: sudo apt-get install -y llvm-15 jq
     - name: llvm-cov
       run: |


### PR DESCRIPTION
Fix for failures like https://github.com/eic/EICrecon/actions/runs/5556691154/jobs/10150278283
https://github.com/actions/runner-images/issues/7452