### PR TITLE
TrackParamTruthInit: revert accidental swap of theta and phi error values

### DIFF
--- a/src/algorithms/tracking/TrackParamTruthInit.cc
+++ b/src/algorithms/tracking/TrackParamTruthInit.cc
@@ -97,7 +97,7 @@ eicrecon::TrackParamTruthInit::produce(const edm4hep::MCParticleCollection* mcpa
         track_parameter.setTheta(theta); //theta [rad]
         track_parameter.setPhi(phi); // phi [rad]
         track_parameter.setQOverP(charge / pinit); // Q/p [e/GeV]
-        track_parameter.setMomentumError({0.05, 0.01, 0.1}); // sqrt(variance) on theta, phi, q/p [rad, rad, e/GeV]
+        track_parameter.setMomentumError({0.01, 0.05, 0.1}); // sqrt(variance) on theta, phi, q/p [rad, rad, e/GeV]
         track_parameter.setTime(mcparticle.getTime()); // time [ns]
         track_parameter.setTimeError(10e9); // error on time [ns]
         track_parameter.setCharge(charge); // charge


### PR DESCRIPTION
Fixes: 95aa36c2 ('fix: rewrite TrackParamTruthInit to create edm4eic::TrackParameters (#766)')

When reviewing #766, the assumption was that the PR was supposed to implement a refactoring and result in no change. There was a minor defect that wasn't discovered during the review. A pair of constants were switched. This PR reverts that change.

There is however another, actually significant remaining effect, unlike the `eicrecon::TrackParameters` the `edm4eic::TrackParameters` can't propagate values from `Acts::PerigeeSurface`. Instead, global position = {0, 0, 0} is used now:
https://github.com/eic/EICrecon/blob/95aa36c2b652b4b78b0c8024786c0d5c9dbcad85/src/global/tracking/CKFTracking_factory.cc#L82-L83

If we take the old commit dd98b254d228896a40ebbee088f693fe44b6d2c8 and apply
```diff
diff --git a/src/algorithms/tracking/TrackParamTruthInit.cc b/src/algorithms/tracking/TrackParamTruthInit.cc
index 76be3b83..cf4315ba 100644
--- a/src/algorithms/tracking/TrackParamTruthInit.cc
+++ b/src/algorithms/tracking/TrackParamTruthInit.cc
@@ -94,7 +94,7 @@ eicrecon::TrackParameters *eicrecon::TrackParamTruthInit::produce(const edm4hep:
 
     //// Construct a perigee surface as the target surface
     auto pSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>(
-            Acts::Vector3{part->getVertex().x * mm, part->getVertex().y * mm, part->getVertex().z * mm});
+            Acts::Vector3{0, 0, 0});
 
     //params(Acts::eBoundQOverP) = charge/p;
     auto result = new eicrecon::TrackParameters({pSurface, params, charge, cov});
```
Then the remaining differences become very insignificant, consistent with use of different floating point precision and conversions between errors and covariances (sqrt/^2).