### PR TITLE
fix: allow for = in working dir for datamodel glue

### DIFF
--- a/src/services/io/podio/make_datamodel_glue.py
+++ b/src/services/io/podio/make_datamodel_glue.py
@@ -37,7 +37,6 @@ if EDM4EIC_ROOT :
 for arg in sys.argv:
     if arg.startswith('WORKING_DIR'):
         if '=' in arg: WORKING_DIR = arg.split('=',1)[1]
-        print(WORKING_DIR)
     if arg.startswith('EDM4HEP_INCLUDE_DIR'):
         if '=' in arg: EDM4HEP_INCLUDE_DIR = arg.split('=',1)[1]
     if arg.startswith('EDM4EIC_INCLUDE_DIR'):

--- a/src/services/io/podio/make_datamodel_glue.py
+++ b/src/services/io/podio/make_datamodel_glue.py
@@ -36,11 +36,12 @@ if EDM4EIC_ROOT :
 # poor man's command line parsing
 for arg in sys.argv:
     if arg.startswith('WORKING_DIR'):
-        if '=' in arg: WORKING_DIR = arg.split('=')[1]
+        if '=' in arg: WORKING_DIR = arg.split('=',1)[1]
+        print(WORKING_DIR)
     if arg.startswith('EDM4HEP_INCLUDE_DIR'):
-        if '=' in arg: EDM4HEP_INCLUDE_DIR = arg.split('=')[1]
+        if '=' in arg: EDM4HEP_INCLUDE_DIR = arg.split('=',1)[1]
     if arg.startswith('EDM4EIC_INCLUDE_DIR'):
-        if '=' in arg: EDM4EIC_INCLUDE_DIR = arg.split('=')[1]
+        if '=' in arg: EDM4EIC_INCLUDE_DIR = arg.split('=',1)[1]
 
 # Check if EDM4HEP_ROOT is set
 if not EDM4HEP_INCLUDE_DIR:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
We specify the working dir where datamodel glue headers are written as a key-value pair argument, `WORKING_DIR=dir`. If we then take field 1 after a split on '=', we discard parts of the directory if it contains '=' characters. This fixes the split to only split on the first '=' character.

Use case: when we build a git tag or branch in spack, we give an equivalent version for dependency resolution purposes, e.g `eicrecon@git.feature-branch=v1.4.0`. For the version of spack we are using, this leads to staging directories with that full version string.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: [build failures](https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/1840504))
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.