### PR TITLE
feat: rewrite InclusiveKinematics algorithms to operate on podio collections

### DIFF
--- a/src/algorithms/reco/Beam.h
+++ b/src/algorithms/reco/Beam.h
@@ -13,11 +13,11 @@ namespace eicrecon {
 
   template<class T>
   auto find_first_with_pdg(
-      const std::vector<T*>& parts,
+      const T& parts,
       const std::set<int32_t>& pdg) {
-    std::vector<T*> c;
+    T c;
     for (const auto& p: parts) {
-      if (pdg.count(p->getPDG()) > 0) {
+      if (pdg.count(p.getPDG()) > 0) {
         c.push_back(p);
         break;
       }
@@ -27,13 +27,13 @@ namespace eicrecon {
 
   template<class T>
   auto find_first_with_status_pdg(
-      const std::vector<T*>& parts,
+      const T& parts,
       const std::set<int32_t>& status,
       const std::set<int32_t>& pdg) {
-    std::vector<T*> c;
+    T c;
     for (const auto& p: parts) {
-      if (status.count(p->getGeneratorStatus()) > 0 &&
-          pdg.count(p->getPDG()) > 0) {
+      if (status.count(p.getGeneratorStatus()) > 0 &&
+          pdg.count(p.getPDG()) > 0) {
         c.push_back(p);
         break;
       }
@@ -41,19 +41,19 @@ namespace eicrecon {
     return c;
   }
 
-  inline auto find_first_beam_electron(const std::vector<const edm4hep::MCParticle*>& mcparts) {
+  inline auto find_first_beam_electron(const edm4hep::MCParticleCollection& mcparts) {
     return find_first_with_status_pdg(mcparts, {4}, {11});
   }
 
-  inline auto find_first_beam_hadron(const std::vector<const edm4hep::MCParticle*>& mcparts) {
+  inline auto find_first_beam_hadron(const edm4hep::MCParticleCollection& mcparts) {
     return find_first_with_status_pdg(mcparts, {4}, {2212, 2112});
   }
 
-  inline auto find_first_scattered_electron(const std::vector<const edm4hep::MCParticle*>& mcparts) {
+  inline auto find_first_scattered_electron(const edm4hep::MCParticleCollection& mcparts) {
     return find_first_with_status_pdg(mcparts, {1}, {11});
   }
 
-  inline auto find_first_scattered_electron(const std::vector<const edm4eic::ReconstructedParticle*>& rcparts) {
+  inline auto find_first_scattered_electron(const edm4eic::ReconstructedParticleCollection& rcparts) {
     return find_first_with_pdg(rcparts, {11});
   }
 

--- a/src/algorithms/reco/Beam.h
+++ b/src/algorithms/reco/Beam.h
@@ -16,6 +16,7 @@ namespace eicrecon {
       const T& parts,
       const std::set<int32_t>& pdg) {
     T c;
+    c.setSubsetCollection();
     for (const auto& p: parts) {
       if (pdg.count(p.getPDG()) > 0) {
         c.push_back(p);
@@ -31,6 +32,7 @@ namespace eicrecon {
       const std::set<int32_t>& status,
       const std::set<int32_t>& pdg) {
     T c;
+    c.setSubsetCollection();
     for (const auto& p: parts) {
       if (status.count(p.getGeneratorStatus()) > 0 &&
           pdg.count(p.getPDG()) > 0) {

--- a/src/algorithms/reco/InclusiveKinematicsDA.cc
+++ b/src/algorithms/reco/InclusiveKinematicsDA.cc
@@ -35,7 +35,7 @@ namespace eicrecon {
     const edm4eic::MCRecoParticleAssociationCollection& rcassoc) {
 
     // Resulting inclusive kinematics
-    auto kinematics = std::unique_ptr<edm4eic::InclusiveKinematicsCollection>();
+    auto kinematics = std::make_unique<edm4eic::InclusiveKinematicsCollection>();
     // Get incoming electron beam
     const auto ei_coll = find_first_beam_electron(mcparts);
     if (ei_coll.size() == 0) {

--- a/src/algorithms/reco/InclusiveKinematicsDA.cc
+++ b/src/algorithms/reco/InclusiveKinematicsDA.cc
@@ -29,22 +29,22 @@ namespace eicrecon {
     // }
   }
 
-  std::vector<edm4eic::InclusiveKinematics*> InclusiveKinematicsDA::execute(
-    std::vector<const edm4hep::MCParticle *> mcparts,
-    std::vector<const edm4eic::ReconstructedParticle *> rcparts,
-    std::vector<const edm4eic::MCRecoParticleAssociation *> rcassoc) {
+  std::unique_ptr<edm4eic::InclusiveKinematicsCollection> InclusiveKinematicsDA::execute(
+    const edm4hep::MCParticleCollection& mcparts,
+    const edm4eic::ReconstructedParticleCollection& rcparts,
+    const edm4eic::MCRecoParticleAssociationCollection& rcassoc) {
 
     // Resulting inclusive kinematics
-    std::vector<edm4eic::InclusiveKinematics *> kinematics;
+    auto kinematics = std::unique_ptr<edm4eic::InclusiveKinematicsCollection>();
     // Get incoming electron beam
     const auto ei_coll = find_first_beam_electron(mcparts);
-    if (ei_coll.empty()) {
+    if (ei_coll.size() == 0) {
       m_log->debug("No beam electron found");
       return kinematics;
     }
     const PxPyPzEVector ei(
       round_beam_four_momentum(
-        ei_coll[0]->getMomentum(),
+        ei_coll[0].getMomentum(),
         m_electron,
         {-5.0, -10.0, -18.0},
         0.0)
@@ -52,32 +52,32 @@ namespace eicrecon {
 
     // Get incoming hadron beam
     const auto pi_coll = find_first_beam_hadron(mcparts);
-    if (pi_coll.empty()) {
+    if (pi_coll.size() == 0) {
       m_log->debug("No beam hadron found");
       return kinematics;
     }
     const PxPyPzEVector pi(
       round_beam_four_momentum(
-        pi_coll[0]->getMomentum(),
-        pi_coll[0]->getPDG() == 2212 ? m_proton : m_neutron,
+        pi_coll[0].getMomentum(),
+        pi_coll[0].getPDG() == 2212 ? m_proton : m_neutron,
         {41.0, 100.0, 275.0},
         m_crossingAngle)
       );
 
     // Get first scattered electron
     const auto ef_coll = find_first_scattered_electron(mcparts);
-    if (ef_coll.empty()) {
+    if (ef_coll.size() == 0) {
       m_log->debug("No truth scattered electron found");
       return kinematics;
     }
     // Associate first scattered electron with reconstructed electrons
     //const auto ef_assoc = std::find_if(
-    //  rcassoc.begin(),
+    //  rcassoc->begin(),
     //  rcassoc.end(),
     //  [&ef_coll](const auto& a){ return a.getSimID() == ef_coll[0].getObjectID().index; });
     auto ef_assoc = rcassoc.begin();
     for (; ef_assoc != rcassoc.end(); ++ef_assoc) {
-      if ((*ef_assoc)->getSimID() == (unsigned) ef_coll[0]->getObjectID().index) {
+      if (ef_assoc->getSimID() == (unsigned) ef_coll[0].getObjectID().index) {
         break;
       }
     }
@@ -85,7 +85,7 @@ namespace eicrecon {
       m_log->debug("Truth scattered electron not in reconstructed particles");
       return kinematics;
     }
-    const auto ef_rc{(*ef_assoc)->getRec()};
+    const auto ef_rc{ef_assoc->getRec()};
     const auto ef_rc_id{ef_rc.getObjectID().index};
 
     // Loop over reconstructed particles to get all outgoing particles
@@ -113,9 +113,9 @@ namespace eicrecon {
 
     for (const auto& p: rcparts) {
       // Get the scattered electron index and angle
-      if (p->getObjectID().index == ef_rc_id) {
+      if (p.getObjectID().index == ef_rc_id) {
         // Lorentz vector in lab frame
-        PxPyPzEVector e_lab(p->getMomentum().x, p->getMomentum().y, p->getMomentum().z, p->getEnergy());
+        PxPyPzEVector e_lab(p.getMomentum().x, p.getMomentum().y, p.getMomentum().z, p.getEnergy());
         // Boost to colinear frame
         PxPyPzEVector e_boosted = apply_boost(boost, e_lab);
 
@@ -124,7 +124,7 @@ namespace eicrecon {
       // Sum over all particles other than scattered electron
       } else {
         // Lorentz vector in lab frame
-        PxPyPzEVector hf_lab(p->getMomentum().x, p->getMomentum().y, p->getMomentum().z, p->getEnergy());
+        PxPyPzEVector hf_lab(p.getMomentum().x, p.getMomentum().y, p.getMomentum().z, p.getEnergy());
         // Boost to colinear frame
         PxPyPzEVector hf_boosted = apply_boost(boost, hf_lab);
 
@@ -152,13 +152,11 @@ namespace eicrecon {
     const auto x_da = Q2_da / (4.*ei.energy()*pi.energy()*y_da);
     const auto nu_da = Q2_da / (2.*m_proton*x_da);
     const auto W_da = sqrt(m_proton*m_proton + 2*m_proton*nu_da - Q2_da);
-    edm4eic::MutableInclusiveKinematics kin(x_da, Q2_da, W_da, y_da, nu_da);
+    auto kin = kinematics->create(x_da, Q2_da, W_da, y_da, nu_da);
     kin.setScat(ef_rc);
 
     m_log->debug("x,Q2,W,y,nu = {},{},{},{},{}", kin.getX(),
             kin.getQ2(), kin.getW(), kin.getY(), kin.getNu());
-
-    kinematics.push_back(new edm4eic::InclusiveKinematics(kin));
 
     return kinematics;
   }

--- a/src/algorithms/reco/InclusiveKinematicsDA.h
+++ b/src/algorithms/reco/InclusiveKinematicsDA.h
@@ -26,15 +26,15 @@ namespace eicrecon {
 
         void init(std::shared_ptr<spdlog::logger> logger);
 
-        std::vector<edm4eic::InclusiveKinematics*> execute(
-                std::vector<const edm4hep::MCParticle*> mcparts,
-                std::vector<const edm4eic::ReconstructedParticle*> rcparts,
-                std::vector<const edm4eic::MCRecoParticleAssociation*> rcassoc
+        std::unique_ptr<edm4eic::InclusiveKinematicsCollection> execute(
+                const edm4hep::MCParticleCollection& mcparts,
+                const edm4eic::ReconstructedParticleCollection& rcparts,
+                const edm4eic::MCRecoParticleAssociationCollection& rcassoc
         );
 
     private:
         std::shared_ptr<spdlog::logger> m_log;
         double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
-        };
+    };
 
 } // namespace eicrecon

--- a/src/algorithms/reco/InclusiveKinematicsElectron.cc
+++ b/src/algorithms/reco/InclusiveKinematicsElectron.cc
@@ -35,7 +35,7 @@ namespace eicrecon {
     const edm4eic::MCRecoParticleAssociationCollection& rcassoc) {
 
     // Resulting inclusive kinematics
-    auto kinematics = std::unique_ptr<edm4eic::InclusiveKinematicsCollection>();
+    auto kinematics = std::make_unique<edm4eic::InclusiveKinematicsCollection>();
 
     // 1. find_if
     //const auto mc_first_electron = std::find_if(

--- a/src/algorithms/reco/InclusiveKinematicsElectron.h
+++ b/src/algorithms/reco/InclusiveKinematicsElectron.h
@@ -26,15 +26,15 @@ namespace eicrecon {
 
         void init(std::shared_ptr<spdlog::logger> logger);
 
-        std::vector<edm4eic::InclusiveKinematics*> execute(
-                std::vector<const edm4hep::MCParticle*> mcparts,
-                std::vector<const edm4eic::ReconstructedParticle*> rcparts,
-                std::vector<const edm4eic::MCRecoParticleAssociation*> rcassoc
+        std::unique_ptr<edm4eic::InclusiveKinematicsCollection> execute(
+                const edm4hep::MCParticleCollection& mcparts,
+                const edm4eic::ReconstructedParticleCollection& rcparts,
+                const edm4eic::MCRecoParticleAssociationCollection& rcassoc
         );
 
     private:
         std::shared_ptr<spdlog::logger> m_log;
         double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
-        };
+    };
 
 } // namespace eicrecon

--- a/src/algorithms/reco/InclusiveKinematicsJB.cc
+++ b/src/algorithms/reco/InclusiveKinematicsJB.cc
@@ -35,7 +35,7 @@ namespace eicrecon {
     const edm4eic::MCRecoParticleAssociationCollection& rcassoc) {
 
     // Resulting inclusive kinematics
-    auto kinematics = std::unique_ptr<edm4eic::InclusiveKinematicsCollection>();
+    auto kinematics = std::make_unique<edm4eic::InclusiveKinematicsCollection>();
     // Get incoming electron beam
     const auto ei_coll = find_first_beam_electron(mcparts);
     if (ei_coll.size() == 0) {

--- a/src/algorithms/reco/InclusiveKinematicsJB.cc
+++ b/src/algorithms/reco/InclusiveKinematicsJB.cc
@@ -29,22 +29,22 @@ namespace eicrecon {
     // }
   }
 
-  std::vector<edm4eic::InclusiveKinematics*> InclusiveKinematicsJB::execute(
-    std::vector<const edm4hep::MCParticle *> mcparts,
-    std::vector<const edm4eic::ReconstructedParticle *> rcparts,
-    std::vector<const edm4eic::MCRecoParticleAssociation *> rcassoc) {
+  std::unique_ptr<edm4eic::InclusiveKinematicsCollection> InclusiveKinematicsJB::execute(
+    const edm4hep::MCParticleCollection& mcparts,
+    const edm4eic::ReconstructedParticleCollection& rcparts,
+    const edm4eic::MCRecoParticleAssociationCollection& rcassoc) {
 
     // Resulting inclusive kinematics
-    std::vector<edm4eic::InclusiveKinematics *> kinematics;
+    auto kinematics = std::unique_ptr<edm4eic::InclusiveKinematicsCollection>();
     // Get incoming electron beam
     const auto ei_coll = find_first_beam_electron(mcparts);
-    if (ei_coll.empty()) {
+    if (ei_coll.size() == 0) {
       m_log->debug("No beam electron found");
       return kinematics;
     }
     const PxPyPzEVector ei(
       round_beam_four_momentum(
-        ei_coll[0]->getMomentum(),
+        ei_coll[0].getMomentum(),
         m_electron,
         {-5.0, -10.0, -18.0},
         0.0)
@@ -52,21 +52,21 @@ namespace eicrecon {
 
     // Get incoming hadron beam
     const auto pi_coll = find_first_beam_hadron(mcparts);
-    if (pi_coll.empty()) {
+    if (pi_coll.size() == 0) {
       m_log->debug("No beam hadron found");
       return kinematics;
     }
     const PxPyPzEVector pi(
       round_beam_four_momentum(
-        pi_coll[0]->getMomentum(),
-        pi_coll[0]->getPDG() == 2212 ? m_proton : m_neutron,
+        pi_coll[0].getMomentum(),
+        pi_coll[0].getPDG() == 2212 ? m_proton : m_neutron,
         {41.0, 100.0, 275.0},
         m_crossingAngle)
       );
 
     // Get first scattered electron
     const auto ef_coll = find_first_scattered_electron(mcparts);
-    if (ef_coll.empty()) {
+    if (ef_coll.size() == 0) {
       m_log->debug("No truth scattered electron found");
       return kinematics;
     }
@@ -77,7 +77,7 @@ namespace eicrecon {
     //  [&ef_coll](const auto& a){ return a.getSimID() == ef_coll[0].getObjectID().index; });
     auto ef_assoc = rcassoc.begin();
     for (; ef_assoc != rcassoc.end(); ++ef_assoc) {
-      if ((*ef_assoc)->getSimID() == (unsigned) ef_coll[0]->getObjectID().index) {
+      if (ef_assoc->getSimID() == (unsigned) ef_coll[0].getObjectID().index) {
         break;
       }
     }
@@ -85,7 +85,7 @@ namespace eicrecon {
       m_log->debug("Truth scattered electron not in reconstructed particles");
       return kinematics;
     }
-    const auto ef_rc{(*ef_assoc)->getRec()};
+    const auto ef_rc{ef_assoc->getRec()};
     const auto ef_rc_id{ef_rc.getObjectID().index};
 
     // Loop over reconstructed particles to get all outgoing particles other than the scattered electron
@@ -112,12 +112,12 @@ namespace eicrecon {
 
     for (const auto& p: rcparts) {
       // Get the scattered electron index and angle
-      if (p->getObjectID().index == ef_rc_id) {
+      if (p.getObjectID().index == ef_rc_id) {
 
       // Sum over all particles other than scattered electron
       } else {
         // Lorentz vector in lab frame
-        PxPyPzEVector hf_lab(p->getMomentum().x, p->getMomentum().y, p->getMomentum().z, p->getEnergy());
+        PxPyPzEVector hf_lab(p.getMomentum().x, p.getMomentum().y, p.getMomentum().z, p.getEnergy());
         // Boost to colinear frame
         PxPyPzEVector hf_boosted = apply_boost(boost, hf_lab);
 
@@ -144,13 +144,11 @@ namespace eicrecon {
     const auto x_jb = Q2_jb / (4.*ei.energy()*pi.energy()*y_jb);
     const auto nu_jb = Q2_jb / (2.*m_proton*x_jb);
     const auto W_jb = sqrt(m_proton*m_proton + 2*m_proton*nu_jb - Q2_jb);
-    edm4eic::MutableInclusiveKinematics kin(x_jb, Q2_jb, W_jb, y_jb, nu_jb);
+    auto kin = kinematics->create(x_jb, Q2_jb, W_jb, y_jb, nu_jb);
     kin.setScat(ef_rc);
 
     m_log->debug("x,Q2,W,y,nu = {},{},{},{},{}", kin.getX(),
             kin.getQ2(), kin.getW(), kin.getY(), kin.getNu());
-
-    kinematics.push_back(new edm4eic::InclusiveKinematics(kin));
 
     return kinematics;
   }

--- a/src/algorithms/reco/InclusiveKinematicsJB.h
+++ b/src/algorithms/reco/InclusiveKinematicsJB.h
@@ -26,15 +26,15 @@ namespace eicrecon {
 
         void init(std::shared_ptr<spdlog::logger> logger);
 
-        std::vector<edm4eic::InclusiveKinematics*> execute(
-                std::vector<const edm4hep::MCParticle*> mcparts,
-                std::vector<const edm4eic::ReconstructedParticle*> rcparts,
-                std::vector<const edm4eic::MCRecoParticleAssociation*> rcassoc
+        std::unique_ptr<edm4eic::InclusiveKinematicsCollection> execute(
+                const edm4hep::MCParticleCollection& mcparts,
+                const edm4eic::ReconstructedParticleCollection& rcparts,
+                const edm4eic::MCRecoParticleAssociationCollection& rcassoc
         );
 
     private:
         std::shared_ptr<spdlog::logger> m_log;
         double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
-        };
+    };
 
 } // namespace eicrecon

--- a/src/algorithms/reco/InclusiveKinematicsSigma.cc
+++ b/src/algorithms/reco/InclusiveKinematicsSigma.cc
@@ -35,7 +35,7 @@ namespace eicrecon {
     const edm4eic::MCRecoParticleAssociationCollection& rcassoc) {
 
     // Resulting inclusive kinematics
-    auto kinematics = std::unique_ptr<edm4eic::InclusiveKinematicsCollection>();
+    auto kinematics = std::make_unique<edm4eic::InclusiveKinematicsCollection>();
 
     // Get incoming electron beam
     const auto ei_coll = find_first_beam_electron(mcparts);

--- a/src/algorithms/reco/InclusiveKinematicsSigma.h
+++ b/src/algorithms/reco/InclusiveKinematicsSigma.h
@@ -26,15 +26,15 @@ namespace eicrecon {
 
         void init(std::shared_ptr<spdlog::logger> logger);
 
-        std::vector<edm4eic::InclusiveKinematics*> execute(
-                std::vector<const edm4hep::MCParticle*> mcparts,
-                std::vector<const edm4eic::ReconstructedParticle*> rcparts,
-                std::vector<const edm4eic::MCRecoParticleAssociation*> rcassoc
+        std::unique_ptr<edm4eic::InclusiveKinematicsCollection> execute(
+                const edm4hep::MCParticleCollection& mcparts,
+                const edm4eic::ReconstructedParticleCollection& rcparts,
+                const edm4eic::MCRecoParticleAssociationCollection& rcassoc
         );
 
     private:
         std::shared_ptr<spdlog::logger> m_log;
         double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
-        };
+    };
 
 } // namespace eicrecon

--- a/src/algorithms/reco/InclusiveKinematicsTruth.cc
+++ b/src/algorithms/reco/InclusiveKinematicsTruth.cc
@@ -36,7 +36,7 @@ namespace eicrecon {
     const edm4hep::MCParticleCollection& mcparts) {
 
     // Resulting inclusive kinematics
-    auto kinematics = std::unique_ptr<edm4eic::InclusiveKinematicsCollection>();
+    auto kinematics = std::make_unique<edm4eic::InclusiveKinematicsCollection>();
 
     // Loop over generated particles to get incoming electron and proton beams
     // and the scattered electron. In the presence of QED radition on the incoming

--- a/src/algorithms/reco/InclusiveKinematicsTruth.cc
+++ b/src/algorithms/reco/InclusiveKinematicsTruth.cc
@@ -32,11 +32,11 @@ namespace eicrecon {
     // }
   }
 
-  std::vector<edm4eic::InclusiveKinematics*> InclusiveKinematicsTruth::execute(
-    std::vector<const edm4hep::MCParticle *> mcparts) {
+  std::unique_ptr<edm4eic::InclusiveKinematicsCollection> InclusiveKinematicsTruth::execute(
+    const edm4hep::MCParticleCollection& mcparts) {
 
     // Resulting inclusive kinematics
-    std::vector<edm4eic::InclusiveKinematics *> kinematics;
+    auto kinematics = std::unique_ptr<edm4eic::InclusiveKinematicsCollection>();
 
     // Loop over generated particles to get incoming electron and proton beams
     // and the scattered electron. In the presence of QED radition on the incoming
@@ -46,24 +46,24 @@ namespace eicrecon {
 
     // Get incoming electron beam
     const auto ei_coll = find_first_beam_electron(mcparts);
-    if (ei_coll.empty()) {
+    if (ei_coll.size() == 0) {
       m_log->debug("No beam electron found");
       return kinematics;
     }
-    const auto ei_p = ei_coll[0]->getMomentum();
+    const auto ei_p = ei_coll[0].getMomentum();
     const auto ei_p_mag = edm4eic::magnitude(ei_p);
     const auto ei_mass = m_electron;
     const PxPyPzEVector ei(ei_p.x, ei_p.y, ei_p.z, std::hypot(ei_p_mag, ei_mass));
 
     // Get incoming hadron beam
     const auto pi_coll = find_first_beam_hadron(mcparts);
-    if (pi_coll.empty()) {
+    if (pi_coll.size() == 0) {
       m_log->debug("No beam hadron found");
       return kinematics;
     }
-    const auto pi_p = pi_coll[0]->getMomentum();
+    const auto pi_p = pi_coll[0].getMomentum();
     const auto pi_p_mag = edm4eic::magnitude(pi_p);
-    const auto pi_mass = pi_coll[0]->getPDG() == 2212 ? m_proton : m_neutron;
+    const auto pi_mass = pi_coll[0].getPDG() == 2212 ? m_proton : m_neutron;
     const PxPyPzEVector pi(pi_p.x, pi_p.y, pi_p.z, std::hypot(pi_p_mag, pi_mass));
 
     // Get first scattered electron
@@ -72,11 +72,11 @@ namespace eicrecon {
     // it may be better to trace back each final-state electron and see which one originates from
     // the beam.
     const auto ef_coll = find_first_scattered_electron(mcparts);
-    if (ef_coll.empty()) {
+    if (ef_coll.size() == 0) {
       m_log->debug("No truth scattered electron found");
       return kinematics;
     }
-    const auto ef_p = ef_coll[0]->getMomentum();
+    const auto ef_p = ef_coll[0].getMomentum();
     const auto ef_p_mag = edm4eic::magnitude(ef_p);
     const auto ef_mass = m_electron;
     const PxPyPzEVector ef(ef_p.x, ef_p.y, ef_p.z, std::hypot(ef_p_mag, ef_mass));
@@ -89,12 +89,10 @@ namespace eicrecon {
     const auto nu = q_dot_pi / pi_mass;
     const auto x = Q2 / (2.*q_dot_pi);
     const auto W = sqrt(pi_mass*pi_mass + 2.*q_dot_pi - Q2);
-    edm4eic::MutableInclusiveKinematics kin(x, Q2, W, y, nu);
+    auto kin = kinematics->create(x, Q2, W, y, nu);
 
     m_log->debug("x,Q2,W,y,nu = {},{},{},{},{}", kin.getX(),
             kin.getQ2(), kin.getW(), kin.getY(), kin.getNu());
-
-    kinematics.push_back(new edm4eic::InclusiveKinematics(kin));
 
     return kinematics;
   }

--- a/src/algorithms/reco/InclusiveKinematicsTruth.h
+++ b/src/algorithms/reco/InclusiveKinematicsTruth.h
@@ -26,14 +26,13 @@ namespace eicrecon {
 
         void init(std::shared_ptr<spdlog::logger> logger);
 
-        std::vector<edm4eic::InclusiveKinematics*> execute(
-                std::vector<const edm4hep::MCParticle*> mcparts
-
+        std::unique_ptr<edm4eic::InclusiveKinematicsCollection> execute(
+                const edm4hep::MCParticleCollection& mcparts
         );
 
     private:
         std::shared_ptr<spdlog::logger> m_log;
         double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
-        };
+    };
 
 } // namespace eicrecon

--- a/src/algorithms/reco/InclusiveKinematicseSigma.cc
+++ b/src/algorithms/reco/InclusiveKinematicseSigma.cc
@@ -35,7 +35,7 @@ namespace eicrecon {
     const edm4eic::MCRecoParticleAssociationCollection& rcassoc) {
 
     // Resulting inclusive kinematics
-    auto kinematics = std::unique_ptr<edm4eic::InclusiveKinematicsCollection>();
+    auto kinematics = std::make_unique<edm4eic::InclusiveKinematicsCollection>();
 
     // Get incoming electron beam
     const auto ei_coll = find_first_beam_electron(mcparts);

--- a/src/algorithms/reco/InclusiveKinematicseSigma.cc
+++ b/src/algorithms/reco/InclusiveKinematicseSigma.cc
@@ -29,23 +29,23 @@ namespace eicrecon {
     // }
   }
 
-  std::vector<edm4eic::InclusiveKinematics*> InclusiveKinematicseSigma::execute(
-    std::vector<const edm4hep::MCParticle *> mcparts,
-    std::vector<const edm4eic::ReconstructedParticle *> rcparts,
-    std::vector<const edm4eic::MCRecoParticleAssociation *> rcassoc) {
+  std::unique_ptr<edm4eic::InclusiveKinematicsCollection> InclusiveKinematicseSigma::execute(
+    const edm4hep::MCParticleCollection& mcparts,
+    const edm4eic::ReconstructedParticleCollection& rcparts,
+    const edm4eic::MCRecoParticleAssociationCollection& rcassoc) {
 
     // Resulting inclusive kinematics
-    std::vector<edm4eic::InclusiveKinematics *> kinematics;
+    auto kinematics = std::unique_ptr<edm4eic::InclusiveKinematicsCollection>();
 
     // Get incoming electron beam
     const auto ei_coll = find_first_beam_electron(mcparts);
-    if (ei_coll.empty()) {
+    if (ei_coll.size() == 0) {
       m_log->debug("No beam electron found");
       return kinematics;
     }
     const PxPyPzEVector ei(
       round_beam_four_momentum(
-        ei_coll[0]->getMomentum(),
+        ei_coll[0].getMomentum(),
         m_electron,
         {-5.0, -10.0, -18.0},
         0.0)
@@ -53,21 +53,21 @@ namespace eicrecon {
 
     // Get incoming hadron beam
     const auto pi_coll = find_first_beam_hadron(mcparts);
-    if (pi_coll.empty()) {
+    if (pi_coll.size() == 0) {
       m_log->debug("No beam hadron found");
       return kinematics;
     }
     const PxPyPzEVector pi(
       round_beam_four_momentum(
-        pi_coll[0]->getMomentum(),
-        pi_coll[0]->getPDG() == 2212 ? m_proton : m_neutron,
+        pi_coll[0].getMomentum(),
+        pi_coll[0].getPDG() == 2212 ? m_proton : m_neutron,
         {41.0, 100.0, 275.0},
         m_crossingAngle)
       );
 
     // Get first scattered electron
     const auto ef_coll = find_first_scattered_electron(mcparts);
-    if (ef_coll.empty()) {
+    if (ef_coll.size() == 0) {
       m_log->debug("No truth scattered electron found");
       return kinematics;
     }
@@ -78,7 +78,7 @@ namespace eicrecon {
     //  [&ef_coll](const auto& a){ return a.getSimID() == ef_coll[0].getObjectID().index; });
     auto ef_assoc = rcassoc.begin();
     for (; ef_assoc != rcassoc.end(); ++ef_assoc) {
-      if ((*ef_assoc)->getSimID() == (unsigned) ef_coll[0]->getObjectID().index) {
+      if (ef_assoc->getSimID() == (unsigned) ef_coll[0].getObjectID().index) {
         break;
       }
     }
@@ -86,7 +86,7 @@ namespace eicrecon {
       m_log->debug("Truth scattered electron not in reconstructed particles");
       return kinematics;
     }
-    const auto ef_rc{(*ef_assoc)->getRec()};
+    const auto ef_rc{ef_assoc->getRec()};
     const auto ef_rc_id{ef_rc.getObjectID().index};
 
     // Loop over reconstructed particles to get all outgoing particles
@@ -116,9 +116,9 @@ namespace eicrecon {
 
     for (const auto& p: rcparts) {
       // Get the scattered electron index and angle
-      if (p->getObjectID().index == ef_rc_id) {
+      if (p.getObjectID().index == ef_rc_id) {
         // Lorentz vector in lab frame
-        PxPyPzEVector e_lab(p->getMomentum().x, p->getMomentum().y, p->getMomentum().z, p->getEnergy());
+        PxPyPzEVector e_lab(p.getMomentum().x, p.getMomentum().y, p.getMomentum().z, p.getEnergy());
         // Boost to colinear frame
         PxPyPzEVector e_boosted = apply_boost(boost, e_lab);
 
@@ -128,7 +128,7 @@ namespace eicrecon {
       // Sum over all particles other than scattered electron
       } else {
         // Lorentz vector in lab frame
-        PxPyPzEVector hf_lab(p->getMomentum().x, p->getMomentum().y, p->getMomentum().z, p->getEnergy());
+        PxPyPzEVector hf_lab(p.getMomentum().x, p.getMomentum().y, p.getMomentum().z, p.getEnergy());
         // Boost to colinear frame
         PxPyPzEVector hf_boosted = apply_boost(boost, hf_lab);
 
@@ -162,17 +162,15 @@ namespace eicrecon {
     const auto y_esig = Q2_esig / (4.*ei.energy()*pi.energy()*x_esig); //equivalent to (2*ei.energy() / sigma_tot)*y_sig
     const auto nu_esig = Q2_esig / (2.*m_proton*x_esig);
     const auto W_esig = sqrt(m_proton*m_proton + 2*m_proton*nu_esig - Q2_esig);
-    edm4eic::MutableInclusiveKinematics kin(x_esig, Q2_esig, W_esig, y_esig, nu_esig);
+    auto kin = kinematics->create(x_esig, Q2_esig, W_esig, y_esig, nu_esig);
     kin.setScat(ef_rc);
 
     // Debugging output
     m_log->debug("x,Q2,W,y,nu = {},{},{},{},{}", kin.getX(),
             kin.getQ2(), kin.getW(), kin.getY(), kin.getNu());
 
-    kinematics.push_back(new edm4eic::InclusiveKinematics(kin));
-
     return kinematics;
-    }
+  }
 
 
 } // namespace Jug::Reco

--- a/src/algorithms/reco/InclusiveKinematicseSigma.h
+++ b/src/algorithms/reco/InclusiveKinematicseSigma.h
@@ -26,15 +26,15 @@ namespace eicrecon {
 
         void init(std::shared_ptr<spdlog::logger> logger);
 
-        std::vector<edm4eic::InclusiveKinematics*> execute(
-                std::vector<const edm4hep::MCParticle*> mcparts,
-                std::vector<const edm4eic::ReconstructedParticle*> rcparts,
-                std::vector<const edm4eic::MCRecoParticleAssociation*> rcassoc
+        std::unique_ptr<edm4eic::InclusiveKinematicsCollection> execute(
+                const edm4hep::MCParticleCollection& mcparts,
+                const edm4eic::ReconstructedParticleCollection& rcparts,
+                const edm4eic::MCRecoParticleAssociationCollection& rcassoc
         );
 
     private:
         std::shared_ptr<spdlog::logger> m_log;
         double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
-        };
+    };
 
 } // namespace eicrecon

--- a/src/global/reco/InclusiveKinematicsDA_factory.cc
+++ b/src/global/reco/InclusiveKinematicsDA_factory.cc
@@ -9,12 +9,11 @@
 
 #include "InclusiveKinematicsDA_factory.h"
 
-#include <edm4hep/MCParticle.h>
-#include <edm4eic/ReconstructedParticle.h>
-#include <edm4eic/InclusiveKinematics.h>
+#include <edm4hep/MCParticleCollection.h>
+#include <edm4eic/ReconstructedParticleCollection.h>
+#include <edm4eic/InclusiveKinematicsCollection.h>
 #include "services/log/Log_service.h"
 #include "extensions/spdlog/SpdlogExtensions.h"
-#include <algorithms/tracking/ParticlesFromTrackFitResult.h>
 
 namespace eicrecon {
 
@@ -37,16 +36,16 @@ namespace eicrecon {
     }
 
     void InclusiveKinematicsDA_factory::Process(const std::shared_ptr<const JEvent> &event) {
-        auto mc_particles = event->Get<edm4hep::MCParticle>("MCParticles");
-        auto rc_particles = event->Get<edm4eic::ReconstructedParticle>("ReconstructedChargedParticles");
-        auto rc_particles_assoc = event->Get<edm4eic::MCRecoParticleAssociation>("ReconstructedChargedParticleAssociations");
+        const auto* mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase("MCParticles"));
+        const auto* rc_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase("ReconstructedChargedParticles"));
+        const auto* rc_particles_assoc = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase("ReconstructedChargedParticleAssociations"));
 
         auto inclusive_kinematics = m_inclusive_kinematics_algo.execute(
-            mc_particles,
-            rc_particles,
-            rc_particles_assoc
+            *mc_particles,
+            *rc_particles,
+            *rc_particles_assoc
         );
 
-        Set(inclusive_kinematics);
+        SetCollection(std::move(inclusive_kinematics));
     }
 } // eicrecon

--- a/src/global/reco/InclusiveKinematicsDA_factory.cc
+++ b/src/global/reco/InclusiveKinematicsDA_factory.cc
@@ -36,9 +36,9 @@ namespace eicrecon {
     }
 
     void InclusiveKinematicsDA_factory::Process(const std::shared_ptr<const JEvent> &event) {
-        const auto* mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase("MCParticles"));
-        const auto* rc_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase("ReconstructedChargedParticles"));
-        const auto* rc_particles_assoc = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase("ReconstructedChargedParticleAssociations"));
+        const auto* mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase(GetInputTags()[0]));
+        const auto* rc_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase(GetInputTags()[1]));
+        const auto* rc_particles_assoc = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase(GetInputTags()[2]));
 
         auto inclusive_kinematics = m_inclusive_kinematics_algo.execute(
             *mc_particles,

--- a/src/global/reco/InclusiveKinematicsDA_factory.h
+++ b/src/global/reco/InclusiveKinematicsDA_factory.h
@@ -5,11 +5,7 @@
 
 #include <extensions/jana/JChainFactoryT.h>
 #include <extensions/spdlog/SpdlogMixin.h>
-#include <spdlog/logger.h>
-#include <edm4eic/ReconstructedParticle.h>
-#include <edm4eic/InclusiveKinematics.h>
 #include <algorithms/reco/InclusiveKinematicsDA.h>
-
 
 namespace eicrecon {
 

--- a/src/global/reco/InclusiveKinematicsDA_factory.h
+++ b/src/global/reco/InclusiveKinematicsDA_factory.h
@@ -26,9 +26,8 @@ namespace eicrecon {
 
         /** Event by event processing **/
         void Process(const std::shared_ptr<const JEvent> &event) override;
-    protected:
 
-        std::vector<std::string> m_input_assoc_tags = {"InclusiveKinematicsDA"};
+    protected:
         InclusiveKinematicsDA m_inclusive_kinematics_algo;
 
     };

--- a/src/global/reco/InclusiveKinematicsElectron_factory.cc
+++ b/src/global/reco/InclusiveKinematicsElectron_factory.cc
@@ -9,12 +9,11 @@
 
 #include "InclusiveKinematicsElectron_factory.h"
 
-#include <edm4hep/MCParticle.h>
-#include <edm4eic/ReconstructedParticle.h>
-#include <edm4eic/InclusiveKinematics.h>
+#include <edm4hep/MCParticleCollection.h>
+#include <edm4eic/ReconstructedParticleCollection.h>
+#include <edm4eic/InclusiveKinematicsCollection.h>
 #include "services/log/Log_service.h"
 #include "extensions/spdlog/SpdlogExtensions.h"
-#include <algorithms/tracking/ParticlesFromTrackFitResult.h>
 
 namespace eicrecon {
 
@@ -37,16 +36,16 @@ namespace eicrecon {
     }
 
     void InclusiveKinematicsElectron_factory::Process(const std::shared_ptr<const JEvent> &event) {
-        auto mc_particles = event->Get<edm4hep::MCParticle>("MCParticles");
-        auto rc_particles = event->Get<edm4eic::ReconstructedParticle>("ReconstructedChargedParticles");
-        auto rc_particles_assoc = event->Get<edm4eic::MCRecoParticleAssociation>("ReconstructedChargedParticleAssociations");
+        const auto* mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase("MCParticles"));
+        const auto* rc_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase("ReconstructedChargedParticles"));
+        const auto* rc_particles_assoc = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase("ReconstructedChargedParticleAssociations"));
 
         auto inclusive_kinematics = m_inclusive_kinematics_algo.execute(
-            mc_particles,
-            rc_particles,
-            rc_particles_assoc
+            *mc_particles,
+            *rc_particles,
+            *rc_particles_assoc
         );
 
-        Set(inclusive_kinematics);
+        SetCollection(std::move(inclusive_kinematics));
     }
 } // eicrecon

--- a/src/global/reco/InclusiveKinematicsElectron_factory.cc
+++ b/src/global/reco/InclusiveKinematicsElectron_factory.cc
@@ -36,9 +36,9 @@ namespace eicrecon {
     }
 
     void InclusiveKinematicsElectron_factory::Process(const std::shared_ptr<const JEvent> &event) {
-        const auto* mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase("MCParticles"));
-        const auto* rc_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase("ReconstructedChargedParticles"));
-        const auto* rc_particles_assoc = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase("ReconstructedChargedParticleAssociations"));
+        const auto* mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase(GetInputTags()[0]));
+        const auto* rc_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase(GetInputTags()[1]));
+        const auto* rc_particles_assoc = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase(GetInputTags()[2]));
 
         auto inclusive_kinematics = m_inclusive_kinematics_algo.execute(
             *mc_particles,

--- a/src/global/reco/InclusiveKinematicsElectron_factory.h
+++ b/src/global/reco/InclusiveKinematicsElectron_factory.h
@@ -5,11 +5,7 @@
 
 #include <extensions/jana/JChainFactoryT.h>
 #include <extensions/spdlog/SpdlogMixin.h>
-#include <spdlog/logger.h>
-#include <edm4eic/ReconstructedParticle.h>
-#include <edm4eic/InclusiveKinematics.h>
 #include <algorithms/reco/InclusiveKinematicsElectron.h>
-
 
 namespace eicrecon {
 

--- a/src/global/reco/InclusiveKinematicsElectron_factory.h
+++ b/src/global/reco/InclusiveKinematicsElectron_factory.h
@@ -26,9 +26,8 @@ namespace eicrecon {
 
         /** Event by event processing **/
         void Process(const std::shared_ptr<const JEvent> &event) override;
-    protected:
 
-        std::vector<std::string> m_input_assoc_tags = {"InclusiveKinematicsElectron"};
+    protected:
         InclusiveKinematicsElectron m_inclusive_kinematics_algo;
 
     };

--- a/src/global/reco/InclusiveKinematicsJB_factory.cc
+++ b/src/global/reco/InclusiveKinematicsJB_factory.cc
@@ -9,12 +9,11 @@
 
 #include "InclusiveKinematicsJB_factory.h"
 
-#include <edm4hep/MCParticle.h>
-#include <edm4eic/ReconstructedParticle.h>
-#include <edm4eic/InclusiveKinematics.h>
+#include <edm4hep/MCParticleCollection.h>
+#include <edm4eic/ReconstructedParticleCollection.h>
+#include <edm4eic/InclusiveKinematicsCollection.h>
 #include "services/log/Log_service.h"
 #include "extensions/spdlog/SpdlogExtensions.h"
-#include <algorithms/tracking/ParticlesFromTrackFitResult.h>
 
 namespace eicrecon {
 
@@ -37,16 +36,16 @@ namespace eicrecon {
     }
 
     void InclusiveKinematicsJB_factory::Process(const std::shared_ptr<const JEvent> &event) {
-        auto mc_particles = event->Get<edm4hep::MCParticle>("MCParticles");
-        auto rc_particles = event->Get<edm4eic::ReconstructedParticle>("ReconstructedChargedParticles");
-        auto rc_particles_assoc = event->Get<edm4eic::MCRecoParticleAssociation>("ReconstructedChargedParticleAssociations");
+        const auto* mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase("MCParticles"));
+        const auto* rc_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase("ReconstructedChargedParticles"));
+        const auto* rc_particles_assoc = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase("ReconstructedChargedParticleAssociations"));
 
         auto inclusive_kinematics = m_inclusive_kinematics_algo.execute(
-            mc_particles,
-            rc_particles,
-            rc_particles_assoc
+            *mc_particles,
+            *rc_particles,
+            *rc_particles_assoc
         );
 
-        Set(inclusive_kinematics);
+        SetCollection(std::move(inclusive_kinematics));
     }
 } // eicrecon

--- a/src/global/reco/InclusiveKinematicsJB_factory.cc
+++ b/src/global/reco/InclusiveKinematicsJB_factory.cc
@@ -36,9 +36,9 @@ namespace eicrecon {
     }
 
     void InclusiveKinematicsJB_factory::Process(const std::shared_ptr<const JEvent> &event) {
-        const auto* mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase("MCParticles"));
-        const auto* rc_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase("ReconstructedChargedParticles"));
-        const auto* rc_particles_assoc = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase("ReconstructedChargedParticleAssociations"));
+        const auto* mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase(GetInputTags()[0]));
+        const auto* rc_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase(GetInputTags()[1]));
+        const auto* rc_particles_assoc = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase(GetInputTags()[2]));
 
         auto inclusive_kinematics = m_inclusive_kinematics_algo.execute(
             *mc_particles,

--- a/src/global/reco/InclusiveKinematicsJB_factory.h
+++ b/src/global/reco/InclusiveKinematicsJB_factory.h
@@ -5,11 +5,7 @@
 
 #include <extensions/jana/JChainFactoryT.h>
 #include <extensions/spdlog/SpdlogMixin.h>
-#include <spdlog/logger.h>
-#include <edm4eic/ReconstructedParticle.h>
-#include <edm4eic/InclusiveKinematics.h>
 #include <algorithms/reco/InclusiveKinematicsJB.h>
-
 
 namespace eicrecon {
 

--- a/src/global/reco/InclusiveKinematicsJB_factory.h
+++ b/src/global/reco/InclusiveKinematicsJB_factory.h
@@ -26,9 +26,8 @@ namespace eicrecon {
 
         /** Event by event processing **/
         void Process(const std::shared_ptr<const JEvent> &event) override;
-    protected:
 
-        std::vector<std::string> m_input_assoc_tags = {"InclusiveKinematicsJB"};
+    protected:
         InclusiveKinematicsJB m_inclusive_kinematics_algo;
 
     };

--- a/src/global/reco/InclusiveKinematicsSigma_factory.cc
+++ b/src/global/reco/InclusiveKinematicsSigma_factory.cc
@@ -9,12 +9,11 @@
 
 #include "InclusiveKinematicsSigma_factory.h"
 
-#include <edm4hep/MCParticle.h>
-#include <edm4eic/ReconstructedParticle.h>
-#include <edm4eic/InclusiveKinematics.h>
+#include <edm4hep/MCParticleCollection.h>
+#include <edm4eic/ReconstructedParticleCollection.h>
+#include <edm4eic/InclusiveKinematicsCollection.h>
 #include "services/log/Log_service.h"
 #include "extensions/spdlog/SpdlogExtensions.h"
-#include <algorithms/tracking/ParticlesFromTrackFitResult.h>
 
 namespace eicrecon {
 
@@ -37,16 +36,16 @@ namespace eicrecon {
     }
 
     void InclusiveKinematicsSigma_factory::Process(const std::shared_ptr<const JEvent> &event) {
-        auto mc_particles = event->Get<edm4hep::MCParticle>("MCParticles");
-        auto rc_particles = event->Get<edm4eic::ReconstructedParticle>("ReconstructedChargedParticles");
-        auto rc_particles_assoc = event->Get<edm4eic::MCRecoParticleAssociation>("ReconstructedChargedParticleAssociations");
+        const auto* mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase("MCParticles"));
+        const auto* rc_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase("ReconstructedChargedParticles"));
+        const auto* rc_particles_assoc = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase("ReconstructedChargedParticleAssociations"));
 
         auto inclusive_kinematics = m_inclusive_kinematics_algo.execute(
-            mc_particles,
-            rc_particles,
-            rc_particles_assoc
+            *mc_particles,
+            *rc_particles,
+            *rc_particles_assoc
         );
 
-        Set(inclusive_kinematics);
+        SetCollection(std::move(inclusive_kinematics));
     }
 } // eicrecon

--- a/src/global/reco/InclusiveKinematicsSigma_factory.cc
+++ b/src/global/reco/InclusiveKinematicsSigma_factory.cc
@@ -36,9 +36,9 @@ namespace eicrecon {
     }
 
     void InclusiveKinematicsSigma_factory::Process(const std::shared_ptr<const JEvent> &event) {
-        const auto* mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase("MCParticles"));
-        const auto* rc_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase("ReconstructedChargedParticles"));
-        const auto* rc_particles_assoc = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase("ReconstructedChargedParticleAssociations"));
+        const auto* mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase(GetInputTags()[0]));
+        const auto* rc_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase(GetInputTags()[1]));
+        const auto* rc_particles_assoc = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase(GetInputTags()[2]));
 
         auto inclusive_kinematics = m_inclusive_kinematics_algo.execute(
             *mc_particles,

--- a/src/global/reco/InclusiveKinematicsSigma_factory.h
+++ b/src/global/reco/InclusiveKinematicsSigma_factory.h
@@ -5,11 +5,7 @@
 
 #include <extensions/jana/JChainFactoryT.h>
 #include <extensions/spdlog/SpdlogMixin.h>
-#include <spdlog/logger.h>
-#include <edm4eic/ReconstructedParticle.h>
-#include <edm4eic/InclusiveKinematics.h>
 #include <algorithms/reco/InclusiveKinematicsSigma.h>
-
 
 namespace eicrecon {
 

--- a/src/global/reco/InclusiveKinematicsSigma_factory.h
+++ b/src/global/reco/InclusiveKinematicsSigma_factory.h
@@ -26,9 +26,8 @@ namespace eicrecon {
 
         /** Event by event processing **/
         void Process(const std::shared_ptr<const JEvent> &event) override;
-    protected:
 
-        std::vector<std::string> m_input_assoc_tags = {"InclusiveKinematicsSigma"};
+    protected:
         InclusiveKinematicsSigma m_inclusive_kinematics_algo;
 
     };

--- a/src/global/reco/InclusiveKinematicsTruth_factory.cc
+++ b/src/global/reco/InclusiveKinematicsTruth_factory.cc
@@ -9,12 +9,10 @@
 
 #include "InclusiveKinematicsTruth_factory.h"
 
-#include <edm4hep/MCParticle.h>
-#include <edm4eic/ReconstructedParticle.h>
-#include <edm4eic/InclusiveKinematics.h>
+#include <edm4hep/MCParticleCollection.h>
+#include <edm4eic/InclusiveKinematicsCollection.h>
 #include "services/log/Log_service.h"
 #include "extensions/spdlog/SpdlogExtensions.h"
-#include <algorithms/tracking/ParticlesFromTrackFitResult.h>
 
 namespace eicrecon {
 
@@ -37,12 +35,12 @@ namespace eicrecon {
     }
 
     void InclusiveKinematicsTruth_factory::Process(const std::shared_ptr<const JEvent> &event) {
-        auto mc_particles = event->Get<edm4hep::MCParticle>("MCParticles");
+        const auto* mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase("MCParticles"));
 
         auto inclusive_kinematics = m_inclusive_kinematics_algo.execute(
-            mc_particles
+            *mc_particles
         );
 
-        Set(inclusive_kinematics);
+        SetCollection(std::move(inclusive_kinematics));
     }
 } // eicrecon

--- a/src/global/reco/InclusiveKinematicsTruth_factory.cc
+++ b/src/global/reco/InclusiveKinematicsTruth_factory.cc
@@ -35,7 +35,7 @@ namespace eicrecon {
     }
 
     void InclusiveKinematicsTruth_factory::Process(const std::shared_ptr<const JEvent> &event) {
-        const auto* mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase("MCParticles"));
+        const auto* mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase(GetInputTags()[0]));
 
         auto inclusive_kinematics = m_inclusive_kinematics_algo.execute(
             *mc_particles

--- a/src/global/reco/InclusiveKinematicsTruth_factory.h
+++ b/src/global/reco/InclusiveKinematicsTruth_factory.h
@@ -26,9 +26,8 @@ namespace eicrecon {
 
         /** Event by event processing **/
         void Process(const std::shared_ptr<const JEvent> &event) override;
-    protected:
 
-        std::vector<std::string> m_input_assoc_tags = {"InclusiveKinematicsTruth"};
+    protected:
         InclusiveKinematicsTruth m_inclusive_kinematics_algo;
 
     };

--- a/src/global/reco/InclusiveKinematicsTruth_factory.h
+++ b/src/global/reco/InclusiveKinematicsTruth_factory.h
@@ -5,11 +5,7 @@
 
 #include <extensions/jana/JChainFactoryT.h>
 #include <extensions/spdlog/SpdlogMixin.h>
-#include <spdlog/logger.h>
-#include <edm4eic/ReconstructedParticle.h>
-#include <edm4eic/InclusiveKinematics.h>
 #include <algorithms/reco/InclusiveKinematicsTruth.h>
-
 
 namespace eicrecon {
 

--- a/src/global/reco/InclusiveKinematicseSigma_factory.cc
+++ b/src/global/reco/InclusiveKinematicseSigma_factory.cc
@@ -9,12 +9,11 @@
 
 #include "InclusiveKinematicseSigma_factory.h"
 
-#include <edm4hep/MCParticle.h>
-#include <edm4eic/ReconstructedParticle.h>
-#include <edm4eic/InclusiveKinematics.h>
+#include <edm4hep/MCParticleCollection.h>
+#include <edm4eic/ReconstructedParticleCollection.h>
+#include <edm4eic/InclusiveKinematicsCollection.h>
 #include "services/log/Log_service.h"
 #include "extensions/spdlog/SpdlogExtensions.h"
-#include <algorithms/tracking/ParticlesFromTrackFitResult.h>
 
 namespace eicrecon {
 
@@ -37,16 +36,16 @@ namespace eicrecon {
     }
 
     void InclusiveKinematicseSigma_factory::Process(const std::shared_ptr<const JEvent> &event) {
-        auto mc_particles = event->Get<edm4hep::MCParticle>("MCParticles");
-        auto rc_particles = event->Get<edm4eic::ReconstructedParticle>("ReconstructedChargedParticles");
-        auto rc_particles_assoc = event->Get<edm4eic::MCRecoParticleAssociation>("ReconstructedChargedParticleAssociations");
+        const auto* mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase("MCParticles"));
+        const auto* rc_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase("ReconstructedChargedParticles"));
+        const auto* rc_particles_assoc = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase("ReconstructedChargedParticleAssociations"));
 
         auto inclusive_kinematics = m_inclusive_kinematics_algo.execute(
-            mc_particles,
-            rc_particles,
-            rc_particles_assoc
+            *mc_particles,
+            *rc_particles,
+            *rc_particles_assoc
         );
 
-        Set(inclusive_kinematics);
+        SetCollection(std::move(inclusive_kinematics));
     }
 } // eicrecon

--- a/src/global/reco/InclusiveKinematicseSigma_factory.cc
+++ b/src/global/reco/InclusiveKinematicseSigma_factory.cc
@@ -36,9 +36,9 @@ namespace eicrecon {
     }
 
     void InclusiveKinematicseSigma_factory::Process(const std::shared_ptr<const JEvent> &event) {
-        const auto* mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase("MCParticles"));
-        const auto* rc_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase("ReconstructedChargedParticles"));
-        const auto* rc_particles_assoc = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase("ReconstructedChargedParticleAssociations"));
+        const auto* mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase(GetInputTags()[0]));
+        const auto* rc_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase(GetInputTags()[1]));
+        const auto* rc_particles_assoc = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase(GetInputTags()[2]));
 
         auto inclusive_kinematics = m_inclusive_kinematics_algo.execute(
             *mc_particles,

--- a/src/global/reco/InclusiveKinematicseSigma_factory.h
+++ b/src/global/reco/InclusiveKinematicseSigma_factory.h
@@ -26,9 +26,8 @@ namespace eicrecon {
 
         /** Event by event processing **/
         void Process(const std::shared_ptr<const JEvent> &event) override;
-    protected:
 
-        std::vector<std::string> m_input_assoc_tags = {"InclusiveKinematicseSigma"};
+    protected:
         InclusiveKinematicseSigma m_inclusive_kinematics_algo;
 
     };

--- a/src/global/reco/InclusiveKinematicseSigma_factory.h
+++ b/src/global/reco/InclusiveKinematicseSigma_factory.h
@@ -5,11 +5,7 @@
 
 #include <extensions/jana/JChainFactoryT.h>
 #include <extensions/spdlog/SpdlogMixin.h>
-#include <spdlog/logger.h>
-#include <edm4eic/ReconstructedParticle.h>
-#include <edm4eic/InclusiveKinematics.h>
 #include <algorithms/reco/InclusiveKinematicseSigma.h>
-
 
 namespace eicrecon {
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This converts the InclusiveKinematics algorithms and factories (back) to using podio collections (from `std::vector<T*>`).

Because JANA2 expects `std::unique_ptr`, the algorithms are creating `std::unique_ptr`s of the collections. Ultimately it may be nice to just create collection and `std::move` it...

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.