### PR TITLE
fix: GeneratedParticles: ignore MCParticles with generatorStatus != 1

### DIFF
--- a/src/algorithms/reco/MC2SmearedParticle.cc
+++ b/src/algorithms/reco/MC2SmearedParticle.cc
@@ -18,7 +18,7 @@ void eicrecon::MC2SmearedParticle::init(std::shared_ptr<spdlog::logger> logger) 
 
 edm4eic::ReconstructedParticle *eicrecon::MC2SmearedParticle::produce(const edm4hep::MCParticle *mc_particle) {
 
-    if (mc_particle->getGeneratorStatus() > 1) {
+    if (mc_particle->getGeneratorStatus() != 1) {
         m_log->debug("ignoring particle with generatorStatus = {}", mc_particle->getGeneratorStatus());
         return nullptr;
     }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The GeneratedParticles branch all MCParticles which are thrown into the detector, in the ReconstructedParticles format (for easy comparison). This means we should not include `generatorStatus == 0` as was the case until now.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: GeneratedParticles includes more particles than intended)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, excludes secondary particles (which should be determined from MCParticles based on the bit pattern in simulatorStatus).