### PR TITLE
fix: rm unused output{Seeded}Particles from TrackingResult_factory

### DIFF
--- a/src/algorithms/tracking/ParticlesFromTrackFit.cc
+++ b/src/algorithms/tracking/ParticlesFromTrackFit.cc
@@ -29,10 +29,9 @@ void eicrecon::Reco::ParticlesFromTrackFit::init(std::shared_ptr<spdlog::logger>
     m_log = log;
 }
 
-ParticlesFromTrackFitResult eicrecon::Reco::ParticlesFromTrackFit::execute(const std::vector<const eicrecon::TrackingResultTrajectory *> &trajectories) {
+std::unique_ptr<edm4eic::TrackParametersCollection> eicrecon::Reco::ParticlesFromTrackFit::execute(const std::vector<const eicrecon::TrackingResultTrajectory *> &trajectories) {
 
-    // create output collections
-    auto rec_parts = std::make_unique<edm4eic::ReconstructedParticleCollection >();
+    // create output collection
     auto track_pars = std::make_unique<edm4eic::TrackParametersCollection>();
 
     m_log->debug("Trajectories size: {}", std::size(trajectories));
@@ -107,35 +106,7 @@ ParticlesFromTrackFitResult eicrecon::Reco::ParticlesFromTrackFit::execute(const
             track_pars->push_back(pars);
         }
 
-        auto tsize = trackTips.size();
-        m_log->debug("# fitted parameters : {}", tsize);
-
-        if (tsize == 0) {
-            continue;
-        }
-
-        mj.visitBackwards(tsize - 1, [&](auto&& trackstate) {
-            // debug() << trackstate.hasPredicted() << endmsg;
-            // debug() << trackstate.predicted() << endmsg;
-            auto params = trackstate.predicted(); //<< endmsg;
-
-            double p0 = (1.0 / params[Acts::eBoundQOverP]) / Acts::UnitConstants::GeV;
-            m_log->debug("track predicted p = {} GeV", p0);
-            if (std::abs(p0) > 500) {
-                m_log->debug("skipping!");
-                return;
-            }
-
-            auto rec_part = rec_parts->create();
-            rec_part.setMomentum(
-                    edm4eic::sphericalToVector(
-                            1.0 / std::abs(params[Acts::eBoundQOverP]),
-                            params[Acts::eBoundTheta],
-                            params[Acts::eBoundPhi])
-            );
-            rec_part.setCharge(static_cast<int16_t>(std::copysign(1., params[Acts::eBoundQOverP])));
-        });
     }
 
-    return std::make_pair(std::move(rec_parts), std::move(track_pars));
+    return std::move(track_pars);
 }

--- a/src/algorithms/tracking/ParticlesFromTrackFit.h
+++ b/src/algorithms/tracking/ParticlesFromTrackFit.h
@@ -12,9 +12,6 @@
 #include "JugTrack/TrackingResultTrajectory.hpp"
 
 
