### PR TITLE
fix: rm failing MC2SmearedParticleConfig include

### DIFF
--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -8,7 +8,6 @@
 
 #include <extensions/jana/JChainFactoryGeneratorT.h>
 #include <extensions/jana/JChainMultifactoryGeneratorT.h>
-#include <algorithms/reco/MC2SmearedParticleConfig.h>
 
 #include "MC2SmearedParticle_factory.h"
 #include "MatchClusters_factory.h"

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -28,8 +28,6 @@ void InitPlugin(JApplication *app) {
 
     using namespace eicrecon;
 
-    MC2SmearedParticleConfig smearing_default_config {0};  // No momentum smearing by default
-
     app->Add(new JChainFactoryGeneratorT<MC2SmearedParticle_factory>(
             {"MCParticles"}, "GeneratedParticles"));
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This removes an include of a removed header, removed in #778.

When we run CI tests, we use an eic-shell container that has EICrecon already installed. That means that removing a header file in the test build can still cause that header file to be found in the system directories. This then only shows up in an actual clean build later on.

Short of revamping our CI, I don't really know of a way to prevent this from happening in the short term.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: failing nightly at https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/1799855#L1974)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.