### PR TITLE
fix: depend on datamodel version headers in datamodel glue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ add_compile_definitions(HAVE_PODIO)
 # PODIO, EDM4HEP, EDM4EIC event models
 find_package(Eigen3 REQUIRED)
 find_package(podio REQUIRED)
-find_package(EDM4HEP 0.9 REQUIRED)
+find_package(EDM4HEP REQUIRED)
 find_package(EDM4EIC REQUIRED)
 
 # DD4Hep is required for the most of the part

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ add_compile_definitions(HAVE_PODIO)
 # PODIO, EDM4HEP, EDM4EIC event models
 find_package(Eigen3 REQUIRED)
 find_package(podio REQUIRED)
-find_package(EDM4HEP REQUIRED)
+find_package(EDM4HEP 0.9 REQUIRED)
 find_package(EDM4EIC REQUIRED)
 
 # DD4Hep is required for the most of the part

--- a/src/services/io/podio/CMakeLists.txt
+++ b/src/services/io/podio/CMakeLists.txt
@@ -31,6 +31,15 @@ plugin_glob_all(${PLUGIN_NAME})
 get_target_property(EDM4HEP_INTERFACE_INCLUDE_DIRECTORIES EDM4HEP::edm4hep INTERFACE_INCLUDE_DIRECTORIES)
 get_target_property(EDM4EIC_INTERFACE_INCLUDE_DIRECTORIES EDM4EIC::edm4eic INTERFACE_INCLUDE_DIRECTORIES)
 
+# Get the datamodel version headers
+set(EDM_VERSION_INCLUDES )
+if(${EDM4HEP_VERSION} VERSION_GREATER_EQUAL "0.9")
+  list(APPEND EDM_VERSION_INCLUDES ${EDM4HEP_INTERFACE_INCLUDE_DIRECTORIES}/edm4hep/EDM4hepVersion.h)
+endif()
+if(${EDM4EIC_VERSION} VERSION_GREATER_EQUAL "2.1.0")
+  list(APPEND EDM_VERSION_INCLUDES ${EDM4EIC_INTERFACE_INCLUDE_DIRECTORIES}/edm4eic/EDM4eicVersion.h)
+endif()
+
 # Generate the datamodel header files.
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/datamodel_glue.h ${CMAKE_CURRENT_BINARY_DIR}/datamodel_includes.h
@@ -39,9 +48,7 @@ add_custom_command(
         EDM4HEP_INCLUDE_DIR=${EDM4HEP_INTERFACE_INCLUDE_DIRECTORIES}
         EDM4EIC_INCLUDE_DIR=${EDM4EIC_INTERFACE_INCLUDE_DIRECTORIES}
     MAIN_DEPENDENCY ${PROJECT_SOURCE_DIR}/make_datamodel_glue.py
-    DEPENDS
-        ${EDM4HEP_INTERFACE_INCLUDE_DIRECTORIES}/edm4hep/EDM4hepVersion.h
-        ${EDM4EIC_INTERFACE_INCLUDE_DIRECTORIES}/edm4eic/EDM4eicVersion.h
+    DEPENDS ${EDM_VERSION_INCLUDES}
 )
 
 # Add include directories (works same as target_include_directories)