-using ParticlesFromTrackFitResult = std::pair<std::unique_ptr<edm4eic::ReconstructedParticleCollection>,
-                                              std::unique_ptr<edm4eic::TrackParametersCollection>>;
-
 namespace eicrecon::Reco {
 
     /** Extract the particles form fit trajectories.
@@ -29,7 +26,7 @@ namespace eicrecon::Reco {
     public:
         void init(std::shared_ptr<spdlog::logger> log);
 
-        ParticlesFromTrackFitResult execute(const std::vector<const eicrecon::TrackingResultTrajectory *> &trajectories);
+        std::unique_ptr<edm4eic::TrackParametersCollection> execute(const std::vector<const eicrecon::TrackingResultTrajectory *> &trajectories);
 
     };
 } // namespace Jug::Reco

--- a/src/benchmarks/reconstruction/tracking_efficiency/TrackingEfficiency_processor.cc
+++ b/src/benchmarks/reconstruction/tracking_efficiency/TrackingEfficiency_processor.cc
@@ -67,7 +67,7 @@ void TrackingEfficiency_processor::Process(const std::shared_ptr<const JEvent>& 
 
     // EXAMPLE I
     // This is access to for final result of the calculation/data transformation of central detector CFKTracking:
-    auto reco_particles = event->Get<edm4eic::ReconstructedParticle>("outputParticles");
+    auto reco_particles = event->Get<edm4eic::ReconstructedParticle>("ReconstructedChargedParticles");
 
     m_log->debug("Tracking reconstructed particles N={}: ", reco_particles.size());
     m_log->debug("   {:<5} {:>8} {:>8} {:>8} {:>8} {:>8}","[i]", "[px]", "[py]", "[pz]", "[P]", "[P*3]");

--- a/src/global/tracking/TrackingResult_factory.cc
+++ b/src/global/tracking/TrackingResult_factory.cc
@@ -26,9 +26,8 @@ void TrackingResult_factory::Process(const std::shared_ptr<const JEvent> &event)
     try {
         // Collect all hits
         auto trajectories = event->Get<eicrecon::TrackingResultTrajectory>(input_tag);
-        auto result = m_particle_maker_algo.execute(trajectories);
-        SetCollection<edm4eic::ReconstructedParticle>(GetOutputTags()[0], std::move(result.first));
-        SetCollection<edm4eic::TrackParameters>(GetOutputTags()[1], std::move(result.second));
+        auto track_params = m_particle_maker_algo.execute(trajectories);
+        SetCollection<edm4eic::TrackParameters>(GetOutputTags()[0], std::move(track_params));
     }
     catch(std::exception &e) {
         throw JException(e.what());

--- a/src/global/tracking/TrackingResult_factory.h
+++ b/src/global/tracking/TrackingResult_factory.h
@@ -17,8 +17,7 @@ public:
                                     const std::vector<std::string>& output_tags):
     JChainMultifactoryT(std::move(tag), input_tags, output_tags) {
 
-        DeclarePodioOutput<edm4eic::ReconstructedParticle>(GetOutputTags()[0]);
-        DeclarePodioOutput<edm4eic::TrackParameters>(GetOutputTags()[1]);
+        DeclarePodioOutput<edm4eic::TrackParameters>(GetOutputTags()[0]);
     }
 
 

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -90,8 +90,7 @@ void InitPlugin(JApplication *app) {
     app->Add(new JChainMultifactoryGeneratorT<TrackingResult_factory>(
             "CentralTrackingParticles",                       // Tag name for multifactory
             {"CentralCKFTrajectories"},                       // eicrecon::TrackingResultTrajectory
-            {"outputParticles",                               // edm4eic::ReconstructedParticle
-             "outputTrackParameters"},                        // edm4eic::TrackParameters
+            {"outputTrackParameters"},                        // edm4eic::TrackParameters
             app));
 
     app->Add(new JChainMultifactoryGeneratorT<ParticlesWithTruthPID_factory>(
@@ -107,8 +106,7 @@ void InitPlugin(JApplication *app) {
     app->Add(new JChainMultifactoryGeneratorT<TrackingResult_factory>(
             "CentralTrackingParticles",                       // Tag name for multifactory
             {"CentralCKFSeededTrajectories"},                 // eicrecon::TrackingResultTrajectory
-            {"outputSeededParticles",                         // edm4eic::ReconstructedParticle
-             "outputSeededTrackParameters"},                  // edm4eic::TrackParameters
+            {"outputSeededTrackParameters"},                  // edm4eic::TrackParameters
             app));
 
     app->Add(new JChainMultifactoryGeneratorT<ParticlesWithTruthPID_factory>(


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This removes the unused output{Seeded}Particles collection from the tracking plugin, and removes the ReconstructedParticle output from the TrackingResult algorithm and factory.

The construction of ReconstructedParticles (which includes PID information) is not something that should be done at this stage of the track reconstruction chain (and indeed the results are ignored).

The `TrackingEfficiency_processor` was updated to process the `ReconstructedChargedParticles` collection which is (later) produced from tracks.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: unused collection, incorrect use of ReconstructedParticles)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.