### PR TITLE
fix: rm CRTP on SpdlogMixin, variadic template factory, unnecessary `using` in factories

### DIFF
--- a/src/benchmarks/reconstruction/tof_efficiency/TofEfficiency_processor.cc
+++ b/src/benchmarks/reconstruction/tof_efficiency/TofEfficiency_processor.cc
@@ -10,7 +10,7 @@
 void TofEfficiency_processor::InitWithGlobalRootLock(){
     std::string plugin_name=("tof_efficiency");
 
-    InitLogger(plugin_name);
+    InitLogger(GetApplication(), plugin_name);
 
     // Get JANA application
     auto app = GetApplication();

--- a/src/benchmarks/reconstruction/tof_efficiency/TofEfficiency_processor.h
+++ b/src/benchmarks/reconstruction/tof_efficiency/TofEfficiency_processor.h
@@ -20,7 +20,7 @@
 #include <edm4eic/TrackerHit.h>
 
 
-class TofEfficiency_processor: public JEventProcessorSequentialRoot, public eicrecon::SpdlogMixin<TofEfficiency_processor>  {
+class TofEfficiency_processor: public JEventProcessorSequentialRoot, public eicrecon::SpdlogMixin  {
 private:
 
     // Data objects we will need from JANA

--- a/src/detectors/B0ECAL/B0ECAL.cc
+++ b/src/detectors/B0ECAL/B0ECAL.cc
@@ -13,16 +13,6 @@
 
 #include "ProtoCluster_factory_B0ECalIslandProtoClusters.h"
 
-
-namespace eicrecon {
-  using RawCalorimeterHit_factory_B0ECalRawHits = CalorimeterHitDigi_factoryT<>;
-  using CalorimeterHit_factory_B0ECalRecHits = CalorimeterHitReco_factoryT<>;
-  using ProtoCluster_factory_B0ECalTruthProtoClusters = CalorimeterTruthClustering_factoryT<>;
-  using Cluster_factory_B0ECalTruthClusters = CalorimeterClusterRecoCoG_factoryT<>;
-  using Cluster_factory_B0ECalClusters = CalorimeterClusterRecoCoG_factoryT<>;
-}
-
-
 extern "C" {
     void InitPlugin(JApplication *app) {
 
@@ -30,7 +20,7 @@ extern "C" {
 
         InitJANAPlugin(app);
 
-        app->Add(new JChainMultifactoryGeneratorT<RawCalorimeterHit_factory_B0ECalRawHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
           "B0ECalRawHits", {"B0ECalHits"}, {"B0ECalRawHits"},
           {
             .eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV},
@@ -44,7 +34,7 @@ extern "C" {
           },
           app   // TODO: Remove me once fixed
         ));
-        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHit_factory_B0ECalRecHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitReco_factoryT>(
           "B0ECalRecHits", {"B0ECalRawHits"}, {"B0ECalRecHits"},
           {
             .capADC = 16384,
@@ -60,7 +50,7 @@ extern "C" {
           },
           app   // TODO: Remove me once fixed
         ));
-        app->Add(new JChainMultifactoryGeneratorT<ProtoCluster_factory_B0ECalTruthProtoClusters>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterTruthClustering_factoryT>(
           "B0ECalTruthProtoClusters", {"B0ECalRecHits", "B0ECalHits"}, {"B0ECalTruthProtoClusters"},
           app   // TODO: Remove me once fixed
         ));
@@ -69,7 +59,7 @@ extern "C" {
         ));
 
         app->Add(
-          new JChainMultifactoryGeneratorT<Cluster_factory_B0ECalClusters>(
+          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT>(
              "B0ECalClusters",
             {"B0ECalIslandProtoClusters",  // edm4eic::ProtoClusterCollection
              "B0ECalHits"},                // edm4hep::SimCalorimeterHitCollection
@@ -88,7 +78,7 @@ extern "C" {
         );
 
         app->Add(
-          new JChainMultifactoryGeneratorT<Cluster_factory_B0ECalTruthClusters>(
+          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT>(
              "B0ECalTruthClusters",
             {"B0ECalTruthProtoClusters",        // edm4eic::ProtoClusterCollection
              "B0ECalHits"},                     // edm4hep::SimCalorimeterHitCollection

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -19,14 +19,6 @@
 #include "Cluster_factory_EcalBarrelImagingClusters.h"
 #include "Cluster_factory_EcalBarrelImagingMergedClusters.h"
 
-namespace eicrecon {
-  using RawCalorimeterHit_factory_EcalBarrelScFiRawHits = CalorimeterHitDigi_factoryT<>;
-  using RawCalorimeterHit_factory_EcalBarrelImagingRawHits = CalorimeterHitDigi_factoryT<>;
-  using CalorimeterHit_factory_EcalBarrelScFiRecHits = CalorimeterHitReco_factoryT<>;
-  using CalorimeterHit_factory_EcalBarrelScFiMergedHits = CalorimeterHitsMerger_factoryT<>;
-  using Cluster_factory_EcalBarrelScFiClusters = CalorimeterClusterRecoCoG_factoryT<>;
-}
-
 extern "C" {
     void InitPlugin(JApplication *app) {
 
@@ -78,7 +70,7 @@ extern "C" {
           {"EcalBarrelScFiRecHits"}, "EcalBarrelScFiProtoClusters"
         ));
         app->Add(
-          new JChainMultifactoryGeneratorT<Cluster_factory_EcalBarrelScFiClusters>(
+          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT<>>(
              "EcalBarrelScFiClusters",
             {"EcalBarrelScFiProtoClusters",        // edm4eic::ProtoClusterCollection
              "EcalBarrelScFiHits"},                // edm4hep::SimCalorimeterHitCollection

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -26,7 +26,7 @@ extern "C" {
 
         InitJANAPlugin(app);
 
-        app->Add(new JChainMultifactoryGeneratorT<RawCalorimeterHit_factory_EcalBarrelScFiRawHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
            "EcalBarrelScFiRawHits",
            {"EcalBarrelScFiHits"},
            {"EcalBarrelScFiRawHits"},
@@ -44,7 +44,7 @@ extern "C" {
            },
            app   // TODO: Remove me once fixed
         ));
-        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHit_factory_EcalBarrelScFiRecHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitReco_factoryT>(
           "EcalBarrelScFiRecHits", {"EcalBarrelScFiRawHits"}, {"EcalBarrelScFiRecHits"},
           {
             .capADC = 16384,
@@ -70,7 +70,7 @@ extern "C" {
           {"EcalBarrelScFiRecHits"}, "EcalBarrelScFiProtoClusters"
         ));
         app->Add(
-          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT<>>(
+          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT>(
              "EcalBarrelScFiClusters",
             {"EcalBarrelScFiProtoClusters",        // edm4eic::ProtoClusterCollection
              "EcalBarrelScFiHits"},                // edm4hep::SimCalorimeterHitCollection
@@ -88,7 +88,7 @@ extern "C" {
           )
         );
 
-        app->Add(new JChainMultifactoryGeneratorT<RawCalorimeterHit_factory_EcalBarrelImagingRawHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
            "EcalBarrelImagingRawHits",
           {"EcalBarrelImagingHits"},
           {"EcalBarrelImagingRawHits"},

--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -13,15 +13,6 @@
 
 #include "ProtoCluster_factory_HcalBarrelIslandProtoClusters.h"
 
-
-namespace eicrecon {
-  using RawCalorimeterHit_factory_HcalBarrelRawHits = CalorimeterHitDigi_factoryT<>;
-  using CalorimeterHit_factory_HcalBarrelRecHits = CalorimeterHitReco_factoryT<>;
-  using ProtoCluster_factory_HcalBarrelTruthProtoClusters = CalorimeterTruthClustering_factoryT<>;
-  using Cluster_factory_HcalBarrelTruthClusters = CalorimeterClusterRecoCoG_factoryT<>;
-  using Cluster_factory_HcalBarrelClusters = CalorimeterClusterRecoCoG_factoryT<>;
-}
-
 extern "C" {
     void InitPlugin(JApplication *app) {
 
@@ -29,7 +20,7 @@ extern "C" {
 
         InitJANAPlugin(app);
 
-        app->Add(new JChainMultifactoryGeneratorT<RawCalorimeterHit_factory_HcalBarrelRawHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
           "HcalBarrelRawHits", {"HcalBarrelHits"}, {"HcalBarrelRawHits"},
           {
             .eRes = {},
@@ -45,7 +36,7 @@ extern "C" {
           },
           app   // TODO: Remove me once fixed
 	));
-        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHit_factory_HcalBarrelRecHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitReco_factoryT>(
           "HcalBarrelRecHits", {"HcalBarrelRawHits"}, {"HcalBarrelRecHits"},
           {
             .capADC = 65536,
@@ -62,7 +53,7 @@ extern "C" {
           },
           app   // TODO: Remove me once fixed
 	));
-        app->Add(new JChainMultifactoryGeneratorT<ProtoCluster_factory_HcalBarrelTruthProtoClusters>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterTruthClustering_factoryT>(
           "HcalBarrelTruthProtoClusters", {"HcalBarrelRecHits", "HcalBarrelHits"}, {"HcalBarrelTruthProtoClusters"},
           app   // TODO: Remove me once fixed
         ));
@@ -71,7 +62,7 @@ extern "C" {
 	));
 
         app->Add(
-          new JChainMultifactoryGeneratorT<Cluster_factory_HcalBarrelClusters>(
+          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT>(
              "HcalBarrelClusters",
             {"HcalBarrelIslandProtoClusters",  // edm4eic::ProtoClusterCollection
              "HcalBarrelHits"},                // edm4hep::SimCalorimeterHitCollection
@@ -90,7 +81,7 @@ extern "C" {
         );
 
         app->Add(
-          new JChainMultifactoryGeneratorT<Cluster_factory_HcalBarrelTruthClusters>(
+          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT>(
              "HcalBarrelTruthClusters",
             {"HcalBarrelTruthProtoClusters",        // edm4eic::ProtoClusterCollection
              "HcalBarrelHits"},                     // edm4hep::SimCalorimeterHitCollection

--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -13,14 +13,6 @@
 
 #include "ProtoCluster_factory_EcalEndcapNIslandProtoClusters.h"
 
-namespace eicrecon {
-  using RawCalorimeterHit_factory_EcalEndcapNRawHits = CalorimeterHitDigi_factoryT<>;
-  using CalorimeterHit_factory_EcalEndcapNRecHits = CalorimeterHitReco_factoryT<>;
-  using ProtoCluster_factory_EcalEndcapNTruthProtoClusters = CalorimeterTruthClustering_factoryT<>;
-  using Cluster_factory_EcalEndcapNTruthClusters = CalorimeterClusterRecoCoG_factoryT<>;
-  using Cluster_factory_EcalEndcapNClusters = CalorimeterClusterRecoCoG_factoryT<>;
-}
-
 extern "C" {
     void InitPlugin(JApplication *app) {
 
@@ -28,7 +20,7 @@ extern "C" {
 
         InitJANAPlugin(app);
 
-        app->Add(new JChainMultifactoryGeneratorT<RawCalorimeterHit_factory_EcalEndcapNRawHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
           "EcalEndcapNRawHits", {"EcalEndcapNHits"}, {"EcalEndcapNRawHits"},
           {
             .eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV},
@@ -42,7 +34,7 @@ extern "C" {
           },
           app   // TODO: Remove me once fixed
 	));
-        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHit_factory_EcalEndcapNRecHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitReco_factoryT>(
           "EcalEndcapNRecHits", {"EcalEndcapNRawHits"}, {"EcalEndcapNRecHits"},
           {
             .capADC = 16384,
@@ -58,7 +50,7 @@ extern "C" {
           },
           app   // TODO: Remove me once fixed
 	));
-        app->Add(new JChainMultifactoryGeneratorT<ProtoCluster_factory_EcalEndcapNTruthProtoClusters>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterTruthClustering_factoryT>(
           "EcalEndcapNTruthProtoClusters", {"EcalEndcapNRecHits", "EcalEndcapNHits"}, {"EcalEndcapNTruthProtoClusters"},
           app   // TODO: Remove me once fixed
         ));
@@ -67,7 +59,7 @@ extern "C" {
 	));
 
         app->Add(
-          new JChainMultifactoryGeneratorT<Cluster_factory_EcalEndcapNTruthClusters>(
+          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT>(
              "EcalEndcapNTruthClusters",
             {"EcalEndcapNTruthProtoClusters",        // edm4eic::ProtoClusterCollection
              "EcalEndcapNHits"},                     // edm4hep::SimCalorimeterHitCollection
@@ -86,7 +78,7 @@ extern "C" {
         );
 
         app->Add(
-          new JChainMultifactoryGeneratorT<Cluster_factory_EcalEndcapNClusters>(
+          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT>(
              "EcalEndcapNClusters",
             {"EcalEndcapNIslandProtoClusters",  // edm4eic::ProtoClusterCollection
              "EcalEndcapNHits"},                // edm4hep::SimCalorimeterHitCollection

--- a/src/detectors/EHCAL/EHCAL.cc
+++ b/src/detectors/EHCAL/EHCAL.cc
@@ -14,16 +14,6 @@
 
 #include "ProtoCluster_factory_HcalEndcapNIslandProtoClusters.h"
 
-
-namespace eicrecon {
-  using RawCalorimeterHit_factory_HcalEndcapNRawHits = CalorimeterHitDigi_factoryT<>;
-  using CalorimeterHit_factory_HcalEndcapNRecHits = CalorimeterHitReco_factoryT<>;
-  using CalorimeterHit_factory_HcalEndcapNMergedHits = CalorimeterHitsMerger_factoryT<>;
-  using ProtoCluster_factory_HcalEndcapNTruthProtoClusters = CalorimeterTruthClustering_factoryT<>;
-  using Cluster_factory_HcalEndcapNTruthClusters = CalorimeterClusterRecoCoG_factoryT<>;
-  using Cluster_factory_HcalEndcapNClusters = CalorimeterClusterRecoCoG_factoryT<>;
-}
-
 extern "C" {
     void InitPlugin(JApplication *app) {
 
@@ -31,7 +21,7 @@ extern "C" {
 
         InitJANAPlugin(app);
 
-        app->Add(new JChainMultifactoryGeneratorT<RawCalorimeterHit_factory_HcalEndcapNRawHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
           "HcalEndcapNRawHits", {"HcalEndcapNHits"}, {"HcalEndcapNRawHits"},
           {
             .tRes = 0.0 * dd4hep::ns,
@@ -44,7 +34,7 @@ extern "C" {
           },
           app   // TODO: Remove me once fixed
         ));
-        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHit_factory_HcalEndcapNRecHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitReco_factoryT>(
           "HcalEndcapNRecHits", {"HcalEndcapNRawHits"}, {"HcalEndcapNRecHits"},
           {
             .capADC = 1024,
@@ -59,7 +49,7 @@ extern "C" {
           },
           app   // TODO: Remove me once fixed
         ));
-        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHit_factory_HcalEndcapNMergedHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitsMerger_factoryT>(
           "HcalEndcapNMergedHits", {"HcalEndcapNRecHits"}, {"HcalEndcapNMergedHits"},
           {
             .readout = "HcalEndcapNHits",
@@ -68,7 +58,7 @@ extern "C" {
           },
           app   // TODO: Remove me once fixed
         ));
-        app->Add(new JChainMultifactoryGeneratorT<ProtoCluster_factory_HcalEndcapNTruthProtoClusters>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterTruthClustering_factoryT>(
           "HcalEndcapNTruthProtoClusters", {"HcalEndcapNRecHits", "HcalEndcapNHits"}, {"HcalEndcapNTruthProtoClusters"},
           app   // TODO: Remove me once fixed
         ));
@@ -76,7 +66,7 @@ extern "C" {
           {"HcalEndcapNRecHits"}, "HcalEndcapNIslandProtoClusters"
         ));
         app->Add(
-          new JChainMultifactoryGeneratorT<Cluster_factory_HcalEndcapNTruthClusters>(
+          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT>(
              "HcalEndcapNTruthClusters",
             {"HcalEndcapNTruthProtoClusters",        // edm4eic::ProtoClusterCollection
              "HcalEndcapNHits"},                     // edm4hep::SimCalorimeterHitCollection
@@ -95,7 +85,7 @@ extern "C" {
         );
 
         app->Add(
-          new JChainMultifactoryGeneratorT<Cluster_factory_HcalEndcapNClusters>(
+          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT>(
              "HcalEndcapNClusters",
             {"HcalEndcapNIslandProtoClusters",  // edm4eic::ProtoClusterCollection
              "HcalEndcapNHits"},                // edm4hep::SimCalorimeterHitCollection

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -15,19 +15,6 @@
 
 #include "ProtoCluster_factory_EcalEndcapPInsertIslandProtoClusters.h"
 
-namespace eicrecon {
-  using RawCalorimeterHit_factory_EcalEndcapPRawHits = CalorimeterHitDigi_factoryT<>;
-  using RawCalorimeterHit_factory_EcalEndcapPInsertRawHits = CalorimeterHitDigi_factoryT<>;
-  using CalorimeterHit_factory_EcalEndcapPRecHits = CalorimeterHitReco_factoryT<>;
-  using CalorimeterHit_factory_EcalEndcapPInsertRecHits = CalorimeterHitReco_factoryT<>;
-  using ProtoCluster_factory_EcalEndcapPTruthProtoClusters = CalorimeterTruthClustering_factoryT<>;
-  using ProtoCluster_factory_EcalEndcapPInsertTruthProtoClusters = CalorimeterTruthClustering_factoryT<>;
-  using Cluster_factory_EcalEndcapPTruthClusters = CalorimeterClusterRecoCoG_factoryT<>;
-  using Cluster_factory_EcalEndcapPClusters = CalorimeterClusterRecoCoG_factoryT<>;
-  using Cluster_factory_EcalEndcapPInsertTruthClusters = CalorimeterClusterRecoCoG_factoryT<>;
-  using Cluster_factory_EcalEndcapPInsertClusters = CalorimeterClusterRecoCoG_factoryT<>;
-}
-
 extern "C" {
     void InitPlugin(JApplication *app) {
 
@@ -35,7 +22,7 @@ extern "C" {
 
         InitJANAPlugin(app);
 
-        app->Add(new JChainMultifactoryGeneratorT<RawCalorimeterHit_factory_EcalEndcapPRawHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
           "EcalEndcapPRawHits", {"EcalEndcapPHits"}, {"EcalEndcapPRawHits"},
           {
             .eRes = {0.00340 * sqrt(dd4hep::GeV), 0.0009, 0.0 * dd4hep::GeV}, // (0.340% / sqrt(E)) \oplus 0.09%
@@ -50,7 +37,7 @@ extern "C" {
           },
           app   // TODO: Remove me once fixed
         ));
-        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHit_factory_EcalEndcapPRecHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitReco_factoryT>(
           "EcalEndcapPRecHits", {"EcalEndcapPRawHits"}, {"EcalEndcapPRecHits"},
           {
             .capADC = 65536,
@@ -65,7 +52,7 @@ extern "C" {
           },
           app   // TODO: Remove me once fixed
         ));
-        app->Add(new JChainMultifactoryGeneratorT<ProtoCluster_factory_EcalEndcapPTruthProtoClusters>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterTruthClustering_factoryT>(
           "EcalEndcapPTruthProtoClusters", {"EcalEndcapPRecHits", "EcalEndcapPHits"}, {"EcalEndcapPTruthProtoClusters"},
           app   // TODO: Remove me once fixed
         ));
@@ -74,7 +61,7 @@ extern "C" {
         ));
 
         app->Add(
-          new JChainMultifactoryGeneratorT<Cluster_factory_EcalEndcapPTruthClusters>(
+          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT>(
              "EcalEndcapPTruthClusters",
             {"EcalEndcapPTruthProtoClusters",        // edm4eic::ProtoClusterCollection
              "EcalEndcapPHits"},                     // edm4hep::SimCalorimeterHitCollection
@@ -93,7 +80,7 @@ extern "C" {
         );
 
         app->Add(
-          new JChainMultifactoryGeneratorT<Cluster_factory_EcalEndcapPClusters>(
+          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT>(
              "EcalEndcapPClusters",
             {"EcalEndcapPIslandProtoClusters",  // edm4eic::ProtoClusterCollection
              "EcalEndcapPHits"},                // edm4hep::SimCalorimeterHitCollection
@@ -111,7 +98,7 @@ extern "C" {
           )
         );
 
-        app->Add(new JChainMultifactoryGeneratorT<RawCalorimeterHit_factory_EcalEndcapPInsertRawHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
           "EcalEndcapPInsertRawHits", {"EcalEndcapPInsertHits"}, {"EcalEndcapPInsertRawHits"},
           {
             .eRes = {0.00340 * sqrt(dd4hep::GeV), 0.0009, 0.0 * dd4hep::GeV}, // (0.340% / sqrt(E)) \oplus 0.09%
@@ -125,7 +112,7 @@ extern "C" {
           },
           app   // TODO: Remove me once fixed
         ));
-        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHit_factory_EcalEndcapPInsertRecHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitReco_factoryT>(
           "EcalEndcapPInsertRecHits", {"EcalEndcapPInsertRawHits"}, {"EcalEndcapPInsertRecHits"},
           {
             .capADC = 16384,
@@ -140,7 +127,7 @@ extern "C" {
           },
           app   // TODO: Remove me once fixed
         ));
-        app->Add(new JChainMultifactoryGeneratorT<ProtoCluster_factory_EcalEndcapPInsertTruthProtoClusters>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterTruthClustering_factoryT>(
           "EcalEndcapPInsertTruthProtoClusters", {"EcalEndcapPInsertRecHits", "EcalEndcapPInsertHits"}, {"EcalEndcapPInsertTruthProtoClusters"},
           app   // TODO: Remove me once fixed
         ));
@@ -149,7 +136,7 @@ extern "C" {
         ));
 
         app->Add(
-          new JChainMultifactoryGeneratorT<Cluster_factory_EcalEndcapPInsertTruthClusters>(
+          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT>(
              "EcalEndcapPInsertTruthClusters",
             {"EcalEndcapPInsertTruthProtoClusters",        // edm4eic::ProtoClusterCollection
              "EcalEndcapPInsertHits"},                     // edm4hep::SimCalorimeterHitCollection
@@ -168,7 +155,7 @@ extern "C" {
         );
 
         app->Add(
-          new JChainMultifactoryGeneratorT<Cluster_factory_EcalEndcapPInsertClusters>(
+          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT>(
              "EcalEndcapPInsertClusters",
             {"EcalEndcapPInsertIslandProtoClusters",  // edm4eic::ProtoClusterCollection
              "EcalEndcapPInsertHits"},                // edm4hep::SimCalorimeterHitCollection

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -18,26 +18,6 @@
 
 #include "ProtoCluster_factory_LFHCALIslandProtoClusters.h"
 
-namespace eicrecon {
-  using RawCalorimeterHit_factory_HcalEndcapPRawHits = CalorimeterHitDigi_factoryT<>;
-  using RawCalorimeterHit_factory_HcalEndcapPInsertRawHits = CalorimeterHitDigi_factoryT<>;
-  using RawCalorimeterHit_factory_LFHCALRawHits = CalorimeterHitDigi_factoryT<>;
-  using CalorimeterHit_factory_HcalEndcapPRecHits = CalorimeterHitReco_factoryT<>;
-  using CalorimeterHit_factory_HcalEndcapPInsertRecHits = CalorimeterHitReco_factoryT<>;
-  using CalorimeterHit_factory_LFHCALRecHits = CalorimeterHitReco_factoryT<>;
-  using CalorimeterHit_factory_HcalEndcapPMergedHits = CalorimeterHitsMerger_factoryT<>;
-  using CalorimeterHit_factory_HcalEndcapPInsertMergedHits = CalorimeterHitsMerger_factoryT<>;
-  using ProtoCluster_factory_HcalEndcapPTruthProtoClusters = CalorimeterTruthClustering_factoryT<>;
-  using ProtoCluster_factory_HcalEndcapPInsertTruthProtoClusters = CalorimeterTruthClustering_factoryT<>;
-  using ProtoCluster_factory_LFHCALTruthProtoClusters = CalorimeterTruthClustering_factoryT<>;
-  using Cluster_factory_HcalEndcapPTruthClusters =  CalorimeterClusterRecoCoG_factoryT<>;
-  using Cluster_factory_HcalEndcapPClusters = CalorimeterClusterRecoCoG_factoryT<>;
-  using Cluster_factory_HcalEndcapPInsertTruthClusters =  CalorimeterClusterRecoCoG_factoryT<>;
-  using Cluster_factory_HcalEndcapPInsertClusters =  CalorimeterClusterRecoCoG_factoryT<>;
-  using Cluster_factory_LFHCALTruthClusters = CalorimeterClusterRecoCoG_factoryT<>;
-  using Cluster_factory_LFHCALClusters = CalorimeterClusterRecoCoG_factoryT<>;
-}
-
 extern "C" {
     void InitPlugin(JApplication *app) {
 
@@ -45,7 +25,7 @@ extern "C" {
 
         InitJANAPlugin(app);
 
-        app->Add(new JChainMultifactoryGeneratorT<RawCalorimeterHit_factory_HcalEndcapPRawHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
            "HcalEndcapPRawHits", {"HcalEndcapPHits"}, {"HcalEndcapPRawHits"},
            {
              .eRes = {},
@@ -59,7 +39,7 @@ extern "C" {
            },
            app   // TODO: Remove me once fixed
         ));
-        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHit_factory_HcalEndcapPRecHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitReco_factoryT>(
           "HcalEndcapPRecHits", {"HcalEndcapPRawHits"}, {"HcalEndcapPRecHits"},
           {
             .capADC = 65536,
@@ -74,7 +54,7 @@ extern "C" {
           },
           app   // TODO: Remove me once fixed
         ));
-        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHit_factory_HcalEndcapPMergedHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitsMerger_factoryT>(
           "HcalEndcapPMergedHits", {"HcalEndcapPRecHits"}, {"HcalEndcapPMergedHits"},
           {
             .readout = "HcalEndcapPHits",
@@ -83,7 +63,7 @@ extern "C" {
           },
           app   // TODO: Remove me once fixed
         ));
-        app->Add(new JChainMultifactoryGeneratorT<ProtoCluster_factory_HcalEndcapPTruthProtoClusters>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterTruthClustering_factoryT>(
           "HcalEndcapPTruthProtoClusters", {"HcalEndcapPRecHits", "HcalEndcapPHits"}, {"HcalEndcapPTruthProtoClusters"},
           app   // TODO: Remove me once fixed
         ));
@@ -92,7 +72,7 @@ extern "C" {
         ));
 
         app->Add(
-          new JChainMultifactoryGeneratorT<Cluster_factory_HcalEndcapPTruthClusters>(
+          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT>(
              "HcalEndcapPTruthClusters",
             {"HcalEndcapPTruthProtoClusters",        // edm4eic::ProtoClusterCollection
              "HcalEndcapPHits"},                     // edm4hep::SimCalorimeterHitCollection
@@ -111,7 +91,7 @@ extern "C" {
         );
 
         app->Add(
-          new JChainMultifactoryGeneratorT<Cluster_factory_HcalEndcapPClusters>(
+          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT>(
              "HcalEndcapPClusters",
             {"HcalEndcapPIslandProtoClusters",  // edm4eic::ProtoClusterCollection
              "HcalEndcapPHits"},                // edm4hep::SimCalorimeterHitCollection
@@ -129,7 +109,7 @@ extern "C" {
           )
         );
 
-        app->Add(new JChainMultifactoryGeneratorT<RawCalorimeterHit_factory_HcalEndcapPInsertRawHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
            "HcalEndcapPInsertRawHits", {"HcalEndcapPInsertHits"}, {"HcalEndcapPInsertRawHits"},
            {
              .eRes = {},
@@ -143,7 +123,7 @@ extern "C" {
            },
           app   // TODO: Remove me once fixed
         ));
-        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHit_factory_HcalEndcapPInsertRecHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitReco_factoryT>(
           "HcalEndcapPInsertRecHits", {"HcalEndcapPInsertRawHits"}, {"HcalEndcapPInsertRecHits"},
           {
             .capADC = 32768,
@@ -158,7 +138,7 @@ extern "C" {
           },
           app   // TODO: Remove me once fixed
         ));
-        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHit_factory_HcalEndcapPInsertMergedHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitsMerger_factoryT>(
           "HcalEndcapPInsertMergedHits", {"HcalEndcapPInsertRecHits"}, {"HcalEndcapPInsertMergedHits"},
           {
             .readout = "HcalEndcapPInsertHits",
@@ -167,7 +147,7 @@ extern "C" {
           },
           app   // TODO: Remove me once fixed
         ));
-        app->Add(new JChainMultifactoryGeneratorT<ProtoCluster_factory_HcalEndcapPInsertTruthProtoClusters>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterTruthClustering_factoryT>(
           "HcalEndcapPInsertTruthProtoClusters", {"HcalEndcapPInsertMergedHits", "HcalEndcapPInsertHits"}, {"HcalEndcapPInsertTruthProtoClusters"},
           app   // TODO: Remove me once fixed
         ));
@@ -176,7 +156,7 @@ extern "C" {
         ));
 
         app->Add(
-          new JChainMultifactoryGeneratorT<Cluster_factory_HcalEndcapPTruthClusters>(
+          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT>(
              "HcalEndcapPInsertTruthClusters",
             {"HcalEndcapPInsertTruthProtoClusters",        // edm4eic::ProtoClusterCollection
              "HcalEndcapPInsertHits"},                     // edm4hep::SimCalorimeterHitCollection
@@ -195,7 +175,7 @@ extern "C" {
         );
 
         app->Add(
-          new JChainMultifactoryGeneratorT<Cluster_factory_HcalEndcapPInsertClusters>(
+          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT>(
              "HcalEndcapPInsertClusters",
             {"HcalEndcapPInsertIslandProtoClusters",  // edm4eic::ProtoClusterCollection
              "HcalEndcapPInsertHits"},                // edm4hep::SimCalorimeterHitCollection
@@ -213,7 +193,7 @@ extern "C" {
           )
         );
 
-        app->Add(new JChainMultifactoryGeneratorT<RawCalorimeterHit_factory_LFHCALRawHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
           "LFHCALRawHits", {"LFHCALHits"}, {"LFHCALRawHits"},
           {
             .eRes = {},
@@ -230,7 +210,7 @@ extern "C" {
           },
           app   // TODO: Remove me once fixed
         ));
-        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHit_factory_LFHCALRecHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitReco_factoryT>(
           "LFHCALRecHits", {"LFHCALRawHits"}, {"LFHCALRecHits"},
           {
             .capADC = 65536,
@@ -261,7 +241,7 @@ extern "C" {
           },
           app   // TODO: Remove me once fixed
         ));
-        app->Add(new JChainMultifactoryGeneratorT<ProtoCluster_factory_LFHCALTruthProtoClusters>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterTruthClustering_factoryT>(
           "LFHCALTruthProtoClusters", {"LFHCALRecHits", "LFHCALHits"}, {"LFHCALTruthProtoClusters"},
           app   // TODO: Remove me once fixed
         ));
@@ -270,7 +250,7 @@ extern "C" {
         ));
 
         app->Add(
-          new JChainMultifactoryGeneratorT<Cluster_factory_LFHCALTruthClusters>(
+          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT>(
              "LFHCALTruthClusters",
             {"LFHCALTruthProtoClusters",        // edm4eic::ProtoClusterCollection
              "LFHCALHits"},                     // edm4hep::SimCalorimeterHitCollection
@@ -289,7 +269,7 @@ extern "C" {
         );
 
         app->Add(
-          new JChainMultifactoryGeneratorT<Cluster_factory_LFHCALClusters>(
+          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT>(
              "LFHCALClusters",
             {"LFHCALIslandProtoClusters",  // edm4eic::ProtoClusterCollection
              "LFHCALHits"},                // edm4hep::SimCalorimeterHitCollection

--- a/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
+++ b/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
@@ -13,14 +13,6 @@
 
 #include "ProtoCluster_factory_EcalLumiSpecIslandProtoClusters.h"
 
-namespace eicrecon {
-  using RawCalorimeterHit_factory_EcalLumiSpecRawHits = CalorimeterHitDigi_factoryT<>;
-  using CalorimeterHit_factory_EcalLumiSpecRecHits = CalorimeterHitReco_factoryT<>;
-  using ProtoCluster_factory_EcalLumiSpecTruthProtoClusters = CalorimeterTruthClustering_factoryT<>;
-  using Cluster_factory_EcalLumiSpecTruthClusters = CalorimeterClusterRecoCoG_factoryT<>;
-  using Cluster_factory_EcalLumiSpecClusters = CalorimeterClusterRecoCoG_factoryT<>;
-}
-
 extern "C" {
     void InitPlugin(JApplication *app) {
 
@@ -28,7 +20,7 @@ extern "C" {
 
         InitJANAPlugin(app);
 
-        app->Add(new JChainMultifactoryGeneratorT<RawCalorimeterHit_factory_EcalLumiSpecRawHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
           "EcalLumiSpecRawHits", {"LumiSpecCALHits"}, {"EcalLumiSpecRawHits"},
           {
             .eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV}, // flat 2%
@@ -42,7 +34,7 @@ extern "C" {
           },
           app   // TODO: Remove me once fixed
         ));
-        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHit_factory_EcalLumiSpecRecHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitReco_factoryT>(
           "EcalLumiSpecRecHits", {"EcalLumiSpecRawHits"}, {"EcalLumiSpecRecHits"},
           {
             .capADC = 16384,
@@ -58,7 +50,7 @@ extern "C" {
           },
           app   // TODO: Remove me once fixed
         ));
-        app->Add(new JChainMultifactoryGeneratorT<ProtoCluster_factory_EcalLumiSpecTruthProtoClusters>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterTruthClustering_factoryT>(
           "EcalLumiSpecTruthProtoClusters", {"EcalLumiSpecRecHits", "LumiSpecCALHits"}, {"EcalLumiSpecTruthProtoClusters"},
           app   // TODO: Remove me once fixed
         ));
@@ -67,7 +59,7 @@ extern "C" {
         ));
 
         app->Add(
-          new JChainMultifactoryGeneratorT<Cluster_factory_EcalLumiSpecClusters>(
+          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT>(
              "EcalLumiSpecClusters",
             {"EcalLumiSpecIslandProtoClusters",  // edm4eic::ProtoClusterCollection
              "LumiSpecCALHits"},                 // edm4hep::SimCalorimeterHitCollection
@@ -86,7 +78,7 @@ extern "C" {
         );
 
         app->Add(
-          new JChainMultifactoryGeneratorT<Cluster_factory_EcalLumiSpecTruthClusters>(
+          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT>(
              "EcalLumiSpecTruthClusters",
             {"EcalLumiSpecTruthProtoClusters",        // edm4eic::ProtoClusterCollection
              "LumiSpecCALHits"},                      // edm4hep::SimCalorimeterHitCollection

--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -13,15 +13,6 @@
 
 #include "ProtoCluster_factory_ZDCEcalIslandProtoClusters.h"
 
-
-namespace eicrecon {
-  using RawCalorimeterHit_factory_ZDCEcalRawHits = CalorimeterHitDigi_factoryT<>;
-  using CalorimeterHit_factory_ZDCEcalRecHits = CalorimeterHitReco_factoryT<>;
-  using ProtoCluster_factory_ZDCEcalTruthProtoClusters = CalorimeterTruthClustering_factoryT<>;
-  using Cluster_factory_ZDCEcalTruthClusters = CalorimeterClusterRecoCoG_factoryT<>;
-  using Cluster_factory_ZDCEcalClusters = CalorimeterClusterRecoCoG_factoryT<>;
-}
-
 extern "C" {
     void InitPlugin(JApplication *app) {
 
@@ -29,7 +20,7 @@ extern "C" {
 
         InitJANAPlugin(app);
 
-        app->Add(new JChainMultifactoryGeneratorT<RawCalorimeterHit_factory_ZDCEcalRawHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
 	  "ZDCEcalRawHits", {"ZDCEcalHits"}, {"ZDCEcalRawHits"},
           {
             .tRes = 0.0 * dd4hep::ns,
@@ -42,7 +33,7 @@ extern "C" {
           },
           app   // TODO: Remove me once fixed
 	));
-        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHit_factory_ZDCEcalRecHits>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitReco_factoryT>(
 	  "ZDCEcalRecHits", {"ZDCEcalRawHits"}, {"ZDCEcalRecHits"},
           {
             .capADC = 8096,
@@ -57,7 +48,7 @@ extern "C" {
           },
           app   // TODO: Remove me once fixed
         ));
-        app->Add(new JChainMultifactoryGeneratorT<ProtoCluster_factory_ZDCEcalTruthProtoClusters>(
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterTruthClustering_factoryT>(
           "ZDCEcalTruthProtoClusters", {"ZDCEcalRecHits", "ZDCEcalHits"}, {"ZDCEcalTruthProtoClusters"},
           app   // TODO: Remove me once fixed
         ));
@@ -66,7 +57,7 @@ extern "C" {
         ));
 
         app->Add(
-          new JChainMultifactoryGeneratorT<Cluster_factory_ZDCEcalTruthClusters>(
+          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT>(
              "ZDCEcalTruthClusters",
             {"ZDCEcalTruthProtoClusters",        // edm4eic::ProtoClusterCollection
              "ZDCEcalHits"},                     // edm4hep::SimCalorimeterHitCollection
@@ -85,7 +76,7 @@ extern "C" {
         );
 
         app->Add(
-          new JChainMultifactoryGeneratorT<Cluster_factory_ZDCEcalClusters>(
+          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT>(
              "ZDCEcalClusters",
             {"ZDCEcalIslandProtoClusters",  // edm4eic::ProtoClusterCollection
              "ZDCEcalHits"},                // edm4hep::SimCalorimeterHitCollection

--- a/src/extensions/spdlog/SpdlogMixin.h
+++ b/src/extensions/spdlog/SpdlogMixin.h
@@ -11,17 +11,14 @@
 #include "SpdlogExtensions.h"
 
 namespace eicrecon {
-    template <class T>
     class SpdlogMixin {
-        /** Is it a bird? Is it a plane? No! It is CRTP logger mixin...
-         *
-         * How to use it?
+        /** Logger mixin
          *
          * @example:
-         *      class MyFactory : JFactory, SpdlogMixin<MyFactory> {
+         *      class MyFactory : JFactory, SpdlogMixin {
          *
          *          void Init() {
-         *              InitLogger("MyPlugin:MyFactory");
+         *              InitLogger(GetApplication(), "MyPlugin:MyFactory");
          *
          *              // Logger is ready and can be used:
          *              m_log->info("MyFactory logger initialized");
@@ -35,6 +32,7 @@ namespace eicrecon {
     public:
         /**
          * Initializes logger through current LogService
+         * @param app - JApplication pointer, as obtained from GetApplication()
          * @param param_prefix - name of both logger and user parameter
          * @param default_level - optional - default log level, overrides default logging level
          *                          : trace, debug, info, warn, err, critical, off
@@ -45,14 +43,12 @@ namespace eicrecon {
          *          if no user flag is provided
          *
          * @example:
-         *      InitLogger("BTRK:TrackerHits")           // Default log level is set the same as in system
-         *      InitLogger("BTRK:TrackerHits", "info")   // By default log level is info
+         *      InitLogger(GetApplication(), "BTRK:TrackerHits")           // Default log level is set the same as in system
+         *      InitLogger(GetApplication(), "BTRK:TrackerHits", "info")   // By default log level is info
          *
          *  will create "BTRK:TrackerHits" logger and check -PBTRK:TrackerHits:LogLevel user parameter
          */
-        void InitLogger(const std::string &param_prefix, const std::string &default_level = "") {
-
-            JApplication* app = static_cast<T*>(this)->GetApplication();
+        void InitLogger(JApplication* app, const std::string &param_prefix, const std::string &default_level = "") {
 
             // Logger. Get plugin level sub-log
             m_log = app->GetService<Log_service>()->logger(param_prefix);

--- a/src/factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h
+++ b/src/factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h
@@ -12,15 +12,11 @@
 
 namespace eicrecon {
 
-// variadic template parameter T unused
-template<template<typename> typename... T>
 class CalorimeterClusterRecoCoG_factoryT :
     public JChainMultifactoryT<CalorimeterClusterRecoCoGConfig>,
-    public SpdlogMixin<CalorimeterClusterRecoCoG_factoryT<T...>>,
-    public T<CalorimeterClusterRecoCoG_factoryT<T...>>... {
+    public SpdlogMixin {
 
   public:
-    using SpdlogMixin<CalorimeterClusterRecoCoG_factoryT>::logger;
 
     explicit CalorimeterClusterRecoCoG_factoryT(
         std::string tag,
@@ -49,7 +45,7 @@ class CalorimeterClusterRecoCoG_factoryT :
         m_detector = geoSvc->detector();
 
         // SpdlogMixin logger initialization, sets m_log
-        SpdlogMixin<CalorimeterClusterRecoCoG_factoryT>::InitLogger(JChainMultifactoryT<CalorimeterClusterRecoCoGConfig>::GetPrefix(), "info");
+        InitLogger(app, GetPrefix(), "info");
 
         // Algorithm configuration
         auto cfg = GetDefaultConfig();

--- a/src/factories/calorimetry/CalorimeterHitDigi_factoryT.h
+++ b/src/factories/calorimetry/CalorimeterHitDigi_factoryT.h
@@ -12,15 +12,11 @@
 
 namespace eicrecon {
 
-// variadic template parameter T unused
-template<template<typename> typename... T>
-class CalorimeterHitDigi_factoryT :
+  class CalorimeterHitDigi_factoryT :
     public JChainMultifactoryT<CalorimeterHitDigiConfig>,
-    public SpdlogMixin<CalorimeterHitDigi_factoryT<T...>>,
-    public T<CalorimeterHitDigi_factoryT<T...>>... {
+    public SpdlogMixin {
 
   public:
-    using SpdlogMixin<CalorimeterHitDigi_factoryT>::logger;
 
     explicit CalorimeterHitDigi_factoryT(
         std::string tag,
@@ -45,7 +41,7 @@ class CalorimeterHitDigi_factoryT :
         auto geoSvc = app->template GetService<JDD4hep_service>();
 
         // SpdlogMixin logger initialization, sets m_log
-        SpdlogMixin<CalorimeterHitDigi_factoryT>::InitLogger(JChainMultifactoryT<CalorimeterHitDigiConfig>::GetPrefix(), "info");
+        InitLogger(app, GetPrefix(), "info");
 
         // Algorithm configuration
         auto cfg = GetDefaultConfig();

--- a/src/factories/calorimetry/CalorimeterHitReco_factoryT.h
+++ b/src/factories/calorimetry/CalorimeterHitReco_factoryT.h
@@ -11,15 +11,11 @@
 
 namespace eicrecon {
 
-// variadic template parameter T unused
-template<template<typename> typename... T>
 class CalorimeterHitReco_factoryT :
     public JChainMultifactoryT<CalorimeterHitRecoConfig>,
-    public SpdlogMixin<CalorimeterHitReco_factoryT<T...>>,
-    public T<CalorimeterHitReco_factoryT<T...>>... {
+    public SpdlogMixin {
 
   public:
-    using SpdlogMixin<CalorimeterHitReco_factoryT>::logger;
 
     explicit CalorimeterHitReco_factoryT(
         std::string tag,
@@ -44,7 +40,7 @@ class CalorimeterHitReco_factoryT :
         auto geoSvc = app->template GetService<JDD4hep_service>();
 
         // SpdlogMixin logger initialization, sets m_log
-        SpdlogMixin<CalorimeterHitReco_factoryT>::InitLogger(JChainMultifactoryT<CalorimeterHitRecoConfig>::GetPrefix(), "info");
+        InitLogger(app, GetPrefix(), "info");
 
         // Algorithm configuration
         auto cfg = GetDefaultConfig();

--- a/src/factories/calorimetry/CalorimeterHitsMerger_factoryT.h
+++ b/src/factories/calorimetry/CalorimeterHitsMerger_factoryT.h
@@ -11,15 +11,11 @@
 
 namespace eicrecon {
 
-// variadic template parameter T unused
-template<template<typename> typename... T>
 class CalorimeterHitsMerger_factoryT :
     public JChainMultifactoryT<CalorimeterHitsMergerConfig>,
-    public SpdlogMixin<CalorimeterHitsMerger_factoryT<T...>>,
-    public T<CalorimeterHitsMerger_factoryT<T...>>... {
+    public SpdlogMixin {
 
   public:
-    using SpdlogMixin<CalorimeterHitsMerger_factoryT>::logger;
 
     explicit CalorimeterHitsMerger_factoryT(
         std::string tag,
@@ -44,7 +40,7 @@ class CalorimeterHitsMerger_factoryT :
         auto geoSvc = app->template GetService<JDD4hep_service>();
 
         // SpdlogMixin logger initialization, sets m_log
-        SpdlogMixin<CalorimeterHitsMerger_factoryT>::InitLogger(JChainMultifactoryT<CalorimeterHitsMergerConfig>::GetPrefix(), "info");
+        InitLogger(app, GetPrefix(), "info");
 
         // Algorithm configuration
         auto cfg = GetDefaultConfig();

--- a/src/factories/calorimetry/CalorimeterTruthClustering_factoryT.h
+++ b/src/factories/calorimetry/CalorimeterTruthClustering_factoryT.h
@@ -12,15 +12,11 @@
 
 namespace eicrecon {
 
-// variadic template parameter T unused
-template<template<typename> typename... T>
 class CalorimeterTruthClustering_factoryT :
     public JChainMultifactoryT<NoConfig>,
-    public SpdlogMixin<CalorimeterTruthClustering_factoryT<T...>>,
-    public T<CalorimeterTruthClustering_factoryT<T...>>... {
+    public SpdlogMixin {
 
   public:
-    using SpdlogMixin<CalorimeterTruthClustering_factoryT>::logger;
 
     explicit CalorimeterTruthClustering_factoryT(
         std::string tag,
@@ -37,7 +33,7 @@ class CalorimeterTruthClustering_factoryT :
         auto app = GetApplication();
 
         // SpdlogMixin logger initialization, sets m_log
-        SpdlogMixin<CalorimeterTruthClustering_factoryT>::InitLogger(JChainMultifactoryT<NoConfig>::GetPrefix(), "info");
+        InitLogger(app, GetPrefix(), "info");
 
         m_algo.init(logger());
     }

--- a/src/global/digi/PhotoMultiplierHitDigi_factory.cc
+++ b/src/global/digi/PhotoMultiplierHitDigi_factory.cc
@@ -12,7 +12,7 @@ void eicrecon::PhotoMultiplierHitDigi_factory::Init() {
 
   // services
   auto geo_service = app->GetService<JDD4hep_service>();
-  InitLogger(prefix, "info");
+  InitLogger(app, prefix, "info");
   m_log->debug("PhotoMultiplierHitDigi_factory: plugin='{}' prefix='{}'", plugin, prefix);
 
   // get readout info (if a RICH)

--- a/src/global/digi/PhotoMultiplierHitDigi_factory.h
+++ b/src/global/digi/PhotoMultiplierHitDigi_factory.h
@@ -30,7 +30,7 @@ namespace eicrecon {
 
     class PhotoMultiplierHitDigi_factory :
             public JChainMultifactoryT<PhotoMultiplierHitDigiConfig>,
-            public SpdlogMixin<PhotoMultiplierHitDigi_factory> {
+            public SpdlogMixin {
 
     public:
 

--- a/src/global/digi/ReconstructedParticle_factory_SmearedFarForwardParticles.h
+++ b/src/global/digi/ReconstructedParticle_factory_SmearedFarForwardParticles.h
@@ -14,7 +14,7 @@
 
 namespace eicrecon {
 
-class ReconstructedParticle_factory_SmearedFarForwardParticles : public eicrecon::JFactoryPodioT<edm4eic::ReconstructedParticle>, public eicrecon::SpdlogMixin<ReconstructedParticle_factory_SmearedFarForwardParticles>, SmearedFarForwardParticles {
+class ReconstructedParticle_factory_SmearedFarForwardParticles : public eicrecon::JFactoryPodioT<edm4eic::ReconstructedParticle>, public eicrecon::SpdlogMixin, SmearedFarForwardParticles {
 
 public:
 
@@ -27,9 +27,9 @@ public:
     /** One time initialization **/
     void Init() override{
 
-        InitLogger("Digi:SmearedFarForwardParticles", "info");
+        InitLogger(GetApplication(), "Digi:SmearedFarForwardParticles", "info");
         // (this line seems quite awkward)
-        this->SmearedFarForwardParticles::m_log = this->eicrecon::SpdlogMixin<ReconstructedParticle_factory_SmearedFarForwardParticles>::m_log;
+        this->SmearedFarForwardParticles::m_log = this->eicrecon::SpdlogMixin::m_log;
 
         initialize();
     }

--- a/src/global/digi/SiliconTrackerDigi_factory.cc
+++ b/src/global/digi/SiliconTrackerDigi_factory.cc
@@ -26,7 +26,7 @@ void eicrecon::SiliconTrackerDigi_factory::Init() {
     InitDataTags(param_prefix);
 
     // Logger. Get plugin level sub-log
-    InitLogger(param_prefix, "info");
+    InitLogger(app, param_prefix, "info");
 
     // Setup digitization algorithm
     auto cfg = GetDefaultConfig();

--- a/src/global/digi/SiliconTrackerDigi_factory.h
+++ b/src/global/digi/SiliconTrackerDigi_factory.h
@@ -26,7 +26,7 @@ namespace eicrecon {
 
     class SiliconTrackerDigi_factory :
             public JChainFactoryT<edm4eic::RawTrackerHit, SiliconTrackerDigiConfig>,
-            public SpdlogMixin<SiliconTrackerDigi_factory> {
+            public SpdlogMixin {
 
     public:
 

--- a/src/global/pid/IrtCherenkovParticleID_factory.cc
+++ b/src/global/pid/IrtCherenkovParticleID_factory.cc
@@ -12,7 +12,7 @@ void eicrecon::IrtCherenkovParticleID_factory::Init() {
   auto prefix = GetPrefix();
 
   // services
-  InitLogger(prefix, "info");
+  InitLogger(app, prefix, "info");
   m_richGeoSvc   = app->GetService<RichGeo_service>();
   m_irt_det_coll = m_richGeoSvc->GetIrtGeo(plugin)->GetIrtDetectorCollection();
   m_log->debug("IrtCherenkovParticleID_factory: plugin='{}' prefix='{}'", plugin, prefix);

--- a/src/global/pid/IrtCherenkovParticleID_factory.h
+++ b/src/global/pid/IrtCherenkovParticleID_factory.h
@@ -28,7 +28,7 @@ namespace eicrecon {
 
   class IrtCherenkovParticleID_factory :
     public JChainMultifactoryT<IrtCherenkovParticleIDConfig>,
-    public SpdlogMixin<IrtCherenkovParticleID_factory>
+    public SpdlogMixin
   {
 
     public:

--- a/src/global/pid/MergeCherenkovParticleID_factory.cc
+++ b/src/global/pid/MergeCherenkovParticleID_factory.cc
@@ -13,7 +13,7 @@ void eicrecon::MergeCherenkovParticleID_factory::Init() {
   InitDataTags(prefix);
 
   // services
-  InitLogger(prefix, "info");
+  InitLogger(app, prefix, "info");
   m_log->debug("MergeCherenkovParticleID_factory: plugin='{}' prefix='{}'", plugin, prefix);
 
   // config

--- a/src/global/pid/MergeCherenkovParticleID_factory.h
+++ b/src/global/pid/MergeCherenkovParticleID_factory.h
@@ -26,7 +26,7 @@ namespace eicrecon {
 
   class MergeCherenkovParticleID_factory :
     public JChainFactoryT<edm4eic::CherenkovParticleID, MergeParticleIDConfig>,
-    public SpdlogMixin<MergeCherenkovParticleID_factory>
+    public SpdlogMixin
   {
 
     public:

--- a/src/global/pid/MergeTrack_factory.cc
+++ b/src/global/pid/MergeTrack_factory.cc
@@ -13,7 +13,7 @@ void eicrecon::MergeTrack_factory::Init() {
   InitDataTags(prefix);
 
   // services
-  InitLogger(prefix, "info");
+  InitLogger(app, prefix, "info");
   m_algo.AlgorithmInit(m_log);
   m_log->debug("MergeTrack_factory: plugin='{}' prefix='{}'", plugin, prefix);
 

--- a/src/global/pid/MergeTrack_factory.h
+++ b/src/global/pid/MergeTrack_factory.h
@@ -24,7 +24,7 @@ namespace eicrecon {
 
   class MergeTrack_factory :
     public JChainFactoryT<edm4eic::TrackSegment>,
-    public SpdlogMixin<MergeTrack_factory>
+    public SpdlogMixin
   {
 
     public:

--- a/src/global/pid/RichTrack_factory.cc
+++ b/src/global/pid/RichTrack_factory.cc
@@ -14,7 +14,7 @@ void eicrecon::RichTrack_factory::Init() {
   // services
   m_richGeoSvc = app->GetService<RichGeo_service>();
   m_actsSvc    = app->GetService<ACTSGeo_service>();
-  InitLogger(prefix, "info");
+  InitLogger(app, prefix, "info");
   m_propagation_algo.init(m_actsSvc->actsGeoProvider(), m_log);
   m_log->debug("RichTrack_factory: plugin='{}' prefix='{}'", plugin, prefix);
 

--- a/src/global/pid/RichTrack_factory.h
+++ b/src/global/pid/RichTrack_factory.h
@@ -26,7 +26,7 @@
 namespace eicrecon {
   class RichTrack_factory :
     public JChainMultifactoryT<RichTrackConfig>,
-    public SpdlogMixin<RichTrack_factory>
+    public SpdlogMixin
   {
     public:
 

--- a/src/global/reco/GeneratedJets_factory.cc
+++ b/src/global/reco/GeneratedJets_factory.cc
@@ -22,7 +22,7 @@ namespace eicrecon {
         InitDataTags(param_prefix);
 
         // SpdlogMixin logger initialization, sets m_log
-        InitLogger(param_prefix, "info");
+        InitLogger(GetApplication(), param_prefix, "info");
 
         m_jet_algo.init(m_log);
     }

--- a/src/global/reco/GeneratedJets_factory.h
+++ b/src/global/reco/GeneratedJets_factory.h
@@ -15,7 +15,7 @@ namespace eicrecon {
 
     class GeneratedJets_factory :
             public JChainFactoryT<edm4eic::ReconstructedParticle>,
-            public SpdlogMixin<GeneratedJets_factory> {
+            public SpdlogMixin {
 
     public:
         explicit GeneratedJets_factory(std::vector<std::string> default_input_tags):

--- a/src/global/reco/InclusiveKinematicsDA_factory.cc
+++ b/src/global/reco/InclusiveKinematicsDA_factory.cc
@@ -26,7 +26,7 @@ namespace eicrecon {
         InitDataTags(param_prefix);
 
         // SpdlogMixin logger initialization, sets m_log
-        InitLogger(param_prefix, "info");
+        InitLogger(GetApplication(), param_prefix, "info");
 
         m_inclusive_kinematics_algo.init(m_log);
     }

--- a/src/global/reco/InclusiveKinematicsDA_factory.h
+++ b/src/global/reco/InclusiveKinematicsDA_factory.h
@@ -11,7 +11,7 @@ namespace eicrecon {
 
     class InclusiveKinematicsDA_factory :
             public JChainFactoryT<edm4eic::InclusiveKinematics>,
-            public SpdlogMixin<InclusiveKinematicsDA_factory> {
+            public SpdlogMixin {
 
     public:
         explicit InclusiveKinematicsDA_factory(std::vector<std::string> default_input_tags):

--- a/src/global/reco/InclusiveKinematicsElectron_factory.cc
+++ b/src/global/reco/InclusiveKinematicsElectron_factory.cc
@@ -26,7 +26,7 @@ namespace eicrecon {
         InitDataTags(param_prefix);
 
         // SpdlogMixin logger initialization, sets m_log
-        InitLogger(param_prefix, "info");
+        InitLogger(GetApplication(), param_prefix, "info");
 
         m_inclusive_kinematics_algo.init(m_log);
     }

--- a/src/global/reco/InclusiveKinematicsElectron_factory.h
+++ b/src/global/reco/InclusiveKinematicsElectron_factory.h
@@ -11,7 +11,7 @@ namespace eicrecon {
 
     class InclusiveKinematicsElectron_factory :
             public JChainFactoryT<edm4eic::InclusiveKinematics>,
-            public SpdlogMixin<InclusiveKinematicsElectron_factory> {
+            public SpdlogMixin {
 
     public:
         explicit InclusiveKinematicsElectron_factory(std::vector<std::string> default_input_tags):

--- a/src/global/reco/InclusiveKinematicsJB_factory.cc
+++ b/src/global/reco/InclusiveKinematicsJB_factory.cc
@@ -26,7 +26,7 @@ namespace eicrecon {
         InitDataTags(param_prefix);
 
         // SpdlogMixin logger initialization, sets m_log
-        InitLogger(param_prefix, "info");
+        InitLogger(GetApplication(), param_prefix, "info");
 
         m_inclusive_kinematics_algo.init(m_log);
     }

--- a/src/global/reco/InclusiveKinematicsJB_factory.h
+++ b/src/global/reco/InclusiveKinematicsJB_factory.h
@@ -11,7 +11,7 @@ namespace eicrecon {
 
     class InclusiveKinematicsJB_factory :
             public JChainFactoryT<edm4eic::InclusiveKinematics>,
-            public SpdlogMixin<InclusiveKinematicsJB_factory> {
+            public SpdlogMixin {
 
     public:
         explicit InclusiveKinematicsJB_factory(std::vector<std::string> default_input_tags):

--- a/src/global/reco/InclusiveKinematicsSigma_factory.cc
+++ b/src/global/reco/InclusiveKinematicsSigma_factory.cc
@@ -26,7 +26,7 @@ namespace eicrecon {
         InitDataTags(param_prefix);
 
         // SpdlogMixin logger initialization, sets m_log
-        InitLogger(param_prefix, "info");
+        InitLogger(GetApplication(), param_prefix, "info");
 
         m_inclusive_kinematics_algo.init(m_log);
     }

--- a/src/global/reco/InclusiveKinematicsSigma_factory.h
+++ b/src/global/reco/InclusiveKinematicsSigma_factory.h
@@ -11,7 +11,7 @@ namespace eicrecon {
 
     class InclusiveKinematicsSigma_factory :
             public JChainFactoryT<edm4eic::InclusiveKinematics>,
-            public SpdlogMixin<InclusiveKinematicsSigma_factory> {
+            public SpdlogMixin {
 
     public:
         explicit InclusiveKinematicsSigma_factory(std::vector<std::string> default_input_tags):

--- a/src/global/reco/InclusiveKinematicsTruth_factory.cc
+++ b/src/global/reco/InclusiveKinematicsTruth_factory.cc
@@ -25,7 +25,7 @@ namespace eicrecon {
         InitDataTags(param_prefix);
 
         // SpdlogMixin logger initialization, sets m_log
-        InitLogger(param_prefix, "info");
+        InitLogger(GetApplication(), param_prefix, "info");
 
         m_inclusive_kinematics_algo.init(m_log);
     }

--- a/src/global/reco/InclusiveKinematicsTruth_factory.h
+++ b/src/global/reco/InclusiveKinematicsTruth_factory.h
@@ -11,7 +11,7 @@ namespace eicrecon {
 
     class InclusiveKinematicsTruth_factory :
             public JChainFactoryT<edm4eic::InclusiveKinematics>,
-            public SpdlogMixin<InclusiveKinematicsTruth_factory> {
+            public SpdlogMixin {
 
     public:
         explicit InclusiveKinematicsTruth_factory(std::vector<std::string> default_input_tags):

--- a/src/global/reco/InclusiveKinematicseSigma_factory.cc
+++ b/src/global/reco/InclusiveKinematicseSigma_factory.cc
@@ -26,7 +26,7 @@ namespace eicrecon {
         InitDataTags(param_prefix);
 
         // SpdlogMixin logger initialization, sets m_log
-        InitLogger(param_prefix, "info");
+        InitLogger(GetApplication(), param_prefix, "info");
 
         m_inclusive_kinematics_algo.init(m_log);
     }

--- a/src/global/reco/InclusiveKinematicseSigma_factory.h
+++ b/src/global/reco/InclusiveKinematicseSigma_factory.h
@@ -11,7 +11,7 @@ namespace eicrecon {
 
     class InclusiveKinematicseSigma_factory :
             public JChainFactoryT<edm4eic::InclusiveKinematics>,
-            public SpdlogMixin<InclusiveKinematicseSigma_factory> {
+            public SpdlogMixin {
 
     public:
         explicit InclusiveKinematicseSigma_factory(std::vector<std::string> default_input_tags):

--- a/src/global/reco/MC2SmearedParticle_factory.cc
+++ b/src/global/reco/MC2SmearedParticle_factory.cc
@@ -17,7 +17,7 @@ namespace eicrecon {
         InitDataTags(param_prefix);
 
         // Logger. Get plugin level sub-log
-        InitLogger(param_prefix, "info");
+        InitLogger(app, param_prefix, "info");
 
         // Initialize digitization algorithm
         m_smearing_algo.init(m_log);

--- a/src/global/reco/MC2SmearedParticle_factory.h
+++ b/src/global/reco/MC2SmearedParticle_factory.h
@@ -16,7 +16,7 @@ namespace eicrecon {
 
     class MC2SmearedParticle_factory:
             public JChainFactoryT<edm4eic::ReconstructedParticle>,
-            public SpdlogMixin<MC2SmearedParticle_factory> {
+            public SpdlogMixin {
     public:
 
         explicit MC2SmearedParticle_factory(const std::vector<std::string> &default_input_tags)

--- a/src/global/reco/MatchClusters_factory.cc
+++ b/src/global/reco/MatchClusters_factory.cc
@@ -24,7 +24,7 @@ namespace eicrecon {
     void MatchClusters_factory::Init() {
 
         // SpdlogMixin logger initialization, sets m_log
-        InitLogger(GetPrefix(), "info");
+        InitLogger(GetApplication(), GetPrefix(), "info");
 
         m_match_algo.init(m_log);
 

--- a/src/global/reco/MatchClusters_factory.h
+++ b/src/global/reco/MatchClusters_factory.h
@@ -16,7 +16,7 @@ namespace eicrecon {
 
     class MatchClusters_factory :
             public JChainMultifactoryT<NoConfig>,
-            public SpdlogMixin<MatchClusters_factory> {
+            public SpdlogMixin {
 
     public:
         explicit MatchClusters_factory(std::string tag,

--- a/src/global/reco/ReconstructedElectrons_factory.h
+++ b/src/global/reco/ReconstructedElectrons_factory.h
@@ -19,7 +19,7 @@ namespace eicrecon {
 
   class ReconstructedElectrons_factory :
     public JChainFactoryT<edm4eic::ReconstructedParticle>,
-    public SpdlogMixin<ReconstructedElectrons_factory>
+    public SpdlogMixin
   {
 
     public:
@@ -37,7 +37,7 @@ namespace eicrecon {
         InitDataTags(prefix);
 
         // services
-        InitLogger(prefix, "info");
+        InitLogger(app, prefix, "info");
         m_algo.init(m_log);
       }
 

--- a/src/global/reco/ReconstructedJets_factory.cc
+++ b/src/global/reco/ReconstructedJets_factory.cc
@@ -20,7 +20,7 @@ namespace eicrecon {
         InitDataTags(param_prefix);
 
         // SpdlogMixin logger initialization, sets m_log
-        InitLogger(param_prefix, "info");
+        InitLogger(GetApplication(), param_prefix, "info");
 
         m_jet_algo.init(m_log);
     }

--- a/src/global/reco/ReconstructedJets_factory.h
+++ b/src/global/reco/ReconstructedJets_factory.h
@@ -15,7 +15,7 @@ namespace eicrecon {
 
     class ReconstructedJets_factory :
             public JChainFactoryT<edm4eic::ReconstructedParticle>,
-            public SpdlogMixin<ReconstructedJets_factory> {
+            public SpdlogMixin {
 
     public:
         explicit ReconstructedJets_factory(std::vector<std::string> default_input_tags):

--- a/src/global/tracking/CKFTracking_factory.cc
+++ b/src/global/tracking/CKFTracking_factory.cc
@@ -26,7 +26,7 @@ void eicrecon::CKFTracking_factory::Init() {
     InitDataTags(param_prefix);
 
     // Initialize logger
-    InitLogger(param_prefix, "info");
+    InitLogger(app, param_prefix, "info");
 
     // Get ACTS context from ACTSGeo service
     auto acts_service = app->GetService<ACTSGeo_service>();

--- a/src/global/tracking/CKFTracking_factory.h
+++ b/src/global/tracking/CKFTracking_factory.h
@@ -18,7 +18,7 @@ namespace eicrecon {
 
     class CKFTracking_factory :
             public JChainFactoryT<eicrecon::TrackingResultTrajectory, CKFTrackingConfig, JFactoryT>,
-            public SpdlogMixin<CKFTracking_factory> {
+            public SpdlogMixin {
 
     public:
         CKFTracking_factory( std::vector<std::string> default_input_tags, CKFTrackingConfig cfg):

--- a/src/global/tracking/IterativeVertexFinder_factory.cc
+++ b/src/global/tracking/IterativeVertexFinder_factory.cc
@@ -23,7 +23,7 @@ void eicrecon::IterativeVertexFinder_factory::Init() {
   InitDataTags(param_prefix);
 
   // Initialize logger
-  InitLogger(param_prefix, "info");
+  InitLogger(app, param_prefix, "info");
 
   // Get ACTS context from ACTSGeo service
   auto acts_service  = app->GetService<ACTSGeo_service>();

--- a/src/global/tracking/IterativeVertexFinder_factory.h
+++ b/src/global/tracking/IterativeVertexFinder_factory.h
@@ -18,7 +18,7 @@ namespace eicrecon {
 
 class IterativeVertexFinder_factory
     : public JChainFactoryT<edm4eic::Vertex, IterativeVertexFinderConfig>,
-      public SpdlogMixin<IterativeVertexFinder_factory> {
+      public SpdlogMixin {
 
 public:
   explicit IterativeVertexFinder_factory(std::vector<std::string> default_input_tags,

--- a/src/global/tracking/ParticlesWithTruthPID_factory.cc
+++ b/src/global/tracking/ParticlesWithTruthPID_factory.cc
@@ -16,7 +16,7 @@ void eicrecon::ParticlesWithTruthPID_factory::Init() {
     std::string param_prefix = plugin_name + ":" + GetTag();
 
     // SpdlogMixin logger initialization, sets m_log
-    InitLogger(GetPrefix(), "info");
+    InitLogger(app, GetPrefix(), "info");
     m_matching_algo.init(m_log);
 }
 

--- a/src/global/tracking/ParticlesWithTruthPID_factory.h
+++ b/src/global/tracking/ParticlesWithTruthPID_factory.h
@@ -16,7 +16,7 @@ namespace eicrecon {
 
     class ParticlesWithTruthPID_factory :
             public JChainMultifactoryT<ParticlesWithTruthPIDConfig>,
-            public SpdlogMixin<ParticlesWithTruthPID_factory> {
+            public SpdlogMixin {
 
     public:
         explicit ParticlesWithTruthPID_factory( std::string tag,

--- a/src/global/tracking/TrackParamTruthInit_factory.cc
+++ b/src/global/tracking/TrackParamTruthInit_factory.cc
@@ -15,7 +15,7 @@ void eicrecon::TrackParamTruthInit_factory::Init() {
     InitDataTags(param_prefix);
 
     // Initialize logger
-    InitLogger(param_prefix, "info");
+    InitLogger(app, param_prefix, "info");
 
     // Algorithm configuration
     auto cfg = GetDefaultConfig();

--- a/src/global/tracking/TrackParamTruthInit_factory.h
+++ b/src/global/tracking/TrackParamTruthInit_factory.h
@@ -14,7 +14,7 @@ namespace eicrecon {
 
     class TrackParamTruthInit_factory :
             public JChainFactoryT<edm4eic::TrackParameters, TrackParamTruthInitConfig>,
-            public SpdlogMixin<TrackParamTruthInit_factory> {
+            public SpdlogMixin {
 
     public:
         TrackParamTruthInit_factory( std::vector<std::string> default_input_tags, TrackParamTruthInitConfig cfg):

--- a/src/global/tracking/TrackProjector_factory.cc
+++ b/src/global/tracking/TrackProjector_factory.cc
@@ -20,7 +20,7 @@ namespace eicrecon {
         InitDataTags(param_prefix);
 
         // SpdlogMixin logger initialization, sets m_log
-        InitLogger(param_prefix);
+        InitLogger(GetApplication(), param_prefix);
 
         auto acts_service = GetApplication()->GetService<ACTSGeo_service>();
 

--- a/src/global/tracking/TrackProjector_factory.h
+++ b/src/global/tracking/TrackProjector_factory.h
@@ -17,7 +17,7 @@ namespace eicrecon {
 
     class TrackProjector_factory:
     public JChainFactoryT<edm4eic::TrackSegment, TrackProjectorConfig>,
-            public SpdlogMixin<TrackProjector_factory> {
+            public SpdlogMixin {
 
     public:
         explicit TrackProjector_factory( std::vector<std::string> default_input_tags, TrackProjectorConfig cfg):

--- a/src/global/tracking/TrackSeeding_factory.cc
+++ b/src/global/tracking/TrackSeeding_factory.cc
@@ -25,7 +25,7 @@ void eicrecon::TrackSeeding_factory::Init() {
     InitDataTags(param_prefix);
 
     // Initialize logger
-    InitLogger(param_prefix, "info");
+    InitLogger(app, param_prefix, "info");
 
     // Get ACTS context from ACTSGeo service
     auto acts_service = app->GetService<ACTSGeo_service>();

--- a/src/global/tracking/TrackSeeding_factory.h
+++ b/src/global/tracking/TrackSeeding_factory.h
@@ -18,7 +18,7 @@ namespace eicrecon {
 
     class TrackSeeding_factory :
             public JChainFactoryT<edm4eic::TrackParameters, OrthogonalTrackSeedingConfig>,
-            public SpdlogMixin<TrackSeeding_factory> {
+            public SpdlogMixin {
 
     public:
         TrackSeeding_factory( std::vector<std::string> default_input_tags, OrthogonalTrackSeedingConfig cfg):

--- a/src/global/tracking/TrackerHitReconstruction_factory.cc
+++ b/src/global/tracking/TrackerHitReconstruction_factory.cc
@@ -22,7 +22,7 @@ void TrackerHitReconstruction_factory::Init() {
     app->SetDefaultParameter(param_prefix + ":TimeResolution", m_reco_algo.getConfig().time_resolution, "threshold");
 
     // Init logger from default or user parameters
-    InitLogger(param_prefix);
+    InitLogger(app, param_prefix);
 
     // Init input collections tags and read from user parameters
     InitDataTags(param_prefix);

--- a/src/global/tracking/TrackerHitReconstruction_factory.h
+++ b/src/global/tracking/TrackerHitReconstruction_factory.h
@@ -22,7 +22,7 @@
 
 class TrackerHitReconstruction_factory :
         public JChainFactoryT<edm4eic::TrackerHit, eicrecon::TrackerHitReconstructionConfig>,
-        public eicrecon::SpdlogMixin<TrackerHitReconstruction_factory> {
+        public eicrecon::SpdlogMixin {
 
 public:
     TrackerHitReconstruction_factory( std::vector<std::string> default_input_tags, eicrecon::TrackerHitReconstructionConfig cfg):

--- a/src/global/tracking/TrackingResult_factory.cc
+++ b/src/global/tracking/TrackingResult_factory.cc
@@ -11,7 +11,7 @@
 void TrackingResult_factory::Init() {
 
     // SpdlogMixin logger initialization, sets m_log
-    InitLogger(GetPrefix(), "info");
+    InitLogger(GetApplication(), GetPrefix(), "info");
 
     m_particle_maker_algo.init(m_log);
 }

--- a/src/global/tracking/TrackingResult_factory.h
+++ b/src/global/tracking/TrackingResult_factory.h
@@ -11,7 +11,7 @@
 
 class TrackingResult_factory:
         public JChainMultifactoryT<NoConfig>,
-        public eicrecon::SpdlogMixin<TrackingResult_factory> {
+        public eicrecon::SpdlogMixin {
 public:
     explicit TrackingResult_factory(std::string tag,
                                     const std::vector<std::string>& input_tags,

--- a/src/tests/geometry_navigation_test/GeometryNavigationSteps_processor.cc
+++ b/src/tests/geometry_navigation_test/GeometryNavigationSteps_processor.cc
@@ -38,7 +38,7 @@ void GeometryNavigationSteps_processor::Init()
     m_dir_main = file->mkdir(plugin_name.c_str());
 
     // Get log level from user parameter or default
-    InitLogger(plugin_name);
+    InitLogger(app, plugin_name);
 
     auto acts_service = GetApplication()->GetService<ACTSGeo_service>();
 

--- a/src/tests/geometry_navigation_test/GeometryNavigationSteps_processor.h
+++ b/src/tests/geometry_navigation_test/GeometryNavigationSteps_processor.h
@@ -15,7 +15,7 @@ class JApplication;
 
 class GeometryNavigationSteps_processor:
         public JEventProcessor,
-        public eicrecon::SpdlogMixin<GeometryNavigationSteps_processor>   // this automates proper log initialization
+        public eicrecon::SpdlogMixin   // this automates proper log initialization
 {
 public:
     explicit GeometryNavigationSteps_processor(JApplication *);

--- a/src/tests/track_propagation_test/TrackPropagationTest_processor.cc
+++ b/src/tests/track_propagation_test/TrackPropagationTest_processor.cc
@@ -49,7 +49,7 @@ void TrackPropagationTest_processor::Init()
     m_dir_main = file->mkdir(plugin_name.c_str());
 
     // Get log level from user parameter or default
-    InitLogger(plugin_name);
+    InitLogger(app, plugin_name);
 
     auto acts_service = GetApplication()->GetService<ACTSGeo_service>();
 

--- a/src/tests/track_propagation_test/TrackPropagationTest_processor.h
+++ b/src/tests/track_propagation_test/TrackPropagationTest_processor.h
@@ -16,7 +16,7 @@ class JApplication;
 
 class TrackPropagationTest_processor:
         public JEventProcessor,
-        public eicrecon::SpdlogMixin<TrackPropagationTest_processor>   // this automates proper log initialization
+        public eicrecon::SpdlogMixin   // this automates proper log initialization
 {
 public:
     explicit TrackPropagationTest_processor(JApplication *);

--- a/src/tests/track_seeding_test/TrackSeedingTest_processor.cc
+++ b/src/tests/track_seeding_test/TrackSeedingTest_processor.cc
@@ -49,7 +49,7 @@ void TrackSeedingTest_processor::Init()
     m_dir_main = file->mkdir(plugin_name.c_str());
 
     // Get log level from user parameter or default
-    InitLogger(plugin_name);
+    InitLogger(app, plugin_name);
 
     auto acts_service = GetApplication()->GetService<ACTSGeo_service>();
 

--- a/src/tests/track_seeding_test/TrackSeedingTest_processor.h
+++ b/src/tests/track_seeding_test/TrackSeedingTest_processor.h
@@ -16,7 +16,7 @@ class JApplication;
 
 class TrackSeedingTest_processor:
         public JEventProcessor,
-        public eicrecon::SpdlogMixin<TrackSeedingTest_processor>   // this automates proper log initialization
+        public eicrecon::SpdlogMixin   // this automates proper log initialization
 {
 public:
     explicit TrackSeedingTest_processor(JApplication *);

--- a/src/utilities/dump_flags/DumpFlags_processor.cc
+++ b/src/utilities/dump_flags/DumpFlags_processor.cc
@@ -32,7 +32,7 @@ void DumpFlags_processor::Init()
     app->SetDefaultParameter("dump_flags:screen", m_print_to_screen, "If not empty, print summary to screen at end of job");
 
 
-    InitLogger("dump_flags", "info");
+    InitLogger(app, "dump_flags", "info");
 }
 
 

--- a/src/utilities/dump_flags/DumpFlags_processor.h
+++ b/src/utilities/dump_flags/DumpFlags_processor.h
@@ -6,7 +6,7 @@
 class JEvent;
 class JApplication;
 
-class DumpFlags_processor: public JEventProcessor, public eicrecon::SpdlogMixin<DumpFlags_processor>
+class DumpFlags_processor: public JEventProcessor, public eicrecon::SpdlogMixin
 {
 public:
     explicit DumpFlags_processor(JApplication *);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This removes the CRTP pattern on the SpdlogMixin, which in turn allows us to get rid of the variadic template on the factory template, which in turn allows us simplify what is included in the plugin:
- no more template factory creation, just `app->Add(new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT>(..))`,
- no more `using Cluster_factory_EcalBarrelScFiClusters = CalorimeterClusterRecoCoG_factoryT<>` statements needed anymore,
- but we need to pass the `JApplication* app = GetApplication()` to the `SpdlogMixin::InitLogger`, is all.

Less boilerplate leads to less requirements to keep changing code. These `using` lines were really starting to pile up. Another step towards non-templated factories. Wait! No, this is probably it!

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @nathanwbrei @veprbl

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.