### PR TITLE
ci: compress debug symbols

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -25,13 +25,14 @@ jobs:
           - CC: gcc
             CXX: g++
             CMAKE_BUILD_TYPE: Debug
+            CXXFLAGS: -gz
           - CC: clang
             CXX: clang++
             CMAKE_BUILD_TYPE: Release
           - CC: clang
             CXX: clang++
             CMAKE_BUILD_TYPE: Debug
-            CXXFLAGS: -fprofile-instr-generate -fcoverage-mapping
+            CXXFLAGS: -gz -fprofile-instr-generate -fcoverage-mapping
     env:
       ASAN_OPTIONS: suppressions=${{ github.workspace }}/.github/asan.supp:malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:detect_stack_use_after_return=1:detect_odr_violation=0:new_delete_type_mismatch=0
       LSAN_OPTIONS: suppressions=${{ github.workspace }}/.github/lsan.supp:exitcode=0


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This compresses the debug symbol section in both clang and gcc compiled debug builds. Smaller builds mean faster cache retrievals and faster pipelines.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.