### PR TITLE
update max eta forward limit in truth seeder to 6

### DIFF
--- a/src/algorithms/tracking/TrackParamTruthInitConfig.h
+++ b/src/algorithms/tracking/TrackParamTruthInitConfig.h
@@ -12,7 +12,7 @@ struct TrackParamTruthInitConfig {
     double m_maxVertexY       = 80  * Acts::UnitConstants::mm;
     double m_maxVertexZ       = 200 * Acts::UnitConstants::mm;
     double m_minMomentum      = 100 * Acts::UnitConstants::MeV;
-    double m_maxEtaForward    = 4.0;
+    double m_maxEtaForward    = 6.0;
     double m_maxEtaBackward   = 4.1;
     double m_momentumSmear    = 0.1;
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Update max eta forward limit to 6 to take far forward events into account for reconstruction by default

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #833)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No
