### PR TITLE
services/log: remove timestamp from log messages, allow configuring format

### DIFF
--- a/src/services/log/Log_service.cc
+++ b/src/services/log/Log_service.cc
@@ -16,6 +16,10 @@ Log_service::Log_service(JApplication *app) {
     m_log_level_str = "info";
     m_application->SetDefaultParameter("eicrecon:LogLevel", m_log_level_str, "log_level: trace, debug, info, warn, error, critical, off");
     spdlog::default_logger()->set_level(eicrecon::ParseLogLevel(m_log_level_str));
+
+    m_log_format_str = "[%n] [%^%l%$] %v";
+    m_application->SetDefaultParameter("eicrecon:LogFormat", m_log_level_str, "spdlog pattern string");
+    spdlog::set_pattern(m_log_format_str);
 }
 
 

--- a/src/services/log/Log_service.h
+++ b/src/services/log/Log_service.h
@@ -36,4 +36,5 @@ private:
     std::recursive_mutex m_lock;
     JApplication* m_application;
     std::string m_log_level_str;
+    std::string m_log_format_str;
 };


### PR DESCRIPTION
During development, it is often needed to diff log files, which can be cumbersome if timestamps are printed. It doesn't seem like we have a strong need to get timestamps in the production logs at the time, but if that will be needed, it can now be re-enabled using eicrecon::LogFormat option.