### PR TITLE
ci: collect all jana.dot and jana.svg into single artifact, and publish

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -438,6 +438,9 @@ jobs:
   # to embed into docs
   build-docs-advanced:
     runs-on: ubuntu-latest
+    needs:
+      - eicrecon-gun
+      - eicrecon-dis
     container:
       image: alpine:latest
       volumes:
@@ -456,7 +459,7 @@ jobs:
           name: docs
           path: publishing_docs/
           if-no-files-found: error
-      - uses: action/download-artifact@v3
+      - uses: actions/download-artifact@v3
         with:
           name: jana.dot
           path: publishing_docs/dot/

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -314,6 +314,9 @@ jobs:
           export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
           chmod a+x bin/*
           $PWD/bin/eicrecon -Ppodio:output_file=rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -Pplugins=dump_flags,janadot -Pdump_flags:json=${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json -Pjana:warmup_timeout=0 -Pjana:timeout=0
+          dot -Tsvg jana.dot > jana.svg
+          mv jana.dot rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.dot
+          mv jana.svg rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.svg
     - uses: actions/upload-artifact@v3
       with:
         name: rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
@@ -326,8 +329,10 @@ jobs:
         if-no-files-found: error
     - uses: actions/upload-artifact@v3
       with:
-        name: rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.dot
-        path: jana.dot
+        name: jana.dot
+        path: |
+          *.dot
+          *.svg
         if-no-files-found: error
 
   eicrecon-gun-EcalLumiSpec:
@@ -412,6 +417,9 @@ jobs:
           export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
           chmod a+x bin/*
           $PWD/bin/eicrecon -Ppodio:output_file=rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root -Pplugins=janadot -Pjana:warmup_timeout=0 -Pjana:timeout=0
+          dot -Tsvg jana.dot > jana.svg
+          mv jana.dot rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.dot
+          mv jana.svg rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.svg
     - uses: actions/upload-artifact@v3
       with:
         name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root
@@ -419,8 +427,10 @@ jobs:
         if-no-files-found: error
     - uses: actions/upload-artifact@v3
       with:
-        name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.dot
-        path: jana.dot
+        name: jana.dot
+        path: |
+          *.dot
+          *.svg
         if-no-files-found: error
 
   # build-docs and deploy-docs copy doxygen.yml functionality
@@ -446,6 +456,10 @@ jobs:
           name: docs
           path: publishing_docs/
           if-no-files-found: error
+      - uses: action/download-artifact@v3
+        with:
+          name: jana.dot
+          path: publishing_docs/dot/
       - run:
           apk add tar bash
         # FIXME bash not really required: see https://github.com/actions/upload-pages-artifact/pull/14


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Instead of a separate artifact for each jana.dot, this puts them all into a single artifact. That then makes it easier to publish them on GitHub Pages.

TODO:
- [x] add `graphviz` to the container, https://eicweb.phy.anl.gov/containers/eic_container/-/merge_requests/652

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.