### PR TITLE
Reverted default Silicon Tracker Digi threshold to 0

### DIFF
--- a/src/algorithms/digi/SiliconTrackerDigiConfig.h
+++ b/src/algorithms/digi/SiliconTrackerDigiConfig.h
@@ -6,7 +6,7 @@ namespace eicrecon {
 
   struct SiliconTrackerDigiConfig {
     // sub-systems should overwrite their own
-    // NB: be aware of thresholds in npsim!
+    // NB: be aware of thresholds in npsim! E.g. https://github.com/eic/npsim/pull/9/files
     double threshold  = 0 * dd4hep::keV;
     double timeResolution = 8;   /// TODO 8 of what units??? Same TODO in juggler. Probably [ns]
   };


### PR DESCRIPTION
### Briefly, what does this PR introduce?
SiliconTrackerDigiConfig has a threshold. This should be overwritten by sub-systems and thus by default be 0.
NB: be aware of thresholds in npsim! E.g. https://github.com/eic/npsim/pull/9/files

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [x] _Comments_ have been added
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
Yes