--- a/src/services/io/podio/CMakeLists.txt
+++ b/src/services/io/podio/CMakeLists.txt
@@ -33,12 +33,15 @@ get_target_property(EDM4EIC_INTERFACE_INCLUDE_DIRECTORIES EDM4EIC::edm4eic INTER
 
 # Generate the datamodel header files.
 add_custom_command(
-        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/datamodel_glue.h ${CMAKE_CURRENT_BINARY_DIR}/datamodel_includes.h
-        COMMAND python3 ${PROJECT_SOURCE_DIR}/make_datamodel_glue.py
-                WORKING_DIR=${CMAKE_CURRENT_BINARY_DIR}
-                EDM4HEP_INCLUDE_DIR=${EDM4HEP_INTERFACE_INCLUDE_DIRECTORIES}
-                EDM4EIC_INCLUDE_DIR=${EDM4EIC_INTERFACE_INCLUDE_DIRECTORIES}
-        MAIN_DEPENDENCY ${PROJECT_SOURCE_DIR}/make_datamodel_glue.py
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/datamodel_glue.h ${CMAKE_CURRENT_BINARY_DIR}/datamodel_includes.h
+    COMMAND python3 ${PROJECT_SOURCE_DIR}/make_datamodel_glue.py
+        WORKING_DIR=${CMAKE_CURRENT_BINARY_DIR}
+        EDM4HEP_INCLUDE_DIR=${EDM4HEP_INTERFACE_INCLUDE_DIRECTORIES}
+        EDM4EIC_INCLUDE_DIR=${EDM4EIC_INTERFACE_INCLUDE_DIRECTORIES}
+    MAIN_DEPENDENCY ${PROJECT_SOURCE_DIR}/make_datamodel_glue.py
+    DEPENDS
+        ${EDM4HEP_INTERFACE_INCLUDE_DIRECTORIES}/edm4hep/EDM4HEPVersion.h
+        ${EDM4EIC_INTERFACE_INCLUDE_DIRECTORIES}/edm4eic/EDM4EICVersion.h
 )
 
 # Add include directories (works same as target_include_directories)
@@ -53,7 +56,7 @@ root_generate_dictionary(G__datamodel_vectors ${datamodel_BINARY_DIR}/datamodel_
 
 # Install root dictionaries made by PODIO
 set(my_root_dict_files
-        ${PROJECT_BINARY_DIR}/lib${PLUGIN_NAME}_plugin_rdict.pcm
-        ${PROJECT_BINARY_DIR}/lib${PLUGIN_NAME}_plugin.rootmap
-        )
+    ${PROJECT_BINARY_DIR}/lib${PLUGIN_NAME}_plugin_rdict.pcm
+    ${PROJECT_BINARY_DIR}/lib${PLUGIN_NAME}_plugin.rootmap
+)
 install(FILES ${my_root_dict_files} DESTINATION ${PLUGIN_OUTPUT_DIRECTORY})

--- a/src/services/io/podio/CMakeLists.txt
+++ b/src/services/io/podio/CMakeLists.txt
@@ -40,8 +40,8 @@ add_custom_command(
         EDM4EIC_INCLUDE_DIR=${EDM4EIC_INTERFACE_INCLUDE_DIRECTORIES}
     MAIN_DEPENDENCY ${PROJECT_SOURCE_DIR}/make_datamodel_glue.py
     DEPENDS
-        ${EDM4HEP_INTERFACE_INCLUDE_DIRECTORIES}/edm4hep/EDM4HEPVersion.h
-        ${EDM4EIC_INTERFACE_INCLUDE_DIRECTORIES}/edm4eic/EDM4EICVersion.h
+        ${EDM4HEP_INTERFACE_INCLUDE_DIRECTORIES}/edm4hep/EDM4hepVersion.h
+        ${EDM4EIC_INTERFACE_INCLUDE_DIRECTORIES}/edm4eic/EDM4eicVersion.h
 )
 
 # Add include directories (works same as target_include_directories)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This will force rebuilding of the datamodel glue headers in local development copies when the data model changes version.

Depends on:
- [x] upgrade eic-shell to EDM4hep 0.9, https://eicweb.phy.anl.gov/containers/eic_container/-/merge_requests/689
- [x] roll out eic-shell with EDM4hep 0.9 to cvmfs and github actions
- [ ] ~~update minimum required EDM4hep version to 0.9~~ (compatibility is ensured by febc5f78674ab65ede01b617e950fe46564bd38b)
- [x] update EDM4eic to provide version header, https://github.com/eic/EDM4eic/pull/40,
- [x] release new EDM4eic version 2.1.0
- [x] upgrade eic-spack to provide EDM4eic version 2.1.0, https://github.com/eic/eic-spack/pull/521
- [x] upgrade eic-shell to EDM4eic 2.1, https://eicweb.phy.anl.gov/containers/eic_container/-/merge_requests/690
- [x] roll out eic-shell with EDM4eic 2.1 to cvmfs and github actions
- [ ] ~~update minimum required EDM4hep version to 2.1~~ (compatibility is ensured by febc5f78674ab65ede01b617e950fe46564bd38b )

### What kind of change does this PR introduce?
- [x] Bug fix (issue: `cmake --fresh` does not rebuild datamodel glue header when switching datamodel versions)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.