### PR TITLE
fix: read `materials-map` string constant in ACTSGeo_service

### DIFF
--- a/src/services/geometry/acts/ACTSGeo_service.cc
+++ b/src/services/geometry/acts/ACTSGeo_service.cc
@@ -39,9 +39,15 @@ std::shared_ptr<const ActsGeometryProvider> ACTSGeo_service::actsGeoProvider() {
             }
 
             // Get material map from user parameter
-            // By default DD4Hep downloads material map to <run-dir>
-            std::string material_map_file = "calibrations/materials-map.cbor";
-            m_app->SetDefaultParameter("acts:MaterialMap", material_map_file, "JSon material map file path");
+            std::string material_map_file;
+            try {
+              material_map_file = m_dd4hepGeo->constant<string>("materials-map");
+            } catch (const std::runtime_error& e) {
+              material_map_file = "calibrations/materials-map.cbor";
+            } catch (...) {
+              throw e;
+            }
+            m_app->SetDefaultParameter("acts:MaterialMap", material_map_file, "JSON/CBOR material map file path");
 
             // Initialize m_acts_provider
             m_acts_provider = std::make_shared<ActsGeometryProvider>();

--- a/src/services/geometry/acts/ACTSGeo_service.cc
+++ b/src/services/geometry/acts/ACTSGeo_service.cc
@@ -44,8 +44,6 @@ std::shared_ptr<const ActsGeometryProvider> ACTSGeo_service::actsGeoProvider() {
               material_map_file = m_dd4hepGeo->constant<std::string>("materials-map");
             } catch (const std::runtime_error& e) {
               material_map_file = "calibrations/materials-map.cbor";
-            } catch (...) {
-              throw;
             }
             m_app->SetDefaultParameter("acts:MaterialMap", material_map_file, "JSON/CBOR material map file path");
 

--- a/src/services/geometry/acts/ACTSGeo_service.cc
+++ b/src/services/geometry/acts/ACTSGeo_service.cc
@@ -41,11 +41,11 @@ std::shared_ptr<const ActsGeometryProvider> ACTSGeo_service::actsGeoProvider() {
             // Get material map from user parameter
             std::string material_map_file;
             try {
-              material_map_file = m_dd4hepGeo->constant<string>("materials-map");
+              material_map_file = m_dd4hepGeo->constant<std::string>("materials-map");
             } catch (const std::runtime_error& e) {
               material_map_file = "calibrations/materials-map.cbor";
             } catch (...) {
-              throw e;
+              throw;
             }
             m_app->SetDefaultParameter("acts:MaterialMap", material_map_file, "JSON/CBOR material map file path");
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The `calibrations/materials-map.cbor` path can now be passed via the geometry instead of being hard-coded in the reconstruction code. This was causing difficulties since brycecanyon and craterlake were forced to write to `calibrations/materials-map.cbor`. This allows us now to write to different files.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: avoid hard-coding materials-map path in reconstruction)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No. Reverts to previous behavior until defined in geometry.