### PR TITLE
fix: move jana ticker pausing from CKFTracking into ActsGeo service

### DIFF
--- a/src/global/tracking/CKFTracking_factory.cc
+++ b/src/global/tracking/CKFTracking_factory.cc
@@ -85,13 +85,6 @@ void eicrecon::CKFTracking_factory::Process(const std::shared_ptr<const JEvent> 
         acts_track_params.emplace_back(pSurface, params, charge, cov);
     }
 
-    // Reading the geometry may take a long time and if the JANA ticker is enabled, it will keep printing
-    // while no other output is coming which makes it look like something is wrong. Disable the ticker
-    // while parsing and loading the geometry
-    auto tickerEnabled = GetApplication()->IsTickerEnabled();
-    GetApplication()->SetTicker( false );
-
-
     // Convert vector of source links to a sorted in geometry order container used in tracking
     eicrecon::IndexSourceLinkContainer source_links;
     auto measurements_ptr = source_linker_result->measurements;
@@ -125,7 +118,4 @@ void eicrecon::CKFTracking_factory::Process(const std::shared_ptr<const JEvent> 
     catch(std::exception &e) {
         throw JException(e.what());
     }
-
-    // Enable ticker back
-    GetApplication()->SetTicker(tickerEnabled);
 }

--- a/src/services/geometry/acts/ACTSGeo_service.h
+++ b/src/services/geometry/acts/ACTSGeo_service.h
@@ -1,20 +1,5 @@
-//
-//
-// TODO: Fix the following:
-// This class inspired by and benefited from the work done here at the following
-// links. A couple of lines were outright copied.
-//
-// https://eicweb.phy.anl.gov/EIC/juggler/-/blob/master/JugBase/src/components/GeoSvc.h
-// https://eicweb.phy.anl.gov/EIC/juggler/-/blob/master/JugBase/src/components/GeoSvc.cpp
-//
-// Copyright carried by that code:
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2022 Whitney Armstrong, Wouter Deconinck,
-// Copyright 2022, Dmitry Romanov
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
-//
-
+// Copyright (C) 2022 Whitney Armstrong, Wouter Deconinck, Dmitry Romanov
 
 #pragma once
 
@@ -49,12 +34,10 @@ private:
     ACTSGeo_service()=default;
     void acquire_services(JServiceLocator *) override;
 
-    std::once_flag init_flag;
+    std::once_flag m_init_flag;
     JApplication *m_app = nullptr;
     dd4hep::Detector* m_dd4hepGeo = nullptr;
     std::shared_ptr<ActsGeometryProvider> m_acts_provider;
-	//std::shared_ptr<const dd4hep::rec::CellIDPositionConverter> m_cellid_converter = nullptr;
-    //std::vector<std::string> m_xmlFileNames;
 
     // General acts log
     std::shared_ptr<spdlog::logger> m_log;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The reason for pausing the jana ticker is because the ActsGeo takes long to initialize. This moves the pausing to that initialization.

Also, opportunistically:
- renamed class member `init_flag` to `m_init_flag` for consistency,
- removed commented lines,
- corrected license header for explicitly derived code.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: logically incorrect location for addressing this behavior)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No. Maybe during long-duration tracking steps, there will now be tickers shown whereas previously they were suppressed completely during all tracking.