### PR TITLE
CalorimeterHitDigi: don't add a hit when none of the merged hits meet the timing requirement

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -190,6 +190,7 @@ std::unique_ptr<edm4hep::RawCalorimeterHitCollection> CalorimeterHitDigi::signal
                 }
             }
         }
+        if (time > m_cfg.capTime) continue;
 
         // safety check
         const double eResRel = (edep > m_cfg.threshold)


### PR DESCRIPTION
There was an edge case when all hits could be skipped in the previous loop and then the algorithm would still proceed to add a hit with edep=0. Most common case to trigger that, would be if there is only a single hit (e.g. if we were to use this code path for calorimeters for which the hit merging is not required).

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators @FriederikeBock @steinber @rymilton

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No