### PR TITLE
test: disable vertex knowledge in truth seeding (do not merge)

### DIFF
--- a/src/algorithms/tracking/TrackParamTruthInit.cc
+++ b/src/algorithms/tracking/TrackParamTruthInit.cc
@@ -38,10 +38,11 @@ eicrecon::TrackParameters *eicrecon::TrackParamTruthInit::produce(const edm4hep:
 
 
     // require close to interaction vertex
-    if (abs(part->getVertex().x) * mm > m_cfg.m_maxVertexX
-        || abs(part->getVertex().y) * mm > m_cfg.m_maxVertexY
-        || abs(part->getVertex().z) * mm > m_cfg.m_maxVertexZ) {
-        m_log->trace("ignoring particle with vs = {} [mm]", part->getVertex());
+    auto& v = part->getVertex();
+    if (abs(v.x) * mm > m_cfg.m_maxVertexX
+        || abs(v.y) * mm > m_cfg.m_maxVertexY
+        || abs(v.z) * mm > m_cfg.m_maxVertexZ) {
+        m_log->trace("ignoring particle with vs = {} [mm]", v);
         return nullptr;
     }
 
@@ -85,8 +86,8 @@ eicrecon::TrackParameters *eicrecon::TrackParamTruthInit::produce(const edm4hep:
     cov(Acts::eBoundTime, Acts::eBoundTime)     = 10.0e9*ns*10.0e9*ns;
 
     Acts::BoundVector  params;
-    params(Acts::eBoundLoc0)   = 0.0 * mm ;  // cylinder radius
-    params(Acts::eBoundLoc1)   = 0.0 * mm ;  // cylinder length
+    params(Acts::eBoundLoc0)   = std::hypot(v.x, v.y) * mm ;  // cylinder radius
+    params(Acts::eBoundLoc1)   = v.z * mm ;  // cylinder length
     params(Acts::eBoundPhi)    = phi;
     params(Acts::eBoundTheta)  = theta;
     params(Acts::eBoundQOverP) = charge / (pinit * GeV);

--- a/src/algorithms/tracking/TrackParamTruthInit.cc
+++ b/src/algorithms/tracking/TrackParamTruthInit.cc
@@ -94,7 +94,7 @@ eicrecon::TrackParameters *eicrecon::TrackParamTruthInit::produce(const edm4hep:
 
     //// Construct a perigee surface as the target surface
     auto pSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>(
-            Acts::Vector3{part->getVertex().x * mm, part->getVertex().y * mm, part->getVertex().z * mm});
+            Acts::Vector3{0,0,0});
 
     //params(Acts::eBoundQOverP) = charge/p;
     auto result = new eicrecon::TrackParameters({pSurface, params, charge, cov});


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This disables the truth vertex in the perigee surface.