### PR TITLE
feat: make the factory-factory a variadic template (more evil things)

### DIFF
--- a/src/detectors/B0ECAL/B0ECAL.cc
+++ b/src/detectors/B0ECAL/B0ECAL.cc
@@ -14,19 +14,8 @@
 
 
 namespace eicrecon {
-    class Cluster_factory_B0ECalTruthClusters: public CalorimeterClusterRecoCoG_factoryT<Cluster_factory_B0ECalTruthClusters> {
-    public:
-        template <typename... Args>
-        Cluster_factory_B0ECalTruthClusters(Args&&... args)
-        : CalorimeterClusterRecoCoG_factoryT<Cluster_factory_B0ECalTruthClusters>(std::forward<Args>(args)...) { }
-    };
-
-    class Cluster_factory_B0ECalClusters: public CalorimeterClusterRecoCoG_factoryT<Cluster_factory_B0ECalClusters> {
-    public:
-        template <typename... Args>
-        Cluster_factory_B0ECalClusters(Args&&... args)
-        : CalorimeterClusterRecoCoG_factoryT<Cluster_factory_B0ECalClusters>(std::forward<Args>(args)...) { }
-    };
+    using Cluster_factory_B0ECalTruthClusters = CalorimeterClusterRecoCoG_factoryT<>;
+    using Cluster_factory_B0ECalClusters = CalorimeterClusterRecoCoG_factoryT<>;
 }
 
 

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -26,27 +26,9 @@
 
 
 namespace eicrecon {
-    class Cluster_factory_EcalBarrelSciGlassTruthClusters: public CalorimeterClusterRecoCoG_factoryT<Cluster_factory_EcalBarrelSciGlassTruthClusters> {
-    public:
-        template <typename... Args>
-        Cluster_factory_EcalBarrelSciGlassTruthClusters(Args&&... args)
-        : CalorimeterClusterRecoCoG_factoryT<Cluster_factory_EcalBarrelSciGlassTruthClusters>(std::forward<Args>(args)...) { }
-    };
-
-    class Cluster_factory_EcalBarrelSciGlassClusters: public CalorimeterClusterRecoCoG_factoryT<Cluster_factory_EcalBarrelSciGlassClusters> {
-    public:
-        template <typename... Args>
-        Cluster_factory_EcalBarrelSciGlassClusters(Args&&... args)
-        : CalorimeterClusterRecoCoG_factoryT<Cluster_factory_EcalBarrelSciGlassClusters>(std::forward<Args>(args)...) { }
-    };
-
-    class Cluster_factory_EcalBarrelScFiClusters: public CalorimeterClusterRecoCoG_factoryT<Cluster_factory_EcalBarrelScFiClusters> {
-    public:
-        template <typename... Args>
-        Cluster_factory_EcalBarrelScFiClusters(Args&&... args)
-        : CalorimeterClusterRecoCoG_factoryT<Cluster_factory_EcalBarrelScFiClusters>(std::forward<Args>(args)...) { }
-    };
-
+    using Cluster_factory_EcalBarrelSciGlassTruthClusters = CalorimeterClusterRecoCoG_factoryT<>;
+    using Cluster_factory_EcalBarrelSciGlassClusters = CalorimeterClusterRecoCoG_factoryT<>;
+    using Cluster_factory_EcalBarrelScFiClusters = CalorimeterClusterRecoCoG_factoryT<>;
 }
 
 extern "C" {

--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -14,19 +14,8 @@
 
 
 namespace eicrecon {
-    class Cluster_factory_HcalBarrelTruthClusters: public CalorimeterClusterRecoCoG_factoryT<Cluster_factory_HcalBarrelTruthClusters> {
-    public:
-        template <typename... Args>
-        Cluster_factory_HcalBarrelTruthClusters(Args&&... args)
-        : CalorimeterClusterRecoCoG_factoryT<Cluster_factory_HcalBarrelTruthClusters>(std::forward<Args>(args)...) { }
-    };
-
-    class Cluster_factory_HcalBarrelClusters: public CalorimeterClusterRecoCoG_factoryT<Cluster_factory_HcalBarrelClusters> {
-    public:
-        template <typename... Args>
-        Cluster_factory_HcalBarrelClusters(Args&&... args)
-        : CalorimeterClusterRecoCoG_factoryT<Cluster_factory_HcalBarrelClusters>(std::forward<Args>(args)...) { }
-    };
+    using Cluster_factory_HcalBarrelTruthClusters = CalorimeterClusterRecoCoG_factoryT<>;
+    using Cluster_factory_HcalBarrelClusters = CalorimeterClusterRecoCoG_factoryT<>;
 }
 
 extern "C" {

--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -13,19 +13,8 @@
 #include "ProtoCluster_factory_EcalEndcapNIslandProtoClusters.h"
 
 namespace eicrecon {
-    class Cluster_factory_EcalEndcapNTruthClusters: public CalorimeterClusterRecoCoG_factoryT<Cluster_factory_EcalEndcapNTruthClusters> {
-    public:
-        template <typename... Args>
-        Cluster_factory_EcalEndcapNTruthClusters(Args&&... args)
-        : CalorimeterClusterRecoCoG_factoryT<Cluster_factory_EcalEndcapNTruthClusters>(std::forward<Args>(args)...) { }
-    };
-
-    class Cluster_factory_EcalEndcapNClusters: public CalorimeterClusterRecoCoG_factoryT<Cluster_factory_EcalEndcapNClusters> {
-    public:
-        template <typename... Args>
-        Cluster_factory_EcalEndcapNClusters(Args&&... args)
-        : CalorimeterClusterRecoCoG_factoryT<Cluster_factory_EcalEndcapNClusters>(std::forward<Args>(args)...) { }
-    };
+    using Cluster_factory_EcalEndcapNTruthClusters = CalorimeterClusterRecoCoG_factoryT<>;
+    using Cluster_factory_EcalEndcapNClusters = CalorimeterClusterRecoCoG_factoryT<>;
 }
 
 extern "C" {

--- a/src/detectors/EHCAL/EHCAL.cc
+++ b/src/detectors/EHCAL/EHCAL.cc
@@ -15,19 +15,8 @@
 
 
 namespace eicrecon {
-    class Cluster_factory_HcalEndcapNTruthClusters: public CalorimeterClusterRecoCoG_factoryT<Cluster_factory_HcalEndcapNTruthClusters> {
-    public:
-        template <typename... Args>
-        Cluster_factory_HcalEndcapNTruthClusters(Args&&... args)
-        : CalorimeterClusterRecoCoG_factoryT<Cluster_factory_HcalEndcapNTruthClusters>(std::forward<Args>(args)...) { }
-    };
-
-    class Cluster_factory_HcalEndcapNClusters: public CalorimeterClusterRecoCoG_factoryT<Cluster_factory_HcalEndcapNClusters> {
-    public:
-        template <typename... Args>
-        Cluster_factory_HcalEndcapNClusters(Args&&... args)
-        : CalorimeterClusterRecoCoG_factoryT<Cluster_factory_HcalEndcapNClusters>(std::forward<Args>(args)...) { }
-    };
+    using Cluster_factory_HcalEndcapNTruthClusters = CalorimeterClusterRecoCoG_factoryT<>;
+    using Cluster_factory_HcalEndcapNClusters = CalorimeterClusterRecoCoG_factoryT<>;
 }
 
 extern "C" {

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -18,33 +18,10 @@
 #include "ProtoCluster_factory_EcalEndcapPInsertIslandProtoClusters.h"
 
 namespace eicrecon {
-    class Cluster_factory_EcalEndcapPTruthClusters: public CalorimeterClusterRecoCoG_factoryT<Cluster_factory_EcalEndcapPTruthClusters> {
-    public:
-        template <typename... Args>
-        Cluster_factory_EcalEndcapPTruthClusters(Args&&... args)
-        : CalorimeterClusterRecoCoG_factoryT<Cluster_factory_EcalEndcapPTruthClusters>(std::forward<Args>(args)...) { }
-    };
-
-    class Cluster_factory_EcalEndcapPClusters: public CalorimeterClusterRecoCoG_factoryT<Cluster_factory_EcalEndcapPClusters> {
-    public:
-        template <typename... Args>
-        Cluster_factory_EcalEndcapPClusters(Args&&... args)
-        : CalorimeterClusterRecoCoG_factoryT<Cluster_factory_EcalEndcapPClusters>(std::forward<Args>(args)...) { }
-    };
-
-    class Cluster_factory_EcalEndcapPInsertTruthClusters: public CalorimeterClusterRecoCoG_factoryT<Cluster_factory_EcalEndcapPInsertTruthClusters> {
-    public:
-        template <typename... Args>
-        Cluster_factory_EcalEndcapPInsertTruthClusters(Args&&... args)
-        : CalorimeterClusterRecoCoG_factoryT<Cluster_factory_EcalEndcapPInsertTruthClusters>(std::forward<Args>(args)...) { }
-    };
-
-    class Cluster_factory_EcalEndcapPInsertClusters: public CalorimeterClusterRecoCoG_factoryT<Cluster_factory_EcalEndcapPInsertClusters> {
-    public:
-        template <typename... Args>
-        Cluster_factory_EcalEndcapPInsertClusters(Args&&... args)
-        : CalorimeterClusterRecoCoG_factoryT<Cluster_factory_EcalEndcapPInsertClusters>(std::forward<Args>(args)...) { }
-    };
+    using Cluster_factory_EcalEndcapPTruthClusters = CalorimeterClusterRecoCoG_factoryT<>;
+    using Cluster_factory_EcalEndcapPClusters = CalorimeterClusterRecoCoG_factoryT<>;
+    using Cluster_factory_EcalEndcapPInsertTruthClusters = CalorimeterClusterRecoCoG_factoryT<>;
+    using Cluster_factory_EcalEndcapPInsertClusters = CalorimeterClusterRecoCoG_factoryT<>;
 }
 
 extern "C" {

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -25,48 +25,12 @@
 #include "ProtoCluster_factory_LFHCALIslandProtoClusters.h"
 
 namespace eicrecon {
-    class Cluster_factory_HcalEndcapPTruthClusters: public CalorimeterClusterRecoCoG_factoryT<Cluster_factory_HcalEndcapPTruthClusters> {
-    public:
-        template <typename... Args>
-        Cluster_factory_HcalEndcapPTruthClusters(Args&&... args)
-        : CalorimeterClusterRecoCoG_factoryT<Cluster_factory_HcalEndcapPTruthClusters>(std::forward<Args>(args)...) { }
-    };
-
-    class Cluster_factory_HcalEndcapPClusters: public CalorimeterClusterRecoCoG_factoryT<Cluster_factory_HcalEndcapPClusters> {
-    public:
-        template <typename... Args>
-        Cluster_factory_HcalEndcapPClusters(Args&&... args)
-        : CalorimeterClusterRecoCoG_factoryT<Cluster_factory_HcalEndcapPClusters>(std::forward<Args>(args)...) { }
-    };
-
-    class Cluster_factory_HcalEndcapPInsertTruthClusters: public CalorimeterClusterRecoCoG_factoryT<Cluster_factory_HcalEndcapPInsertTruthClusters> {
-    public:
-        template <typename... Args>
-        Cluster_factory_HcalEndcapPInsertTruthClusters(Args&&... args)
-        : CalorimeterClusterRecoCoG_factoryT<Cluster_factory_HcalEndcapPInsertTruthClusters>(std::forward<Args>(args)...) { }
-    };
-
-    class Cluster_factory_HcalEndcapPInsertClusters: public CalorimeterClusterRecoCoG_factoryT<Cluster_factory_HcalEndcapPInsertClusters> {
-    public:
-        template <typename... Args>
-        Cluster_factory_HcalEndcapPInsertClusters(Args&&... args)
-        : CalorimeterClusterRecoCoG_factoryT<Cluster_factory_HcalEndcapPInsertClusters>(std::forward<Args>(args)...) { }
-    };
-
-    class Cluster_factory_LFHCALTruthClusters: public CalorimeterClusterRecoCoG_factoryT<Cluster_factory_LFHCALTruthClusters> {
-    public:
-        template <typename... Args>
-        Cluster_factory_LFHCALTruthClusters(Args&&... args)
-        : CalorimeterClusterRecoCoG_factoryT<Cluster_factory_LFHCALTruthClusters>(std::forward<Args>(args)...) { }
-    };
-
-    class Cluster_factory_LFHCALClusters: public CalorimeterClusterRecoCoG_factoryT<Cluster_factory_LFHCALClusters> {
-    public:
-        template <typename... Args>
-        Cluster_factory_LFHCALClusters(Args&&... args)
-        : CalorimeterClusterRecoCoG_factoryT<Cluster_factory_LFHCALClusters>(std::forward<Args>(args)...) { }
-    };
-
+    using Cluster_factory_HcalEndcapPTruthClusters =  CalorimeterClusterRecoCoG_factoryT<>;
+    using Cluster_factory_HcalEndcapPClusters = CalorimeterClusterRecoCoG_factoryT<>;
+    using Cluster_factory_HcalEndcapPInsertTruthClusters =  CalorimeterClusterRecoCoG_factoryT<>;
+    using Cluster_factory_HcalEndcapPInsertClusters =  CalorimeterClusterRecoCoG_factoryT<>;
+    using Cluster_factory_LFHCALTruthClusters = CalorimeterClusterRecoCoG_factoryT<>;
+    using Cluster_factory_LFHCALClusters = CalorimeterClusterRecoCoG_factoryT<>;
 }
 
 extern "C" {

--- a/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
+++ b/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
@@ -13,19 +13,8 @@
 #include "ProtoCluster_factory_EcalLumiSpecIslandProtoClusters.h"
 
 namespace eicrecon {
-    class Cluster_factory_EcalLumiSpecTruthClusters: public CalorimeterClusterRecoCoG_factoryT<Cluster_factory_EcalLumiSpecTruthClusters> {
-    public:
-        template <typename... Args>
-        Cluster_factory_EcalLumiSpecTruthClusters(Args&&... args)
-        : CalorimeterClusterRecoCoG_factoryT<Cluster_factory_EcalLumiSpecTruthClusters>(std::forward<Args>(args)...) { }
-    };
-
-    class Cluster_factory_EcalLumiSpecClusters: public CalorimeterClusterRecoCoG_factoryT<Cluster_factory_EcalLumiSpecClusters> {
-    public:
-        template <typename... Args>
-        Cluster_factory_EcalLumiSpecClusters(Args&&... args)
-        : CalorimeterClusterRecoCoG_factoryT<Cluster_factory_EcalLumiSpecClusters>(std::forward<Args>(args)...) { }
-    };
+    using Cluster_factory_EcalLumiSpecTruthClusters = CalorimeterClusterRecoCoG_factoryT<>;
+    using Cluster_factory_EcalLumiSpecClusters = CalorimeterClusterRecoCoG_factoryT<>;
 }
 
 extern "C" {

--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -14,19 +14,8 @@
 
 
 namespace eicrecon {
-    class Cluster_factory_ZDCEcalTruthClusters: public CalorimeterClusterRecoCoG_factoryT<Cluster_factory_ZDCEcalTruthClusters> {
-    public:
-        template <typename... Args>
-        Cluster_factory_ZDCEcalTruthClusters(Args&&... args)
-        : CalorimeterClusterRecoCoG_factoryT<Cluster_factory_ZDCEcalTruthClusters>(std::forward<Args>(args)...) { }
-    };
-
-    class Cluster_factory_ZDCEcalClusters: public CalorimeterClusterRecoCoG_factoryT<Cluster_factory_ZDCEcalClusters> {
-    public:
-        template <typename... Args>
-        Cluster_factory_ZDCEcalClusters(Args&&... args)
-        : CalorimeterClusterRecoCoG_factoryT<Cluster_factory_ZDCEcalClusters>(std::forward<Args>(args)...) { }
-    };
+    using Cluster_factory_ZDCEcalTruthClusters = CalorimeterClusterRecoCoG_factoryT<>;
+    using Cluster_factory_ZDCEcalClusters = CalorimeterClusterRecoCoG_factoryT<>;
 }
 
 extern "C" {

--- a/src/factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h
+++ b/src/factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h
@@ -12,13 +12,15 @@
 
 namespace eicrecon {
 
-template<class T>
+// variadic template parameter T unused
+template<template<typename> typename... T>
 class CalorimeterClusterRecoCoG_factoryT :
     public JChainMultifactoryT<CalorimeterClusterRecoCoGConfig>,
-    public SpdlogMixin<T> {
+    public SpdlogMixin<CalorimeterClusterRecoCoG_factoryT<T...>>,
+    public T<CalorimeterClusterRecoCoG_factoryT<T...>>... {
 
   public:
-    using SpdlogMixin<T>::logger;
+    using SpdlogMixin<CalorimeterClusterRecoCoG_factoryT>::logger;
 
     explicit CalorimeterClusterRecoCoG_factoryT(
         std::string tag,
@@ -47,7 +49,7 @@ class CalorimeterClusterRecoCoG_factoryT :
         m_detector = geoSvc->detector();
 
         // SpdlogMixin logger initialization, sets m_log
-        SpdlogMixin<T>::InitLogger(JChainMultifactoryT<CalorimeterClusterRecoCoGConfig>::GetPrefix(), "info");
+        SpdlogMixin<CalorimeterClusterRecoCoG_factoryT>::InitLogger(JChainMultifactoryT<CalorimeterClusterRecoCoGConfig>::GetPrefix(), "info");
 
         // Algorithm configuration
         auto cfg = GetDefaultConfig();


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The wordiness of the current factory-factory,
```cpp
class Cluster_factory_EcalBarrelSciGlassTruthClusters :
  public CalorimeterClusterRecoCoG_factoryT<Cluster_factory_EcalBarrelSciGlassTruthClusters>
{
  public:
    template <typename... Args>
    Cluster_factory_EcalBarrelSciGlassTruthClusters(Args&&... args)
    :  CalorimeterClusterRecoCoG_factoryT<Cluster_factory_EcalBarrelSciGlassTruthClusters>(std::forward<Args>(args)...)
      { }
};
```
has been bothering me since #666. This always seemed like it should be possible to express it more elegantly, with a `using` or so.

However, the naive approach
```cpp
using Cluster_factory_EcalBarrelSciGlassTruthClusters =
CalorimeterClusterRecoCoG_factoryT<Cluster_factory_EcalBarrelSciGlassTruthClusters>;
```
fails out of the gate since you can't use the lhs in the rhs.

This PR introduces an approach that does allow the `using` approach to work, and it actually makes it even snappier:
```cpp
using Cluster_factory_EcalBarrelSciGlassTruthClusters = CalorimeterClusterRecoCoG_factoryT<>;
```
(because why repeat yourself).

This doesn't fix #628...

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @veprbl @nathanwbrei 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.