### PR TITLE
feat: convert CKFTracking factory to multifactory

### DIFF
--- a/src/global/tracking/CKFTracking_factory.cc
+++ b/src/global/tracking/CKFTracking_factory.cc
@@ -21,9 +21,6 @@ void eicrecon::CKFTracking_factory::Init() {
     std::string plugin_name = GetPluginName();
     std::string param_prefix = plugin_name+ ":" + GetTag();
 
-    // Initialize input tags
-    InitDataTags(param_prefix);
-
     // Initialize logger
     InitLogger(app, param_prefix, "info");
 
@@ -41,10 +38,6 @@ void eicrecon::CKFTracking_factory::Init() {
     // Initialize algorithm
     m_tracking_algo.applyConfig(cfg);
     m_tracking_algo.init(acts_service->actsGeoProvider(), m_log);
-}
-
-void eicrecon::CKFTracking_factory::ChangeRun(const std::shared_ptr<const JEvent> &event) {
-
 }
 
 void eicrecon::CKFTracking_factory::Process(const std::shared_ptr<const JEvent> &event) {
@@ -113,7 +106,7 @@ void eicrecon::CKFTracking_factory::Process(const std::shared_ptr<const JEvent> 
                 acts_track_params);
 
         // Save the result
-        Set(trajectories);
+        SetData(GetOutputTags()[0], trajectories);
     }
     catch(std::exception &e) {
         throw JException(e.what());

--- a/src/global/tracking/CKFTracking_factory.h
+++ b/src/global/tracking/CKFTracking_factory.h
@@ -11,25 +11,29 @@
 #include "algorithms/tracking/TrackerSourceLinkerResult.h"
 
 #include "extensions/spdlog/SpdlogMixin.h"
-#include "extensions/jana/JChainFactoryT.h"
-
+#include "extensions/jana/JChainMultifactoryT.h"
 
 namespace eicrecon {
 
     class CKFTracking_factory :
-            public JChainFactoryT<eicrecon::TrackingResultTrajectory, CKFTrackingConfig, JFactoryT>,
+            public JChainMultifactoryT<CKFTrackingConfig>,
             public SpdlogMixin {
 
     public:
-        CKFTracking_factory( std::vector<std::string> default_input_tags, CKFTrackingConfig cfg):
-                JChainFactoryT<eicrecon::TrackingResultTrajectory, CKFTrackingConfig, JFactoryT>(std::move(default_input_tags), cfg ) {
+
+        explicit CKFTracking_factory(
+            std::string tag,
+            const std::vector<std::string>& input_tags,
+            const std::vector<std::string>& output_tags,
+            CKFTrackingConfig cfg)
+        : JChainMultifactoryT<CKFTrackingConfig>(std::move(tag), input_tags, output_tags, cfg) {
+
+            DeclareOutput<eicrecon::TrackingResultTrajectory>(GetOutputTags()[0]);
+
         }
 
         /** One time initialization **/
         void Init() override;
-
-        /** On run change preparations **/
-        void ChangeRun(const std::shared_ptr<const JEvent> &event) override;
 
         /** Event by event processing **/
         void Process(const std::shared_ptr<const JEvent> &event) override;

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -54,14 +54,32 @@ void InitPlugin(JApplication *app) {
     app->Add(new JChainFactoryGeneratorT<TrackerSourceLinker_factory>(
             {"CentralTrackingRecHits"}, "CentralTrackerSourceLinker"));
 
-    app->Add(new JChainFactoryGeneratorT<CKFTracking_factory>(
-            {"InitTrackParams", "CentralTrackerSourceLinker"}, "CentralCKFTrajectories"));
+    app->Add(new JChainMultifactoryGeneratorT<CKFTracking_factory>(
+        "CentralCKFTrajectories",
+        {
+            "InitTrackParams",
+            "CentralTrackerSourceLinker"
+        },
+        {
+            "CentralCKFTrajectories"
+        },
+        app
+    ));
 
     app->Add(new JChainFactoryGeneratorT<TrackSeeding_factory>(
             {"CentralTrackingRecHits"}, "CentralTrackSeedingResults"));
 
-    app->Add(new JChainFactoryGeneratorT<CKFTracking_factory>(
-            {"CentralTrackSeedingResults", "CentralTrackerSourceLinker"}, "CentralCKFSeededTrajectories"));
+    app->Add(new JChainMultifactoryGeneratorT<CKFTracking_factory>(
+        "CentralCKFSeededTrajectories",
+        {
+            "CentralTrackSeedingResults",
+            "CentralTrackerSourceLinker"
+        },
+        {
+            "CentralCKFSeededTrajectories"
+        },
+        app
+    ));
 
     app->Add(new JChainFactoryGeneratorT<TrackProjector_factory>(
             {"CentralCKFTrajectories"}, "CentralTrackSegments"));


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This converts the CKFTracking factory to a multifactory without any other changes. This is a preparation for a next changes that has the CKFTracking factory emit also podio collections.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: CKFTracking multifactory can accommodate podio outputs)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.