### PR TITLE
JOmniFactory as potential successor to JChainFactory 

### DIFF
--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -26,7 +26,7 @@ macro(plugin_add _name)
     find_package(JANA REQUIRED)
 
     # TODO: NWB: This really needs to be a dependency of JANA itself.
-    # If we don't do this here, CMake will later refuse to accept that podio is 
+    # If we don't do this here, CMake will later refuse to accept that podio is
     # indeed a dependency of JANA and aggressively reorders my target_link_list
     # to reflect this misapprehension.
     # https://gitlab.kitware.com/cmake/cmake/blob/v3.13.2/Source/cmComputeLinkDepends.cxx

--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -25,6 +25,13 @@ macro(plugin_add _name)
     # Include JANA by default
     find_package(JANA REQUIRED)
 
+    # TODO: NWB: This really needs to be a dependency of JANA itself.
+    # If we don't do this here, CMake will later refuse to accept that podio is 
+    # indeed a dependency of JANA and aggressively reorders my target_link_list
+    # to reflect this misapprehension.
+    # https://gitlab.kitware.com/cmake/cmake/blob/v3.13.2/Source/cmComputeLinkDepends.cxx
+    find_package(podio REQUIRED)
+
     # include logging by default
     find_package(spdlog REQUIRED)
 
@@ -42,8 +49,7 @@ macro(plugin_add _name)
         target_include_directories(${_name}_plugin SYSTEM PUBLIC ${JANA_INCLUDE_DIR} )
         target_include_directories(${_name}_plugin SYSTEM PUBLIC ${ROOT_INCLUDE_DIRS} )
         set_target_properties(${_name}_plugin PROPERTIES PREFIX "" OUTPUT_NAME "${_name}" SUFFIX ".so")
-        target_link_libraries(${_name}_plugin ${JANA_LIB} spdlog::spdlog)
-        target_link_libraries(${_name}_plugin ${JANA_LIB} fmt::fmt)
+        target_link_libraries(${_name}_plugin ${JANA_LIB} podio::podio podio::podioRootIO spdlog::spdlog fmt::fmt)
         target_link_libraries(${_name}_plugin Microsoft.GSL::GSL)
 
         # Install plugin
@@ -63,8 +69,8 @@ macro(plugin_add _name)
 
         target_include_directories(${_name}_library PUBLIC ${EICRECON_SOURCE_DIR}/src)
         target_include_directories(${_name}_library SYSTEM PUBLIC ${JANA_INCLUDE_DIR} )
-        target_link_libraries(${_name}_library ${JANA_LIB} spdlog::spdlog)
-        target_link_libraries(${_name}_library ${JANA_LIB} fmt::fmt)
+        target_link_libraries(${_name}_library ${JANA_LIB} podio::podio podio::podioRootIO spdlog::spdlog)
+        target_link_libraries(${_name}_library ${JANA_LIB} podio::podio podio::podioRootIO fmt::fmt)
         target_link_libraries(${_name}_library Microsoft.GSL::GSL)
 
         # Install plugin

--- a/src/detectors/B0ECAL/B0ECAL.cc
+++ b/src/detectors/B0ECAL/B0ECAL.cc
@@ -1,15 +1,18 @@
 // Copyright 2022, David Lawrence
 // Subject to the terms in the LICENSE file found in the top-level directory.
-//
-//
+
+
 
 #include "extensions/jana/JChainMultifactoryGeneratorT.h"
+#include "extensions/jana/JOmniFactoryGeneratorT.h"
 
-#include "factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h"
+#include "factories/calorimetry/CalorimeterClusterRecoCoG_factory.h"
 #include "factories/calorimetry/CalorimeterHitDigi_factoryT.h"
 #include "factories/calorimetry/CalorimeterHitReco_factoryT.h"
 #include "factories/calorimetry/CalorimeterTruthClustering_factoryT.h"
 #include "factories/calorimetry/CalorimeterIslandCluster_factoryT.h"
+
+
 
 extern "C" {
     void InitPlugin(JApplication *app) {
@@ -67,7 +70,7 @@ extern "C" {
         ));
 
         app->Add(
-          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT>(
+          new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
              "B0ECalClusters",
             {"B0ECalIslandProtoClusters",  // edm4eic::ProtoClusterCollection
              "B0ECalHits"},                // edm4hep::SimCalorimeterHitCollection
@@ -86,7 +89,7 @@ extern "C" {
         );
 
         app->Add(
-          new JChainMultifactoryGeneratorT<CalorimeterClusterRecoCoG_factoryT>(
+          new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
              "B0ECalTruthClusters",
             {"B0ECalTruthProtoClusters",        // edm4eic::ProtoClusterCollection
              "B0ECalHits"},                     // edm4hep::SimCalorimeterHitCollection

--- a/src/detectors/B0ECAL/B0ECAL.cc
+++ b/src/detectors/B0ECAL/B0ECAL.cc
@@ -84,7 +84,7 @@ extern "C" {
               .depthCorrection = 0.0,
               .enableEtaBounds = false
             },
-            app   // TODO: Remove me once fixed
+            app
           )
         );
 
@@ -103,7 +103,7 @@ extern "C" {
               .depthCorrection = 0.0,
               .enableEtaBounds = false
             },
-            app   // TODO: Remove me once fixed
+            app
           )
         );
     }

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -437,6 +437,6 @@ public:
     std::shared_ptr<spdlog::logger> &logger() { return m_logger; }
 
     /// Retrieve reference to embedded config object
