### PR TITLE
feat: settable seed per CalorimeterHitDigi algorithm

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -53,6 +53,9 @@ void CalorimeterHitDigi::AlgorithmInit(std::shared_ptr<spdlog::logger>& logger) 
     // generator. Ideally, this would be seeded with the run number+event number, but for
     // now, just use default values defined in header file.
 
+    // set random seed
+    generator.seed(m_seed);
+
     // set energy resolution numbers
     m_log=logger;
 

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.h
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.h
@@ -39,6 +39,9 @@ public:
     // Name of input data type (collection)
     std::string              m_input_tag;
 
+    // random seed
+    unsigned int             m_seed = 0;
+
     // additional smearing resolutions
     std::vector<double>      u_eRes;
     double                   m_tRes;

--- a/src/detectors/B0ECAL/RawCalorimeterHit_factory_B0ECalRawHits.h
+++ b/src/detectors/B0ECAL/RawCalorimeterHit_factory_B0ECalRawHits.h
@@ -38,6 +38,9 @@ public:
 
         auto app = GetApplication();
 
+        // random seed
+        m_seed=0x583FA66E;
+
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
         u_eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV};
         m_tRes = 0.0 * dd4hep::ns;

--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelImagingRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelImagingRawHits.h
@@ -36,6 +36,9 @@ public:
 
         auto app = GetApplication();
 
+        // random seed
+        m_seed=0x0C613B15;
+
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
         u_eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV};
         m_tRes = 0.0 * dd4hep::ns;

--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelScFiRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelScFiRawHits.h
@@ -36,6 +36,9 @@ public:
 
         auto app = GetApplication();
 
+        // random seed
+        m_seed=0xFC500096;
+
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
         u_eRes = {0.0 * sqrt(dd4hep::GeV), 0.0, 0.0 * dd4hep::GeV};
         m_tRes = 0.0 * dd4hep::ns;

--- a/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelSciGlassRawHits.h
+++ b/src/detectors/BEMC/RawCalorimeterHit_factory_EcalBarrelSciGlassRawHits.h
@@ -37,6 +37,9 @@ public:
 
         auto app = GetApplication();
 
+        // random seed
+        m_seed=0xE644AD78;
+
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
         u_eRes =  {0.0 * sqrt(dd4hep::GeV), 0.0, 0.0 * dd4hep::GeV};
         m_tRes = 0.0 * dd4hep::ns;

--- a/src/detectors/BHCAL/RawCalorimeterHit_factory_HcalBarrelRawHits.h
+++ b/src/detectors/BHCAL/RawCalorimeterHit_factory_HcalBarrelRawHits.h
@@ -38,6 +38,9 @@ public:
 
         auto app = GetApplication();
 
+        // random seed
+        m_seed=0xDBFF85F4;
+
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
         u_eRes = {};
         m_tRes = 0.0 * dd4hep::ns;

--- a/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapNRawHits.h
+++ b/src/detectors/EEMC/RawCalorimeterHit_factory_EcalEndcapNRawHits.h
@@ -38,6 +38,9 @@ public:
 
         auto app = GetApplication();
 
+        // random seed
+        m_seed=0x50FD2201;
+
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
         u_eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV}; // flat 2%
         m_tRes = 0.0 * dd4hep::ns;

--- a/src/detectors/EHCAL/RawCalorimeterHit_factory_HcalEndcapNRawHits.h
+++ b/src/detectors/EHCAL/RawCalorimeterHit_factory_HcalEndcapNRawHits.h
@@ -38,6 +38,9 @@ public:
 
         auto app = GetApplication();
 
+        // random seed
+        m_seed=0xDEB11159;
+
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
         u_eRes = {};
         m_tRes = 0.0 * dd4hep::ns;

