### PR TITLE
feat: convert calorimetry JFactoryT to JChainFactoryT

### DIFF
--- a/src/detectors/B0ECAL/B0ECAL.cc
+++ b/src/detectors/B0ECAL/B0ECAL.cc
@@ -3,6 +3,7 @@
 //
 //
 
+#include <extensions/jana/JChainFactoryGeneratorT.h>
 #include <extensions/jana/JChainMultifactoryGeneratorT.h>
 
 #include <factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h>
@@ -26,10 +27,18 @@ extern "C" {
 
         InitJANAPlugin(app);
 
-        app->Add(new JFactoryGeneratorT<RawCalorimeterHit_factory_B0ECalRawHits>());
-        app->Add(new JFactoryGeneratorT<CalorimeterHit_factory_B0ECalRecHits>());
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_B0ECalTruthProtoClusters>());
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_B0ECalIslandProtoClusters>());
+        app->Add(new JChainFactoryGeneratorT<RawCalorimeterHit_factory_B0ECalRawHits>(
+          {"B0ECalHits"}, "B0ECalRawHits"
+        ));
+        app->Add(new JChainFactoryGeneratorT<CalorimeterHit_factory_B0ECalRecHits>(
+          {"B0ECalRawHits"}, "B0ECalRecHits"
+        ));
+        app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_B0ECalTruthProtoClusters>(
+          {"B0ECalRecHits"}, "B0ECalTruthProtoClusters"
+        ));
+        app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_B0ECalIslandProtoClusters>(
+          {"B0ECalRecHits"}, "B0ECalIslandProtoClusters"
+        ));
 
         app->Add(
           new JChainMultifactoryGeneratorT<Cluster_factory_B0ECalClusters>(

--- a/src/detectors/B0ECAL/B0ECAL.cc
+++ b/src/detectors/B0ECAL/B0ECAL.cc
@@ -34,7 +34,7 @@ extern "C" {
           {"B0ECalRawHits"}, "B0ECalRecHits"
         ));
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_B0ECalTruthProtoClusters>(
-          {"B0ECalRecHits"}, "B0ECalTruthProtoClusters"
+          {"B0ECalRecHits", "B0ECalHits"}, "B0ECalTruthProtoClusters"
         ));
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_B0ECalIslandProtoClusters>(
           {"B0ECalRecHits"}, "B0ECalIslandProtoClusters"

--- a/src/detectors/B0ECAL/CalorimeterHit_factory_B0ECalRecHits.h
+++ b/src/detectors/B0ECAL/CalorimeterHit_factory_B0ECalRecHits.h
@@ -4,18 +4,18 @@
 
 #include <edm4eic/CalorimeterHitCollection.h>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <algorithms/calorimetry/CalorimeterHitReco.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class CalorimeterHit_factory_B0ECalRecHits : public eicrecon::JFactoryPodioT<edm4eic::CalorimeterHit>, CalorimeterHitReco {
+class CalorimeterHit_factory_B0ECalRecHits : public JChainFactoryT<edm4eic::CalorimeterHit>, CalorimeterHitReco {
 
 public:
     //------------------------------------------
     // Constructor
-    CalorimeterHit_factory_B0ECalRecHits(){
-        SetTag("B0ECalRecHits");
+    CalorimeterHit_factory_B0ECalRecHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::CalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -24,7 +24,6 @@ public:
     void Init() override{
         auto app = GetApplication();
 
-        m_input_tag = "B0ECalRawHits";
 
         // digitization settings, must be consistent with digi class
         m_capADC=16384;//{this, "capacityADC", 8096};
@@ -49,7 +48,6 @@ public:
         m_localDetElement="";         // from ATHENA's reconstruction.py (i.e. not defined there)
         u_localDetFields={};          // from ATHENA's reconstruction.py (i.e. not defined there)
 
-        app->SetDefaultParameter("B0ECAL:B0ECalRecHits:input_tag",        m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("B0ECAL:B0ECalRecHits:capacityADC",      m_capADC);
         app->SetDefaultParameter("B0ECAL:B0ECalRecHits:dynamicRangeADC",  m_dyRangeADC);
         app->SetDefaultParameter("B0ECAL:B0ECalRecHits:pedestalMean",     m_pedMeanADC);

--- a/src/detectors/B0ECAL/CalorimeterHit_factory_B0ECalRecHits.h
+++ b/src/detectors/B0ECAL/CalorimeterHit_factory_B0ECalRecHits.h
@@ -22,8 +22,9 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        InitDataTags(GetPluginName() + ":" + GetTag());
 
+        auto app = GetApplication();
 
         // digitization settings, must be consistent with digi class
         m_capADC=16384;//{this, "capacityADC", 8096};

--- a/src/detectors/B0ECAL/CalorimeterHit_factory_B0ECalRecHits.h
+++ b/src/detectors/B0ECAL/CalorimeterHit_factory_B0ECalRecHits.h
@@ -78,7 +78,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        rawhits = event->Get<edm4hep::RawCalorimeterHit>(m_input_tag);
+        rawhits = event->Get<edm4hep::RawCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/B0ECAL/ProtoCluster_factory_B0ECalIslandProtoClusters.h
+++ b/src/detectors/B0ECAL/ProtoCluster_factory_B0ECalIslandProtoClusters.h
@@ -82,7 +82,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        hits = event->Get<edm4eic::CalorimeterHit>(m_input_tag);
+        hits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/B0ECAL/ProtoCluster_factory_B0ECalIslandProtoClusters.h
+++ b/src/detectors/B0ECAL/ProtoCluster_factory_B0ECalIslandProtoClusters.h
@@ -6,19 +6,19 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterIslandCluster.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class ProtoCluster_factory_B0ECalIslandProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, CalorimeterIslandCluster {
+class ProtoCluster_factory_B0ECalIslandProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, CalorimeterIslandCluster {
 
 public:
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_B0ECalIslandProtoClusters(){
-        SetTag("B0ECalIslandProtoClusters");
+    ProtoCluster_factory_B0ECalIslandProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -26,7 +26,6 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_input_tag = "B0ECalRecHits";
 
         // adjacency matrix
         m_geoSvcName = "GeoSvc";
@@ -51,7 +50,6 @@ public:
         u_transverseEnergyProfileMetric = "globalDistEtaPhi";
         u_transverseEnergyProfileScale = 1.;
 
-        app->SetDefaultParameter("B0ECAL:B0ECalIslandProtoClusters:input_tag",        m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("B0ECAL:B0ECalIslandProtoClusters:geoServiceName", m_geoSvcName);
         app->SetDefaultParameter("B0ECAL:B0ECalIslandProtoClusters:readoutClass", m_readout);
         app->SetDefaultParameter("B0ECAL:B0ECalIslandProtoClusters:sectorDist",   m_sectorDist);

--- a/src/detectors/B0ECAL/ProtoCluster_factory_B0ECalIslandProtoClusters.h
+++ b/src/detectors/B0ECAL/ProtoCluster_factory_B0ECalIslandProtoClusters.h
@@ -25,6 +25,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         // adjacency matrix

--- a/src/detectors/B0ECAL/ProtoCluster_factory_B0ECalTruthProtoClusters.h
+++ b/src/detectors/B0ECAL/ProtoCluster_factory_B0ECalTruthProtoClusters.h
@@ -8,19 +8,19 @@
 
 #include <edm4eic/ProtoClusterCollection.h>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterTruthClustering.h>
 
 
 
-class ProtoCluster_factory_B0ECalTruthProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
+class ProtoCluster_factory_B0ECalTruthProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
 
 public:
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_B0ECalTruthProtoClusters(){
-        SetTag("B0ECalTruthProtoClusters");
+    ProtoCluster_factory_B0ECalTruthProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -28,10 +28,7 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_inputHit_tag="B0ECalRecHits";
-        m_inputMCHit_tag="B0ECalHits";
 
-        app->SetDefaultParameter("EEMC:B0ECalTruthProtoClusters:inputHit_tag",        m_inputHit_tag, "Name of input collection to use");
 
         AlgorithmInit(m_log);
     }
@@ -46,8 +43,8 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        m_inputHits = event->Get<edm4eic::CalorimeterHit>(m_inputHit_tag);
-        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(m_inputMCHit_tag);
+        m_inputHits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
+        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[1]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();
@@ -59,6 +56,4 @@ public:
 
 private:
     // Name of input data type (collection)
-    std::string              m_inputHit_tag;
-    std::string              m_inputMCHit_tag;
 };

--- a/src/detectors/B0ECAL/ProtoCluster_factory_B0ECalTruthProtoClusters.h
+++ b/src/detectors/B0ECAL/ProtoCluster_factory_B0ECalTruthProtoClusters.h
@@ -27,8 +27,9 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        InitDataTags(GetPluginName() + ":" + GetTag());
 
+        auto app = GetApplication();
 
         AlgorithmInit(m_log);
     }

--- a/src/detectors/B0ECAL/ProtoCluster_factory_B0ECalTruthProtoClusters.h
+++ b/src/detectors/B0ECAL/ProtoCluster_factory_B0ECalTruthProtoClusters.h
@@ -53,7 +53,4 @@ public:
         Set(m_outputProtoClusters);
         m_outputProtoClusters.clear(); // not really needed, but better to not leave dangling pointers around
     }
-
-private:
-    // Name of input data type (collection)
 };

--- a/src/detectors/B0ECAL/ProtoCluster_factory_B0ECalTruthProtoClusters.h
+++ b/src/detectors/B0ECAL/ProtoCluster_factory_B0ECalTruthProtoClusters.h
@@ -29,8 +29,6 @@ public:
     void Init() override{
         InitDataTags(GetPluginName() + ":" + GetTag());
 
-        auto app = GetApplication();
-
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/B0ECAL/RawCalorimeterHit_factory_B0ECalRawHits.h
+++ b/src/detectors/B0ECAL/RawCalorimeterHit_factory_B0ECalRawHits.h
@@ -12,7 +12,7 @@
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JEvent.h>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterHitDigi.h>
 #include <services/log/Log_service.h>
@@ -20,14 +20,14 @@
 
 
 
-class RawCalorimeterHit_factory_B0ECalRawHits : public eicrecon::JFactoryPodioT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
+class RawCalorimeterHit_factory_B0ECalRawHits : public JChainFactoryT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
 
 public:
 
     //------------------------------------------
     // Constructor
-    RawCalorimeterHit_factory_B0ECalRawHits() {
-        SetTag("B0ECalRawHits");
+    RawCalorimeterHit_factory_B0ECalRawHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4hep::RawCalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -37,7 +37,6 @@ public:
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
-        m_input_tag = "B0ECalHits";
         u_eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV};
         m_tRes = 0.0 * dd4hep::ns;
         m_capADC = 16384;
@@ -54,7 +53,6 @@ public:
 
 
         // This is another option for exposing the data members as JANA configuration parameters.
-        app->SetDefaultParameter("B0ECAL:B0ECalRawHits:input_tag",        m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("B0ECAL:B0ECalRawHits:energyResolutions",u_eRes);
         app->SetDefaultParameter("B0ECAL:B0ECalRawHits:timeResolution",   m_tRes);
         app->SetDefaultParameter("B0ECAL:B0ECalRawHits:capacityADC",      m_capADC);

--- a/src/detectors/B0ECAL/RawCalorimeterHit_factory_B0ECalRawHits.h
+++ b/src/detectors/B0ECAL/RawCalorimeterHit_factory_B0ECalRawHits.h
@@ -34,6 +34,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override {
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm

--- a/src/detectors/B0ECAL/RawCalorimeterHit_factory_B0ECalRawHits.h
+++ b/src/detectors/B0ECAL/RawCalorimeterHit_factory_B0ECalRawHits.h
@@ -81,7 +81,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override {
         // Prefill inputs
-        simhits = event->Get<edm4hep::SimCalorimeterHit>(m_input_tag);
+        simhits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/B0ECAL/TruthCluster_factory_B0ECalTruthProtoClusters.h
+++ b/src/detectors/B0ECAL/TruthCluster_factory_B0ECalTruthProtoClusters.h
@@ -25,8 +25,6 @@ public:
     void Init() override{
         InitDataTags(GetPluginName() + ":" + GetTag());
 
-        auto app = GetApplication();
-
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/B0ECAL/TruthCluster_factory_B0ECalTruthProtoClusters.h
+++ b/src/detectors/B0ECAL/TruthCluster_factory_B0ECalTruthProtoClusters.h
@@ -38,8 +38,8 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        m_inputHits = event->Get<edm4eic::CalorimeterHit>(m_input_tags[0]);
-        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(m_input_tags[1]);
+        m_inputHits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0][0]);
+        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[0][1]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/B0ECAL/TruthCluster_factory_B0ECalTruthProtoClusters.h
+++ b/src/detectors/B0ECAL/TruthCluster_factory_B0ECalTruthProtoClusters.h
@@ -6,17 +6,17 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterTruthClustering.h>
 
-class TruthCluster_factory_B0ECalTruthProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
+class TruthCluster_factory_B0ECalTruthProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
 
 public:
     //------------------------------------------
     // Constructor
-    TruthCluster_factory_B0ECalTruthProtoClusters(){
-        SetTag("B0ECalTruthProtoClusters");
+    TruthCluster_factory_B0ECalTruthProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -24,10 +24,6 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_inputHit_tag = "B0ECalTruthProtoClusters";
-        m_inputMCHit_tag = "B0ECalHits";
-
-        app->SetDefaultParameter("EEMC:B0ECalTruthProtoClusters:inputHit_tag",        m_inputHit_tag, "Name of input collection to use");
 
         AlgorithmInit(m_log);
     }
@@ -42,8 +38,8 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        m_inputHits = event->Get<edm4eic::CalorimeterHit>(m_inputHit_tag);
-        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(m_inputMCHit_tag);
+        m_inputHits = event->Get<edm4eic::CalorimeterHit>(m_input_tags[0]);
+        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(m_input_tags[1]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();
@@ -52,10 +48,4 @@ public:
         Set(m_outputProtoClusters);
         m_outputProtoClusters.clear(); // not really needed, but better to not leave dangling pointers around
     }
-
-private:
-    // Name of input data type (collection)
-    std::string              m_inputHit_tag;
-    std::string              m_inputMCHit_tag;
-
 };

--- a/src/detectors/B0ECAL/TruthCluster_factory_B0ECalTruthProtoClusters.h
+++ b/src/detectors/B0ECAL/TruthCluster_factory_B0ECalTruthProtoClusters.h
@@ -23,6 +23,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         AlgorithmInit(m_log);

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -144,7 +144,10 @@ extern "C" {
           )
         );
         app->Add(new JChainFactoryGeneratorT<Cluster_factory_EcalBarrelSciGlassMergedTruthClusters>(
-          {},
+          {
+            "EcalBarrelSciGlassTruthClusters",
+            "EcalBarrelSciGlassTruthClusterAssociations"
+          },
 	  "EcalBarrelSciGlassMergedTruthCluster"
 	));
     }

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -110,10 +110,13 @@ extern "C" {
           {"EcalBarrelImagingProtoClusters"}, "EcalBarrelImagingClusters"
         ));
         app->Add(new JChainFactoryGeneratorT<Cluster_factory_EcalBarrelImagingMergedClusters>(
-          {"EcalBarrelImagingClusters",
+          {
+            "MCParticles",
             "EcalBarrelScFiClusters",
-            "EcalBarrelImagingClusterAssociations",
-            "EcalBarrelScFiClusterAssociations"},
+            "EcalBarrelScFiClusterAssociations",
+            "EcalBarrelImagingClusters",
+            "EcalBarrelImagingClusterAssociations"
+          },
           "EcalBarrelImagingMergedClusters"
         ));
 

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -3,6 +3,7 @@
 //
 //
 
+#include <extensions/jana/JChainFactoryGeneratorT.h>
 #include <extensions/jana/JChainMultifactoryGeneratorT.h>
 
 #include <factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h>
@@ -38,9 +39,15 @@ extern "C" {
 
         InitJANAPlugin(app);
 
-        app->Add(new JFactoryGeneratorT<RawCalorimeterHit_factory_EcalBarrelSciGlassRawHits>());
-        app->Add(new JFactoryGeneratorT<CalorimeterHit_factory_EcalBarrelSciGlassRecHits>());
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_EcalBarrelSciGlassProtoClusters>());
+        app->Add(new JChainFactoryGeneratorT<RawCalorimeterHit_factory_EcalBarrelSciGlassRawHits>(
+          {"EcalBarrelSciGlassHits"}, "EcalBarrelSciGlassRawHits"
+        ));
+        app->Add(new JChainFactoryGeneratorT<CalorimeterHit_factory_EcalBarrelSciGlassRecHits>(
+          {"EcalBarrelSciGlassRawHits"}, "EcalBarrelSciGlassRecHits"
+        ));
+        app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_EcalBarrelSciGlassProtoClusters>(
+          {"EcalBarrelSciGlassRecHits"}, "EcalBarrelSciGlassProtoClusters"
+        ));
         app->Add(
           new JChainMultifactoryGeneratorT<Cluster_factory_EcalBarrelSciGlassClusters>(
              "EcalBarrelSciGlassClusters",
@@ -61,9 +68,15 @@ extern "C" {
         );
 
 
-        app->Add(new JFactoryGeneratorT<RawCalorimeterHit_factory_EcalBarrelScFiRawHits>());
-        app->Add(new JFactoryGeneratorT<CalorimeterHit_factory_EcalBarrelScFiRecHits>());
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_EcalBarrelScFiProtoClusters>());
+        app->Add(new JChainFactoryGeneratorT<RawCalorimeterHit_factory_EcalBarrelScFiRawHits>(
+          {"EcalBarrelScFiHits"}, "EcalBarrelScFiRawHits"
+        ));
+        app->Add(new JChainFactoryGeneratorT<CalorimeterHit_factory_EcalBarrelScFiRecHits>(
+          {"EcalBarrelScFiRawHits"}, "EcalBarrelScFiRecHits"
+        ));
+        app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_EcalBarrelScFiProtoClusters>(
+          {"EcalBarrelScFiRecHits"}, "EcalBarrelScFiProtoClusters"
+        ));
         app->Add(
           new JChainMultifactoryGeneratorT<Cluster_factory_EcalBarrelScFiClusters>(
              "EcalBarrelScFiClusters",
@@ -83,18 +96,35 @@ extern "C" {
           )
         );
 
-        app->Add(new JFactoryGeneratorT<RawCalorimeterHit_factory_EcalBarrelImagingRawHits>());
-        app->Add(new JFactoryGeneratorT<CalorimeterHit_factory_EcalBarrelImagingRecHits>());
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_EcalBarrelImagingProtoClusters>());
+        app->Add(new JChainFactoryGeneratorT<RawCalorimeterHit_factory_EcalBarrelImagingRawHits>(
+          {"EcalBarrelImagingHits"}, "EcalBarrelImagingRawHits"
+        ));
+        app->Add(new JChainFactoryGeneratorT<CalorimeterHit_factory_EcalBarrelImagingRecHits>(
+          {"EcalBarrelImagingRawHits"}, "EcalBarrelImagingRecHits"
+        ));
+        app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_EcalBarrelImagingProtoClusters>(
+          {"EcalBarrelImagingRecHits"}, "EcalBarrelImagingProtoClusters"
+        ));
 
-        app->Add(new JFactoryGeneratorT<Cluster_factory_EcalBarrelImagingClusters>());
-        app->Add(new JFactoryGeneratorT<Cluster_factory_EcalBarrelImagingMergedClusters>());
+        app->Add(new JChainFactoryGeneratorT<Cluster_factory_EcalBarrelImagingClusters>(
+          {"EcalBarrelImagingProtoClusters"}, "EcalBarrelImagingClusters"
+        ));
+        app->Add(new JChainFactoryGeneratorT<Cluster_factory_EcalBarrelImagingMergedClusters>(
+          {"EcalBarrelImagingClusters",
+            "EcalBarrelScFiClusters",
+            "EcalBarrelImagingClusterAssociations",
+            "EcalBarrelScFiClusterAssociations"},
+          "EcalBarrelImagingMergedClusters"
+        ));
 
         // Inserted types (so they can be written to output podio file)
         app->Add(new JFactoryGeneratorT<JFactoryT<edm4eic::Cluster>>("EcalBarrelImagingLayers"));
         app->Add(new JFactoryGeneratorT<JFactoryT<edm4eic::MCRecoClusterParticleAssociation>>("EcalBarrelImagingClusterAssociations"));
 
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_EcalBarrelSciGlassTruthProtoClusters>());
+        app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_EcalBarrelSciGlassTruthProtoClusters>(
+	    {},
+	    "EcalBarrelSciGlassTruthProtoClusters"
+	));
         app->Add(
           new JChainMultifactoryGeneratorT<Cluster_factory_EcalBarrelSciGlassTruthClusters>(
              "EcalBarrelSciGlassTruthClusters",
@@ -113,6 +143,9 @@ extern "C" {
             app   // TODO: Remove me once fixed
           )
         );
-        app->Add(new JFactoryGeneratorT<Cluster_factory_EcalBarrelSciGlassMergedTruthClusters>());
+        app->Add(new JChainFactoryGeneratorT<Cluster_factory_EcalBarrelSciGlassMergedTruthClusters>(
+          {},
+	  "EcalBarrelSciGlassMergedTruthCluster"
+	));
     }
 }

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -122,7 +122,10 @@ extern "C" {
         app->Add(new JFactoryGeneratorT<JFactoryT<edm4eic::MCRecoClusterParticleAssociation>>("EcalBarrelImagingClusterAssociations"));
 
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_EcalBarrelSciGlassTruthProtoClusters>(
-	    {},
+	    {
+              "EcalBarrelSciGlassRecHits",
+              "EcalBarrelSciGlassHits",
+            },
 	    "EcalBarrelSciGlassTruthProtoClusters"
 	));
         app->Add(

--- a/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelImagingRecHits.h
+++ b/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelImagingRecHits.h
@@ -1,13 +1,13 @@
 
 #pragma once
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 
 #include <algorithms/calorimetry/ImagingPixelReco.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class CalorimeterHit_factory_EcalBarrelImagingRecHits : public eicrecon::JFactoryPodioT<edm4eic::CalorimeterHit>, ImagingPixelReco {
+class CalorimeterHit_factory_EcalBarrelImagingRecHits : public JChainFactoryT<edm4eic::CalorimeterHit>, ImagingPixelReco {
 
 public:
 
@@ -16,8 +16,8 @@ public:
 
     //------------------------------------------
     // Constructor
-    CalorimeterHit_factory_EcalBarrelImagingRecHits(){
-        SetTag("EcalBarrelImagingRecHits");
+    CalorimeterHit_factory_EcalBarrelImagingRecHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::CalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -40,7 +40,6 @@ public:
         // Calibration!
         m_sampFrac=0.00619766;// from ${DETECTOR_PATH}/calibrations/emcal_barrel_calibration.json
 
-        app->SetDefaultParameter("BEMC:EcalBarrelImagingRecHits:input_tag",        m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelImagingRecHits:layerField",       m_layerField);
         app->SetDefaultParameter("BEMC:EcalBarrelImagingRecHits:sectorField",      m_sectorField);
         app->SetDefaultParameter("BEMC:EcalBarrelImagingRecHits:capacityADC",      m_capADC);

--- a/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelImagingRecHits.h
+++ b/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelImagingRecHits.h
@@ -24,6 +24,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         m_readout = "EcalBarrelImagingHits";

--- a/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelImagingRecHits.h
+++ b/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelImagingRecHits.h
@@ -10,10 +10,6 @@
 class CalorimeterHit_factory_EcalBarrelImagingRecHits : public JChainFactoryT<edm4eic::CalorimeterHit>, ImagingPixelReco {
 
 public:
-
-    std::string m_input_tag  = "EcalBarrelImagingRawHits";
-
-
     //------------------------------------------
     // Constructor
     CalorimeterHit_factory_EcalBarrelImagingRecHits(std::vector<std::string> default_input_tags)
@@ -60,7 +56,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        m_inputHits = event->Get<edm4hep::RawCalorimeterHit>(m_input_tag);
+        m_inputHits = event->Get<edm4hep::RawCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         execute();

--- a/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelScFiMergedHits.h
+++ b/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelScFiMergedHits.h
@@ -44,7 +44,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        m_inputs = event->Get<edm4eic::CalorimeterHit>(m_input_tag);
+        m_inputs = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         execute();

--- a/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelScFiMergedHits.h
+++ b/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelScFiMergedHits.h
@@ -1,19 +1,19 @@
 
 #pragma once
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 
 #include <algorithms/calorimetry/CalorimeterHitsMerger.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class CalorimeterHit_factory_EcalBarrelScFiMergedHits : public eicrecon::JFactoryPodioT<edm4eic::CalorimeterHit>, CalorimeterHitsMerger {
+class CalorimeterHit_factory_EcalBarrelScFiMergedHits : public JChainFactoryT<edm4eic::CalorimeterHit>, CalorimeterHitsMerger {
 
 public:
     //------------------------------------------
     // Constructor
-    CalorimeterHit_factory_EcalBarrelScFiMergedHits(){
-        SetTag("EcalBarrelScFiMergedHits");
+    CalorimeterHit_factory_EcalBarrelScFiMergedHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::CalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -23,7 +23,6 @@ public:
         auto app = GetApplication();
         m_log = app->GetService<Log_service>()->logger(GetTag());
 
-        m_input_tag = "EcalBarrelScFiRecHits";
 
         m_readout="EcalBarrelScFiHits";
         u_fields={"fiber","z"};
@@ -31,7 +30,6 @@ public:
 
         m_geoSvc= app->GetService<JDD4hep_service>();
 
-        app->SetDefaultParameter("BEMC:EcalBarrelscFiMergedHits:input_tag", m_input_tag);
         app->SetDefaultParameter("BEMC:EcalBarrelscFiMergedHits:fields", u_fields);
         app->SetDefaultParameter("BEMC:EcalBarrelscFiMergedHits:refs",  u_refs);
 

--- a/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelScFiMergedHits.h
+++ b/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelScFiMergedHits.h
@@ -53,7 +53,4 @@ public:
         Set(m_outputs);
         m_outputs.clear(); // not really needed, but better to not leave dangling pointers around
     }
-
-private:
-    std::string m_input_tag;
 };

--- a/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelScFiMergedHits.h
+++ b/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelScFiMergedHits.h
@@ -20,6 +20,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
         m_log = app->GetService<Log_service>()->logger(GetTag());
 

--- a/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelScFiRecHits.h
+++ b/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelScFiRecHits.h
@@ -20,8 +20,9 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        InitDataTags(GetPluginName() + ":" + GetTag());
 
+        auto app = GetApplication();
 
         // digitization settings, must be consistent with digi class
         m_capADC=16384;//{this, "capacityADC", 8096};

--- a/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelScFiRecHits.h
+++ b/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelScFiRecHits.h
@@ -80,7 +80,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        rawhits = event->Get<edm4hep::RawCalorimeterHit>(m_input_tag);
+        rawhits = event->Get<edm4hep::RawCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelScFiRecHits.h
+++ b/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelScFiRecHits.h
@@ -1,19 +1,19 @@
 
 #pragma once
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 
 #include <algorithms/calorimetry/CalorimeterHitReco.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class CalorimeterHit_factory_EcalBarrelScFiRecHits : public eicrecon::JFactoryPodioT<edm4eic::CalorimeterHit>, CalorimeterHitReco {
+class CalorimeterHit_factory_EcalBarrelScFiRecHits : public JChainFactoryT<edm4eic::CalorimeterHit>, CalorimeterHitReco {
 
 public:
     //------------------------------------------
     // Constructor
-    CalorimeterHit_factory_EcalBarrelScFiRecHits(){
-        SetTag("EcalBarrelScFiRecHits");
+    CalorimeterHit_factory_EcalBarrelScFiRecHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::CalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -22,7 +22,6 @@ public:
     void Init() override{
         auto app = GetApplication();
 
-        m_input_tag = "EcalBarrelScFiRawHits";
 
         // digitization settings, must be consistent with digi class
         m_capADC=16384;//{this, "capacityADC", 8096};
@@ -53,8 +52,6 @@ public:
         u_maskPosFields = {"fiber", "z"};
 
 
-//        app->SetDefaultParameter("BEMC:tag",              m_input_tag);
-        app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:input_tag",        m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:readout",          m_readout );
         app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:layerField",       m_layerField );
         app->SetDefaultParameter("BEMC:EcalBarrelScFiRecHits:sectorField",      m_sectorField );

--- a/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelSciGlassRecHits.h
+++ b/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelSciGlassRecHits.h
@@ -20,8 +20,9 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        InitDataTags(GetPluginName() + ":" + GetTag());
 
+        auto app = GetApplication();
 
         // digitization settings, must be consistent with digi class
         m_capADC=16384;//{this, "capacityADC", 8096};

--- a/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelSciGlassRecHits.h
+++ b/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelSciGlassRecHits.h
@@ -1,19 +1,19 @@
 
 #pragma once
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 
 #include <algorithms/calorimetry/CalorimeterHitReco.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class CalorimeterHit_factory_EcalBarrelSciGlassRecHits : public eicrecon::JFactoryPodioT<edm4eic::CalorimeterHit>, CalorimeterHitReco {
+class CalorimeterHit_factory_EcalBarrelSciGlassRecHits : public JChainFactoryT<edm4eic::CalorimeterHit>, CalorimeterHitReco {
 
 public:
     //------------------------------------------
     // Constructor
-    CalorimeterHit_factory_EcalBarrelSciGlassRecHits(){
-        SetTag("EcalBarrelSciGlassRecHits");
+    CalorimeterHit_factory_EcalBarrelSciGlassRecHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::CalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -22,7 +22,6 @@ public:
     void Init() override{
         auto app = GetApplication();
 
-        m_input_tag = "EcalBarrelSciGlassRawHits";
 
         // digitization settings, must be consistent with digi class
         m_capADC=16384;//{this, "capacityADC", 8096};
@@ -47,8 +46,6 @@ public:
         m_localDetElement="";         // from ATHENA's reconstruction.py (i.e. not defined there)
         u_localDetFields={};          // from ATHENA's reconstruction.py (i.e. not defined there)
 
-//        app->SetDefaultParameter("BEMC:tag",              m_input_tag);
-        app->SetDefaultParameter("BEMC:EcalBarrelSciGlassRecHits:input_tag",        m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelSciGlassRecHits:capacityADC",      m_capADC);
         app->SetDefaultParameter("BEMC:EcalBarrelSciGlassRecHits:dynamicRangeADC",  m_dyRangeADC);
         app->SetDefaultParameter("BEMC:EcalBarrelSciGlassRecHits:pedestalMean",     m_pedMeanADC);

--- a/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelSciGlassRecHits.h
+++ b/src/detectors/BEMC/CalorimeterHit_factory_EcalBarrelSciGlassRecHits.h
@@ -70,7 +70,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        rawhits = event->Get<edm4hep::RawCalorimeterHit>(m_input_tag);
+        rawhits = event->Get<edm4hep::RawCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelImagingClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelImagingClusters.h
@@ -31,6 +31,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
         //-------- Configuration Parameters ------------
         m_input_simhit_tag="EcalBarrelImagingHits";

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelImagingClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelImagingClusters.h
@@ -6,7 +6,7 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/ImagingClusterReco.h>
 #include <services/log/Log_service.h>
@@ -14,7 +14,7 @@
 
 
 
-class Cluster_factory_EcalBarrelImagingClusters : public eicrecon::JFactoryPodioT<edm4eic::Cluster>, ImagingClusterReco {
+class Cluster_factory_EcalBarrelImagingClusters : public JChainFactoryT<edm4eic::Cluster>, ImagingClusterReco {
 
 public:
 
@@ -23,8 +23,8 @@ public:
 
     //------------------------------------------
     // Constructor
-    Cluster_factory_EcalBarrelImagingClusters(){
-        SetTag("EcalBarrelImagingClusters");
+    Cluster_factory_EcalBarrelImagingClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::Cluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelImagingMergedClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelImagingMergedClusters.h
@@ -5,20 +5,20 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/TruthEnergyPositionClusterMerger.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
 
-class Cluster_factory_EcalBarrelImagingMergedClusters : public eicrecon::JFactoryPodioT<edm4eic::Cluster>, TruthEnergyPositionClusterMerger {
+class Cluster_factory_EcalBarrelImagingMergedClusters : public JChainFactoryT<edm4eic::Cluster>, TruthEnergyPositionClusterMerger {
 
 public:
     //------------------------------------------
     // Constructor
-    Cluster_factory_EcalBarrelImagingMergedClusters(){
-        SetTag("EcalBarrelImagingMergedClusters");
+    Cluster_factory_EcalBarrelImagingMergedClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::Cluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelImagingMergedClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelImagingMergedClusters.h
@@ -26,18 +26,6 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        //-------- Configuration Parameters ------------
-        m_inputMCParticles_tag = "MCParticles";
-        m_energyClusters_tag = "EcalBarrelScFiClusters";
-        m_energyAssociation_tag = "EcalBarrelScFiClusterAssociations";
-        m_positionClusters_tag = "EcalBarrelImagingClusters";
-        m_positionAssociations_tag = "EcalBarrelImagingClusterAssociations";
-
-        app->SetDefaultParameter("BEMC:EcalBarrelImagingMergedClusters:inputMCParticles_tag", m_inputMCParticles_tag);
-        app->SetDefaultParameter("BEMC:EcalBarrelImagingMergedClusters:energyClusters_tag", m_energyClusters_tag);
-        app->SetDefaultParameter("BEMC:EcalBarrelImagingMergedClusters:energyAssociation_tag", m_energyAssociation_tag);
-        app->SetDefaultParameter("BEMC:EcalBarrelImagingMergedClusters:positionClusters_tag", m_positionClusters_tag);
-        app->SetDefaultParameter("BEMC:EcalBarrelImagingMergedClusters:positionAssociations_tag", m_positionAssociations_tag);
 
         initialize();
     }
@@ -48,11 +36,11 @@ public:
     void Process(const std::shared_ptr<const JEvent> &event) override{
 
         // Prefill inputs
-        m_inputMCParticles     = event->Get<edm4hep::MCParticle>(m_inputMCParticles_tag);;
-        m_energyClusters       = event->Get<edm4eic::Cluster>(m_energyClusters_tag);;
-        m_energyAssociations   = event->Get<edm4eic::MCRecoClusterParticleAssociation>(m_energyAssociation_tag);;
-        m_positionClusters     = event->Get<edm4eic::Cluster>(m_positionClusters_tag);;
-        m_positionAssociations = event->Get<edm4eic::MCRecoClusterParticleAssociation>(m_positionAssociations_tag);;
+        m_inputMCParticles     = event->Get<edm4hep::MCParticle>(GetInputTags()[0]);
+        m_energyClusters       = event->Get<edm4eic::Cluster>(GetInputTags()[1]);
+        m_energyAssociations   = event->Get<edm4eic::MCRecoClusterParticleAssociation>(GetInputTags()[2]);
+        m_positionClusters     = event->Get<edm4eic::Cluster>(GetInputTags()[3]);
+        m_positionAssociations = event->Get<edm4eic::MCRecoClusterParticleAssociation>(GetInputTags()[4]);
 
         // Call Process for generic algorithm
         execute();
@@ -63,12 +51,4 @@ public:
         m_outputClusters.clear(); // not really needed, but better to not leave dangling pointers around
         m_outputAssociations.clear();
     }
-
-private:
-    // Name of input data type (collection)
-    std::string m_inputMCParticles_tag;
-    std::string m_energyClusters_tag;
-    std::string m_energyAssociation_tag;
-    std::string m_positionClusters_tag;
-    std::string m_positionAssociations_tag;
 };

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelImagingMergedClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelImagingMergedClusters.h
@@ -27,8 +27,6 @@ public:
     void Init() override{
         InitDataTags(GetPluginName() + ":" + GetTag());
 
-        auto app = GetApplication();
-
         initialize();
     }
 

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelImagingMergedClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelImagingMergedClusters.h
@@ -25,6 +25,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         initialize();

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelSciGlassMergedTruthClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelSciGlassMergedTruthClusters.h
@@ -26,6 +26,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         std::string tag=this->GetTag();

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelSciGlassMergedTruthClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelSciGlassMergedTruthClusters.h
@@ -5,7 +5,7 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterClusterMerger.h>
 #include <services/log/Log_service.h>
@@ -13,13 +13,13 @@
 
 
 
-class Cluster_factory_EcalBarrelSciGlassMergedTruthClusters : public eicrecon::JFactoryPodioT<edm4eic::Cluster>, CalorimeterClusterMerger {
+class Cluster_factory_EcalBarrelSciGlassMergedTruthClusters : public JChainFactoryT<edm4eic::Cluster>, CalorimeterClusterMerger {
 
 public:
     //------------------------------------------
     // Constructor
-    Cluster_factory_EcalBarrelSciGlassMergedTruthClusters(){
-        SetTag("EcalBarrelSciGlassMergedTruthClusters");
+    Cluster_factory_EcalBarrelSciGlassMergedTruthClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::Cluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -34,7 +34,6 @@ public:
         std::string tag=this->GetTag();
         std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
 
-        app->SetDefaultParameter("BEMC:EcalBarrelMergedSciGlassTruthClusters:input_tag", m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelMergedSciGlassTruthClusters:inputAssociations_tag", m_inputAssociations_tag);
 
         AlgorithmInit(m_log);

--- a/src/detectors/BEMC/Cluster_factory_EcalBarrelSciGlassMergedTruthClusters.h
+++ b/src/detectors/BEMC/Cluster_factory_EcalBarrelSciGlassMergedTruthClusters.h
@@ -27,14 +27,9 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        //-------- Configuration Parameters ------------
-        m_input_tag="EcalBarrelSciGlassTruthClusters";
-        m_inputAssociations_tag="EcalBarrelSciGlassTruthClusterAssociations";
 
         std::string tag=this->GetTag();
         std::shared_ptr<spdlog::logger> m_log = app->GetService<Log_service>()->logger(tag);
-
-        app->SetDefaultParameter("BEMC:EcalBarrelMergedSciGlassTruthClusters:inputAssociations_tag", m_inputAssociations_tag);
 
         AlgorithmInit(m_log);
     }
@@ -51,8 +46,8 @@ public:
 
 
         // Prefill inputs
-        m_inputClusters=event->Get<edm4eic::Cluster>(m_input_tag);
-        m_inputAssociations=event->Get<edm4eic::MCRecoClusterParticleAssociation>(m_inputAssociations_tag);
+        m_inputClusters=event->Get<edm4eic::Cluster>(GetInputTags()[0]);
+        m_inputAssociations=event->Get<edm4eic::MCRecoClusterParticleAssociation>(GetInputTags()[1]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();
@@ -64,9 +59,4 @@ public:
         m_outputClusters.clear(); // not really needed, but better to not leave dangling pointers around
         m_outputAssociations.clear();
     }
-
-private:
-    // Name of input data type (collection)
-    std::string              m_input_tag;
-    std::string              m_inputAssociations_tag;
 };

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelImagingProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelImagingProtoClusters.h
@@ -6,13 +6,13 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/ImagingTopoCluster.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class ProtoCluster_factory_EcalBarrelImagingProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, ImagingTopoCluster {
+class ProtoCluster_factory_EcalBarrelImagingProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, ImagingTopoCluster {
 
 public:
 
@@ -20,8 +20,8 @@ public:
 
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_EcalBarrelImagingProtoClusters(){
-        SetTag("EcalBarrelImagingProtoClusters");
+    ProtoCluster_factory_EcalBarrelImagingProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -30,7 +30,6 @@ public:
     void Init() override{
         auto app = GetApplication();
 
-        m_input_tag = "EcalBarrelImagingRecHits";
 
         // from https://eicweb.phy.anl.gov/EIC/benchmarks/physics_benchmarks/-/blob/master/options/reconstruction.py#L593
         u_localDistXY          = {2.0 * dd4hep::mm, 2 * dd4hep::mm};     //  # same layer
@@ -42,7 +41,6 @@ public:
         m_minClusterCenterEdep = 0;
         m_minClusterHitEdep    = 0;
 
-        app->SetDefaultParameter("BEMC:EcalBarrelImagingProtoClusters:input_tag", m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelImagingProtoClusters::localDistXY",    u_localDistXY);
         app->SetDefaultParameter("BEMC:EcalBarrelImagingProtoClusters::layerDistEtaPhi",    u_layerDistEtaPhi);
         app->SetDefaultParameter("BEMC:EcalBarrelImagingProtoClusters::neighbourLayersRange",    m_neighbourLayersRange);

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelImagingProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelImagingProtoClusters.h
@@ -15,9 +15,6 @@
 class ProtoCluster_factory_EcalBarrelImagingProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, ImagingTopoCluster {
 
 public:
-
-    std::string m_input_tag;
-
     //------------------------------------------
     // Constructor
     ProtoCluster_factory_EcalBarrelImagingProtoClusters(std::vector<std::string> default_input_tags)
@@ -58,7 +55,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        m_inputHits = event->Get<edm4eic::CalorimeterHit>(m_input_tag);
+        m_inputHits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         execute();

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelImagingProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelImagingProtoClusters.h
@@ -28,8 +28,9 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        InitDataTags(GetPluginName() + ":" + GetTag());
 
+        auto app = GetApplication();
 
         // from https://eicweb.phy.anl.gov/EIC/benchmarks/physics_benchmarks/-/blob/master/options/reconstruction.py#L593
         u_localDistXY          = {2.0 * dd4hep::mm, 2 * dd4hep::mm};     //  # same layer

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelScFiProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelScFiProtoClusters.h
@@ -25,6 +25,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         m_splitCluster=false;               // from ATHENA reconstruction.py

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelScFiProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelScFiProtoClusters.h
@@ -78,7 +78,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        hits = event->Get<edm4eic::CalorimeterHit>(m_input_tag);
+        hits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelScFiProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelScFiProtoClusters.h
@@ -6,19 +6,19 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterIslandCluster.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class ProtoCluster_factory_EcalBarrelScFiProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, CalorimeterIslandCluster {
+class ProtoCluster_factory_EcalBarrelScFiProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, CalorimeterIslandCluster {
 
 public:
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_EcalBarrelScFiProtoClusters(){
-        SetTag("EcalBarrelScFiProtoClusters");
+    ProtoCluster_factory_EcalBarrelScFiProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -26,7 +26,6 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_input_tag = "EcalBarrelScFiRecHits";
 
         m_splitCluster=false;               // from ATHENA reconstruction.py
         m_minClusterHitEdep=1.0 * dd4hep::MeV;    // from ATHENA reconstruction.py
@@ -49,7 +48,6 @@ public:
         u_globalDistEtaPhi={};//{this, "globalDistEtaPhi", {}};
         u_dimScaledLocalDistXY={};// from ATHENA reconstruction.py
 
-        app->SetDefaultParameter("BEMC:EcalBarrelScFiProtoClusters:input_tag", m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelScFiProtoClusters:splitCluster",             m_splitCluster);
         app->SetDefaultParameter("BEMC:EcalBarrelScFiProtoClusters:minClusterHitEdep",  m_minClusterHitEdep);
         app->SetDefaultParameter("BEMC:EcalBarrelScFiProtoClusters:minClusterCenterEdep",     m_minClusterCenterEdep);

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
@@ -93,7 +93,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        hits = event->Get<edm4eic::CalorimeterHit>(m_input_tag);
+        hits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
@@ -25,6 +25,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         // adjacency matrix

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassProtoClusters.h
@@ -6,19 +6,19 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterIslandCluster.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class ProtoCluster_factory_EcalBarrelSciGlassProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, CalorimeterIslandCluster {
+class ProtoCluster_factory_EcalBarrelSciGlassProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, CalorimeterIslandCluster {
 
 public:
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_EcalBarrelSciGlassProtoClusters(){
-        SetTag("EcalBarrelSciGlassProtoClusters");
+    ProtoCluster_factory_EcalBarrelSciGlassProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -26,7 +26,6 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_input_tag = "EcalBarrelSciGlassRecHits";
 
         // adjacency matrix
         m_geoSvcName = "GeoSvc";
@@ -62,7 +61,6 @@ public:
         u_transverseEnergyProfileMetric = "globalDistEtaPhi";
         u_transverseEnergyProfileScale = 0.06;
 
-        app->SetDefaultParameter("BEMC:EcalBarrelSciGlassProtoClusters:input_tag", m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelSciGlassProtoClusters:geoServiceName", m_geoSvcName);
         app->SetDefaultParameter("BEMC:EcalBarrelSciGlassProtoClusters:readoutClass", m_readout);
         app->SetDefaultParameter("BEMC:EcalBarrelSciGlassProtoClusters:sectorDist",   m_sectorDist);

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassTruthProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassTruthProtoClusters.h
@@ -6,19 +6,19 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterTruthClustering.h>
 
 
 
-class ProtoCluster_factory_EcalBarrelSciGlassTruthProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
+class ProtoCluster_factory_EcalBarrelSciGlassTruthProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
 
 public:
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_EcalBarrelSciGlassTruthProtoClusters(){
-        SetTag("EcalBarrelSciGlassTruthProtoClusters");
+    ProtoCluster_factory_EcalBarrelSciGlassTruthProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -26,10 +26,7 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_inputHit_tag="EcalBarrelSciGlassRecHits";
-        m_inputMCHit_tag="EcalBarrelSciGlassHits";
 
-        app->SetDefaultParameter("BEMC:EcalBarrelSciGlassTruthProtoClusters:inputHit_tag", m_inputHit_tag, "Name of input collection to use");
 
         AlgorithmInit(m_log);
     }
@@ -44,8 +41,8 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        m_inputHits = event->Get<edm4eic::CalorimeterHit>(m_inputHit_tag);
-        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(m_inputMCHit_tag);
+        m_inputHits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
+        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[1]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();
@@ -57,6 +54,4 @@ public:
 
 private:
     // Name of input data type (collection)
-    std::string              m_inputHit_tag;
-    std::string              m_inputMCHit_tag;
 };

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassTruthProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassTruthProtoClusters.h
@@ -25,6 +25,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         AlgorithmInit(m_log);

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassTruthProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassTruthProtoClusters.h
@@ -27,8 +27,6 @@ public:
     void Init() override{
         InitDataTags(GetPluginName() + ":" + GetTag());
 
-        auto app = GetApplication();
-
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassTruthProtoClusters.h
+++ b/src/detectors/BEMC/ProtoCluster_factory_EcalBarrelSciGlassTruthProtoClusters.h
@@ -27,7 +27,6 @@ public:
     void Init() override{
         auto app = GetApplication();
 
-
         AlgorithmInit(m_log);
     }
 
@@ -51,7 +50,4 @@ public:
         Set(m_outputProtoClusters);
         m_outputProtoClusters.clear(); // not really needed, but better to not leave dangling pointers around
     }
-
-private:
-    // Name of input data type (collection)
 };

--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelImagingRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelImagingRawHits.h
@@ -32,6 +32,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override {
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm

--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelImagingRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelImagingRawHits.h
@@ -7,7 +7,7 @@
 #include <random>
 
 #include <JANA/JEvent.h>
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterHitDigi.h>
 #include <edm4hep/SimCalorimeterHit.h>
@@ -18,14 +18,14 @@
 
 
 
-class RawCalorimeterHit_factory_EcalBarrelImagingRawHits : public eicrecon::JFactoryPodioT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
+class RawCalorimeterHit_factory_EcalBarrelImagingRawHits : public JChainFactoryT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
 
 public:
 
     //------------------------------------------
     // Constructor
-    RawCalorimeterHit_factory_EcalBarrelImagingRawHits() {
-        SetTag("EcalBarrelImagingRawHits");
+    RawCalorimeterHit_factory_EcalBarrelImagingRawHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4hep::RawCalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -35,7 +35,6 @@ public:
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
-        m_input_tag = "EcalBarrelImagingHits";
         u_eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV};
         m_tRes = 0.0 * dd4hep::ns;
         m_capADC = 8192;
@@ -49,7 +48,6 @@ public:
         m_geoSvc = app->GetService<JDD4hep_service>(); // TODO: implement named geometry service?
 
         // This is another option for exposing the data members as JANA configuration parameters.
-        app->SetDefaultParameter("BEMC:EcalBarrelImagingRawHits:input_tag", m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelImagingRawHits:energyResolutions",u_eRes);
         app->SetDefaultParameter("BEMC:EcalBarrelImagingRawHits:timeResolution",   m_tRes);
         app->SetDefaultParameter("BEMC:EcalBarrelImagingRawHits:capacityADC",      m_capADC);

--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelImagingRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelImagingRawHits.h
@@ -76,7 +76,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override {
         // Prefill inputs
-        simhits = event->Get<edm4hep::SimCalorimeterHit>(m_input_tag);
+        simhits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelScFiRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelScFiRawHits.h
@@ -32,6 +32,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override {
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm

--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelScFiRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelScFiRawHits.h
@@ -7,7 +7,7 @@
 #include <random>
 
 #include <JANA/JEvent.h>
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterHitDigi.h>
 #include <edm4hep/SimCalorimeterHit.h>
@@ -18,14 +18,14 @@
 
 
 
-class RawCalorimeterHit_factory_EcalBarrelScFiRawHits : public eicrecon::JFactoryPodioT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
+class RawCalorimeterHit_factory_EcalBarrelScFiRawHits : public JChainFactoryT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
 
 public:
 
     //------------------------------------------
     // Constructor
-    RawCalorimeterHit_factory_EcalBarrelScFiRawHits() {
-        SetTag("EcalBarrelScFiRawHits");
+    RawCalorimeterHit_factory_EcalBarrelScFiRawHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4hep::RawCalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -35,7 +35,6 @@ public:
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
-        m_input_tag = "EcalBarrelScFiHits";
         u_eRes = {0.0 * sqrt(dd4hep::GeV), 0.0, 0.0 * dd4hep::GeV};
         m_tRes = 0.0 * dd4hep::ns;
         m_capADC = 16384;
@@ -50,8 +49,6 @@ public:
         m_geoSvc = app->GetService<JDD4hep_service>(); // TODO: implement named geometry service?
 
         // This is another option for exposing the data members as JANA configuration parameters.
-//        app->SetDefaultParameter("BEMC:tag",              m_input_tag);
-        app->SetDefaultParameter("BEMC:EcalBarrelScFiRawHits:input_tag", m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelScFiRawHits:energyResolutions",u_eRes);
         app->SetDefaultParameter("BEMC:EcalBarrelScFiRawHits:timeResolution",   m_tRes);
         app->SetDefaultParameter("BEMC:EcalBarrelScFiRawHits:capacityADC",      m_capADC);

--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelScFiRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelScFiRawHits.h
@@ -77,7 +77,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override {
         // Prefill inputs
-        simhits = event->Get<edm4hep::SimCalorimeterHit>(m_input_tag);
+        simhits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelSciGlassRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelSciGlassRawHits.h
@@ -80,7 +80,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override {
         // Prefill inputs
-        simhits = event->Get<edm4hep::SimCalorimeterHit>(m_input_tag);
+        simhits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelSciGlassRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelSciGlassRawHits.h
@@ -7,7 +7,7 @@
 #include <random>
 
 #include <JANA/JEvent.h>
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterHitDigi.h>
 #include <edm4hep/SimCalorimeterHit.h>
@@ -19,14 +19,14 @@
 
 
 
-class RawCalorimeterHit_factory_EcalBarrelSciGlassRawHits : public eicrecon::JFactoryPodioT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
+class RawCalorimeterHit_factory_EcalBarrelSciGlassRawHits : public JChainFactoryT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
 
 public:
 
     //------------------------------------------
     // Constructor
-    RawCalorimeterHit_factory_EcalBarrelSciGlassRawHits() {
-        SetTag("EcalBarrelSciGlassRawHits");
+    RawCalorimeterHit_factory_EcalBarrelSciGlassRawHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4hep::RawCalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -36,7 +36,6 @@ public:
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
-        m_input_tag = "EcalBarrelSciGlassHits";
         u_eRes =  {0.0 * sqrt(dd4hep::GeV), 0.0, 0.0 * dd4hep::GeV};
         m_tRes = 0.0 * dd4hep::ns;
         m_capADC = 16384;
@@ -53,8 +52,6 @@ public:
 
 
         // This is another option for exposing the data members as JANA configuration parameters.
-//        app->SetDefaultParameter("BEMC:tag",              m_input_tag);
-        app->SetDefaultParameter("BEMC:EcalBarrelSciGlassRawHits:input_tag", m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("BEMC:EcalBarrelSciGlassRawHits:energyResolutions",u_eRes);
         app->SetDefaultParameter("BEMC:EcalBarrelSciGlassRawHits:timeResolution",   m_tRes);
         app->SetDefaultParameter("BEMC:EcalBarrelSciGlassRawHits:capacityADC",      m_capADC);

--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelSciGlassRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelSciGlassRawHits.h
@@ -33,6 +33,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override {
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm

--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -33,7 +33,7 @@ extern "C" {
 	    {"HcalBarrelRawHits"}, "HcalBarrelRecHits"
 	));
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_HcalBarrelTruthProtoClusters>(
-	    {"HcalBarrelRecHits"}, "HcalBarrelTruthProtoClusters"
+	    {"HcalBarrelRecHits", "HcalBarrelHits"}, "HcalBarrelTruthProtoClusters"
         ));
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_HcalBarrelIslandProtoClusters>(
 	    {"HcalBarrelRecHits"}, "HcalBarrelIslandProtoClusters"

--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -3,6 +3,7 @@
 //
 //
 
+#include <extensions/jana/JChainFactoryGeneratorT.h>
 #include <extensions/jana/JChainMultifactoryGeneratorT.h>
 
 #include <factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h>
@@ -25,10 +26,18 @@ extern "C" {
 
         InitJANAPlugin(app);
 
-        app->Add(new JFactoryGeneratorT<RawCalorimeterHit_factory_HcalBarrelRawHits>());
-        app->Add(new JFactoryGeneratorT<CalorimeterHit_factory_HcalBarrelRecHits>());
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_HcalBarrelTruthProtoClusters>());
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_HcalBarrelIslandProtoClusters>());
+        app->Add(new JChainFactoryGeneratorT<RawCalorimeterHit_factory_HcalBarrelRawHits>(
+	    {"HcalBarrelHits"}, "HcalBarrelRawHits"
+	));
+        app->Add(new JChainFactoryGeneratorT<CalorimeterHit_factory_HcalBarrelRecHits>(
+	    {"HcalBarrelRawHits"}, "HcalBarrelRecHits"
+	));
+        app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_HcalBarrelTruthProtoClusters>(
+	    {"HcalBarrelRecHits"}, "HcalBarrelTruthProtoClusters"
+        ));
+        app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_HcalBarrelIslandProtoClusters>(
+	    {"HcalBarrelRecHits"}, "HcalBarrelIslandProtoClusters"
+	));
 
         app->Add(
           new JChainMultifactoryGeneratorT<Cluster_factory_HcalBarrelClusters>(

--- a/src/detectors/BHCAL/CalorimeterHit_factory_HcalBarrelRecHits.h
+++ b/src/detectors/BHCAL/CalorimeterHit_factory_HcalBarrelRecHits.h
@@ -77,7 +77,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        rawhits = event->Get<edm4hep::RawCalorimeterHit>(m_input_tag);
+        rawhits = event->Get<edm4hep::RawCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/BHCAL/CalorimeterHit_factory_HcalBarrelRecHits.h
+++ b/src/detectors/BHCAL/CalorimeterHit_factory_HcalBarrelRecHits.h
@@ -21,8 +21,9 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        InitDataTags(GetPluginName() + ":" + GetTag());
 
+        auto app = GetApplication();
 
         // digitization settings, must be consistent with digi class
         m_capADC=65536;

--- a/src/detectors/BHCAL/CalorimeterHit_factory_HcalBarrelRecHits.h
+++ b/src/detectors/BHCAL/CalorimeterHit_factory_HcalBarrelRecHits.h
@@ -3,18 +3,18 @@
 
 #include <edm4eic/CalorimeterHitCollection.h>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <algorithms/calorimetry/CalorimeterHitReco.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class CalorimeterHit_factory_HcalBarrelRecHits : public eicrecon::JFactoryPodioT<edm4eic::CalorimeterHit>, CalorimeterHitReco {
+class CalorimeterHit_factory_HcalBarrelRecHits : public JChainFactoryT<edm4eic::CalorimeterHit>, CalorimeterHitReco {
 
 public:
     //------------------------------------------
     // Constructor
-    CalorimeterHit_factory_HcalBarrelRecHits(){
-        SetTag("HcalBarrelRecHits");
+    CalorimeterHit_factory_HcalBarrelRecHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::CalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -23,7 +23,6 @@ public:
     void Init() override{
         auto app = GetApplication();
 
-        m_input_tag = "HcalBarrelRawHits";
 
         // digitization settings, must be consistent with digi class
         m_capADC=65536;
@@ -48,7 +47,6 @@ public:
         m_localDetElement="";
         u_localDetFields={};
 
-//        app->SetDefaultParameter("BHCAL:tag",              m_input_tag);
         app->SetDefaultParameter("BHCAL:HcalBarrelRecHits:capacityADC",      m_capADC);
         app->SetDefaultParameter("BHCAL:HcalBarrelRecHits:dynamicRangeADC",  m_dyRangeADC);
         app->SetDefaultParameter("BHCAL:HcalBarrelRecHits:pedestalMean",     m_pedMeanADC);

--- a/src/detectors/BHCAL/ProtoCluster_factory_HcalBarrelIslandProtoClusters.h
+++ b/src/detectors/BHCAL/ProtoCluster_factory_HcalBarrelIslandProtoClusters.h
@@ -94,7 +94,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        hits = event->Get<edm4eic::CalorimeterHit>(m_input_tag);
+        hits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/BHCAL/ProtoCluster_factory_HcalBarrelIslandProtoClusters.h
+++ b/src/detectors/BHCAL/ProtoCluster_factory_HcalBarrelIslandProtoClusters.h
@@ -6,19 +6,19 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterIslandCluster.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class ProtoCluster_factory_HcalBarrelIslandProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, CalorimeterIslandCluster {
+class ProtoCluster_factory_HcalBarrelIslandProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, CalorimeterIslandCluster {
 
 public:
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_HcalBarrelIslandProtoClusters(){
-        SetTag("HcalBarrelIslandProtoClusters");
+    ProtoCluster_factory_HcalBarrelIslandProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -26,7 +26,6 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_input_tag = "HcalBarrelRecHits";
 
         // adjacency matrix
         m_geoSvcName = "GeoSvc";

--- a/src/detectors/BHCAL/ProtoCluster_factory_HcalBarrelIslandProtoClusters.h
+++ b/src/detectors/BHCAL/ProtoCluster_factory_HcalBarrelIslandProtoClusters.h
@@ -25,6 +25,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         // adjacency matrix

--- a/src/detectors/BHCAL/ProtoCluster_factory_HcalBarrelTruthProtoClusters.h
+++ b/src/detectors/BHCAL/ProtoCluster_factory_HcalBarrelTruthProtoClusters.h
@@ -54,7 +54,5 @@ public:
         m_outputProtoClusters.clear(); // not really needed, but better to not leave dangling pointers around
     }
 private:
-    // Name of input data type (collection)
-
     std::shared_ptr<spdlog::logger> m_log;
 };

--- a/src/detectors/BHCAL/ProtoCluster_factory_HcalBarrelTruthProtoClusters.h
+++ b/src/detectors/BHCAL/ProtoCluster_factory_HcalBarrelTruthProtoClusters.h
@@ -30,8 +30,6 @@ public:
     void Init() override{
         InitDataTags(GetPluginName() + ":" + GetTag());
 
-        auto app = GetApplication();
-
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/BHCAL/ProtoCluster_factory_HcalBarrelTruthProtoClusters.h
+++ b/src/detectors/BHCAL/ProtoCluster_factory_HcalBarrelTruthProtoClusters.h
@@ -8,20 +8,20 @@
 
 #include <edm4eic/ProtoClusterCollection.h>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterTruthClustering.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
 
-class ProtoCluster_factory_HcalBarrelTruthProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
+class ProtoCluster_factory_HcalBarrelTruthProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
 
 public:
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_HcalBarrelTruthProtoClusters(){
-        SetTag("HcalBarrelTruthProtoClusters");
+    ProtoCluster_factory_HcalBarrelTruthProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -29,8 +29,6 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_inputHit_tag="HcalBarrelRecHits";
-        m_inputMCHit_tag="HcalBarrelHits";
 
         AlgorithmInit(m_log);
     }
@@ -45,8 +43,8 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        m_inputHits = event->Get<edm4eic::CalorimeterHit>(m_inputHit_tag);
-        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(m_inputMCHit_tag);
+        m_inputHits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
+        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[1]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();
@@ -57,8 +55,6 @@ public:
     }
 private:
     // Name of input data type (collection)
-    std::string              m_inputHit_tag;
-    std::string              m_inputMCHit_tag;
 
     std::shared_ptr<spdlog::logger> m_log;
 };

--- a/src/detectors/BHCAL/ProtoCluster_factory_HcalBarrelTruthProtoClusters.h
+++ b/src/detectors/BHCAL/ProtoCluster_factory_HcalBarrelTruthProtoClusters.h
@@ -28,6 +28,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         AlgorithmInit(m_log);

--- a/src/detectors/BHCAL/RawCalorimeterHit_factory_HcalBarrelRawHits.h
+++ b/src/detectors/BHCAL/RawCalorimeterHit_factory_HcalBarrelRawHits.h
@@ -80,7 +80,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override {
         // Prefill inputs
-        simhits = event->Get<edm4hep::SimCalorimeterHit>(m_input_tag);
+        simhits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/BHCAL/RawCalorimeterHit_factory_HcalBarrelRawHits.h
+++ b/src/detectors/BHCAL/RawCalorimeterHit_factory_HcalBarrelRawHits.h
@@ -12,7 +12,7 @@
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JEvent.h>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterHitDigi.h>
 #include <services/log/Log_service.h>
@@ -20,14 +20,14 @@
 
 
 
-class RawCalorimeterHit_factory_HcalBarrelRawHits : public eicrecon::JFactoryPodioT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
+class RawCalorimeterHit_factory_HcalBarrelRawHits : public JChainFactoryT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
 
 public:
 
     //------------------------------------------
     // Constructor
-    RawCalorimeterHit_factory_HcalBarrelRawHits() {
-        SetTag("HcalBarrelRawHits");
+    RawCalorimeterHit_factory_HcalBarrelRawHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4hep::RawCalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -37,7 +37,6 @@ public:
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
-        m_input_tag = "HcalBarrelHits";
         u_eRes = {};
         m_tRes = 0.0 * dd4hep::ns;
         m_capADC = 65536;
@@ -53,7 +52,6 @@ public:
         m_geoSvc = app->GetService<JDD4hep_service>(); // TODO: implement named geometry service?
 
         // This is another option for exposing the data members as JANA configuration parameters.
-//        app->SetDefaultParameter("BHCAL:tag",              m_input_tag);
         app->SetDefaultParameter("BHCAL:HcalBarrelRawHits:energyResolutions",u_eRes);
         app->SetDefaultParameter("BHCAL:HcalBarrelRawHits:timeResolution",   m_tRes);
         app->SetDefaultParameter("BHCAL:HcalBarrelRawHits:capacityADC",      m_capADC);

--- a/src/detectors/BHCAL/RawCalorimeterHit_factory_HcalBarrelRawHits.h
+++ b/src/detectors/BHCAL/RawCalorimeterHit_factory_HcalBarrelRawHits.h
@@ -34,6 +34,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override {
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm

--- a/src/detectors/EEMC/CalorimeterHit_factory_EcalEndcapNRecHits.h
+++ b/src/detectors/EEMC/CalorimeterHit_factory_EcalEndcapNRecHits.h
@@ -21,8 +21,9 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        InitDataTags(GetPluginName() + ":" + GetTag());
 
+        auto app = GetApplication();
 
         // digitization settings, must be consistent with digi class
         m_capADC=16384;//{this, "capacityADC", 8096};

--- a/src/detectors/EEMC/CalorimeterHit_factory_EcalEndcapNRecHits.h
+++ b/src/detectors/EEMC/CalorimeterHit_factory_EcalEndcapNRecHits.h
@@ -3,18 +3,18 @@
 
 #include <edm4eic/CalorimeterHitCollection.h>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <algorithms/calorimetry/CalorimeterHitReco.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class CalorimeterHit_factory_EcalEndcapNRecHits : public eicrecon::JFactoryPodioT<edm4eic::CalorimeterHit>, CalorimeterHitReco {
+class CalorimeterHit_factory_EcalEndcapNRecHits : public JChainFactoryT<edm4eic::CalorimeterHit>, CalorimeterHitReco {
 
 public:
     //------------------------------------------
     // Constructor
-    CalorimeterHit_factory_EcalEndcapNRecHits(){
-        SetTag("EcalEndcapNRecHits");
+    CalorimeterHit_factory_EcalEndcapNRecHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::CalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -23,7 +23,6 @@ public:
     void Init() override{
         auto app = GetApplication();
 
-        m_input_tag = "EcalEndcapNRawHits";
 
         // digitization settings, must be consistent with digi class
         m_capADC=16384;//{this, "capacityADC", 8096};
@@ -48,8 +47,6 @@ public:
         m_localDetElement="";         // from ATHENA's reconstruction.py (i.e. not defined there)
         u_localDetFields={};          // from ATHENA's reconstruction.py (i.e. not defined there)
 
-//        app->SetDefaultParameter("EEMC:tag",              m_input_tag);
-        app->SetDefaultParameter("EEMC:EcalEndcapNRecHits:input_tag",        m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("EEMC:EcalEndcapNRecHits:capacityADC",      m_capADC);
         app->SetDefaultParameter("EEMC:EcalEndcapNRecHits:dynamicRangeADC",  m_dyRangeADC);
         app->SetDefaultParameter("EEMC:EcalEndcapNRecHits:pedestalMean",     m_pedMeanADC);

--- a/src/detectors/EEMC/CalorimeterHit_factory_EcalEndcapNRecHits.h
+++ b/src/detectors/EEMC/CalorimeterHit_factory_EcalEndcapNRecHits.h
@@ -77,7 +77,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        rawhits = event->Get<edm4hep::RawCalorimeterHit>(m_input_tag);
+        rawhits = event->Get<edm4hep::RawCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -26,13 +26,13 @@ extern "C" {
         InitJANAPlugin(app);
 
         app->Add(new JChainFactoryGeneratorT<RawCalorimeterHit_factory_EcalEndcapNRawHits>(
-	    {"EcalEndcapNHitd"}, "EcalEndcapNRawHits"
+	    {"EcalEndcapNHits"}, "EcalEndcapNRawHits"
 	));
         app->Add(new JChainFactoryGeneratorT<CalorimeterHit_factory_EcalEndcapNRecHits>(
 	    {"EcalEndcapNRawHits"}, "EcalEndcapNRecHits"
 	));
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_EcalEndcapNTruthProtoClusters>(
-	    {"EcalEndcapNRecHits"}, "EcalEndcapNTruthProtoClusters"
+	    {"EcalEndcapNRecHits", "EcalEndcapNHits"}, "EcalEndcapNTruthProtoClusters"
         ));
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_EcalEndcapNIslandProtoClusters>(
 	    {"EcalEndcapNRecHits"}, "EcalEndcapNIslandProtoClusters"

--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -3,6 +3,7 @@
 //
 //
 
+#include <extensions/jana/JChainFactoryGeneratorT.h>
 #include <extensions/jana/JChainMultifactoryGeneratorT.h>
 
 #include <factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h>
@@ -24,10 +25,18 @@ extern "C" {
 
         InitJANAPlugin(app);
 
-        app->Add(new JFactoryGeneratorT<RawCalorimeterHit_factory_EcalEndcapNRawHits>());
-        app->Add(new JFactoryGeneratorT<CalorimeterHit_factory_EcalEndcapNRecHits>());
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_EcalEndcapNTruthProtoClusters>());
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_EcalEndcapNIslandProtoClusters>());
+        app->Add(new JChainFactoryGeneratorT<RawCalorimeterHit_factory_EcalEndcapNRawHits>(
+	    {"EcalEndcapNHitd"}, "EcalEndcapNRawHits"
+	));
+        app->Add(new JChainFactoryGeneratorT<CalorimeterHit_factory_EcalEndcapNRecHits>(
+	    {"EcalEndcapNRawHits"}, "EcalEndcapNRecHits"
+	));
+        app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_EcalEndcapNTruthProtoClusters>(
+	    {"EcalEndcapNRecHits"}, "EcalEndcapNTruthProtoClusters"
+        ));
+        app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_EcalEndcapNIslandProtoClusters>(
+	    {"EcalEndcapNRecHits"}, "EcalEndcapNIslandProtoClusters"
+	));
 
         app->Add(
           new JChainMultifactoryGeneratorT<Cluster_factory_EcalEndcapNTruthClusters>(

--- a/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapNIslandProtoClusters.h
+++ b/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapNIslandProtoClusters.h
@@ -82,7 +82,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        hits = event->Get<edm4eic::CalorimeterHit>(m_input_tag);
+        hits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapNIslandProtoClusters.h
+++ b/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapNIslandProtoClusters.h
@@ -6,19 +6,19 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterIslandCluster.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class ProtoCluster_factory_EcalEndcapNIslandProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, CalorimeterIslandCluster {
+class ProtoCluster_factory_EcalEndcapNIslandProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, CalorimeterIslandCluster {
 
 public:
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_EcalEndcapNIslandProtoClusters(){
-        SetTag("EcalEndcapNIslandProtoClusters");
+    ProtoCluster_factory_EcalEndcapNIslandProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -26,7 +26,6 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_input_tag = "EcalEndcapNRecHits";
 
         // adjacency matrix
         m_geoSvcName = "GeoSvc";
@@ -51,7 +50,6 @@ public:
         u_transverseEnergyProfileMetric = "globalDistEtaPhi";
         u_transverseEnergyProfileScale = 0.08;
 
-        app->SetDefaultParameter("EEMC:EcalEndcapNIslandProtoClusters:input_tag",        m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("EEMC:EcalEndcapNIslandProtoClusters:geoServiceName", m_geoSvcName);
         app->SetDefaultParameter("EEMC:EcalEndcapNIslandProtoClusters:readoutClass", m_readout);
         app->SetDefaultParameter("EEMC:EcalEndcapNIslandProtoClusters:sectorDist",   m_sectorDist);

--- a/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapNIslandProtoClusters.h
+++ b/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapNIslandProtoClusters.h
@@ -25,6 +25,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         // adjacency matrix

--- a/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapNTruthProtoClusters.h
+++ b/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapNTruthProtoClusters.h
@@ -29,7 +29,6 @@ public:
     void Init() override{
         auto app = GetApplication();
 
-
         AlgorithmInit(m_log);
     }
 
@@ -53,7 +52,4 @@ public:
         Set(m_outputProtoClusters);
         m_outputProtoClusters.clear(); // not really needed, but better to not leave dangling pointers around
     }
-
-private:
-    // Name of input data type (collection)
 };

--- a/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapNTruthProtoClusters.h
+++ b/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapNTruthProtoClusters.h
@@ -27,6 +27,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         AlgorithmInit(m_log);

--- a/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapNTruthProtoClusters.h
+++ b/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapNTruthProtoClusters.h
@@ -8,19 +8,19 @@
 
 #include <edm4eic/ProtoClusterCollection.h>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterTruthClustering.h>
 
 
 
-class ProtoCluster_factory_EcalEndcapNTruthProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
+class ProtoCluster_factory_EcalEndcapNTruthProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
 
 public:
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_EcalEndcapNTruthProtoClusters(){
-        SetTag("EcalEndcapNTruthProtoClusters");
+    ProtoCluster_factory_EcalEndcapNTruthProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -28,10 +28,7 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_inputHit_tag="EcalEndcapNRecHits";
-        m_inputMCHit_tag="EcalEndcapNHits";
 
-        app->SetDefaultParameter("EEMC:EcalEndcapNTruthProtoClusters:inputHit_tag",        m_inputHit_tag, "Name of input collection to use");
 
         AlgorithmInit(m_log);
     }
@@ -46,8 +43,8 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        m_inputHits = event->Get<edm4eic::CalorimeterHit>(m_inputHit_tag);
-        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(m_inputMCHit_tag);
+        m_inputHits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
+        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[1]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();
@@ -59,6 +56,4 @@ public:
 
 private:
     // Name of input data type (collection)
-    std::string              m_inputHit_tag;
-    std::string              m_inputMCHit_tag;
 };

--- a/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapNTruthProtoClusters.h
+++ b/src/detectors/EEMC/ProtoCluster_factory_EcalEndcapNTruthProtoClusters.h
@@ -29,8 +29,6 @@ public:
     void Init() override{
         InitDataTags(GetPluginName() + ":" + GetTag());
 
-        auto app = GetApplication();
-
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapNRawHits.h
+++ b/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapNRawHits.h
@@ -80,7 +80,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override {
         // Prefill inputs
-        simhits = event->Get<edm4hep::SimCalorimeterHit>(m_input_tag);
+        simhits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapNRawHits.h
+++ b/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapNRawHits.h
@@ -34,6 +34,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override {
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm

--- a/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapNRawHits.h
+++ b/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapNRawHits.h
@@ -12,7 +12,7 @@
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JEvent.h>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterHitDigi.h>
 #include <services/log/Log_service.h>
@@ -20,14 +20,14 @@
 
 
 
-class RawCalorimeterHit_factory_EcalEndcapNRawHits : public eicrecon::JFactoryPodioT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
+class RawCalorimeterHit_factory_EcalEndcapNRawHits : public JChainFactoryT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
 
 public:
 
     //------------------------------------------
     // Constructor
-    RawCalorimeterHit_factory_EcalEndcapNRawHits() {
-        SetTag("EcalEndcapNRawHits");
+    RawCalorimeterHit_factory_EcalEndcapNRawHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4hep::RawCalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -37,7 +37,6 @@ public:
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
-        m_input_tag = "EcalEndcapNHits";
         u_eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV}; // flat 2%
         m_tRes = 0.0 * dd4hep::ns;
         m_capADC = 16384;
@@ -54,8 +53,6 @@ public:
 
 
         // This is another option for exposing the data members as JANA configuration parameters.
-//        app->SetDefaultParameter("EEMC:tag",              m_input_tag);
-        app->SetDefaultParameter("EEMC:EcalEndcapNRawHits:input_tag",        m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("EEMC:EcalEndcapNRawHits:energyResolutions",u_eRes);
         app->SetDefaultParameter("EEMC:EcalEndcapNRawHits:timeResolution",   m_tRes);
         app->SetDefaultParameter("EEMC:EcalEndcapNRawHits:capacityADC",      m_capADC);

--- a/src/detectors/EHCAL/CalorimeterHit_factory_HcalEndcapNMergedHits.h
+++ b/src/detectors/EHCAL/CalorimeterHit_factory_HcalEndcapNMergedHits.h
@@ -1,19 +1,19 @@
 
 #pragma once
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 
 #include <algorithms/calorimetry/CalorimeterHitsMerger.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class CalorimeterHit_factory_HcalEndcapNMergedHits : public eicrecon::JFactoryPodioT<edm4eic::CalorimeterHit>, CalorimeterHitsMerger {
+class CalorimeterHit_factory_HcalEndcapNMergedHits : public JChainFactoryT<edm4eic::CalorimeterHit>, CalorimeterHitsMerger {
 
 public:
     //------------------------------------------
     // Constructor
-    CalorimeterHit_factory_HcalEndcapNMergedHits(){
-        SetTag("HcalEndcapNMergedHits");
+    CalorimeterHit_factory_HcalEndcapNMergedHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::CalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -23,7 +23,6 @@ public:
         auto app = GetApplication();
         m_log = app->GetService<Log_service>()->logger(GetTag());
 
-        m_input_tag = "HcalEndcapNRecHits";
 
         m_readout="HcalEndcapNHits";
         u_fields={"layer", "slice"};  // from ATHENA's reconstruction.py
@@ -31,7 +30,6 @@ public:
 
         m_geoSvc= app->GetService<JDD4hep_service>();
 
-        app->SetDefaultParameter("EHCAL:HcalEndcapNMergedHits:input_tag", m_input_tag);
         app->SetDefaultParameter("EHCAL:HcalEndcapNMergedHits:readout", m_readout);
         app->SetDefaultParameter("EHCAL:HcalEndcapNMergedHits:fields", u_fields);
         app->SetDefaultParameter("EHCAL:HcalEndcapNMergedHits:refs",  u_refs);

--- a/src/detectors/EHCAL/CalorimeterHit_factory_HcalEndcapNMergedHits.h
+++ b/src/detectors/EHCAL/CalorimeterHit_factory_HcalEndcapNMergedHits.h
@@ -44,7 +44,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        m_inputs = event->Get<edm4eic::CalorimeterHit>(m_input_tag);
+        m_inputs = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         execute();

--- a/src/detectors/EHCAL/CalorimeterHit_factory_HcalEndcapNMergedHits.h
+++ b/src/detectors/EHCAL/CalorimeterHit_factory_HcalEndcapNMergedHits.h
@@ -23,7 +23,6 @@ public:
         auto app = GetApplication();
         m_log = app->GetService<Log_service>()->logger(GetTag());
 
-
         m_readout="HcalEndcapNHits";
         u_fields={"layer", "slice"};  // from ATHENA's reconstruction.py
         u_refs={1, 0};                // from ATHENA's reconstruction.py
@@ -33,7 +32,6 @@ public:
         app->SetDefaultParameter("EHCAL:HcalEndcapNMergedHits:readout", m_readout);
         app->SetDefaultParameter("EHCAL:HcalEndcapNMergedHits:fields", u_fields);
         app->SetDefaultParameter("EHCAL:HcalEndcapNMergedHits:refs",  u_refs);
-
 
         initialize();
     }
@@ -55,7 +53,4 @@ public:
         Set(m_outputs);
         m_outputs.clear(); // not really needed, but better to not leave dangling pointers around
     }
-
-private:
-    std::string m_input_tag;
 };

--- a/src/detectors/EHCAL/CalorimeterHit_factory_HcalEndcapNMergedHits.h
+++ b/src/detectors/EHCAL/CalorimeterHit_factory_HcalEndcapNMergedHits.h
@@ -20,6 +20,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
         m_log = app->GetService<Log_service>()->logger(GetTag());
 

--- a/src/detectors/EHCAL/CalorimeterHit_factory_HcalEndcapNRecHits.h
+++ b/src/detectors/EHCAL/CalorimeterHit_factory_HcalEndcapNRecHits.h
@@ -77,7 +77,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        rawhits = event->Get<edm4hep::RawCalorimeterHit>(m_input_tag);
+        rawhits = event->Get<edm4hep::RawCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/EHCAL/CalorimeterHit_factory_HcalEndcapNRecHits.h
+++ b/src/detectors/EHCAL/CalorimeterHit_factory_HcalEndcapNRecHits.h
@@ -3,18 +3,18 @@
 
 #include <edm4eic/CalorimeterHitCollection.h>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <algorithms/calorimetry/CalorimeterHitReco.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class CalorimeterHit_factory_HcalEndcapNRecHits : public eicrecon::JFactoryPodioT<edm4eic::CalorimeterHit>, CalorimeterHitReco {
+class CalorimeterHit_factory_HcalEndcapNRecHits : public JChainFactoryT<edm4eic::CalorimeterHit>, CalorimeterHitReco {
 
 public:
     //------------------------------------------
     // Constructor
-    CalorimeterHit_factory_HcalEndcapNRecHits(){
-        SetTag("HcalEndcapNRecHits");
+    CalorimeterHit_factory_HcalEndcapNRecHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::CalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -23,7 +23,6 @@ public:
     void Init() override{
         auto app = GetApplication();
 
-        m_input_tag = "HcalEndcapNRawHits";
 
         // digitization settings, must be consistent with digi class
         m_capADC=1024;//{this, "capacityADC", 8096};
@@ -48,7 +47,6 @@ public:
         m_localDetElement="";         // from ATHENA's reconstruction.py (i.e. not defined there)
         u_localDetFields={};          // from ATHENA's reconstruction.py (i.e. not defined there)
 
-//        app->SetDefaultParameter("EHCAL:tag",              m_input_tag);
         app->SetDefaultParameter("EHCAL:HcalEndcapNRecHits:capacityADC",      m_capADC);
         app->SetDefaultParameter("EHCAL:HcalEndcapNRecHits:dynamicRangeADC",  m_dyRangeADC);
         app->SetDefaultParameter("EHCAL:HcalEndcapNRecHits:pedestalMean",     m_pedMeanADC);

--- a/src/detectors/EHCAL/CalorimeterHit_factory_HcalEndcapNRecHits.h
+++ b/src/detectors/EHCAL/CalorimeterHit_factory_HcalEndcapNRecHits.h
@@ -21,8 +21,9 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        InitDataTags(GetPluginName() + ":" + GetTag());
 
+        auto app = GetApplication();
 
         // digitization settings, must be consistent with digi class
         m_capADC=1024;//{this, "capacityADC", 8096};

--- a/src/detectors/EHCAL/EHCAL.cc
+++ b/src/detectors/EHCAL/EHCAL.cc
@@ -34,7 +34,7 @@ extern "C" {
           {"HcalEndcapNRawHits"}, "HcalEndcapNRecHits"
         ));
         app->Add(new JChainFactoryGeneratorT<CalorimeterHit_factory_HcalEndcapNMergedHits>(
-          {"HcalEndcapNRawHits"}, "HcalEndcapNMergedRecHits"
+          {"HcalEndcapNRawHits"}, "HcalEndcapNMergedHits"
         ));
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_HcalEndcapNTruthProtoClusters>(
           {"HcalEndcapNRecHits", "HcalEndcapNHits"}, "HcalEndcapNTruthProtoClusters"

--- a/src/detectors/EHCAL/EHCAL.cc
+++ b/src/detectors/EHCAL/EHCAL.cc
@@ -34,7 +34,7 @@ extern "C" {
           {"HcalEndcapNRawHits"}, "HcalEndcapNRecHits"
         ));
         app->Add(new JChainFactoryGeneratorT<CalorimeterHit_factory_HcalEndcapNMergedHits>(
-          {"HcalEndcapNRawHits"}, "HcalEndcapNMergedHits"
+          {"HcalEndcapNRecHits"}, "HcalEndcapNMergedHits"
         ));
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_HcalEndcapNTruthProtoClusters>(
           {"HcalEndcapNRecHits", "HcalEndcapNHits"}, "HcalEndcapNTruthProtoClusters"

--- a/src/detectors/EHCAL/EHCAL.cc
+++ b/src/detectors/EHCAL/EHCAL.cc
@@ -37,7 +37,7 @@ extern "C" {
           {"HcalEndcapNRawHits"}, "HcalEndcapNMergedRecHits"
         ));
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_HcalEndcapNTruthProtoClusters>(
-          {"HcalEndcapNRecHits"}, "HcalEndcapNTruthProtoClusters"
+          {"HcalEndcapNRecHits", "HcalEndcapNHits"}, "HcalEndcapNTruthProtoClusters"
         ));
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_HcalEndcapNIslandProtoClusters>(
           {"HcalEndcapNRecHits"}, "HcalEndcapNIslandProtoClusters"

--- a/src/detectors/EHCAL/EHCAL.cc
+++ b/src/detectors/EHCAL/EHCAL.cc
@@ -3,6 +3,7 @@
 //
 //
 
+#include <extensions/jana/JChainFactoryGeneratorT.h>
 #include <extensions/jana/JChainMultifactoryGeneratorT.h>
 
 #include <factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h>
@@ -26,11 +27,21 @@ extern "C" {
 
         InitJANAPlugin(app);
 
-        app->Add(new JFactoryGeneratorT<RawCalorimeterHit_factory_HcalEndcapNRawHits>());
-        app->Add(new JFactoryGeneratorT<CalorimeterHit_factory_HcalEndcapNRecHits>());
-        app->Add(new JFactoryGeneratorT<CalorimeterHit_factory_HcalEndcapNMergedHits>());
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_HcalEndcapNTruthProtoClusters>());
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_HcalEndcapNIslandProtoClusters>());
+        app->Add(new JChainFactoryGeneratorT<RawCalorimeterHit_factory_HcalEndcapNRawHits>(
+          {"HcalEndcapNHits"}, "HcalEndcapNRawHits"
+        ));
+        app->Add(new JChainFactoryGeneratorT<CalorimeterHit_factory_HcalEndcapNRecHits>(
+          {"HcalEndcapNRawHits"}, "HcalEndcapNRecHits"
+        ));
+        app->Add(new JChainFactoryGeneratorT<CalorimeterHit_factory_HcalEndcapNMergedHits>(
+          {"HcalEndcapNRawHits"}, "HcalEndcapNMergedRecHits"
+        ));
+        app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_HcalEndcapNTruthProtoClusters>(
+          {"HcalEndcapNRecHits"}, "HcalEndcapNTruthProtoClusters"
+        ));
+        app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_HcalEndcapNIslandProtoClusters>(
+          {"HcalEndcapNRecHits"}, "HcalEndcapNIslandProtoClusters"
+        ));
         app->Add(
           new JChainMultifactoryGeneratorT<Cluster_factory_HcalEndcapNTruthClusters>(
              "HcalEndcapNTruthClusters",

--- a/src/detectors/EHCAL/ProtoCluster_factory_HcalEndcapNIslandProtoClusters.h
+++ b/src/detectors/EHCAL/ProtoCluster_factory_HcalEndcapNIslandProtoClusters.h
@@ -82,7 +82,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        hits = event->Get<edm4eic::CalorimeterHit>(m_input_tag);
+        hits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/EHCAL/ProtoCluster_factory_HcalEndcapNIslandProtoClusters.h
+++ b/src/detectors/EHCAL/ProtoCluster_factory_HcalEndcapNIslandProtoClusters.h
@@ -6,19 +6,19 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterIslandCluster.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class ProtoCluster_factory_HcalEndcapNIslandProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, CalorimeterIslandCluster {
+class ProtoCluster_factory_HcalEndcapNIslandProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, CalorimeterIslandCluster {
 
 public:
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_HcalEndcapNIslandProtoClusters(){
-        SetTag("HcalEndcapNIslandProtoClusters");
+    ProtoCluster_factory_HcalEndcapNIslandProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -26,7 +26,6 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_input_tag = "HcalEndcapNMergedHits";
 
         // adjacency matrix
         m_geoSvcName = "GeoSvc";

--- a/src/detectors/EHCAL/ProtoCluster_factory_HcalEndcapNIslandProtoClusters.h
+++ b/src/detectors/EHCAL/ProtoCluster_factory_HcalEndcapNIslandProtoClusters.h
@@ -25,6 +25,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         // adjacency matrix

--- a/src/detectors/EHCAL/ProtoCluster_factory_HcalEndcapNTruthProtoClusters.h
+++ b/src/detectors/EHCAL/ProtoCluster_factory_HcalEndcapNTruthProtoClusters.h
@@ -8,19 +8,19 @@
 
 #include <edm4eic/ProtoClusterCollection.h>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterTruthClustering.h>
 
 
 
-class ProtoCluster_factory_HcalEndcapNTruthProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
+class ProtoCluster_factory_HcalEndcapNTruthProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
 
 public:
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_HcalEndcapNTruthProtoClusters(){
-        SetTag("HcalEndcapNTruthProtoClusters");
+    ProtoCluster_factory_HcalEndcapNTruthProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -28,8 +28,6 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_inputHit_tag="HcalEndcapNRecHits";
-        m_inputMCHit_tag="HcalEndcapNHits";
 
         AlgorithmInit(m_log);
     }
@@ -44,8 +42,8 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        m_inputHits = event->Get<edm4eic::CalorimeterHit>(m_inputHit_tag);
-        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(m_inputMCHit_tag);
+        m_inputHits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
+        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[1]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();
@@ -56,6 +54,4 @@ public:
     }
 private:
     // Name of input data type (collection)
-    std::string              m_inputHit_tag;
-    std::string              m_inputMCHit_tag;
 };

--- a/src/detectors/EHCAL/ProtoCluster_factory_HcalEndcapNTruthProtoClusters.h
+++ b/src/detectors/EHCAL/ProtoCluster_factory_HcalEndcapNTruthProtoClusters.h
@@ -52,6 +52,4 @@ public:
         Set(m_outputProtoClusters);
         m_outputProtoClusters.clear(); // not really needed, but better to not leave dangling pointers around
     }
-private:
-    // Name of input data type (collection)
 };

--- a/src/detectors/EHCAL/ProtoCluster_factory_HcalEndcapNTruthProtoClusters.h
+++ b/src/detectors/EHCAL/ProtoCluster_factory_HcalEndcapNTruthProtoClusters.h
@@ -27,6 +27,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         AlgorithmInit(m_log);

--- a/src/detectors/EHCAL/ProtoCluster_factory_HcalEndcapNTruthProtoClusters.h
+++ b/src/detectors/EHCAL/ProtoCluster_factory_HcalEndcapNTruthProtoClusters.h
@@ -29,8 +29,6 @@ public:
     void Init() override{
         InitDataTags(GetPluginName() + ":" + GetTag());
 
-        auto app = GetApplication();
-
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/EHCAL/RawCalorimeterHit_factory_HcalEndcapNRawHits.h
+++ b/src/detectors/EHCAL/RawCalorimeterHit_factory_HcalEndcapNRawHits.h
@@ -12,7 +12,7 @@
 #include <edm4hep/RawCalorimeterHit.h>
 #include <edm4hep/RawCalorimeterHitCollection.h>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterHitDigi.h>
 #include <services/log/Log_service.h>
@@ -20,14 +20,14 @@
 
 
 
-class RawCalorimeterHit_factory_HcalEndcapNRawHits : public eicrecon::JFactoryPodioT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
+class RawCalorimeterHit_factory_HcalEndcapNRawHits : public JChainFactoryT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
 
 public:
 
     //------------------------------------------
     // Constructor
-    RawCalorimeterHit_factory_HcalEndcapNRawHits() {
-        SetTag("HcalEndcapNRawHits");
+    RawCalorimeterHit_factory_HcalEndcapNRawHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4hep::RawCalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -37,7 +37,6 @@ public:
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
-        m_input_tag = "HcalEndcapNHits";
         u_eRes = {};
         m_tRes = 0.0 * dd4hep::ns;
         m_capADC = 1024;
@@ -52,7 +51,6 @@ public:
         m_geoSvc = app->GetService<JDD4hep_service>(); // TODO: implement named geometry service?
 
         // This is another option for exposing the data members as JANA configuration parameters.
-//        app->SetDefaultParameter("EHCAL:tag",              m_input_tag);
         app->SetDefaultParameter("EHCAL:HcalEndcapNRawHits:energyResolutions",u_eRes);
         app->SetDefaultParameter("EHCAL:HcalEndcapNRawHits:timeResolution",   m_tRes);
         app->SetDefaultParameter("EHCAL:HcalEndcapNRawHits:capacityADC",      m_capADC);

--- a/src/detectors/EHCAL/RawCalorimeterHit_factory_HcalEndcapNRawHits.h
+++ b/src/detectors/EHCAL/RawCalorimeterHit_factory_HcalEndcapNRawHits.h
@@ -79,7 +79,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override {
         // Prefill inputs
-        simhits = event->Get<edm4hep::SimCalorimeterHit>(m_input_tag);
+        simhits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/EHCAL/RawCalorimeterHit_factory_HcalEndcapNRawHits.h
+++ b/src/detectors/EHCAL/RawCalorimeterHit_factory_HcalEndcapNRawHits.h
@@ -34,6 +34,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override {
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm

--- a/src/detectors/FEMC/CalorimeterHit_factory_EcalEndcapPInsertRecHits.h
+++ b/src/detectors/FEMC/CalorimeterHit_factory_EcalEndcapPInsertRecHits.h
@@ -20,8 +20,9 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        InitDataTags(GetPluginName() + ":" + GetTag());
 
+        auto app = GetApplication();
 
         // digitization settings, must be consistent with digi class
         m_capADC=16384;//{this, "capacityADC", 8096};

--- a/src/detectors/FEMC/CalorimeterHit_factory_EcalEndcapPInsertRecHits.h
+++ b/src/detectors/FEMC/CalorimeterHit_factory_EcalEndcapPInsertRecHits.h
@@ -76,7 +76,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        rawhits = event->Get<edm4hep::RawCalorimeterHit>(m_input_tag);
+        rawhits = event->Get<edm4hep::RawCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/FEMC/CalorimeterHit_factory_EcalEndcapPInsertRecHits.h
+++ b/src/detectors/FEMC/CalorimeterHit_factory_EcalEndcapPInsertRecHits.h
@@ -1,19 +1,19 @@
 
 #pragma once
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 
 #include <algorithms/calorimetry/CalorimeterHitReco.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class CalorimeterHit_factory_EcalEndcapPInsertRecHits : public eicrecon::JFactoryPodioT<edm4eic::CalorimeterHit>, CalorimeterHitReco {
+class CalorimeterHit_factory_EcalEndcapPInsertRecHits : public JChainFactoryT<edm4eic::CalorimeterHit>, CalorimeterHitReco {
 
 public:
     //------------------------------------------
     // Constructor
-    CalorimeterHit_factory_EcalEndcapPInsertRecHits(){
-        SetTag("EcalEndcapPInsertRecHits");
+    CalorimeterHit_factory_EcalEndcapPInsertRecHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::CalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -22,7 +22,6 @@ public:
     void Init() override{
         auto app = GetApplication();
 
-        m_input_tag = "EcalEndcapPInsertRawHits";
 
         // digitization settings, must be consistent with digi class
         m_capADC=16384;//{this, "capacityADC", 8096};
@@ -47,8 +46,6 @@ public:
         m_localDetElement="";         // from ATHENA's reconstruction.py (i.e. not defined there)
         u_localDetFields={};          // from ATHENA's reconstruction.py (i.e. not defined there)
 
-//        app->SetDefaultParameter("FEMC:tag",              m_input_tag);
-        app->SetDefaultParameter("FEMC:EcalEndcapPInsertRecHits:input_tag",        m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("FEMC:EcalEndcapPInsertRecHits:capacityADC",      m_capADC);
         app->SetDefaultParameter("FEMC:EcalEndcapPInsertRecHits:dynamicRangeADC",  m_dyRangeADC);
         app->SetDefaultParameter("FEMC:EcalEndcapPInsertRecHits:pedestalMean",     m_pedMeanADC);

--- a/src/detectors/FEMC/CalorimeterHit_factory_EcalEndcapPRecHits.h
+++ b/src/detectors/FEMC/CalorimeterHit_factory_EcalEndcapPRecHits.h
@@ -77,7 +77,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        rawhits = event->Get<edm4hep::RawCalorimeterHit>(m_input_tag);
+        rawhits = event->Get<edm4hep::RawCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/FEMC/CalorimeterHit_factory_EcalEndcapPRecHits.h
+++ b/src/detectors/FEMC/CalorimeterHit_factory_EcalEndcapPRecHits.h
@@ -21,8 +21,9 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        InitDataTags(GetPluginName() + ":" + GetTag());
 
+        auto app = GetApplication();
 
         // digitization settings, must be consistent with digi class
         m_capADC=65536;//2^16 old: 16384

--- a/src/detectors/FEMC/CalorimeterHit_factory_EcalEndcapPRecHits.h
+++ b/src/detectors/FEMC/CalorimeterHit_factory_EcalEndcapPRecHits.h
@@ -3,18 +3,18 @@
 
 #include <edm4eic/CalorimeterHitCollection.h>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <algorithms/calorimetry/CalorimeterHitReco.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class CalorimeterHit_factory_EcalEndcapPRecHits : public eicrecon::JFactoryPodioT<edm4eic::CalorimeterHit>, CalorimeterHitReco {
+class CalorimeterHit_factory_EcalEndcapPRecHits : public JChainFactoryT<edm4eic::CalorimeterHit>, CalorimeterHitReco {
 
 public:
     //------------------------------------------
     // Constructor
-    CalorimeterHit_factory_EcalEndcapPRecHits(){
-        SetTag("EcalEndcapPRecHits");
+    CalorimeterHit_factory_EcalEndcapPRecHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::CalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -23,7 +23,6 @@ public:
     void Init() override{
         auto app = GetApplication();
 
-        m_input_tag = "EcalEndcapPRawHits";
 
         // digitization settings, must be consistent with digi class
         m_capADC=65536;//2^16 old: 16384
@@ -48,8 +47,6 @@ public:
         m_localDetElement="";         // from ATHENA's reconstruction.py (i.e. not defined there)
         u_localDetFields={};          // from ATHENA's reconstruction.py (i.e. not defined there)
 
-//        app->SetDefaultParameter("FEMC:tag",              m_input_tag);
-        app->SetDefaultParameter("FEMC:EcalEndcapPRecHits:input_tag",        m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("FEMC:EcalEndcapPRecHits:capacityADC",      m_capADC);
         app->SetDefaultParameter("FEMC:EcalEndcapPRecHits:dynamicRangeADC",  m_dyRangeADC);
         app->SetDefaultParameter("FEMC:EcalEndcapPRecHits:pedestalMean",     m_pedMeanADC);

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -39,7 +39,7 @@ extern "C" {
           {"EcalEndcapPRawHits"}, "EcalEndcapPRecHits"
         ));
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_EcalEndcapPTruthProtoClusters>(
-          {"EcalEndcapPRecHits"}, "EcalEndcapPTruthProtoClusters"
+          {"EcalEndcapPRecHits", "EcalEndcapPHits"}, "EcalEndcapPTruthProtoClusters"
         ));
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_EcalEndcapPIslandProtoClusters>(
           {"EcalEndcapPRecHits"}, "EcalEndcapPIslandProtoClusters"
@@ -90,7 +90,7 @@ extern "C" {
           {"EcalEndcapPInsertRawHits"}, "EcalEndcapPInsertRecHits"
         ));
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_EcalEndcapPInsertTruthProtoClusters>(
-          {"EcalEndcapPInsertRecHits"}, "EcalEndcapPInsertTruthProtoClusters"
+          {"EcalEndcapPInsertRecHits", "EcalEndcapPInsertHits"}, "EcalEndcapPInsertTruthProtoClusters"
         ));
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_EcalEndcapPInsertIslandProtoClusters>(
           {"EcalEndcapPInsertRecHits"}, "EcalEndcapPInsertIslandProtoClusters"

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -3,6 +3,7 @@
 //
 //
 
+#include <extensions/jana/JChainFactoryGeneratorT.h>
 #include <extensions/jana/JChainMultifactoryGeneratorT.h>
 
 #include <factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h>
@@ -31,10 +32,18 @@ extern "C" {
 
         InitJANAPlugin(app);
 
-        app->Add(new JFactoryGeneratorT<RawCalorimeterHit_factory_EcalEndcapPRawHits>());
-        app->Add(new JFactoryGeneratorT<CalorimeterHit_factory_EcalEndcapPRecHits>());
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_EcalEndcapPTruthProtoClusters>());
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_EcalEndcapPIslandProtoClusters>());
+        app->Add(new JChainFactoryGeneratorT<RawCalorimeterHit_factory_EcalEndcapPRawHits>(
+          {"EcalEndcapPHits"}, "EcalEndcapPRawHits"
+        ));
+        app->Add(new JChainFactoryGeneratorT<CalorimeterHit_factory_EcalEndcapPRecHits>(
+          {"EcalEndcapPRawHits"}, "EcalEndcapPRecHits"
+        ));
+        app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_EcalEndcapPTruthProtoClusters>(
+          {"EcalEndcapPRecHits"}, "EcalEndcapPTruthProtoClusters"
+        ));
+        app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_EcalEndcapPIslandProtoClusters>(
+          {"EcalEndcapPRecHits"}, "EcalEndcapPIslandProtoClusters"
+        ));
 
         app->Add(
           new JChainMultifactoryGeneratorT<Cluster_factory_EcalEndcapPTruthClusters>(
@@ -74,10 +83,18 @@ extern "C" {
           )
         );
 
-        app->Add(new JFactoryGeneratorT<RawCalorimeterHit_factory_EcalEndcapPInsertRawHits>());
-        app->Add(new JFactoryGeneratorT<CalorimeterHit_factory_EcalEndcapPInsertRecHits>());
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_EcalEndcapPInsertTruthProtoClusters>());
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_EcalEndcapPInsertIslandProtoClusters>());
+        app->Add(new JChainFactoryGeneratorT<RawCalorimeterHit_factory_EcalEndcapPInsertRawHits>(
+          {"EcalEndcapPInsertHits"}, "EcalEndcapPInsertRawHits"
+        ));
+        app->Add(new JChainFactoryGeneratorT<CalorimeterHit_factory_EcalEndcapPInsertRecHits>(
+          {"EcalEndcapPInsertRawHits"}, "EcalEndcapPInsertRecHits"
+        ));
+        app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_EcalEndcapPInsertTruthProtoClusters>(
+          {"EcalEndcapPInsertRecHits"}, "EcalEndcapPInsertTruthProtoClusters"
+        ));
+        app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_EcalEndcapPInsertIslandProtoClusters>(
+          {"EcalEndcapPInsertRecHits"}, "EcalEndcapPInsertIslandProtoClusters"
+        ));
 
         app->Add(
           new JChainMultifactoryGeneratorT<Cluster_factory_EcalEndcapPInsertTruthClusters>(

--- a/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPInsertIslandProtoClusters.h
+++ b/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPInsertIslandProtoClusters.h
@@ -82,7 +82,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        hits = event->Get<edm4eic::CalorimeterHit>(m_input_tag);
+        hits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPInsertIslandProtoClusters.h
+++ b/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPInsertIslandProtoClusters.h
@@ -6,19 +6,19 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterIslandCluster.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class ProtoCluster_factory_EcalEndcapPInsertIslandProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, CalorimeterIslandCluster {
+class ProtoCluster_factory_EcalEndcapPInsertIslandProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, CalorimeterIslandCluster {
 
 public:
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_EcalEndcapPInsertIslandProtoClusters(){
-        SetTag("EcalEndcapPInsertIslandProtoClusters");
+    ProtoCluster_factory_EcalEndcapPInsertIslandProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -26,7 +26,6 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_input_tag = "EcalEndcapPInsertRecHits";
 
         // adjacency matrix
         m_geoSvcName = "GeoSvc";
@@ -51,7 +50,6 @@ public:
         u_transverseEnergyProfileMetric = "globalDistEtaPhi";
         u_transverseEnergyProfileScale = 1.;
 
-        app->SetDefaultParameter("FEMC:EcalEndcapPInsertIslandProtoClusters:input_tag",        m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("FEMC:EcalEndcapPInsertIslandProtoClusters:geoServiceName", m_geoSvcName);
         app->SetDefaultParameter("FEMC:EcalEndcapPInsertIslandProtoClusters:readoutClass", m_readout);
         app->SetDefaultParameter("FEMC:EcalEndcapPInsertIslandProtoClusters:sectorDist",   m_sectorDist);

--- a/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPInsertIslandProtoClusters.h
+++ b/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPInsertIslandProtoClusters.h
@@ -25,6 +25,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         // adjacency matrix

--- a/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPInsertTruthProtoClusters.h
+++ b/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPInsertTruthProtoClusters.h
@@ -27,7 +27,6 @@ public:
     void Init() override{
         auto app = GetApplication();
 
-
         AlgorithmInit(m_log);
     }
 
@@ -51,6 +50,4 @@ public:
         Set(m_outputProtoClusters);
         m_outputProtoClusters.clear(); // not really needed, but better to not leave dangling pointers around
     }
-private:
-    // Name of input data type (collection)
 };

--- a/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPInsertTruthProtoClusters.h
+++ b/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPInsertTruthProtoClusters.h
@@ -25,6 +25,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         AlgorithmInit(m_log);

--- a/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPInsertTruthProtoClusters.h
+++ b/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPInsertTruthProtoClusters.h
@@ -27,8 +27,6 @@ public:
     void Init() override{
         InitDataTags(GetPluginName() + ":" + GetTag());
 
-        auto app = GetApplication();
-
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPInsertTruthProtoClusters.h
+++ b/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPInsertTruthProtoClusters.h
@@ -6,19 +6,19 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterTruthClustering.h>
 
 
 
-class ProtoCluster_factory_EcalEndcapPInsertTruthProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
+class ProtoCluster_factory_EcalEndcapPInsertTruthProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
 
 public:
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_EcalEndcapPInsertTruthProtoClusters(){
-        SetTag("EcalEndcapPInsertTruthProtoClusters");
+    ProtoCluster_factory_EcalEndcapPInsertTruthProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -26,10 +26,7 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_inputHit_tag="EcalEndcapPInsertRecHits";
-        m_inputMCHit_tag="EcalEndcapPInsertHits";
 
-        app->SetDefaultParameter("FEMC:EcalEndcapPInsertTruthProtoClusters:inputHit_tag",        m_inputHit_tag, "Name of input collection to use");
 
         AlgorithmInit(m_log);
     }
@@ -44,8 +41,8 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        m_inputHits = event->Get<edm4eic::CalorimeterHit>(m_inputHit_tag);
-        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(m_inputMCHit_tag);
+        m_inputHits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
+        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[1]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();
@@ -56,6 +53,4 @@ public:
     }
 private:
     // Name of input data type (collection)
-    std::string              m_inputHit_tag;
-    std::string              m_inputMCHit_tag;
 };

--- a/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPIslandProtoClusters.h
+++ b/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPIslandProtoClusters.h
@@ -82,7 +82,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        hits = event->Get<edm4eic::CalorimeterHit>(m_input_tag);
+        hits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPIslandProtoClusters.h
+++ b/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPIslandProtoClusters.h
@@ -25,6 +25,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         // adjacency matrix

--- a/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPIslandProtoClusters.h
+++ b/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPIslandProtoClusters.h
@@ -6,19 +6,19 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterIslandCluster.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class ProtoCluster_factory_EcalEndcapPIslandProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, CalorimeterIslandCluster {
+class ProtoCluster_factory_EcalEndcapPIslandProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, CalorimeterIslandCluster {
 
 public:
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_EcalEndcapPIslandProtoClusters(){
-        SetTag("EcalEndcapPIslandProtoClusters");
+    ProtoCluster_factory_EcalEndcapPIslandProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -26,7 +26,6 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_input_tag = "EcalEndcapPRecHits";
 
         // adjacency matrix
         m_geoSvcName = "GeoSvc";
@@ -51,7 +50,6 @@ public:
         u_transverseEnergyProfileMetric = "globalDistEtaPhi";
         u_transverseEnergyProfileScale = 0.04;
 
-        app->SetDefaultParameter("FEMC:EcalEndcapPIslandProtoClusters:input_tag",        m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("FEMC:EcalEndcapPIslandProtoClusters:geoServiceName", m_geoSvcName);
         app->SetDefaultParameter("FEMC:EcalEndcapPIslandProtoClusters:readoutClass", m_readout);
         app->SetDefaultParameter("FEMC:EcalEndcapPIslandProtoClusters:sectorDist",   m_sectorDist);

--- a/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPTruthProtoClusters.h
+++ b/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPTruthProtoClusters.h
@@ -8,19 +8,19 @@
 
 #include <edm4eic/ProtoClusterCollection.h>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterTruthClustering.h>
 
 
 
-class ProtoCluster_factory_EcalEndcapPTruthProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
+class ProtoCluster_factory_EcalEndcapPTruthProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
 
 public:
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_EcalEndcapPTruthProtoClusters(){
-        SetTag("EcalEndcapPTruthProtoClusters");
+    ProtoCluster_factory_EcalEndcapPTruthProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -28,10 +28,7 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_inputHit_tag="EcalEndcapPRecHits";
-        m_inputMCHit_tag="EcalEndcapPHits";
 
-        app->SetDefaultParameter("FEMC:EcalEndcapPTruthProtoClusters:inputHit_tag",        m_inputHit_tag, "Name of input collection to use");
 
         AlgorithmInit(m_log);
     }
@@ -46,8 +43,8 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        m_inputHits = event->Get<edm4eic::CalorimeterHit>(m_inputHit_tag);
-        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(m_inputMCHit_tag);
+        m_inputHits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
+        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[1]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();
@@ -58,6 +55,4 @@ public:
     }
 private:
     // Name of input data type (collection)
-    std::string              m_inputHit_tag;
-    std::string              m_inputMCHit_tag;
 };

--- a/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPTruthProtoClusters.h
+++ b/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPTruthProtoClusters.h
@@ -29,7 +29,6 @@ public:
     void Init() override{
         auto app = GetApplication();
 
-
         AlgorithmInit(m_log);
     }
 
@@ -53,6 +52,4 @@ public:
         Set(m_outputProtoClusters);
         m_outputProtoClusters.clear(); // not really needed, but better to not leave dangling pointers around
     }
-private:
-    // Name of input data type (collection)
 };

--- a/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPTruthProtoClusters.h
+++ b/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPTruthProtoClusters.h
@@ -27,6 +27,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         AlgorithmInit(m_log);

--- a/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPTruthProtoClusters.h
+++ b/src/detectors/FEMC/ProtoCluster_factory_EcalEndcapPTruthProtoClusters.h
@@ -29,8 +29,6 @@ public:
     void Init() override{
         InitDataTags(GetPluginName() + ":" + GetTag());
 
-        auto app = GetApplication();
-
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/FEMC/RawCalorimeterHit_factory_EcalEndcapPInsertRawHits.h
+++ b/src/detectors/FEMC/RawCalorimeterHit_factory_EcalEndcapPInsertRawHits.h
@@ -32,6 +32,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override {
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm

--- a/src/detectors/FEMC/RawCalorimeterHit_factory_EcalEndcapPInsertRawHits.h
+++ b/src/detectors/FEMC/RawCalorimeterHit_factory_EcalEndcapPInsertRawHits.h
@@ -77,7 +77,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override {
         // Prefill inputs
-        simhits = event->Get<edm4hep::SimCalorimeterHit>(m_input_tag);
+        simhits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/FEMC/RawCalorimeterHit_factory_EcalEndcapPInsertRawHits.h
+++ b/src/detectors/FEMC/RawCalorimeterHit_factory_EcalEndcapPInsertRawHits.h
@@ -7,7 +7,7 @@
 #include <random>
 
 #include <JANA/JEvent.h>
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterHitDigi.h>
 #include <edm4hep/SimCalorimeterHit.h>
@@ -18,14 +18,14 @@
 
 
 
-class RawCalorimeterHit_factory_EcalEndcapPInsertRawHits : public eicrecon::JFactoryPodioT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
+class RawCalorimeterHit_factory_EcalEndcapPInsertRawHits : public JChainFactoryT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
 
 public:
 
     //------------------------------------------
     // Constructor
-    RawCalorimeterHit_factory_EcalEndcapPInsertRawHits() {
-        SetTag("EcalEndcapPInsertRawHits");
+    RawCalorimeterHit_factory_EcalEndcapPInsertRawHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4hep::RawCalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -35,7 +35,6 @@ public:
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
-        m_input_tag = "EcalEndcapPInsertHits";
         u_eRes = {0.00340 * sqrt(dd4hep::GeV), 0.0009, 0.0 * dd4hep::GeV}; // (0.340% / sqrt(E)) \oplus 0.09%
         m_tRes = 0.0 * dd4hep::ns;
         m_capADC = 16384;
@@ -50,8 +49,6 @@ public:
         m_geoSvc = app->GetService<JDD4hep_service>(); // TODO: implement named geometry service?
 
         // This is another option for exposing the data members as JANA configuration parameters.
-//        app->SetDefaultParameter("FEMC:tag",              m_input_tag);
-        app->SetDefaultParameter("FEMC:EcalEndcapPInsertRawHits:input_tag",        m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("FEMC:EcalEndcapPInsertRawHits:energyResolutions",u_eRes);
         app->SetDefaultParameter("FEMC:EcalEndcapPInsertRawHits:timeResolution",   m_tRes);
         app->SetDefaultParameter("FEMC:EcalEndcapPInsertRawHits:capacityADC",      m_capADC);

--- a/src/detectors/FEMC/RawCalorimeterHit_factory_EcalEndcapPRawHits.h
+++ b/src/detectors/FEMC/RawCalorimeterHit_factory_EcalEndcapPRawHits.h
@@ -12,7 +12,7 @@
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JEvent.h>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterHitDigi.h>
 #include <services/log/Log_service.h>
@@ -20,14 +20,14 @@
 
 
 
-class RawCalorimeterHit_factory_EcalEndcapPRawHits : public eicrecon::JFactoryPodioT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
+class RawCalorimeterHit_factory_EcalEndcapPRawHits : public JChainFactoryT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
 
 public:
 
     //------------------------------------------
     // Constructor
-    RawCalorimeterHit_factory_EcalEndcapPRawHits() {
-        SetTag("EcalEndcapPRawHits");
+    RawCalorimeterHit_factory_EcalEndcapPRawHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4hep::RawCalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -37,7 +37,6 @@ public:
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
-        m_input_tag = "EcalEndcapPHits";
         u_eRes = {0.00340 * sqrt(dd4hep::GeV), 0.0009, 0.0 * dd4hep::GeV}; // (0.340% / sqrt(E)) \oplus 0.09%
         m_tRes = 0.0 ;
         m_capTime = 100 ; // given in ns, 4 samples in HGCROC
@@ -55,8 +54,6 @@ public:
 
 
         // This is another option for exposing the data members as JANA configuration parameters.
-//        app->SetDefaultParameter("FEMC:tag",              m_input_tag);
-        app->SetDefaultParameter("FEMC:EcalEndcapPRawHits:input_tag",        m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("FEMC:EcalEndcapPRawHits:energyResolutions",u_eRes);
         app->SetDefaultParameter("FEMC:EcalEndcapPRawHits:timeResolution",   m_tRes);
         app->SetDefaultParameter("FEMC:EcalEndcapPRawHits:capacityADC",      m_capADC);

--- a/src/detectors/FEMC/RawCalorimeterHit_factory_EcalEndcapPRawHits.h
+++ b/src/detectors/FEMC/RawCalorimeterHit_factory_EcalEndcapPRawHits.h
@@ -82,7 +82,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override {
         // Prefill inputs
-        simhits = event->Get<edm4hep::SimCalorimeterHit>(m_input_tag);
+        simhits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/FEMC/RawCalorimeterHit_factory_EcalEndcapPRawHits.h
+++ b/src/detectors/FEMC/RawCalorimeterHit_factory_EcalEndcapPRawHits.h
@@ -34,6 +34,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override {
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm

--- a/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPInsertMergedHits.h
+++ b/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPInsertMergedHits.h
@@ -1,19 +1,19 @@
 
 #pragma once
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 
 #include <algorithms/calorimetry/CalorimeterHitsMerger.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class CalorimeterHit_factory_HcalEndcapPInsertMergedHits : public eicrecon::JFactoryPodioT<edm4eic::CalorimeterHit>, CalorimeterHitsMerger {
+class CalorimeterHit_factory_HcalEndcapPInsertMergedHits : public JChainFactoryT<edm4eic::CalorimeterHit>, CalorimeterHitsMerger {
 
 public:
     //------------------------------------------
     // Constructor
-    CalorimeterHit_factory_HcalEndcapPInsertMergedHits(){
-        SetTag("HcalEndcapPInsertMergedHits");
+    CalorimeterHit_factory_HcalEndcapPInsertMergedHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::CalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -23,7 +23,6 @@ public:
         auto app = GetApplication();
         m_log = app->GetService<Log_service>()->logger(GetTag());
 
-        m_input_tag = "HcalEndcapPInsertRecHits";
 
         m_readout="HcalEndcapPInsertHits";
         u_fields={"layer", "slice"};  // from ATHENA's reconstruction.py
@@ -31,7 +30,6 @@ public:
 
         m_geoSvc= app->GetService<JDD4hep_service>();
 
-        app->SetDefaultParameter("FHCAL:HcalEndcapPInsertMergedHits:input_tag", m_input_tag);
         app->SetDefaultParameter("FHCAL:HcalEndcapPInsertMergedHits:fields", u_fields);
         app->SetDefaultParameter("FHCAL:HcalEndcapPInsertMergedHits:refs",  u_refs);
 

--- a/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPInsertMergedHits.h
+++ b/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPInsertMergedHits.h
@@ -23,7 +23,6 @@ public:
         auto app = GetApplication();
         m_log = app->GetService<Log_service>()->logger(GetTag());
 
-
         m_readout="HcalEndcapPInsertHits";
         u_fields={"layer", "slice"};  // from ATHENA's reconstruction.py
         u_refs={1, 0};                // from ATHENA's reconstruction.py
@@ -53,7 +52,4 @@ public:
         Set(m_outputs);
         m_outputs.clear(); // not really needed, but better to not leave dangling pointers around
     }
-
-private:
-    std::string m_input_tag;
 };

--- a/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPInsertMergedHits.h
+++ b/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPInsertMergedHits.h
@@ -43,7 +43,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        m_inputs = event->Get<edm4eic::CalorimeterHit>(m_input_tag);
+        m_inputs = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         execute();

--- a/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPInsertMergedHits.h
+++ b/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPInsertMergedHits.h
@@ -20,6 +20,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
         m_log = app->GetService<Log_service>()->logger(GetTag());
 

--- a/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPInsertRecHits.h
+++ b/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPInsertRecHits.h
@@ -20,8 +20,9 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        InitDataTags(GetPluginName() + ":" + GetTag());
 
+        auto app = GetApplication();
 
         // digitization settings, must be consistent with digi class
         m_capADC=32768;//{this, "capacityADC", 8096};

--- a/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPInsertRecHits.h
+++ b/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPInsertRecHits.h
@@ -1,19 +1,19 @@
 
 #pragma once
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 
 #include <algorithms/calorimetry/CalorimeterHitReco.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class CalorimeterHit_factory_HcalEndcapPInsertRecHits : public eicrecon::JFactoryPodioT<edm4eic::CalorimeterHit>, CalorimeterHitReco {
+class CalorimeterHit_factory_HcalEndcapPInsertRecHits : public JChainFactoryT<edm4eic::CalorimeterHit>, CalorimeterHitReco {
 
 public:
     //------------------------------------------
     // Constructor
-    CalorimeterHit_factory_HcalEndcapPInsertRecHits(){
-        SetTag("HcalEndcapPInsertRecHits");
+    CalorimeterHit_factory_HcalEndcapPInsertRecHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::CalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -22,7 +22,6 @@ public:
     void Init() override{
         auto app = GetApplication();
 
-        m_input_tag = "HcalEndcapPInsertRawHits";
 
         // digitization settings, must be consistent with digi class
         m_capADC=32768;//{this, "capacityADC", 8096};
@@ -47,7 +46,6 @@ public:
         m_localDetElement="";         // from ATHENA's reconstruction.py (i.e. not defined there)
         u_localDetFields={};          // from ATHENA's reconstruction.py (i.e. not defined there)
 
-//        app->SetDefaultParameter("FHCAL:tag",              m_input_tag);
         app->SetDefaultParameter("FHCAL:HcalEndcapPInsertRecHits:capacityADC",      m_capADC);
         app->SetDefaultParameter("FHCAL:HcalEndcapPInsertRecHits:dynamicRangeADC",  m_dyRangeADC);
         app->SetDefaultParameter("FHCAL:HcalEndcapPInsertRecHits:pedestalMean",     m_pedMeanADC);

--- a/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPInsertRecHits.h
+++ b/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPInsertRecHits.h
@@ -76,7 +76,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        rawhits = event->Get<edm4hep::RawCalorimeterHit>(m_input_tag);
+        rawhits = event->Get<edm4hep::RawCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPMergedHits.h
+++ b/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPMergedHits.h
@@ -23,7 +23,6 @@ public:
         auto app = GetApplication();
         m_log = app->GetService<Log_service>()->logger(GetTag());
 
-
         m_readout="HcalEndcapPHits";
         u_fields={"layer", "slice"};  // from ATHENA's reconstruction.py
         u_refs={1, 0};                // from ATHENA's reconstruction.py
@@ -54,7 +53,4 @@ public:
         Set(m_outputs);
         m_outputs.clear(); // not really needed, but better to not leave dangling pointers around
     }
-
-private:
-    std::string m_input_tag;
 };

--- a/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPMergedHits.h
+++ b/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPMergedHits.h
@@ -44,7 +44,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        m_inputs = event->Get<edm4eic::CalorimeterHit>(m_input_tag);
+        m_inputs = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         execute();

--- a/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPMergedHits.h
+++ b/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPMergedHits.h
@@ -1,19 +1,19 @@
 
 #pragma once
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 
 #include <algorithms/calorimetry/CalorimeterHitsMerger.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class CalorimeterHit_factory_HcalEndcapPMergedHits : public eicrecon::JFactoryPodioT<edm4eic::CalorimeterHit>, CalorimeterHitsMerger {
+class CalorimeterHit_factory_HcalEndcapPMergedHits : public JChainFactoryT<edm4eic::CalorimeterHit>, CalorimeterHitsMerger {
 
 public:
     //------------------------------------------
     // Constructor
-    CalorimeterHit_factory_HcalEndcapPMergedHits(){
-        SetTag("HcalEndcapPMergedHits");
+    CalorimeterHit_factory_HcalEndcapPMergedHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::CalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -23,7 +23,6 @@ public:
         auto app = GetApplication();
         m_log = app->GetService<Log_service>()->logger(GetTag());
 
-        m_input_tag = "HcalEndcapPRecHits";
 
         m_readout="HcalEndcapPHits";
         u_fields={"layer", "slice"};  // from ATHENA's reconstruction.py
@@ -31,7 +30,6 @@ public:
 
         m_geoSvc= app->GetService<JDD4hep_service>();
 
-        app->SetDefaultParameter("FHCAL:HcalEndcapPMergedHits:input_tag", m_input_tag);
         app->SetDefaultParameter("FHCAL:HcalEndcapPMergedHits:readout", m_readout);
         app->SetDefaultParameter("FHCAL:HcalEndcapPMergedHits:fields", u_fields);
         app->SetDefaultParameter("FHCAL:HcalEndcapPMergedHits:refs",  u_refs);

--- a/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPMergedHits.h
+++ b/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPMergedHits.h
@@ -20,6 +20,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
         m_log = app->GetService<Log_service>()->logger(GetTag());
 

--- a/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPRecHits.h
+++ b/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPRecHits.h
@@ -3,18 +3,18 @@
 
 #include <edm4eic/CalorimeterHitCollection.h>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <algorithms/calorimetry/CalorimeterHitReco.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class CalorimeterHit_factory_HcalEndcapPRecHits : public eicrecon::JFactoryPodioT<edm4eic::CalorimeterHit>, CalorimeterHitReco {
+class CalorimeterHit_factory_HcalEndcapPRecHits : public JChainFactoryT<edm4eic::CalorimeterHit>, CalorimeterHitReco {
 
 public:
     //------------------------------------------
     // Constructor
-    CalorimeterHit_factory_HcalEndcapPRecHits(){
-        SetTag("HcalEndcapPRecHits");
+    CalorimeterHit_factory_HcalEndcapPRecHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::CalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -23,7 +23,6 @@ public:
     void Init() override{
         auto app = GetApplication();
 
-        m_input_tag = "HcalEndcapPRawHits";
 
         // digitization settings, must be consistent with digi class
         m_capADC=65536;
@@ -48,7 +47,6 @@ public:
         m_localDetElement="";         // from ATHENA's reconstruction.py (i.e. not defined there)
         u_localDetFields={};          // from ATHENA's reconstruction.py (i.e. not defined there)
 
-//        app->SetDefaultParameter("FHCAL:tag",              m_input_tag);
         app->SetDefaultParameter("FHCAL:HcalEndcapPRecHits:capacityADC",      m_capADC);
         app->SetDefaultParameter("FHCAL:HcalEndcapPRecHits:dynamicRangeADC",  m_dyRangeADC);
         app->SetDefaultParameter("FHCAL:HcalEndcapPRecHits:pedestalMean",     m_pedMeanADC);

--- a/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPRecHits.h
+++ b/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPRecHits.h
@@ -77,7 +77,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        rawhits = event->Get<edm4hep::RawCalorimeterHit>(m_input_tag);
+        rawhits = event->Get<edm4hep::RawCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPRecHits.h
+++ b/src/detectors/FHCAL/CalorimeterHit_factory_HcalEndcapPRecHits.h
@@ -21,8 +21,9 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        InitDataTags(GetPluginName() + ":" + GetTag());
 
+        auto app = GetApplication();
 
         // digitization settings, must be consistent with digi class
         m_capADC=65536;

--- a/src/detectors/FHCAL/CalorimeterHit_factory_LFHCALRecHits.h
+++ b/src/detectors/FHCAL/CalorimeterHit_factory_LFHCALRecHits.h
@@ -6,18 +6,18 @@
 
 #include <JANA/JFactoryT.h>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <algorithms/calorimetry/CalorimeterHitReco.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class CalorimeterHit_factory_LFHCALRecHits : public eicrecon::JFactoryPodioT<edm4eic::CalorimeterHit>, CalorimeterHitReco {
+class CalorimeterHit_factory_LFHCALRecHits : public JChainFactoryT<edm4eic::CalorimeterHit>, CalorimeterHitReco {
 
 public:
     //------------------------------------------
     // Constructor
-    CalorimeterHit_factory_LFHCALRecHits(){
-        SetTag("LFHCALRecHits");
+    CalorimeterHit_factory_LFHCALRecHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::CalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -26,7 +26,6 @@ public:
     void Init() override{
         auto app = GetApplication();
 
-        m_input_tag = "LFHCALRawHits";
 
         // digitization settings, must be consistent with digi class
         m_capADC=65536;//2^16
@@ -52,7 +51,6 @@ public:
         m_localDetElement="";
         u_localDetFields={};
 
-//        app->SetDefaultParameter("FHCAL:tag",              m_input_tag);
         app->SetDefaultParameter("FHCAL:LFHCALRecHits:capacityADC",      m_capADC);
         app->SetDefaultParameter("FHCAL:LFHCALRecHits:dynamicRangeADC",  m_dyRangeADC);
         app->SetDefaultParameter("FHCAL:LFHCALRecHits:pedestalMean",     m_pedMeanADC);

--- a/src/detectors/FHCAL/CalorimeterHit_factory_LFHCALRecHits.h
+++ b/src/detectors/FHCAL/CalorimeterHit_factory_LFHCALRecHits.h
@@ -24,8 +24,9 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        InitDataTags(GetPluginName() + ":" + GetTag());
 
+        auto app = GetApplication();
 
         // digitization settings, must be consistent with digi class
         m_capADC=65536;//2^16

--- a/src/detectors/FHCAL/CalorimeterHit_factory_LFHCALRecHits.h
+++ b/src/detectors/FHCAL/CalorimeterHit_factory_LFHCALRecHits.h
@@ -81,7 +81,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        rawhits = event->Get<edm4hep::RawCalorimeterHit>(m_input_tag);
+        rawhits = event->Get<edm4hep::RawCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -48,7 +48,7 @@ extern "C" {
           {"HcalEndcapPRawHits"}, "HcalEndcapPRecHits"
         ));
         app->Add(new JChainFactoryGeneratorT<CalorimeterHit_factory_HcalEndcapPMergedHits>(
-          {"HcalEndcapPRawHits"}, "HcalEndcapPMergedHits"
+          {"HcalEndcapPRecHits"}, "HcalEndcapPMergedHits"
         ));
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_HcalEndcapPTruthProtoClusters>(
           {"HcalEndcapPRecHits", "HcalEndcapPHits"}, "HcalEndcapPTruthProtoClusters"
@@ -102,7 +102,7 @@ extern "C" {
           {"HcalEndcapPInsertRawHits"}, "HcalEndcapPInsertRecHits"
         ));
         app->Add(new JChainFactoryGeneratorT<CalorimeterHit_factory_HcalEndcapPInsertMergedHits>(
-          {"HcalEndcapPInsertRawHits"}, "HcalEndcapPInsertMergedHits"
+          {"HcalEndcapPInsertRecHits"}, "HcalEndcapPInsertMergedHits"
         ));
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_HcalEndcapPInsertTruthProtoClusters>(
           {"HcalEndcapPInsertMergedHits", "HcalEndcapPInsertHits"}, "HcalEndcapPInsertTruthProtoClusters"

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -51,7 +51,7 @@ extern "C" {
           {"HcalEndcapPRawHits"}, "HcalEndcapPMergedHits"
         ));
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_HcalEndcapPTruthProtoClusters>(
-          {"HcalEndcapPRecHits"}, "HcalEndcapPTruthProtoClusters"
+          {"HcalEndcapPRecHits", "HcalEndcapPHits"}, "HcalEndcapPTruthProtoClusters"
         ));
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_HcalEndcapPIslandProtoClusters>(
           {"HcalEndcapPRecHits"}, "HcalEndcapPIslandProtoClusters"
@@ -105,7 +105,7 @@ extern "C" {
           {"HcalEndcapPInsertRawHits"}, "HcalEndcapPInsertMergedHits"
         ));
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_HcalEndcapPInsertTruthProtoClusters>(
-          {"HcalEndcapPInsertMergedHits"}, "HcalEndcapPInsertTruthProtoClusters"
+          {"HcalEndcapPInsertMergedHits", "HcalEndcapPInsertHits"}, "HcalEndcapPInsertTruthProtoClusters"
         ));
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_HcalEndcapPInsertIslandProtoClusters>(
           {"HcalEndcapPInsertMergedHits"}, "HcalEndcapPInsertIslandProtoClusters"
@@ -156,7 +156,7 @@ extern "C" {
           {"LFHCALRawHits"}, "LFHCALRecHits"
         ));
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_LFHCALTruthProtoClusters>(
-          {"LFHCALRecHits"}, "LFHCALTruthProtoClusters"
+          {"LFHCALRecHits", "LFHCALHits"}, "LFHCALTruthProtoClusters"
         ));
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_LFHCALIslandProtoClusters>(
           {"LFHCALRecHits"}, "LFHCALIslandProtoClusters"

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -3,6 +3,7 @@
 //
 //
 
+#include <extensions/jana/JChainFactoryGeneratorT.h>
 #include <extensions/jana/JChainMultifactoryGeneratorT.h>
 
 #include <factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h>
@@ -40,11 +41,21 @@ extern "C" {
 
         InitJANAPlugin(app);
 
-        app->Add(new JFactoryGeneratorT<RawCalorimeterHit_factory_HcalEndcapPRawHits>());
-        app->Add(new JFactoryGeneratorT<CalorimeterHit_factory_HcalEndcapPRecHits>());
-        app->Add(new JFactoryGeneratorT<CalorimeterHit_factory_HcalEndcapPMergedHits>());
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_HcalEndcapPTruthProtoClusters>());
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_HcalEndcapPIslandProtoClusters>());
+        app->Add(new JChainFactoryGeneratorT<RawCalorimeterHit_factory_HcalEndcapPRawHits>(
+          {"HcalEndcapPHits"}, "HcalEndcapPRawHits"
+        ));
+        app->Add(new JChainFactoryGeneratorT<CalorimeterHit_factory_HcalEndcapPRecHits>(
+          {"HcalEndcapPRawHits"}, "HcalEndcapPRecHits"
+        ));
+        app->Add(new JChainFactoryGeneratorT<CalorimeterHit_factory_HcalEndcapPMergedHits>(
+          {"HcalEndcapPRawHits"}, "HcalEndcapPMergedHits"
+        ));
+        app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_HcalEndcapPTruthProtoClusters>(
+          {"HcalEndcapPRecHits"}, "HcalEndcapPTruthProtoClusters"
+        ));
+        app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_HcalEndcapPIslandProtoClusters>(
+          {"HcalEndcapPRecHits"}, "HcalEndcapPIslandProtoClusters"
+        ));
 
         app->Add(
           new JChainMultifactoryGeneratorT<Cluster_factory_HcalEndcapPTruthClusters>(
@@ -84,11 +95,21 @@ extern "C" {
           )
         );
 
-        app->Add(new JFactoryGeneratorT<RawCalorimeterHit_factory_HcalEndcapPInsertRawHits>());
-        app->Add(new JFactoryGeneratorT<CalorimeterHit_factory_HcalEndcapPInsertRecHits>());
-        app->Add(new JFactoryGeneratorT<CalorimeterHit_factory_HcalEndcapPInsertMergedHits>());
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_HcalEndcapPInsertTruthProtoClusters>());
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_HcalEndcapPInsertIslandProtoClusters>());
+        app->Add(new JChainFactoryGeneratorT<RawCalorimeterHit_factory_HcalEndcapPInsertRawHits>(
+          {"HcalEndcapPInsertHits"}, "HcalEndcapPInsertRawHits"
+        ));
+        app->Add(new JChainFactoryGeneratorT<CalorimeterHit_factory_HcalEndcapPInsertRecHits>(
+          {"HcalEndcapPInsertRawHits"}, "HcalEndcapPInsertRecHits"
+        ));
+        app->Add(new JChainFactoryGeneratorT<CalorimeterHit_factory_HcalEndcapPInsertMergedHits>(
+          {"HcalEndcapPInsertRawHits"}, "HcalEndcapPInsertMergedHits"
+        ));
+        app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_HcalEndcapPInsertTruthProtoClusters>(
+          {"HcalEndcapPInsertMergedHits"}, "HcalEndcapPInsertTruthProtoClusters"
+        ));
+        app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_HcalEndcapPInsertIslandProtoClusters>(
+          {"HcalEndcapPInsertMergedHits"}, "HcalEndcapPInsertIslandProtoClusters"
+        ));
 
         app->Add(
           new JChainMultifactoryGeneratorT<Cluster_factory_HcalEndcapPTruthClusters>(
@@ -128,10 +149,18 @@ extern "C" {
           )
         );
 
-        app->Add(new JFactoryGeneratorT<RawCalorimeterHit_factory_LFHCALRawHits>());
-        app->Add(new JFactoryGeneratorT<CalorimeterHit_factory_LFHCALRecHits>());
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_LFHCALTruthProtoClusters>());
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_LFHCALIslandProtoClusters>());
+        app->Add(new JChainFactoryGeneratorT<RawCalorimeterHit_factory_LFHCALRawHits>(
+          {"LFHCALHits"}, "LFHCALRawHits"
+        ));
+        app->Add(new JChainFactoryGeneratorT<CalorimeterHit_factory_LFHCALRecHits>(
+          {"LFHCALRawHits"}, "LFHCALRecHits"
+        ));
+        app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_LFHCALTruthProtoClusters>(
+          {"LFHCALRecHits"}, "LFHCALTruthProtoClusters"
+        ));
+        app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_LFHCALIslandProtoClusters>(
+          {"LFHCALRecHits"}, "LFHCALIslandProtoClusters"
+        ));
 
         app->Add(
           new JChainMultifactoryGeneratorT<Cluster_factory_LFHCALTruthClusters>(

--- a/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPInsertIslandProtoClusters.h
+++ b/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPInsertIslandProtoClusters.h
@@ -6,19 +6,19 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterIslandCluster.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class ProtoCluster_factory_HcalEndcapPInsertIslandProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, CalorimeterIslandCluster {
+class ProtoCluster_factory_HcalEndcapPInsertIslandProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, CalorimeterIslandCluster {
 
 public:
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_HcalEndcapPInsertIslandProtoClusters(){
-        SetTag("HcalEndcapPInsertIslandProtoClusters");
+    ProtoCluster_factory_HcalEndcapPInsertIslandProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -26,7 +26,6 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_input_tag = "HcalEndcapPInsertMergedHits";
 
         // adjacency matrix
         m_geoSvcName = "GeoSvc";

--- a/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPInsertIslandProtoClusters.h
+++ b/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPInsertIslandProtoClusters.h
@@ -82,7 +82,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        hits = event->Get<edm4eic::CalorimeterHit>(m_input_tag);
+        hits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPInsertIslandProtoClusters.h
+++ b/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPInsertIslandProtoClusters.h
@@ -25,6 +25,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         // adjacency matrix

--- a/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPInsertTruthProtoClusters.h
+++ b/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPInsertTruthProtoClusters.h
@@ -50,6 +50,4 @@ public:
         Set(m_outputProtoClusters);
         m_outputProtoClusters.clear(); // not really needed, but better to not leave dangling pointers around
     }
-private:
-    // Name of input data type (collection)
 };

--- a/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPInsertTruthProtoClusters.h
+++ b/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPInsertTruthProtoClusters.h
@@ -25,6 +25,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         AlgorithmInit(m_log);

--- a/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPInsertTruthProtoClusters.h
+++ b/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPInsertTruthProtoClusters.h
@@ -27,8 +27,6 @@ public:
     void Init() override{
         InitDataTags(GetPluginName() + ":" + GetTag());
 
-        auto app = GetApplication();
-
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPInsertTruthProtoClusters.h
+++ b/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPInsertTruthProtoClusters.h
@@ -6,19 +6,19 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterTruthClustering.h>
 
 
 
-class ProtoCluster_factory_HcalEndcapPInsertTruthProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
+class ProtoCluster_factory_HcalEndcapPInsertTruthProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
 
 public:
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_HcalEndcapPInsertTruthProtoClusters(){
-        SetTag("HcalEndcapPInsertTruthProtoClusters");
+    ProtoCluster_factory_HcalEndcapPInsertTruthProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -26,8 +26,6 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_inputHit_tag="HcalEndcapPInsertRecHits";
-        m_inputMCHit_tag="HcalEndcapPInsertHits";
 
         AlgorithmInit(m_log);
     }
@@ -42,8 +40,8 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        m_inputHits = event->Get<edm4eic::CalorimeterHit>(m_inputHit_tag);
-        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(m_inputMCHit_tag);
+        m_inputHits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
+        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[1]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();
@@ -54,6 +52,4 @@ public:
     }
 private:
     // Name of input data type (collection)
-    std::string              m_inputHit_tag;
-    std::string              m_inputMCHit_tag;
 };

--- a/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPIslandProtoClusters.h
+++ b/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPIslandProtoClusters.h
@@ -82,7 +82,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        hits = event->Get<edm4eic::CalorimeterHit>(m_input_tag);
+        hits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPIslandProtoClusters.h
+++ b/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPIslandProtoClusters.h
@@ -6,19 +6,19 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterIslandCluster.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class ProtoCluster_factory_HcalEndcapPIslandProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, CalorimeterIslandCluster {
+class ProtoCluster_factory_HcalEndcapPIslandProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, CalorimeterIslandCluster {
 
 public:
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_HcalEndcapPIslandProtoClusters(){
-        SetTag("HcalEndcapPIslandProtoClusters");
+    ProtoCluster_factory_HcalEndcapPIslandProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -26,7 +26,6 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_input_tag = "HcalEndcapPMergedHits";
 
         // adjacency matrix
         m_geoSvcName = "GeoSvc";

--- a/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPIslandProtoClusters.h
+++ b/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPIslandProtoClusters.h
@@ -25,6 +25,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         // adjacency matrix

--- a/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPTruthProtoClusters.h
+++ b/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPTruthProtoClusters.h
@@ -52,6 +52,4 @@ public:
         Set(m_outputProtoClusters);
         m_outputProtoClusters.clear(); // not really needed, but better to not leave dangling pointers around
     }
-private:
-    // Name of input data type (collection)
 };

--- a/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPTruthProtoClusters.h
+++ b/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPTruthProtoClusters.h
@@ -27,6 +27,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         AlgorithmInit(m_log);

--- a/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPTruthProtoClusters.h
+++ b/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPTruthProtoClusters.h
@@ -8,19 +8,19 @@
 
 #include <edm4eic/ProtoClusterCollection.h>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterTruthClustering.h>
 
 
 
-class ProtoCluster_factory_HcalEndcapPTruthProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
+class ProtoCluster_factory_HcalEndcapPTruthProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
 
 public:
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_HcalEndcapPTruthProtoClusters(){
-        SetTag("HcalEndcapPTruthProtoClusters");
+    ProtoCluster_factory_HcalEndcapPTruthProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -28,8 +28,6 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_inputHit_tag="HcalEndcapPRecHits";
-        m_inputMCHit_tag="HcalEndcapPHits";
 
         AlgorithmInit(m_log);
     }
@@ -44,8 +42,8 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        m_inputHits = event->Get<edm4eic::CalorimeterHit>(m_inputHit_tag);
-        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(m_inputMCHit_tag);
+        m_inputHits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
+        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[1]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();
@@ -56,6 +54,4 @@ public:
     }
 private:
     // Name of input data type (collection)
-    std::string              m_inputHit_tag;
-    std::string              m_inputMCHit_tag;
 };

--- a/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPTruthProtoClusters.h
+++ b/src/detectors/FHCAL/ProtoCluster_factory_HcalEndcapPTruthProtoClusters.h
@@ -29,8 +29,6 @@ public:
     void Init() override{
         InitDataTags(GetPluginName() + ":" + GetTag());
 
-        auto app = GetApplication();
-
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/FHCAL/ProtoCluster_factory_LFHCALIslandProtoClusters.h
+++ b/src/detectors/FHCAL/ProtoCluster_factory_LFHCALIslandProtoClusters.h
@@ -26,6 +26,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         // neighbour checking distances

--- a/src/detectors/FHCAL/ProtoCluster_factory_LFHCALIslandProtoClusters.h
+++ b/src/detectors/FHCAL/ProtoCluster_factory_LFHCALIslandProtoClusters.h
@@ -107,7 +107,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        hits = event->Get<edm4eic::CalorimeterHit>(m_input_tag);
+        hits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/FHCAL/ProtoCluster_factory_LFHCALIslandProtoClusters.h
+++ b/src/detectors/FHCAL/ProtoCluster_factory_LFHCALIslandProtoClusters.h
@@ -7,19 +7,19 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterIslandCluster.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class ProtoCluster_factory_LFHCALIslandProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, CalorimeterIslandCluster {
+class ProtoCluster_factory_LFHCALIslandProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, CalorimeterIslandCluster {
 
 public:
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_LFHCALIslandProtoClusters(){
-        SetTag("LFHCALIslandProtoClusters");
+    ProtoCluster_factory_LFHCALIslandProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -27,7 +27,6 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_input_tag = "LFHCALRecHits";
 
         // neighbour checking distances
         m_sectorDist=0 * dd4hep::cm;

--- a/src/detectors/FHCAL/ProtoCluster_factory_LFHCALTruthProtoClusters.h
+++ b/src/detectors/FHCAL/ProtoCluster_factory_LFHCALTruthProtoClusters.h
@@ -28,8 +28,6 @@ public:
     void Init() override{
         InitDataTags(GetPluginName() + ":" + GetTag());
 
-        auto app = GetApplication();
-
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/FHCAL/ProtoCluster_factory_LFHCALTruthProtoClusters.h
+++ b/src/detectors/FHCAL/ProtoCluster_factory_LFHCALTruthProtoClusters.h
@@ -7,19 +7,19 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterTruthClustering.h>
 
 
 
-class ProtoCluster_factory_LFHCALTruthProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
+class ProtoCluster_factory_LFHCALTruthProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
 
 public:
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_LFHCALTruthProtoClusters(){
-        SetTag("LFHCALTruthProtoClusters");
+    ProtoCluster_factory_LFHCALTruthProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -27,8 +27,6 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_inputHit_tag="LFHCALRecHits";
-        m_inputMCHit_tag="LFHCALHits";
 
         AlgorithmInit(m_log);
     }
@@ -43,8 +41,8 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        m_inputHits = event->Get<edm4eic::CalorimeterHit>(m_inputHit_tag);
-        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(m_inputMCHit_tag);
+        m_inputHits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
+        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[1]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();
@@ -55,8 +53,6 @@ public:
     }
 private:
     // Name of input data type (collection)
-    std::string              m_inputHit_tag;
-    std::string              m_inputMCHit_tag;
 };
 
 #endif // _ProtoCLuster_factory_IslandProtoClusters_h_

--- a/src/detectors/FHCAL/ProtoCluster_factory_LFHCALTruthProtoClusters.h
+++ b/src/detectors/FHCAL/ProtoCluster_factory_LFHCALTruthProtoClusters.h
@@ -26,6 +26,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         AlgorithmInit(m_log);

--- a/src/detectors/FHCAL/ProtoCluster_factory_LFHCALTruthProtoClusters.h
+++ b/src/detectors/FHCAL/ProtoCluster_factory_LFHCALTruthProtoClusters.h
@@ -51,8 +51,6 @@ public:
         Set(m_outputProtoClusters);
         m_outputProtoClusters.clear(); // not really needed, but better to not leave dangling pointers around
     }
-private:
-    // Name of input data type (collection)
 };
 
 #endif // _ProtoCLuster_factory_IslandProtoClusters_h_

--- a/src/detectors/FHCAL/RawCalorimeterHit_factory_HcalEndcapPInsertRawHits.h
+++ b/src/detectors/FHCAL/RawCalorimeterHit_factory_HcalEndcapPInsertRawHits.h
@@ -7,7 +7,7 @@
 #include <random>
 
 #include <JANA/JEvent.h>
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterHitDigi.h>
 #include <edm4hep/SimCalorimeterHit.h>
@@ -18,14 +18,14 @@
 
 
 
-class RawCalorimeterHit_factory_HcalEndcapPInsertRawHits : public eicrecon::JFactoryPodioT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
+class RawCalorimeterHit_factory_HcalEndcapPInsertRawHits : public JChainFactoryT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
 
 public:
 
     //------------------------------------------
     // Constructor
-    RawCalorimeterHit_factory_HcalEndcapPInsertRawHits() {
-        SetTag("HcalEndcapPInsertRawHits");
+    RawCalorimeterHit_factory_HcalEndcapPInsertRawHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4hep::RawCalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -35,7 +35,6 @@ public:
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
-        m_input_tag = "HcalEndcapPInsertHits";
         u_eRes = {};
         m_tRes = 0.0 * dd4hep::ns;
         m_capADC = 32768;
@@ -50,7 +49,6 @@ public:
         m_geoSvc = app->GetService<JDD4hep_service>(); // TODO: implement named geometry service?
 
         // This is another option for exposing the data members as JANA configuration parameters.
-//        app->SetDefaultParameter("FHCAL:tag",              m_input_tag);
         app->SetDefaultParameter("FHCAL:HcalEndcapPInsertRawHits:energyResolutions",u_eRes);
         app->SetDefaultParameter("FHCAL:HcalEndcapPInsertRawHits:timeResolution",   m_tRes);
         app->SetDefaultParameter("FHCAL:HcalEndcapPInsertRawHits:capacityADC",      m_capADC);

--- a/src/detectors/FHCAL/RawCalorimeterHit_factory_HcalEndcapPInsertRawHits.h
+++ b/src/detectors/FHCAL/RawCalorimeterHit_factory_HcalEndcapPInsertRawHits.h
@@ -32,6 +32,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override {
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm

--- a/src/detectors/FHCAL/RawCalorimeterHit_factory_HcalEndcapPInsertRawHits.h
+++ b/src/detectors/FHCAL/RawCalorimeterHit_factory_HcalEndcapPInsertRawHits.h
@@ -77,7 +77,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override {
         // Prefill inputs
-        simhits = event->Get<edm4hep::SimCalorimeterHit>(m_input_tag);
+        simhits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/FHCAL/RawCalorimeterHit_factory_HcalEndcapPRawHits.h
+++ b/src/detectors/FHCAL/RawCalorimeterHit_factory_HcalEndcapPRawHits.h
@@ -12,7 +12,7 @@
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JEvent.h>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterHitDigi.h>
 #include <services/log/Log_service.h>
@@ -20,14 +20,14 @@
 
 
 
-class RawCalorimeterHit_factory_HcalEndcapPRawHits : public eicrecon::JFactoryPodioT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
+class RawCalorimeterHit_factory_HcalEndcapPRawHits : public JChainFactoryT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
 
 public:
 
     //------------------------------------------
     // Constructor
-    RawCalorimeterHit_factory_HcalEndcapPRawHits() {
-        SetTag("HcalEndcapPRawHits");
+    RawCalorimeterHit_factory_HcalEndcapPRawHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4hep::RawCalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -37,7 +37,6 @@ public:
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
-        m_input_tag = "HcalEndcapPHits";
         u_eRes = {};
         m_tRes = 0.001 * dd4hep::ns;
         m_capADC = 65536;
@@ -52,7 +51,6 @@ public:
         m_geoSvc = app->GetService<JDD4hep_service>(); // TODO: implement named geometry service?
 
         // This is another option for exposing the data members as JANA configuration parameters.
-//        app->SetDefaultParameter("FHCAL:tag",              m_input_tag);
         app->SetDefaultParameter("FHCAL:HcalEndcapPRawHits:energyResolutions",u_eRes);
         app->SetDefaultParameter("FHCAL:HcalEndcapPRawHits:timeResolution",   m_tRes);
         app->SetDefaultParameter("FHCAL:HcalEndcapPRawHits:capacityADC",      m_capADC);

--- a/src/detectors/FHCAL/RawCalorimeterHit_factory_HcalEndcapPRawHits.h
+++ b/src/detectors/FHCAL/RawCalorimeterHit_factory_HcalEndcapPRawHits.h
@@ -79,7 +79,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override {
         // Prefill inputs
-        simhits = event->Get<edm4hep::SimCalorimeterHit>(m_input_tag);
+        simhits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/FHCAL/RawCalorimeterHit_factory_HcalEndcapPRawHits.h
+++ b/src/detectors/FHCAL/RawCalorimeterHit_factory_HcalEndcapPRawHits.h
@@ -34,6 +34,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override {
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm

--- a/src/detectors/FHCAL/RawCalorimeterHit_factory_LFHCALRawHits.h
+++ b/src/detectors/FHCAL/RawCalorimeterHit_factory_LFHCALRawHits.h
@@ -8,7 +8,7 @@
 #include <random>
 
 #include <JANA/JEvent.h>
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterHitDigi.h>
 #include <edm4hep/SimCalorimeterHit.h>
@@ -19,14 +19,14 @@
 
 
 
-class RawCalorimeterHit_factory_LFHCALRawHits : public eicrecon::JFactoryPodioT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
+class RawCalorimeterHit_factory_LFHCALRawHits : public JChainFactoryT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
 
 public:
 
     //------------------------------------------
     // Constructor
-    RawCalorimeterHit_factory_LFHCALRawHits() {
-        SetTag("LFHCALRawHits");
+    RawCalorimeterHit_factory_LFHCALRawHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4hep::RawCalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -36,7 +36,6 @@ public:
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
-        m_input_tag = "LFHCALHits";
         u_eRes = {};
         m_tRes = 0.0; // in ns
         m_capTime = 100 ; // given in ns, 4 samples in HGCROC
@@ -52,7 +51,6 @@ public:
         m_geoSvc = app->GetService<JDD4hep_service>(); // TODO: implement named geometry service?
 
         // This is another option for exposing the data members as JANA configuration parameters.
-//        app->SetDefaultParameter("FHCAL:tag",              m_input_tag);
         app->SetDefaultParameter("FHCAL:LFHCALRawHits:energyResolutions",u_eRes);
         app->SetDefaultParameter("FHCAL:LFHCALRawHits:maxTimeInt",       m_capTime);
         app->SetDefaultParameter("FHCAL:LFHCALRawHits:timeResolution",   m_tRes);

--- a/src/detectors/FHCAL/RawCalorimeterHit_factory_LFHCALRawHits.h
+++ b/src/detectors/FHCAL/RawCalorimeterHit_factory_LFHCALRawHits.h
@@ -80,7 +80,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override {
         // Prefill inputs
-        simhits = event->Get<edm4hep::SimCalorimeterHit>(m_input_tag);
+        simhits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/FHCAL/RawCalorimeterHit_factory_LFHCALRawHits.h
+++ b/src/detectors/FHCAL/RawCalorimeterHit_factory_LFHCALRawHits.h
@@ -33,6 +33,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override {
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm

--- a/src/detectors/LUMISPECCAL/CalorimeterHit_factory_EcalLumiSpecRecHits.h
+++ b/src/detectors/LUMISPECCAL/CalorimeterHit_factory_EcalLumiSpecRecHits.h
@@ -22,8 +22,9 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        InitDataTags(GetPluginName() + ":" + GetTag());
 
+        auto app = GetApplication();
 
         // digitization settings, must be consistent with digi class
         m_capADC=16384;//{this, "capacityADC", 8096};

--- a/src/detectors/LUMISPECCAL/CalorimeterHit_factory_EcalLumiSpecRecHits.h
+++ b/src/detectors/LUMISPECCAL/CalorimeterHit_factory_EcalLumiSpecRecHits.h
@@ -78,7 +78,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        rawhits = event->Get<edm4hep::RawCalorimeterHit>(m_input_tag);
+        rawhits = event->Get<edm4hep::RawCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/LUMISPECCAL/CalorimeterHit_factory_EcalLumiSpecRecHits.h
+++ b/src/detectors/LUMISPECCAL/CalorimeterHit_factory_EcalLumiSpecRecHits.h
@@ -4,18 +4,18 @@
 #include <edm4eic/CalorimeterHitCollection.h>
 #include <edm4eic/ProtoClusterCollection.h>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <algorithms/calorimetry/CalorimeterHitReco.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class CalorimeterHit_factory_EcalLumiSpecRecHits : public eicrecon::JFactoryPodioT<edm4eic::CalorimeterHit>, CalorimeterHitReco {
+class CalorimeterHit_factory_EcalLumiSpecRecHits : public JChainFactoryT<edm4eic::CalorimeterHit>, CalorimeterHitReco {
 
 public:
     //------------------------------------------
     // Constructor
-    CalorimeterHit_factory_EcalLumiSpecRecHits(){
-        SetTag("EcalLumiSpecRecHits");
+    CalorimeterHit_factory_EcalLumiSpecRecHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::CalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -24,7 +24,6 @@ public:
     void Init() override{
         auto app = GetApplication();
 
-        m_input_tag = "EcalLumiSpecRawHits";
 
         // digitization settings, must be consistent with digi class
         m_capADC=16384;//{this, "capacityADC", 8096};
@@ -49,7 +48,6 @@ public:
         m_localDetElement="";         // from ATHENA's reconstruction.py (i.e. not defined there)
         u_localDetFields={};          // from ATHENA's reconstruction.py (i.e. not defined there)
 
-        app->SetDefaultParameter("LUMISPECCAL:EcalLumiSpecRecHits:input_tag",        m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("LUMISPECCAL:EcalLumiSpecRecHits:capacityADC",      m_capADC);
         app->SetDefaultParameter("LUMISPECCAL:EcalLumiSpecRecHits:dynamicRangeADC",  m_dyRangeADC);
         app->SetDefaultParameter("LUMISPECCAL:EcalLumiSpecRecHits:pedestalMean",     m_pedMeanADC);

--- a/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
+++ b/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
@@ -32,7 +32,7 @@ extern "C" {
           {"EcalLumiSpecRawHits"}, "EcalLumiSpecRecHits"
         ));
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_EcalLumiSpecTruthProtoClusters>(
-          {"EcalLumiSpecRecHits"}, "EcalLumiSpecTruthProtoClusters"
+          {"EcalLumiSpecRecHits", "LumiSpecCALHits"}, "EcalLumiSpecTruthProtoClusters"
         ));
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_EcalLumiSpecIslandProtoClusters>(
           {"EcalLumiSpecRecHits"}, "EcalLumiSpecIslandProtoClusters"

--- a/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
+++ b/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
@@ -3,6 +3,7 @@
 //
 //
 
+#include <extensions/jana/JChainFactoryGeneratorT.h>
 #include <extensions/jana/JChainMultifactoryGeneratorT.h>
 
 #include <factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h>
@@ -24,10 +25,18 @@ extern "C" {
 
         InitJANAPlugin(app);
 
-        app->Add(new JFactoryGeneratorT<RawCalorimeterHit_factory_EcalLumiSpecRawHits>());
-        app->Add(new JFactoryGeneratorT<CalorimeterHit_factory_EcalLumiSpecRecHits>());
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_EcalLumiSpecTruthProtoClusters>());
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_EcalLumiSpecIslandProtoClusters>());
+        app->Add(new JChainFactoryGeneratorT<RawCalorimeterHit_factory_EcalLumiSpecRawHits>(
+          {"LumiSpecCALHits"}, "EcalLumiSpecRawHits"
+        ));
+        app->Add(new JChainFactoryGeneratorT<CalorimeterHit_factory_EcalLumiSpecRecHits>(
+          {"EcalLumiSpecRawHits"}, "EcalLumiSpecRecHits"
+        ));
+        app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_EcalLumiSpecTruthProtoClusters>(
+          {"EcalLumiSpecRecHits"}, "EcalLumiSpecTruthProtoClusters"
+        ));
+        app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_EcalLumiSpecIslandProtoClusters>(
+          {"EcalLumiSpecRecHits"}, "EcalLumiSpecIslandProtoClusters"
+        ));
 
         app->Add(
           new JChainMultifactoryGeneratorT<Cluster_factory_EcalLumiSpecClusters>(

--- a/src/detectors/LUMISPECCAL/ProtoCluster_factory_EcalLumiSpecIslandProtoClusters.h
+++ b/src/detectors/LUMISPECCAL/ProtoCluster_factory_EcalLumiSpecIslandProtoClusters.h
@@ -82,7 +82,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        hits = event->Get<edm4eic::CalorimeterHit>(m_input_tag);
+        hits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/LUMISPECCAL/ProtoCluster_factory_EcalLumiSpecIslandProtoClusters.h
+++ b/src/detectors/LUMISPECCAL/ProtoCluster_factory_EcalLumiSpecIslandProtoClusters.h
@@ -6,19 +6,19 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterIslandCluster.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class ProtoCluster_factory_EcalLumiSpecIslandProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, CalorimeterIslandCluster {
+class ProtoCluster_factory_EcalLumiSpecIslandProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, CalorimeterIslandCluster {
 
 public:
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_EcalLumiSpecIslandProtoClusters(){
-        SetTag("EcalLumiSpecIslandProtoClusters");
+    ProtoCluster_factory_EcalLumiSpecIslandProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -26,7 +26,6 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_input_tag = "EcalLumiSpecRecHits";
 
         // adjacency matrix
         m_geoSvcName = "GeoSvc";
@@ -51,7 +50,6 @@ public:
         u_transverseEnergyProfileMetric = "localDistXY";
         u_transverseEnergyProfileScale = 10. * dd4hep::mm;
 
-        app->SetDefaultParameter("LUMISPECCAL:EcalLumiSpecIslandProtoClusters:input_tag",        m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("LUMISPECCAL:EcalLumiSpecIslandProtoClusters:geoServiceName", m_geoSvcName);
         app->SetDefaultParameter("LUMISPECCAL:EcalLumiSpecIslandProtoClusters:readoutClass", m_readout);
         app->SetDefaultParameter("LUMISPECCAL:EcalLumiSpecIslandProtoClusters:sectorDist",   m_sectorDist);

--- a/src/detectors/LUMISPECCAL/ProtoCluster_factory_EcalLumiSpecIslandProtoClusters.h
+++ b/src/detectors/LUMISPECCAL/ProtoCluster_factory_EcalLumiSpecIslandProtoClusters.h
@@ -25,6 +25,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         // adjacency matrix

--- a/src/detectors/LUMISPECCAL/ProtoCluster_factory_EcalLumiSpecTruthProtoClusters.h
+++ b/src/detectors/LUMISPECCAL/ProtoCluster_factory_EcalLumiSpecTruthProtoClusters.h
@@ -8,19 +8,19 @@
 
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterTruthClustering.h>
 
 
 
-class ProtoCluster_factory_EcalLumiSpecTruthProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
+class ProtoCluster_factory_EcalLumiSpecTruthProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
 
 public:
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_EcalLumiSpecTruthProtoClusters(){
-        SetTag("EcalLumiSpecTruthProtoClusters");
+    ProtoCluster_factory_EcalLumiSpecTruthProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -28,10 +28,7 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_inputHit_tag="EcalLumiSpecRecHits";
-        m_inputMCHit_tag="LumiSpecCALHits";
 
-        app->SetDefaultParameter("LUMISPECCAL:EcalLumiSpecTruthProtoClusters:inputHit_tag",        m_inputHit_tag, "Name of input collection to use");
 
         AlgorithmInit(m_log);
     }
@@ -46,8 +43,8 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        m_inputHits = event->Get<edm4eic::CalorimeterHit>(m_inputHit_tag);
-        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(m_inputMCHit_tag);
+        m_inputHits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
+        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[1]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();
@@ -59,6 +56,4 @@ public:
 
 private:
     // Name of input data type (collection)
-    std::string              m_inputHit_tag;
-    std::string              m_inputMCHit_tag;
 };

--- a/src/detectors/LUMISPECCAL/ProtoCluster_factory_EcalLumiSpecTruthProtoClusters.h
+++ b/src/detectors/LUMISPECCAL/ProtoCluster_factory_EcalLumiSpecTruthProtoClusters.h
@@ -29,7 +29,6 @@ public:
     void Init() override{
         auto app = GetApplication();
 
-
         AlgorithmInit(m_log);
     }
 
@@ -53,7 +52,4 @@ public:
         Set(m_outputProtoClusters);
         m_outputProtoClusters.clear(); // not really needed, but better to not leave dangling pointers around
     }
-
-private:
-    // Name of input data type (collection)
 };

--- a/src/detectors/LUMISPECCAL/ProtoCluster_factory_EcalLumiSpecTruthProtoClusters.h
+++ b/src/detectors/LUMISPECCAL/ProtoCluster_factory_EcalLumiSpecTruthProtoClusters.h
@@ -27,6 +27,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         AlgorithmInit(m_log);

--- a/src/detectors/LUMISPECCAL/ProtoCluster_factory_EcalLumiSpecTruthProtoClusters.h
+++ b/src/detectors/LUMISPECCAL/ProtoCluster_factory_EcalLumiSpecTruthProtoClusters.h
@@ -29,8 +29,6 @@ public:
     void Init() override{
         InitDataTags(GetPluginName() + ":" + GetTag());
 
-        auto app = GetApplication();
-
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/LUMISPECCAL/RawCalorimeterHit_factory_EcalLumiSpecRawHits.h
+++ b/src/detectors/LUMISPECCAL/RawCalorimeterHit_factory_EcalLumiSpecRawHits.h
@@ -80,7 +80,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override {
         // Prefill inputs
-        simhits = event->Get<edm4hep::SimCalorimeterHit>(m_input_tag);
+        simhits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/LUMISPECCAL/RawCalorimeterHit_factory_EcalLumiSpecRawHits.h
+++ b/src/detectors/LUMISPECCAL/RawCalorimeterHit_factory_EcalLumiSpecRawHits.h
@@ -12,7 +12,7 @@
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JEvent.h>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterHitDigi.h>
 #include <services/log/Log_service.h>
@@ -20,14 +20,14 @@
 
 
 
-class RawCalorimeterHit_factory_EcalLumiSpecRawHits : public eicrecon::JFactoryPodioT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
+class RawCalorimeterHit_factory_EcalLumiSpecRawHits : public JChainFactoryT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
 
 public:
 
     //------------------------------------------
     // Constructor
-    RawCalorimeterHit_factory_EcalLumiSpecRawHits() {
-        SetTag("EcalLumiSpecRawHits");
+    RawCalorimeterHit_factory_EcalLumiSpecRawHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4hep::RawCalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -37,7 +37,6 @@ public:
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
-        m_input_tag = "LumiSpecCALHits";
         u_eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV}; // flat 2%
         m_tRes = 0.0 * dd4hep::ns;
         m_capADC = 16384;
@@ -54,7 +53,6 @@ public:
 
 
         // This is another option for exposing the data members as JANA configuration parameters.
-        app->SetDefaultParameter("LUMISPECCAL:EcalLumiSpecRawHits:input_tag",        m_input_tag, "Name of input collection to use");
         app->SetDefaultParameter("LUMISPECCAL:EcalLumiSpecRawHits:energyResolutions",u_eRes);
         app->SetDefaultParameter("LUMISPECCAL:EcalLumiSpecRawHits:timeResolution",   m_tRes);
         app->SetDefaultParameter("LUMISPECCAL:EcalLumiSpecRawHits:capacityADC",      m_capADC);

--- a/src/detectors/LUMISPECCAL/RawCalorimeterHit_factory_EcalLumiSpecRawHits.h
+++ b/src/detectors/LUMISPECCAL/RawCalorimeterHit_factory_EcalLumiSpecRawHits.h
@@ -34,6 +34,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override {
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm

--- a/src/detectors/ZDC/CalorimeterHit_factory_ZDCEcalRecHits.h
+++ b/src/detectors/ZDC/CalorimeterHit_factory_ZDCEcalRecHits.h
@@ -3,18 +3,18 @@
 
 #include <edm4eic/CalorimeterHitCollection.h>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <algorithms/calorimetry/CalorimeterHitReco.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class CalorimeterHit_factory_ZDCEcalRecHits : public eicrecon::JFactoryPodioT<edm4eic::CalorimeterHit>, CalorimeterHitReco {
+class CalorimeterHit_factory_ZDCEcalRecHits : public JChainFactoryT<edm4eic::CalorimeterHit>, CalorimeterHitReco {
 
 public:
     //------------------------------------------
     // Constructor
-    CalorimeterHit_factory_ZDCEcalRecHits(){
-        SetTag("ZDCEcalRecHits");
+    CalorimeterHit_factory_ZDCEcalRecHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::CalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -23,7 +23,6 @@ public:
     void Init() override{
         auto app = GetApplication();
 
-        m_input_tag = "ZDCEcalRawHits";
 
         // digitization settings, must be consistent with digi class
         m_capADC=8096;//{this, "capacityADC", 8096};
@@ -48,7 +47,6 @@ public:
         m_localDetElement="";         // from ATHENA's reconstruction.py (i.e. not defined there)
         u_localDetFields={};          // from ATHENA's reconstruction.py (i.e. not defined there)
 
-//        app->SetDefaultParameter("ZDC:tag",              m_input_tag);
         app->SetDefaultParameter("ZDC:ZDCEcalRecHits:capacityADC",      m_capADC);
         app->SetDefaultParameter("ZDC:ZDCEcalRecHits:dynamicRangeADC",  m_dyRangeADC);
         app->SetDefaultParameter("ZDC:ZDCEcalRecHits:pedestalMean",     m_pedMeanADC);

--- a/src/detectors/ZDC/CalorimeterHit_factory_ZDCEcalRecHits.h
+++ b/src/detectors/ZDC/CalorimeterHit_factory_ZDCEcalRecHits.h
@@ -77,7 +77,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        rawhits = event->Get<edm4hep::RawCalorimeterHit>(m_input_tag);
+        rawhits = event->Get<edm4hep::RawCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/ZDC/CalorimeterHit_factory_ZDCEcalRecHits.h
+++ b/src/detectors/ZDC/CalorimeterHit_factory_ZDCEcalRecHits.h
@@ -21,8 +21,9 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
-        auto app = GetApplication();
+        InitDataTags(GetPluginName() + ":" + GetTag());
 
+        auto app = GetApplication();
 
         // digitization settings, must be consistent with digi class
         m_capADC=8096;//{this, "capacityADC", 8096};

--- a/src/detectors/ZDC/ProtoCluster_factory_ZDCEcalIslandProtoClusters.h
+++ b/src/detectors/ZDC/ProtoCluster_factory_ZDCEcalIslandProtoClusters.h
@@ -84,7 +84,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        hits = event->Get<edm4eic::CalorimeterHit>(m_input_tag);
+        hits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/ZDC/ProtoCluster_factory_ZDCEcalIslandProtoClusters.h
+++ b/src/detectors/ZDC/ProtoCluster_factory_ZDCEcalIslandProtoClusters.h
@@ -6,19 +6,19 @@
 
 #include <random>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterIslandCluster.h>
 #include <services/log/Log_service.h>
 #include <extensions/spdlog/SpdlogExtensions.h>
 
-class ProtoCluster_factory_ZDCEcalIslandProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, CalorimeterIslandCluster {
+class ProtoCluster_factory_ZDCEcalIslandProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, CalorimeterIslandCluster {
 
 public:
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_ZDCEcalIslandProtoClusters(){
-        SetTag("ZDCEcalIslandProtoClusters");
+    ProtoCluster_factory_ZDCEcalIslandProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -26,7 +26,6 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_input_tag = "ZDCEcalRecHits";
 
         // adjacency matrix
         m_geoSvcName = "GeoSvc";

--- a/src/detectors/ZDC/ProtoCluster_factory_ZDCEcalIslandProtoClusters.h
+++ b/src/detectors/ZDC/ProtoCluster_factory_ZDCEcalIslandProtoClusters.h
@@ -25,6 +25,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         // adjacency matrix

--- a/src/detectors/ZDC/ProtoCluster_factory_ZDCEcalTruthProtoClusters.h
+++ b/src/detectors/ZDC/ProtoCluster_factory_ZDCEcalTruthProtoClusters.h
@@ -8,19 +8,19 @@
 
 #include <edm4eic/ProtoClusterCollection.h>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterTruthClustering.h>
 
 
 
-class ProtoCluster_factory_ZDCEcalTruthProtoClusters : public eicrecon::JFactoryPodioT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
+class ProtoCluster_factory_ZDCEcalTruthProtoClusters : public JChainFactoryT<edm4eic::ProtoCluster>, CalorimeterTruthClustering {
 
 public:
     //------------------------------------------
     // Constructor
-    ProtoCluster_factory_ZDCEcalTruthProtoClusters(){
-        SetTag("ZDCEcalTruthProtoClusters");
+    ProtoCluster_factory_ZDCEcalTruthProtoClusters(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4eic::ProtoCluster>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -28,8 +28,6 @@ public:
     // Init
     void Init() override{
         auto app = GetApplication();
-        m_inputHit_tag="ZDCEcalRecHits";
-        m_inputMCHit_tag="ZDCEcalHits";
 
         AlgorithmInit(m_log);
     }
@@ -44,8 +42,8 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override{
         // Prefill inputs
-        m_inputHits = event->Get<edm4eic::CalorimeterHit>(m_inputHit_tag);
-        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(m_inputMCHit_tag);
+        m_inputHits = event->Get<edm4eic::CalorimeterHit>(GetInputTags()[0]);
+        m_mcHits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[1]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();
@@ -57,6 +55,4 @@ public:
 
 private:
     // Name of input data type (collection)
-    std::string              m_inputHit_tag;
-    std::string              m_inputMCHit_tag;
 };

--- a/src/detectors/ZDC/ProtoCluster_factory_ZDCEcalTruthProtoClusters.h
+++ b/src/detectors/ZDC/ProtoCluster_factory_ZDCEcalTruthProtoClusters.h
@@ -52,7 +52,4 @@ public:
         Set(m_outputProtoClusters);
         m_outputProtoClusters.clear(); // not really needed, but better to not leave dangling pointers around
     }
-
-private:
-    // Name of input data type (collection)
 };

--- a/src/detectors/ZDC/ProtoCluster_factory_ZDCEcalTruthProtoClusters.h
+++ b/src/detectors/ZDC/ProtoCluster_factory_ZDCEcalTruthProtoClusters.h
@@ -27,6 +27,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override{
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         AlgorithmInit(m_log);

--- a/src/detectors/ZDC/ProtoCluster_factory_ZDCEcalTruthProtoClusters.h
+++ b/src/detectors/ZDC/ProtoCluster_factory_ZDCEcalTruthProtoClusters.h
@@ -29,8 +29,6 @@ public:
     void Init() override{
         InitDataTags(GetPluginName() + ":" + GetTag());
 
-        auto app = GetApplication();
-
         AlgorithmInit(m_log);
     }
 

--- a/src/detectors/ZDC/RawCalorimeterHit_factory_ZDCEcalRawHits.h
+++ b/src/detectors/ZDC/RawCalorimeterHit_factory_ZDCEcalRawHits.h
@@ -12,7 +12,7 @@
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JEvent.h>
 
-#include <services/io/podio/JFactoryPodioT.h>
+#include <extensions/jana/JChainFactoryT.h>
 #include <services/geometry/dd4hep/JDD4hep_service.h>
 #include <algorithms/calorimetry/CalorimeterHitDigi.h>
 #include <services/log/Log_service.h>
@@ -20,14 +20,14 @@
 
 
 
-class RawCalorimeterHit_factory_ZDCEcalRawHits : public eicrecon::JFactoryPodioT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
+class RawCalorimeterHit_factory_ZDCEcalRawHits : public JChainFactoryT<edm4hep::RawCalorimeterHit>, CalorimeterHitDigi {
 
 public:
 
     //------------------------------------------
     // Constructor
-    RawCalorimeterHit_factory_ZDCEcalRawHits() {
-        SetTag("ZDCEcalRawHits");
+    RawCalorimeterHit_factory_ZDCEcalRawHits(std::vector<std::string> default_input_tags)
+    : JChainFactoryT<edm4hep::RawCalorimeterHit>(std::move(default_input_tags)) {
         m_log = japp->GetService<Log_service>()->logger(GetTag());
     }
 
@@ -37,7 +37,6 @@ public:
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
-        m_input_tag = "ZDCEcalHits";
         u_eRes = {};
         m_tRes = 0.0 * dd4hep::ns;
         m_capADC = 8096;
@@ -52,7 +51,6 @@ public:
         m_geoSvc = app->GetService<JDD4hep_service>(); // TODO: implement named geometry service?
 
         // This is another option for exposing the data members as JANA configuration parameters.
-//        app->SetDefaultParameter("ZDC:tag",              m_input_tag);
         app->SetDefaultParameter("ZDC:ZDCEcalRawHits:energyResolutions",u_eRes);
         app->SetDefaultParameter("ZDC:ZDCEcalRawHits:timeResolution",   m_tRes);
         app->SetDefaultParameter("ZDC:ZDCEcalRawHits:capacityADC",      m_capADC);

--- a/src/detectors/ZDC/RawCalorimeterHit_factory_ZDCEcalRawHits.h
+++ b/src/detectors/ZDC/RawCalorimeterHit_factory_ZDCEcalRawHits.h
@@ -79,7 +79,7 @@ public:
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override {
         // Prefill inputs
-        simhits = event->Get<edm4hep::SimCalorimeterHit>(m_input_tag);
+        simhits = event->Get<edm4hep::SimCalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         AlgorithmProcess();

--- a/src/detectors/ZDC/RawCalorimeterHit_factory_ZDCEcalRawHits.h
+++ b/src/detectors/ZDC/RawCalorimeterHit_factory_ZDCEcalRawHits.h
@@ -34,6 +34,8 @@ public:
     //------------------------------------------
     // Init
     void Init() override {
+        InitDataTags(GetPluginName() + ":" + GetTag());
+
         auto app = GetApplication();
 
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm

--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -33,7 +33,7 @@ extern "C" {
 	  {"ZDCEcalRawHits"}, "ZDCEcalRecHits"
         ));
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_ZDCEcalTruthProtoClusters>(
-	  {"ZDCEcalRecHits"}, "ZDCEcalTruthProtoClusters"
+	  {"ZDCEcalRecHits", "ZDCEcalHits"}, "ZDCEcalTruthProtoClusters"
         ));
         app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_ZDCEcalIslandProtoClusters>(
 	  {"ZDCEcalRecHits"}, "ZDCEcalIslandProtoClusters"

--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -3,6 +3,7 @@
 //
 //
 
+#include <extensions/jana/JChainFactoryGeneratorT.h>
 #include <extensions/jana/JChainMultifactoryGeneratorT.h>
 
 #include <factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h>
@@ -25,10 +26,18 @@ extern "C" {
 
         InitJANAPlugin(app);
 
-        app->Add(new JFactoryGeneratorT<RawCalorimeterHit_factory_ZDCEcalRawHits>());
-        app->Add(new JFactoryGeneratorT<CalorimeterHit_factory_ZDCEcalRecHits>());
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_ZDCEcalTruthProtoClusters>());
-        app->Add(new JFactoryGeneratorT<ProtoCluster_factory_ZDCEcalIslandProtoClusters>());
+        app->Add(new JChainFactoryGeneratorT<RawCalorimeterHit_factory_ZDCEcalRawHits>(
+	  {"ZDCEcalHits"}, "ZDCEcalRawHits"
+	));
+        app->Add(new JChainFactoryGeneratorT<CalorimeterHit_factory_ZDCEcalRecHits>(
+	  {"ZDCEcalRawHits"}, "ZDCEcalRecHits"
+        ));
+        app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_ZDCEcalTruthProtoClusters>(
+	  {"ZDCEcalRecHits"}, "ZDCEcalTruthProtoClusters"
+        ));
+        app->Add(new JChainFactoryGeneratorT<ProtoCluster_factory_ZDCEcalIslandProtoClusters>(
+	  {"ZDCEcalRecHits"}, "ZDCEcalIslandProtoClusters"
+        ));
 
         app->Add(
           new JChainMultifactoryGeneratorT<Cluster_factory_ZDCEcalTruthClusters>(


### PR DESCRIPTION
### Briefly, what does this PR introduce?
All of the calorimetry factories are currently JFactoryT instead of JChainFactoryT, which means that they don't allow for providing a configuration object in the plugin (think: BEMC.cc).

This converts all calorimetry JFactoryT factories to JChainFactoryT, which requires that we specify also the set of input tags, and the output tag in the JChainFactoryGeneratorT constructor in the plugin. These are therefore removed from the factories since they are set in the plugin.

The third argument of the JChainFactoryGeneratorT can become the config object, which can now be introduced in a separate PR, algorithm by algorithm.

All this fits in a three-step process towards simplification:
- make calorimetry algorithms accept external config objects
- collect all configuration in plugin
- remove or reduce dedicate factory code

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators:
  - @veprbl I think this should be largely independent of the conversion to collections, but some diffs will touch close to the context of those changes. I'm going to rebase this after the conversion to collections is done.

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.