-    ConfigT& GetConfig() { return m_config; }
+    ConfigT& config() { return m_config; }
 
 };

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -1,0 +1,442 @@
+// Copyright 2023, Jefferson Science Associates, LLC.
+// Subject to the terms in the LICENSE file found in the top-level directory.
+// Created by Nathan Brei
+
+#pragma once
+
+/**
+ * Omnifactories are a lightweight layer connecting JANA to generic algorithms
+ * It is assumed multiple input data (controlled by input tags)
+ * which might be changed by user parameters.
+ */
+
+#include <datamodel_glue.h>
+#include <JANA/JMultifactory.h>
+#include <JANA/JEvent.h>
+#include <spdlog/spdlog.h>
+#include "extensions/spdlog/SpdlogExtensions.h"
+#include <services/log/Log_service.h>
+
+#include <string>
+#include <vector>
+
+using namespace eicrecon;
+struct EmptyConfig {};
+
+template <typename AlgoT, typename ConfigT=EmptyConfig>
+class JOmniFactory : public JMultifactory {
+public:
+
+    /// ========================
+    /// Handle input collections
+    /// ========================
+
+    struct InputBase {
+        std::string type_name;
+        std::string collection_name;
+        virtual void GetCollection(const JEvent& event) = 0;
+    };
+
+    template <typename T>
+    class Input : public InputBase {
+
+        std::vector<const T*> m_data;
+
+    public:
+        Input(JOmniFactory* owner, std::string default_tag="") {
+            owner->RegisterInput(this);
+            this->collection_name = default_tag;
+            this->type_name = JTypeInfo::demangle<T>();
+        }
+
+        const std::vector<const T*>& operator()() { return m_data; }
+
+    private:
+        friend class JOmniFactory;
+
+        void GetData(const JEvent& event) {
+            m_data = event.Get<T>(this->collection_name);
+        }
+    };
+
+
+    template <typename PodioT>
+    class PodioInput : public InputBase {
+
+        const typename PodioTypeMap<PodioT>::collection_t* m_data;
+
+    public:
+
+        PodioInput(JOmniFactory* owner, std::string default_collection_name="") {
+            owner->RegisterInput(this);
+            this->collection_name = default_collection_name;
+            this->type_name = JTypeInfo::demangle<PodioT>();
+        }
+
+        const typename PodioTypeMap<PodioT>::collection_t* operator()() {
+            return m_data;
+        }
+
+    private:
+        friend class JOmniFactory;
+
+        void GetCollection(const JEvent& event) {
+            m_data = event.GetCollection<PodioT>(this->collection_name);
+        }
+    };
+
+    void RegisterInput(InputBase* input) {
+        m_inputs.push_back(input);
+    }
+
+
+
+    /// =========================
+    /// Handle output collections
+    /// =========================
+
+    struct OutputBase {
+        std::string type_name;
+        std::string collection_name;
+        virtual void CreateHelperFactory(JOmniFactory& fac) = 0;
+        virtual void SetCollection(JOmniFactory& fac) = 0;
+    };
+
+    template <typename T>
+    class Output : public OutputBase {
+        std::vector<T*> m_data;
+
+    public:
+        Output(JOmniFactory* owner, std::string default_tag_name="") {
+            owner->RegisterOutput(this);
+            this->collection_name = default_tag_name;
+            this->type_name = JTypeInfo::demangle<T>();
+        }
+
+        std::vector<T*>& operator()() { return m_data; }
+
+    private:
+        friend class JOmniFactory;
+
+        void CreateHelperFactory(JOmniFactory& fac) override {
+            fac.DeclareOutput<T>(this->tag_name);
+        }
+
+        void SetCollection(JOmniFactory& fac) override {
+            fac.SetData<T>(this->tag_name, this->data);
+        }
+    };
+
+
+    template <typename PodioT>
+    class PodioOutput : public OutputBase {
+
+        std::unique_ptr<typename PodioTypeMap<PodioT>::collection_t> m_data;
+
+    public:
+
+        PodioOutput(JOmniFactory* owner, std::string default_collection_name="") {
+            owner->RegisterOutput(this);
+            this->collection_name = default_collection_name;
+            this->type_name = JTypeInfo::demangle<PodioT>();
+        }
+
+        std::unique_ptr<typename PodioTypeMap<PodioT>::collection_t>& operator()() { return m_data; }
+
+    private:
+        friend class JOmniFactory;
+
+        void CreateHelperFactory(JOmniFactory& fac) override {
+            fac.DeclarePodioOutput<PodioT>(this->collection_name);
+        }
+
+        void SetCollection(JOmniFactory& fac) {
+            if (m_data == nullptr) {
+                throw JException("JOmniFactory: SetCollection failed due to missing output collection '%s'", this->collection_name.c_str());
+                // Otherwise this leads to a PODIO segfault
+            }
+            fac.SetCollection<PodioT>(this->collection_name, std::move(this->m_data));
+        }
+    };
+
+    void RegisterOutput(OutputBase* output) {
+        m_outputs.push_back(output);
+    }
+
+
+    // =================
+    // Handle parameters
+    // =================
+
+    struct ParameterBase {
+        std::string m_name;
+        std::string m_description;
+        virtual void Configure(JParameterManager& parman, const std::string& prefix) = 0;
+        virtual void Configure(std::map<std::string, std::string> fields) = 0;
+    };
+
+    template <typename T>
+    class ParameterRef : public ParameterBase {
+
+        T* m_data;
+
+    public:
+        ParameterRef(JOmniFactory* owner, std::string name, T& slot, std::string description="") {
+            owner->RegisterParameter(this);
+            this->m_name = name;
+            this->m_description = description;
+            m_data = &slot;
+        }
+
+        const T& operator()() { return *m_data; }
+
+    private:
+        friend class JOmniFactory;
+
+        void Configure(JParameterManager& parman, const std::string& prefix) override {
+            parman.SetDefaultParameter(prefix + ":" + this->m_name, *m_data, this->m_description);
+        }
+        void Configure(std::map<std::string, std::string> fields) override {
+            auto it = fields.find(this->m_name);
+            if (it != fields.end()) {
+                const auto& value_str = it->second;
+                *m_data = JParameterManager::Parse<T>(value_str);
+            }
+        }
+    };
+
+    template <typename T>
+    class Parameter : public ParameterBase {
+
+        T m_data;
+
+    public:
+        Parameter(JOmniFactory* owner, std::string name, T default_value, std::string description) {
+            owner->RegisterParameter(this);
+            this->m_name = name;
+            this->m_description = description;
+            m_data = default_value;
+        }
+
+        const T& operator()() { return m_data; }
+
+    private:
+        friend class JOmniFactory;
+
+        void Configure(JParameterManager& parman, const std::string& prefix) override {
+            parman.SetDefaultParameter(m_prefix + ":" + this->m_name, m_data, this->m_description);
+        }
+        void Configure(std::map<std::string, std::string> fields) override {
+            auto it = fields.find(this->m_name);
+            if (it != fields.end()) {
+                const auto& value_str = it->second;
+                m_data = JParameterManager::Parse<T>(value_str);
+            }
+        }
+    };
+
+    void RegisterParameter(ParameterBase* parameter) {
+        m_parameters.push_back(parameter);
+    }
+
+    void ConfigureAllParameters(std::map<std::string, std::string> fields) {
+        for (auto* parameter : this->m_parameters) {
+            parameter->Configure(fields);
+        }
+    }
+
+    // ===============
+    // Handle services
+    // ===============
+
+    struct ServiceBase {
+        virtual void Init(JApplication* app) = 0;
+    };
+
+    template <typename ServiceT>
+    class Service : public ServiceBase {
+
+        std::shared_ptr<ServiceT> m_data;
+
+    public:
+
+        Service(JOmniFactory* owner) {
+            owner->RegisterService(this);
+        }
+
+        ServiceT& operator()() {
+            return *m_data;
+        }
+
+    private:
+
+        friend class JOmniFactory;
+
+        void Init(JApplication* app) {
+            m_data = app->GetService<ServiceT>();
+        }
+
+    };
+
+    void RegisterService(ServiceBase* service) {
+        m_services.push_back(service);
+    }
+
+
+    // ================
+    // Handle resources
+    // ================
+
+    struct ResourceBase {
+        virtual void ChangeRun(const JEvent& event) = 0;
+    };
+
+    template <typename ServiceT, typename ResourceT, typename LambdaT>
+    class Resource : public ResourceBase {
+        ResourceT m_data;
+        LambdaT m_lambda;
+
+    public:
+
+        Resource(JOmniFactory* owner, LambdaT lambda) : m_lambda(lambda) {
+            owner->RegisterResource(this);
+        };
+
+        const ResourceT& operator()() { return m_data; }
+
+    private:
+        friend class JOmniFactory;
+
+        void ChangeRun(const JEvent& event) {
+            auto run_nr = event.GetRunNumber();
+            std::shared_ptr<ServiceT> service = event.GetJApplication()->template GetService<ServiceT>();
+            m_data = m_lambda(service, run_nr);
+        }
+    };
+
+    void RegisterResource(ResourceBase* resource) {
+        m_resources.push_back(resource);
+    }
+
+
+public:
+    std::vector<InputBase*> m_inputs;
+    std::vector<OutputBase*> m_outputs;
+    std::vector<ParameterBase*> m_parameters;
+    std::vector<ServiceBase*> m_services;
+    std::vector<ResourceBase*> m_resources;
+
+private:
+
+    // App belongs on JMultifactory, it is just missing temporarily
+    JApplication* m_app;
+
+    // Plugin name belongs on JMultifactory, it is just missing temporarily
+    std::string m_plugin_name;
+
+    // Prefix for parameters and loggers, derived from plugin name and tag in PreInit().
+    std::string m_prefix;
+
+    /// Current logger
+    std::shared_ptr<spdlog::logger> m_logger;
+
+    /// Configuration
+    ConfigT m_config;
+
+public:
+    inline void PreInit(std::string tag,
+                        std::vector<std::string> default_input_collection_names,
+                        std::vector<std::string> default_output_collection_names ) {
+
+        // TODO: NWB: JMultiFactory::GetTag,SetTag are not currently usable
+        m_prefix = (this->GetPluginName().empty()) ? tag : this->GetPluginName() + ":" + tag;
+
+        // Obtain collection name overrides if provided.
+        // Priority = [JParameterManager, JOmniFactoryGenerator]
+        m_app->SetDefaultParameter(m_prefix + ":InputTags", default_input_collection_names, "Input collection names");
+        m_app->SetDefaultParameter(m_prefix + ":OutputTags", default_output_collection_names, "Output collection names");
+
+        // Set input collection names
+        if (m_inputs.size() != default_input_collection_names.size()) {
+            throw JException("JOmniFactory '%s': Wrong number of input collection names: %d expected, %d found.",
+                             m_prefix.c_str(), m_inputs.size(), default_input_collection_names.size());
+        }
+        size_t i = 0;
+        for (auto* input : m_inputs) {
+           input->collection_name = default_input_collection_names[i++];
+        }
+
+        // Set output collection names and create corresponding helper factories
+        if (m_outputs.size() != default_output_collection_names.size()) {
+            throw JException("JOmniFactory '%s': Wrong number of output collection names: %d expected, %d found.",
+                             m_prefix.c_str(), m_outputs.size(), default_output_collection_names.size());
+        }
+        i = 0;
+        for (auto* output : m_outputs) {
+            output->collection_name = default_output_collection_names[i++];
+            output->CreateHelperFactory(*this);
+        }
+
+        // Obtain logger
+        m_logger = m_app->GetService<Log_service>()->logger(m_prefix);
+
+        // Configure logger. Priority = [JParameterManager, system log level]
+        std::string default_log_level = eicrecon::LogLevelToString(m_logger->level());
+        m_app->SetDefaultParameter(m_prefix + ":LogLevel", default_log_level, "LogLevel: trace, debug, info, warn, err, critical, off");
+        m_logger->set_level(eicrecon::ParseLogLevel(default_log_level));
+    }
+
+    void Init() override {
+        auto app = GetApplication();
+        for (auto* parameter : m_parameters) {
+            parameter->Configure(*(app->GetJParameterManager()), m_prefix);
+        }
+        for (auto* service : m_services) {
+            service->Init(app);
+        }
+        static_cast<AlgoT*>(this)->Configure();
+    }
+
+    void BeginRun(const std::shared_ptr<const JEvent>& event) override {
+        for (auto* resource : m_resources) {
+            resource->ChangeRun(*event);
+        }
+        static_cast<AlgoT*>(this)->ChangeRun(event->GetRunNumber());
+    }
+
+    void Process(const std::shared_ptr<const JEvent> &event) override {
+        try {
+            for (auto* input : m_inputs) {
+                input->GetCollection(*event);
+            }
+            static_cast<AlgoT*>(this)->Process(event->GetRunNumber(), event->GetEventNumber());
+            for (auto* output : m_outputs) {
+                output->SetCollection(*this);
+            }
+        }
+        catch(std::exception &e) {
+            throw JException(e.what());
+            // TODO: NWB: JMultifactory ought to already do this... test and fix if it doesn't
+        }
+    }
+
+
+    using ConfigType = ConfigT;
+
+    void SetApplication(JApplication* app) { m_app = app; }
+
+    JApplication* GetApplication() { return m_app; }
+
+    void SetPluginName(std::string plugin_name) { m_plugin_name = plugin_name; }
+
+    std::string GetPluginName() { return m_plugin_name; }
+
+    inline std::string GetPrefix() { return m_prefix; }
+
+    /// Retrieve reference to already-configured logger
+    std::shared_ptr<spdlog::logger> &logger() { return m_logger; }
+
+    /// Retrieve reference to embedded config object
+    ConfigT& GetConfig() { return m_config; }
+
+};

