### PR TITLE
fix: disable default inclusion of realistic seeder

### DIFF
--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -74,8 +74,10 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "ReconstructedParticleAssociations",
             "ReconstructedChargedParticles",
             "ReconstructedChargedParticleAssociations",
-	    "ReconstructedSeededChargedParticles",
-	    "ReconstructedSeededChargedParticleAssociations",
+            // FIXME: Disable default inclusion of realistic seeding
+            // until the seed finder does not emit NaNs.
+            //"ReconstructedSeededChargedParticles",
+	    //"ReconstructedSeededChargedParticleAssociations",
             "CentralTrackSegments",
 	    "CentralTrackVertices",
             "InclusiveKinematicsDA",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The realistic seed finder is emitting NaNs to the CKF tracking algorithm. This causes crashes in CI test jobs at a high false positive rate. This PR removes the realistic seed finder from the default. It can be added again with `-Ppodio:output_include_collections` for studies. 

As a general note, algorithms should not emit NaNs, and rather than using `isnan` as a cleanup step, the algorithms writers should understand where NaNs are created (e.g. sqrt negative numbers, division by zero, over- or underflow) and should test for domain validity. Most likely the presence of NaNs is pointing to incorrect assumptions when the algorithm is applied.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @bschmookler 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.