### PR TITLE
fix: rename imaging/scfi module to sector

### DIFF
--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -55,7 +55,7 @@ extern "C" {
             .sampFrac = 0.10200085,
             .readout = "EcalBarrelScFiHits",
             .layerField = "layer",
-            .sectorField = "module",
+            .sectorField = "sector",
             .localDetFields = {"system"},
             // here we want to use grid center position (XY) but keeps the z information from fiber-segment
             // TODO: a more realistic way to get z is to reconstruct it from timing
@@ -122,7 +122,7 @@ extern "C" {
             .sampFrac = 0.00619766,
             .readout = "EcalBarrelImagingHits",
             .layerField = "layer",
-            .sectorField = "module",
+            .sectorField = "sector",
           },
            app   // TODO: Remove me once fixed
         ));


### PR DESCRIPTION
### Briefly, what does this PR introduce?
As of https://github.com/eic/epic/pull/490, the naming of the sectors of the imaging and scfi is now correct in the readout field. This is reqiured because there are now actual modules implemented (i.e. chip modules placed on staves). The hierarchy/nomenclature defined by the DSC is system > sector > layer > stave > module > pixel (x,y).

### What kind of change does this PR introduce?
- [x] Bug fix (issue: the usual race condition when we update things...)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.