--- a/src/detectors/FEMC/RawCalorimeterHit_factory_EcalEndcapPInsertRawHits.h
+++ b/src/detectors/FEMC/RawCalorimeterHit_factory_EcalEndcapPInsertRawHits.h
@@ -36,6 +36,9 @@ public:
 
         auto app = GetApplication();
 
+        // random seed
+        m_seed=0xE254A8A9;
+
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
         u_eRes = {0.00340 * sqrt(dd4hep::GeV), 0.0009, 0.0 * dd4hep::GeV}; // (0.340% / sqrt(E)) \oplus 0.09%
         m_tRes = 0.0 * dd4hep::ns;

--- a/src/detectors/FEMC/RawCalorimeterHit_factory_EcalEndcapPRawHits.h
+++ b/src/detectors/FEMC/RawCalorimeterHit_factory_EcalEndcapPRawHits.h
@@ -38,6 +38,9 @@ public:
 
         auto app = GetApplication();
 
+        // random seed
+        m_seed=0x6C4936CE;
+
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
         u_eRes = {0.00340 * sqrt(dd4hep::GeV), 0.0009, 0.0 * dd4hep::GeV}; // (0.340% / sqrt(E)) \oplus 0.09%
         m_tRes = 0.0 ;

--- a/src/detectors/FHCAL/RawCalorimeterHit_factory_HcalEndcapPInsertRawHits.h
+++ b/src/detectors/FHCAL/RawCalorimeterHit_factory_HcalEndcapPInsertRawHits.h
@@ -36,6 +36,9 @@ public:
 
         auto app = GetApplication();
 
+        // random seed
+        m_seed=0x670C84AE;
+
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
         u_eRes = {};
         m_tRes = 0.0 * dd4hep::ns;

--- a/src/detectors/FHCAL/RawCalorimeterHit_factory_HcalEndcapPRawHits.h
+++ b/src/detectors/FHCAL/RawCalorimeterHit_factory_HcalEndcapPRawHits.h
@@ -38,6 +38,9 @@ public:
 
         auto app = GetApplication();
 
+        // random seed
+        m_seed=0x55BD406D;
+
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
         u_eRes = {};
         m_tRes = 0.001 * dd4hep::ns;

--- a/src/detectors/FHCAL/RawCalorimeterHit_factory_LFHCALRawHits.h
+++ b/src/detectors/FHCAL/RawCalorimeterHit_factory_LFHCALRawHits.h
@@ -37,6 +37,9 @@ public:
 
         auto app = GetApplication();
 
+        // random seed
+        m_seed=0xBE09C22F;
+
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
         u_eRes = {};
         m_tRes = 0.0; // in ns

--- a/src/detectors/LUMISPECCAL/RawCalorimeterHit_factory_EcalLumiSpecRawHits.h
+++ b/src/detectors/LUMISPECCAL/RawCalorimeterHit_factory_EcalLumiSpecRawHits.h
@@ -38,6 +38,9 @@ public:
 
         auto app = GetApplication();
 
+        // random seed
+        m_seed=0xA99CDD32;
+
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
         u_eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV}; // flat 2%
         m_tRes = 0.0 * dd4hep::ns;

--- a/src/detectors/ZDC/RawCalorimeterHit_factory_ZDCEcalRawHits.h
+++ b/src/detectors/ZDC/RawCalorimeterHit_factory_ZDCEcalRawHits.h
@@ -38,6 +38,9 @@ public:
 
         auto app = GetApplication();
 
+        // random seed
+        m_seed=0x7F153180;
+
         // Set default values for all config. parameters in CalorimeterHitDigi algorithm
         u_eRes = {};
         m_tRes = 0.0 * dd4hep::ns;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This adds a settable seed (`uint32_t`) for the CalorimeterHitDigi algorithm, defaulting to zero, but settable in the derived factories. If we move to a different structure of factories, they should be able to produce the exact same output, per algorithm/factory, if given the same seed. Not sure this really gives us that much more insight or control, but it gives us a way to make sure we can control each algorithm independently.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.