--- a/src/extensions/jana/JOmniFactoryGeneratorT.h
+++ b/src/extensions/jana/JOmniFactoryGeneratorT.h
@@ -79,7 +79,7 @@ public:
         // Create throwaway factory so we can populate its config using our map<string,string>.
         FactoryT factory;
         factory.ConfigureAllParameters(config_params);
-        auto config = factory.GetConfig();
+        auto config = factory.config();
 
         m_wirings.push_back({.m_tag=tag,
                              .m_default_input_tags=default_input_tags,
@@ -101,7 +101,7 @@ public:
             // factory->SetTag(wiring.m_tag);
             // We do NOT want to do this because JMF will use the tag to suffix the collection names
             // TODO: NWB: Change this in JANA
-            factory->GetConfig() = wiring.m_default_cfg;
+            factory->config() = wiring.m_default_cfg;
 
             // Set up all of the wiring prereqs so that Init() can do its thing
             // Specically, it needs valid input/output tags, a valid logger, and

--- a/src/extensions/jana/JOmniFactoryGeneratorT.h
+++ b/src/extensions/jana/JOmniFactoryGeneratorT.h
@@ -1,0 +1,120 @@
+// Copyright 2023, Jefferson Science Associates, LLC.
+// Subject to the terms in the LICENSE file found in the top-level directory.
+// Created by Nathan Brei
+
+#pragma once
+
+#include <JANA/JFactorySet.h>
+#include <JANA/JFactoryGenerator.h>
+#include <vector>
+
+template<class FactoryT>
+class JOmniFactoryGeneratorT : public JFactoryGenerator {
+public:
+    using FactoryConfigType = typename FactoryT::ConfigType;
+
+private:
+    struct TypedWiring {
+        std::string m_tag;
+        std::vector<std::string> m_default_input_tags;
+        std::vector<std::string> m_default_output_tags;
+        FactoryConfigType m_default_cfg; /// Must be properly copyable!
+    };
+
+    struct UntypedWiring {
+        std::string m_tag;
+        std::vector<std::string> m_default_input_tags;
+        std::vector<std::string> m_default_output_tags;
+        std::map<std::string, std::string> m_config_params;
+    };
+
+public:
+
+
+    explicit JOmniFactoryGeneratorT(std::string tag,
+                                    std::vector<std::string> default_input_tags,
+                                    std::vector<std::string> default_output_tags,
+                                    FactoryConfigType cfg,
+                                    JApplication* app) {
+        m_app = app;
+        m_wirings.push_back({.m_tag=tag,
+                             .m_default_input_tags=default_input_tags,
+                             .m_default_output_tags=default_output_tags,
+                             .m_default_cfg=cfg
+                            });
+    };
+
+    explicit JOmniFactoryGeneratorT(std::string tag,
+                                    std::vector<std::string> default_input_tags,
+                                    std::vector<std::string> default_output_tags,
+                                    JApplication* app) {
+        m_app = app;
+        m_wirings.push_back({.m_tag=tag,
+                                .m_default_input_tags=default_input_tags,
+                                .m_default_output_tags=default_output_tags
+                                });
+
+    }
+
+    explicit JOmniFactoryGeneratorT(JApplication* app) : m_app(app) {
+    }
+
+    void AddWiring(std::string tag,
+                   std::vector<std::string> default_input_tags,
+                   std::vector<std::string> default_output_tags,
+                   FactoryConfigType cfg) {
+
+        m_wirings.push_back({.m_tag=tag,
+                             .m_default_input_tags=default_input_tags,
+                             .m_default_output_tags=default_output_tags,
+                             .m_default_cfg=cfg
+                            });
+    }
+
+    void AddWiring(std::string tag,
+                   std::vector<std::string> default_input_tags,
+                   std::vector<std::string> default_output_tags,
+                   std::map<std::string, std::string> config_params) {
+
+        // Create throwaway factory so we can populate its config using our map<string,string>.
+        FactoryT factory;
+        factory.ConfigureAllParameters(config_params);
+        auto config = factory.GetConfig();
+
+        m_wirings.push_back({.m_tag=tag,
+                             .m_default_input_tags=default_input_tags,
+                             .m_default_output_tags=default_output_tags,
+                             .m_default_cfg=config
+                            });
+
+    }
+
+    void GenerateFactories(JFactorySet *factory_set) override {
+
+        for (const auto& wiring : m_wirings) {
+
+
+            FactoryT *factory = new FactoryT;
+            factory->SetApplication(m_app);
+            factory->SetPluginName(this->GetPluginName());
+            factory->SetFactoryName(JTypeInfo::demangle<FactoryT>());
+            // factory->SetTag(wiring.m_tag);
+            // We do NOT want to do this because JMF will use the tag to suffix the collection names
+            // TODO: NWB: Change this in JANA
+            factory->GetConfig() = wiring.m_default_cfg;
+
+            // Set up all of the wiring prereqs so that Init() can do its thing
+            // Specically, it needs valid input/output tags, a valid logger, and
+            // valid default values in its Config object
+            factory->PreInit(wiring.m_tag, wiring.m_default_input_tags, wiring.m_default_output_tags);
+
+            // Factory is ready
+            factory_set->Add(factory);
+        }
+    }
+
+private:
+    std::vector<TypedWiring> m_wirings;
+    JApplication* m_app;
+
+};

--- a/src/factories/calorimetry/CalorimeterClusterRecoCoG_factory.h
+++ b/src/factories/calorimetry/CalorimeterClusterRecoCoG_factory.h
@@ -1,0 +1,48 @@
+// Copyright 2023, Wouter Deconinck
+// Subject to the terms in the LICENSE file found in the top-level directory.
+//
+
+#pragma once
+
+#include <algorithms/calorimetry/CalorimeterClusterRecoCoG.h>
+#include <services/geometry/dd4hep/JDD4hep_service.h>
+#include <extensions/jana/JOmniFactory.h>
+
+
+namespace eicrecon {
+
+class CalorimeterClusterRecoCoG_factory : public JOmniFactory<CalorimeterClusterRecoCoG_factory, CalorimeterClusterRecoCoGConfig> {
+
+    eicrecon::CalorimeterClusterRecoCoG m_algo;
+
+    PodioInput<edm4eic::ProtoCluster> m_proto_input {this};
+    PodioInput<edm4hep::SimCalorimeterHit> m_mchits_input {this};
+
+    PodioOutput<edm4eic::Cluster> m_cluster_output {this};
+    PodioOutput<edm4eic::MCRecoClusterParticleAssociation> m_assoc_output {this};
+
+    ParameterRef<double> m_samplingFraction {this, "samplingFraction", GetConfig().sampFrac};
+    ParameterRef<double> m_logWeightBase {this, "logWeightBase", GetConfig().logWeightBase};
+    ParameterRef<double> m_depthCorrection {this, "depthCorrection", GetConfig().depthCorrection};
+    ParameterRef<std::string> m_energyWeight {this, "energyWeight", GetConfig().energyWeight};
+    ParameterRef<std::string> m_moduleDimZName {this, "moduleDimZName", GetConfig().moduleDimZName};
+    ParameterRef<bool> m_enableEtaBounds {this, "enableEtaBounds", GetConfig().enableEtaBounds};
+
+    Service<JDD4hep_service> m_geoSvc {this};
+    // Resource<JDD4hep_service, const dd4hep::Detector*> m_detector {this, [](std::shared_ptr<JDD4hep_service> s, int64_t run_nr){ return s->detector(); }}
+
+public:
+    void Configure() {
+        m_algo.applyConfig(GetConfig());
+        m_algo.init(m_geoSvc().detector(), logger());
+    }
+
+    void ChangeRun(int64_t run_number) {
+    }
+
+    void Process(int64_t run_number, uint64_t event_number) {
+        std::tie(m_cluster_output(), m_assoc_output()) = m_algo.process(m_proto_input(), m_mchits_input());
+    }
+};
+
+} // eicrecon

--- a/src/factories/calorimetry/CalorimeterClusterRecoCoG_factory.h
+++ b/src/factories/calorimetry/CalorimeterClusterRecoCoG_factory.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <algorithms/calorimetry/CalorimeterClusterRecoCoG.h>
-#include <services/geometry/dd4hep/JDD4hep_service.h>
+#include <services/geometry/dd4hep/DD4hep_service.h>
 #include <extensions/jana/JOmniFactory.h>
 
 
@@ -21,19 +21,19 @@ class CalorimeterClusterRecoCoG_factory : public JOmniFactory<CalorimeterCluster
     PodioOutput<edm4eic::Cluster> m_cluster_output {this};
     PodioOutput<edm4eic::MCRecoClusterParticleAssociation> m_assoc_output {this};
 
-    ParameterRef<double> m_samplingFraction {this, "samplingFraction", GetConfig().sampFrac};
-    ParameterRef<double> m_logWeightBase {this, "logWeightBase", GetConfig().logWeightBase};
-    ParameterRef<double> m_depthCorrection {this, "depthCorrection", GetConfig().depthCorrection};
-    ParameterRef<std::string> m_energyWeight {this, "energyWeight", GetConfig().energyWeight};
-    ParameterRef<std::string> m_moduleDimZName {this, "moduleDimZName", GetConfig().moduleDimZName};
-    ParameterRef<bool> m_enableEtaBounds {this, "enableEtaBounds", GetConfig().enableEtaBounds};
+    ParameterRef<double> m_samplingFraction {this, "samplingFraction", config().sampFrac};
+    ParameterRef<double> m_logWeightBase {this, "logWeightBase", config().logWeightBase};
+    ParameterRef<double> m_depthCorrection {this, "depthCorrection", config().depthCorrection};
+    ParameterRef<std::string> m_energyWeight {this, "energyWeight", config().energyWeight};
+    ParameterRef<std::string> m_moduleDimZName {this, "moduleDimZName", config().moduleDimZName};
+    ParameterRef<bool> m_enableEtaBounds {this, "enableEtaBounds", config().enableEtaBounds};
 
-    Service<JDD4hep_service> m_geoSvc {this};
-    // Resource<JDD4hep_service, const dd4hep::Detector*> m_detector {this, [](std::shared_ptr<JDD4hep_service> s, int64_t run_nr){ return s->detector(); }}
+    Service<DD4hep_service> m_geoSvc {this};
+    // Resource<DD4hep_service, const dd4hep::Detector*> m_detector {this, [](std::shared_ptr<DD4hep_service> s, int64_t run_nr){ return s->detector(); }}
 
 public:
     void Configure() {
-        m_algo.applyConfig(GetConfig());
+        m_algo.applyConfig(config());
         m_algo.init(m_geoSvc().detector(), logger());
     }
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -3,8 +3,9 @@
 find_package(Catch2 3)
 if(Catch2_FOUND)
     add_subdirectory(algorithms_test)
+    add_subdirectory(omnifactory_test)
 else()
-    message(STATUS "Catch2 is not found. Skipping algorithms_test...")
+    message(STATUS "Catch2 is not found. Skipping algorithms_test, omnifactory_test...")
 endif()
 
 add_subdirectory(reco_test)

--- a/src/tests/omnifactory_test/CMakeLists.txt
+++ b/src/tests/omnifactory_test/CMakeLists.txt
@@ -1,0 +1,34 @@
+# Automatically set plugin name the same as the directory name
+get_filename_component(TEST_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
+
+# These tests can use the Catch2-provided main
+add_executable(${TEST_NAME}
+  JOmniFactoryTests.cc
+  )
+
+find_package(spdlog REQUIRED)
+find_package(fmt REQUIRED)
+
+# Explicit linking to podio::podio is needed due to https://github.com/JeffersonLab/JANA2/issues/151
+# TODO: NWB: Did we ever fix this?
+target_include_directories(${TEST_NAME} PRIVATE ${PROJECT_BINARY_DIR} ${EICRECON_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR} ${JANA_INCLUDE_DIR} ${ROOT_INCLUDE_DIRS} ${datamodel_BINARY_DIR})
+target_link_libraries(${TEST_NAME} PRIVATE
+  log
+  spdlog::spdlog
+  fmt::fmt
+  EDM4EIC::edm4eic
+  EDM4HEP::edm4hep
+  podio
+  ${JANA_LIB}
+  podio::podio
+  podio::podioRootIO
+  ${ROOT_LIBRARIES}
+  Catch2::Catch2WithMain
+  ${CMAKE_DL_LIBS}
+  )
+
+
+# Install executable
+install(TARGETS ${TEST_NAME} DESTINATION bin)
+
+add_test(NAME t_${TEST_NAME} COMMAND env LLVM_PROFILE_FILE=${TEST_NAME}.profraw $<TARGET_FILE:${TEST_NAME}>)

--- a/src/tests/omnifactory_test/CMakeLists.txt
+++ b/src/tests/omnifactory_test/CMakeLists.txt
@@ -16,7 +16,6 @@ target_link_libraries(${TEST_NAME} PRIVATE
   log_plugin
   EDM4EIC::edm4eic
   EDM4HEP::edm4hep
-  podio
   ${JANA_LIB}
   podio::podio
   podio::podioRootIO

--- a/src/tests/omnifactory_test/CMakeLists.txt
+++ b/src/tests/omnifactory_test/CMakeLists.txt
@@ -13,9 +13,7 @@ find_package(fmt REQUIRED)
 # TODO: NWB: Did we ever fix this?
 target_include_directories(${TEST_NAME} PRIVATE ${PROJECT_BINARY_DIR} ${EICRECON_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR} ${JANA_INCLUDE_DIR} ${ROOT_INCLUDE_DIRS} ${datamodel_BINARY_DIR})
 target_link_libraries(${TEST_NAME} PRIVATE
-  log
-  spdlog::spdlog
-  fmt::fmt
+  log_plugin
   EDM4EIC::edm4eic
   EDM4HEP::edm4hep
   podio

--- a/src/tests/omnifactory_test/JOmniFactoryTests.cc
+++ b/src/tests/omnifactory_test/JOmniFactoryTests.cc
@@ -1,0 +1,210 @@
+
+#include <spdlog/logger.h>
+#include <catch2/catch_test_macros.hpp>
+#include <extensions/jana/JOmniFactory.h>
+#include <extensions/jana/JOmniFactoryGeneratorT.h>
+#include <JANA/Services/JComponentManager.h>
+
+#include <edm4hep/SimCalorimeterHitCollection.h>
+
+struct BasicTestAlgConfig {
+    int bucket_count = 42;
+    double threshold = 7.6;
+};
+
+struct BasicTestAlg : public JOmniFactory<BasicTestAlg, BasicTestAlgConfig> {
+
+    PodioOutput<edm4hep::SimCalorimeterHit> output_hits_left {this, "output_hits_left"};
+    PodioOutput<edm4hep::SimCalorimeterHit> output_hits_right {this, "output_hits_right"};
+
+    ParameterRef<int> bucket_count {this, "bucket_count", GetConfig().bucket_count, "The total number of buckets [dimensionless]"};
+    ParameterRef<double> threshold {this, "threshold", GetConfig().threshold, "The max cutoff threshold [V * A * kg^-1 * m^-2 * sec^-3]"};
+
+    std::vector<OutputBase*> GetOutputs() { return this->m_outputs; }
+
+    int m_init_call_count = 0;
+    int m_changerun_call_count = 0;
+    int m_process_call_count = 0;
+
+    void Configure() {
+        m_init_call_count++;
+        logger()->info("Calling BasicTestAlg::Configure");
+    }
+
+    void ChangeRun(int64_t run_number) {
+        m_changerun_call_count++;
+        logger()->info("Calling BasicTestAlg::ChangeRun");
+    }
+
+    void Process(int64_t run_number, uint64_t event_number) {
+        m_process_call_count++;
+        logger()->info("Calling BasicTestAlg::Process with bucket_count={}, threshold={}", GetConfig().bucket_count, GetConfig().threshold);
+        // Provide empty collections (as opposed to nulls) so that PODIO doesn't crash
+        // TODO: NWB: I though multifactories already took care of this under the hood somewhere
+        output_hits_left() = std::make_unique<edm4hep::SimCalorimeterHitCollection>();
+        output_hits_right() = std::make_unique<edm4hep::SimCalorimeterHitCollection>();
+    }
+};
+
+template <typename OutputCollectionT, typename MultifactoryT>
+MultifactoryT* RetrieveMultifactory(JFactorySet* facset, std::string output_collection_name) {
+    auto fac = facset->GetFactory<OutputCollectionT>(output_collection_name);
+    REQUIRE(fac != nullptr);
+    auto helper = dynamic_cast<JMultifactoryHelperPodio<OutputCollectionT>*>(fac);
+    REQUIRE(helper != nullptr);
+    auto multifactory = helper->GetMultifactory();
+    REQUIRE(multifactory != nullptr);
+    auto typed = dynamic_cast<MultifactoryT*>(multifactory);
+    REQUIRE(typed != nullptr);
+    return typed;
+}
+
+TEST_CASE("Registering Podio outputs works") {
+    BasicTestAlg alg;
+    REQUIRE(alg.GetOutputs().size() == 2);
+    REQUIRE(alg.GetOutputs()[0]->collection_name == "output_hits_left");
+    REQUIRE(alg.GetOutputs()[0]->type_name == "edm4hep::SimCalorimeterHit");
+    REQUIRE(alg.GetOutputs()[1]->collection_name == "output_hits_right");
+    REQUIRE(alg.GetOutputs()[1]->type_name == "edm4hep::SimCalorimeterHit");
+}
+
+TEST_CASE("Configuration object is correctly wired from untyped wiring data") {
+    JApplication app;
+    app.AddPlugin("log");
+    app.Initialize();
+    JOmniFactoryGeneratorT<BasicTestAlg> facgen (&app);
+    facgen.AddWiring("ECalTestAlg", {}, {"ECalLeftHits", "ECalRightHits"}, {{"threshold", "6.1"}, {"bucket_count", "22"}});
+
+    JFactorySet facset;
+    facgen.GenerateFactories(&facset);
+    // for (auto* fac : facset.GetAllFactories()) {
+        // std::cout << "typename=" << fac->GetFactoryName() << ", tag=" << fac->GetTag() << std::endl;
+    // }
+
+    auto basictestalg = RetrieveMultifactory<edm4hep::SimCalorimeterHit,BasicTestAlg>(&facset, "ECalLeftHits");
+
+    REQUIRE(basictestalg->threshold() == 6.1);
+    REQUIRE(basictestalg->bucket_count() == 22);
+
+    REQUIRE(basictestalg->GetConfig().threshold == 6.1);
+    REQUIRE(basictestalg->GetConfig().bucket_count == 22);
+
+    REQUIRE(basictestalg->m_init_call_count == 0);
+}
+
+TEST_CASE("Multiple configuration objects are correctly wired from untyped wiring data") {
+    JApplication app;
+    app.AddPlugin("log");
+    app.Initialize();
+    JOmniFactoryGeneratorT<BasicTestAlg> facgen (&app);
+    facgen.AddWiring("BCalTestAlg", {}, {"BCalLeftHits", "BCalRightHits"}, {{"threshold", "6.1"}, {"bucket_count", "22"}});
+    facgen.AddWiring("CCalTestAlg", {}, {"CCalLeftHits", "CCalRightHits"}, {{"threshold", "9.0"}, {"bucket_count", "27"}});
+    facgen.AddWiring("ECalTestAlg", {}, {"ECalLeftHits", "ECalRightHits"}, {{"threshold", "16.25"}, {"bucket_count", "49"}});
+
+    JFactorySet facset;
+    facgen.GenerateFactories(&facset);
+    // for (auto* fac : facset.GetAllFactories()) {
+        // std::cout << "typename=" << fac->GetFactoryName() << ", tag=" << fac->GetTag() << std::endl;
+    // }
+    auto b = RetrieveMultifactory<edm4hep::SimCalorimeterHit,BasicTestAlg>(&facset, "BCalLeftHits");
+    auto c = RetrieveMultifactory<edm4hep::SimCalorimeterHit,BasicTestAlg>(&facset, "CCalLeftHits");
+    auto e = RetrieveMultifactory<edm4hep::SimCalorimeterHit,BasicTestAlg>(&facset, "ECalLeftHits");
+
+    REQUIRE(b->threshold() == 6.1);
+    REQUIRE(b->bucket_count() == 22);
+    REQUIRE(b->GetConfig().threshold == 6.1);
+    REQUIRE(b->GetConfig().bucket_count == 22);
+
+    REQUIRE(c->threshold() == 9.0);
+    REQUIRE(c->bucket_count() == 27);
+    REQUIRE(c->GetConfig().threshold == 9.0);
+    REQUIRE(c->GetConfig().bucket_count == 27);
+
+    REQUIRE(e->threshold() == 16.25);
+    REQUIRE(e->bucket_count() == 49);
+    REQUIRE(e->GetConfig().threshold == 16.25);
+    REQUIRE(e->GetConfig().bucket_count == 49);
+
+    REQUIRE(b->m_init_call_count == 0);
+    REQUIRE(c->m_init_call_count == 0);
+    REQUIRE(e->m_init_call_count == 0);
+}
+
+TEST_CASE("JParameterManager correctly understands which values are defaulted and which are overridden") {
+    JApplication app;
+    app.AddPlugin("log");
+
+    auto facgen = new JOmniFactoryGeneratorT<BasicTestAlg>(&app);
+    facgen->AddWiring("FunTest", {}, {"BCalLeftHits", "BCalRightHits"}, {{"threshold", "6.1"}, {"bucket_count", "22"}});
+    app.Add(facgen);
+
+    app.GetJParameterManager()->SetParameter("FunTest:threshold", 12.0);
+    app.Initialize();
+
+    auto event = std::make_shared<JEvent>();
+    app.GetService<JComponentManager>()->configure_event(*event);
+
+    // for (auto* fac : event->GetFactorySet()->GetAllFactories()) {
+        // std::cout << "typename=" << fac->GetFactoryName() << ", tag=" << fac->GetTag() << std::endl;
+    // }
+
+    // Retrieve multifactory
+    auto b = RetrieveMultifactory<edm4hep::SimCalorimeterHit,BasicTestAlg>(event->GetFactorySet(), "BCalLeftHits");
+
+    // Overrides won't happen until factory gets Init()ed. However, defaults will be applied immediately
+    REQUIRE(b->threshold() == 6.1);
+    REQUIRE(b->GetConfig().threshold == 6.1);
+
+    // Trigger JMF::Execute(), in order to trigger Init(), in order to Configure()s all Parameter fields...
+    auto lefthits = event->Get<edm4hep::SimCalorimeterHit>("BCalLeftHits");
+
+    REQUIRE(b->threshold() == 12.0);
+    REQUIRE(b->GetConfig().threshold == 12.0);
+
+    std::cout << "Showing the full table of config parameters" << std::endl;
+    app.GetJParameterManager()->PrintParameters(true, false, true);
+
+    std::cout << "Showing only overridden config parameters" << std::endl;
+    app.GetJParameterManager()->PrintParameters(false, false, true);
+}
+
+TEST_CASE("Wiring itself is correctly defaulted") {
+    JApplication app;
+    app.AddPlugin("log");
+
+    auto facgen = new JOmniFactoryGeneratorT<BasicTestAlg>(&app);
+    facgen->AddWiring("FunTest", {}, {"BCalLeftHits", "BCalRightHits"}, {{"threshold", "6.1"}});
+    app.Add(facgen);
+    app.Initialize();
+
+    auto event = std::make_shared<JEvent>();
+    app.GetService<JComponentManager>()->configure_event(*event);
+
+    // Retrieve multifactory
+    auto b = RetrieveMultifactory<edm4hep::SimCalorimeterHit,BasicTestAlg>(event->GetFactorySet(), "BCalLeftHits");
+
+    // Overrides won't happen until factory gets Init()ed. However, defaults will be applied immediately
+    REQUIRE(b->bucket_count() == 42);      // Not provided by wiring
+    REQUIRE(b->GetConfig().bucket_count == 42);  // Not provided by wiring
+
+    REQUIRE(b->threshold() == 6.1);        // Provided by wiring
+    REQUIRE(b->GetConfig().threshold == 6.1);    // Provided by wiring
+
+    // Trigger JMF::Execute(), in order to trigger Init(), in order to Configure()s all Parameter fields...
+    auto lefthits = event->Get<edm4hep::SimCalorimeterHit>("BCalLeftHits");
+
+    // We didn't override the config values via the parameter manager, so all of these should be the same
+    REQUIRE(b->bucket_count() == 42);      // Not provided by wiring
+    REQUIRE(b->GetConfig().bucket_count == 42);  // Not provided by wiring
+
+    REQUIRE(b->threshold() == 6.1);        // Provided by wiring
+    REQUIRE(b->GetConfig().threshold == 6.1);    // Provided by wiring
+
+
+    b->logger()->info("Showing the full table of config parameters");
+    app.GetJParameterManager()->PrintParameters(true, false, true);
+
+    b->logger()->info("Showing only overridden config parameters");
+    // Should be empty because everything is defaulted
+    app.GetJParameterManager()->PrintParameters(false, false, true);
+}

--- a/src/tests/omnifactory_test/JOmniFactoryTests.cc
+++ b/src/tests/omnifactory_test/JOmniFactoryTests.cc
@@ -17,8 +17,8 @@ struct BasicTestAlg : public JOmniFactory<BasicTestAlg, BasicTestAlgConfig> {
     PodioOutput<edm4hep::SimCalorimeterHit> output_hits_left {this, "output_hits_left"};
     PodioOutput<edm4hep::SimCalorimeterHit> output_hits_right {this, "output_hits_right"};
 
-    ParameterRef<int> bucket_count {this, "bucket_count", GetConfig().bucket_count, "The total number of buckets [dimensionless]"};
-    ParameterRef<double> threshold {this, "threshold", GetConfig().threshold, "The max cutoff threshold [V * A * kg^-1 * m^-2 * sec^-3]"};
+    ParameterRef<int> bucket_count {this, "bucket_count", config().bucket_count, "The total number of buckets [dimensionless]"};
+    ParameterRef<double> threshold {this, "threshold", config().threshold, "The max cutoff threshold [V * A * kg^-1 * m^-2 * sec^-3]"};
 
     std::vector<OutputBase*> GetOutputs() { return this->m_outputs; }
 
@@ -38,7 +38,7 @@ struct BasicTestAlg : public JOmniFactory<BasicTestAlg, BasicTestAlgConfig> {
 
     void Process(int64_t run_number, uint64_t event_number) {
         m_process_call_count++;
-        logger()->info("Calling BasicTestAlg::Process with bucket_count={}, threshold={}", GetConfig().bucket_count, GetConfig().threshold);
+        logger()->info("Calling BasicTestAlg::Process with bucket_count={}, threshold={}", config().bucket_count, config().threshold);
         // Provide empty collections (as opposed to nulls) so that PODIO doesn't crash
         // TODO: NWB: I though multifactories already took care of this under the hood somewhere
         output_hits_left() = std::make_unique<edm4hep::SimCalorimeterHitCollection>();
@@ -86,8 +86,8 @@ TEST_CASE("Configuration object is correctly wired from untyped wiring data") {
     REQUIRE(basictestalg->threshold() == 6.1);
     REQUIRE(basictestalg->bucket_count() == 22);
 
-    REQUIRE(basictestalg->GetConfig().threshold == 6.1);
-    REQUIRE(basictestalg->GetConfig().bucket_count == 22);
+    REQUIRE(basictestalg->config().threshold == 6.1);
+    REQUIRE(basictestalg->config().bucket_count == 22);
 
     REQUIRE(basictestalg->m_init_call_count == 0);
 }
@@ -112,18 +112,18 @@ TEST_CASE("Multiple configuration objects are correctly wired from untyped wirin
 
     REQUIRE(b->threshold() == 6.1);
     REQUIRE(b->bucket_count() == 22);
-    REQUIRE(b->GetConfig().threshold == 6.1);
-    REQUIRE(b->GetConfig().bucket_count == 22);
+    REQUIRE(b->config().threshold == 6.1);
+    REQUIRE(b->config().bucket_count == 22);
 
     REQUIRE(c->threshold() == 9.0);
     REQUIRE(c->bucket_count() == 27);
-    REQUIRE(c->GetConfig().threshold == 9.0);
-    REQUIRE(c->GetConfig().bucket_count == 27);
+    REQUIRE(c->config().threshold == 9.0);
+    REQUIRE(c->config().bucket_count == 27);
 
     REQUIRE(e->threshold() == 16.25);
     REQUIRE(e->bucket_count() == 49);
-    REQUIRE(e->GetConfig().threshold == 16.25);
-    REQUIRE(e->GetConfig().bucket_count == 49);
+    REQUIRE(e->config().threshold == 16.25);
+    REQUIRE(e->config().bucket_count == 49);
 
     REQUIRE(b->m_init_call_count == 0);
     REQUIRE(c->m_init_call_count == 0);
@@ -153,13 +153,13 @@ TEST_CASE("JParameterManager correctly understands which values are defaulted an
 
     // Overrides won't happen until factory gets Init()ed. However, defaults will be applied immediately
     REQUIRE(b->threshold() == 6.1);
-    REQUIRE(b->GetConfig().threshold == 6.1);
+    REQUIRE(b->config().threshold == 6.1);
 
     // Trigger JMF::Execute(), in order to trigger Init(), in order to Configure()s all Parameter fields...
     auto lefthits = event->Get<edm4hep::SimCalorimeterHit>("BCalLeftHits");
 
     REQUIRE(b->threshold() == 12.0);
-    REQUIRE(b->GetConfig().threshold == 12.0);
+    REQUIRE(b->config().threshold == 12.0);
 
     std::cout << "Showing the full table of config parameters" << std::endl;
     app.GetJParameterManager()->PrintParameters(true, false, true);
@@ -185,20 +185,20 @@ TEST_CASE("Wiring itself is correctly defaulted") {
 
     // Overrides won't happen until factory gets Init()ed. However, defaults will be applied immediately
     REQUIRE(b->bucket_count() == 42);      // Not provided by wiring
-    REQUIRE(b->GetConfig().bucket_count == 42);  // Not provided by wiring
+    REQUIRE(b->config().bucket_count == 42);  // Not provided by wiring
 
     REQUIRE(b->threshold() == 6.1);        // Provided by wiring
-    REQUIRE(b->GetConfig().threshold == 6.1);    // Provided by wiring
+    REQUIRE(b->config().threshold == 6.1);    // Provided by wiring
 
     // Trigger JMF::Execute(), in order to trigger Init(), in order to Configure()s all Parameter fields...
     auto lefthits = event->Get<edm4hep::SimCalorimeterHit>("BCalLeftHits");
 
     // We didn't override the config values via the parameter manager, so all of these should be the same
     REQUIRE(b->bucket_count() == 42);      // Not provided by wiring
-    REQUIRE(b->GetConfig().bucket_count == 42);  // Not provided by wiring
+    REQUIRE(b->config().bucket_count == 42);  // Not provided by wiring
 
     REQUIRE(b->threshold() == 6.1);        // Provided by wiring
-    REQUIRE(b->GetConfig().threshold == 6.1);    // Provided by wiring
+    REQUIRE(b->config().threshold == 6.1);    // Provided by wiring
 
 
     b->logger()->info("Showing the full table of config parameters");


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This PR introduces JOmniFactory, which is designed to have the same functionality as JChainMultifactory with a notably cleaned-up interface. This will eventually support instantiating and wiring factories via an external configuration file and/or script, and may form the basis of a 'generic algorithms' JANA adapter. The hope is that we can migrate all EICrecon factories to use this as their base class and thereby substantially reduce user confusion and boilerplate code.
 
### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
