### PR TITLE
CalorimeterHitDigi: remove duplicate calculation from signal_sum_digi

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -185,11 +185,6 @@ std::unique_ptr<edm4hep::RawCalorimeterHitCollection> CalorimeterHitDigi::signal
             if (hit.getEnergy() > max_edep) {
                 max_edep = hit.getEnergy();
                 mid = hit.getCellID();
-                for (const auto& c : hit.getContributions()) {
-                    if (c.getTime() <= time) {
-                        time = c.getTime();
-                    }
-                }
                 if (timeC <= time) {
                     time = timeC;
                 }


### PR DESCRIPTION
There is no point to iterate over hit contributions twice - `timeC` already contains the earliest time.

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators @FriederikeBock @steinber @rymilton

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No