### PR TITLE
CalorimeterHitDigi: use energy same smearing in signal_sum_digi as in single_hits_digi

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -198,10 +198,12 @@ std::unique_ptr<edm4hep::RawCalorimeterHitCollection> CalorimeterHitDigi::signal
 
         // safety check
         const double eResRel = (edep > m_cfg.threshold)
-                ? m_normDist(generator) * m_cfg.eRes[0] / std::sqrt(edep) +
-                  m_normDist(generator) * m_cfg.eRes[1] +
-                  m_normDist(generator) * m_cfg.eRes[2] / edep
-                  : 0;
+                ? m_normDist(generator) * std::sqrt(
+                     std::pow(m_cfg.eRes[0] / std::sqrt(edep), 2) +
+                     std::pow(m_cfg.eRes[1], 2) +
+                     std::pow(m_cfg.eRes[2] / (edep), 2)
+                  )
+                : 0;
         double    ped     = m_cfg.pedMeanADC + m_normDist(generator) * m_cfg.pedSigmaADC;
         unsigned long long adc     = std::llround(ped + edep * (m_cfg.corrMeanScale + eResRel) / m_cfg.dyRangeADC * m_cfg.capADC);
         unsigned long long tdc     = std::llround((time + m_normDist(generator) * tRes) * stepTDC);


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Towards the goal of unifying the two code patch, this changes signal_sum_digi to have an identical smearing using only a single random number. Both procedures are mathematically identical for large samples, but using a single number is simpler.



### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
not in a significant way