### PR TITLE
fix: mv init TrackParameters edm4eic to ActsExamples conversion into algorithm

### DIFF
--- a/src/algorithms/tracking/CKFTracking.h
+++ b/src/algorithms/tracking/CKFTracking.h
@@ -20,8 +20,8 @@
 #include "ActsExamples/EventData/Trajectories.hpp"
 
 #include <edm4eic/TrackerHitCollection.h>
-#include <edm4eic/TrackParameters.h>
-#include <edm4eic/Trajectory.h>
+#include <edm4eic/TrackParametersCollection.h>
+#include <edm4eic/TrajectoryCollection.h>
 #include <spdlog/logger.h>
 
 #include <Acts/Definitions/Common.hpp>
@@ -75,7 +75,7 @@ namespace eicrecon {
 
         std::vector<ActsExamples::Trajectories*> process(const ActsExamples::IndexSourceLinkContainer &src_links,
                                                                  const ActsExamples::MeasurementContainer &measurements,
-                                                                 const ActsExamples::TrackParametersContainer &init_trk_params);
+                                                                 const edm4eic::TrackParametersCollection &init_trk_params);
 
     private:
         std::shared_ptr<spdlog::logger> m_log;

--- a/src/global/tracking/CKFTracking_factory.cc
+++ b/src/global/tracking/CKFTracking_factory.cc
@@ -50,34 +50,6 @@ void eicrecon::CKFTracking_factory::Process(const std::shared_ptr<const JEvent> 
         return;
     }
 
-    ActsExamples::TrackParametersContainer acts_track_params;
-    for (const auto& track_parameter: *track_parameters) {
-
-        Acts::BoundVector params;
-        params(Acts::eBoundLoc0)   = track_parameter.getLoc().a * Acts::UnitConstants::mm;  // cylinder radius
-        params(Acts::eBoundLoc1)   = track_parameter.getLoc().b * Acts::UnitConstants::mm;  // cylinder length
-        params(Acts::eBoundTheta)  = track_parameter.getTheta();
-        params(Acts::eBoundPhi)    = track_parameter.getPhi();
-        params(Acts::eBoundQOverP) = track_parameter.getQOverP() / Acts::UnitConstants::GeV;
-        params(Acts::eBoundTime)   = track_parameter.getTime() * Acts::UnitConstants::ns;
-
-        double charge = track_parameter.getCharge();
-
-        Acts::BoundSymMatrix cov                    = Acts::BoundSymMatrix::Zero();
-        cov(Acts::eBoundLoc0, Acts::eBoundLoc0)     = std::pow( track_parameter.getLocError().xx ,2)*Acts::UnitConstants::mm*Acts::UnitConstants::mm;
-        cov(Acts::eBoundLoc1, Acts::eBoundLoc1)     = std::pow( track_parameter.getLocError().yy,2)*Acts::UnitConstants::mm*Acts::UnitConstants::mm;
-        cov(Acts::eBoundTheta, Acts::eBoundTheta)   = std::pow( track_parameter.getMomentumError().xx,2);
-        cov(Acts::eBoundPhi, Acts::eBoundPhi)       = std::pow( track_parameter.getMomentumError().yy,2);
-        cov(Acts::eBoundQOverP, Acts::eBoundQOverP) = std::pow( track_parameter.getMomentumError().zz,2) / (Acts::UnitConstants::GeV*Acts::UnitConstants::GeV);
-        cov(Acts::eBoundTime, Acts::eBoundTime)     = std::pow( track_parameter.getTimeError(),2)*Acts::UnitConstants::ns*Acts::UnitConstants::ns;
-
-        // Construct a perigee surface as the target surface
-        auto pSurface = Acts::Surface::makeShared<const Acts::PerigeeSurface>(Acts::Vector3(0,0,0));
-
-        // Create parameters
-        acts_track_params.emplace_back(pSurface, params, charge, cov);
-    }
-
     // Convert vector of source links to a sorted in geometry order container used in tracking
     ActsExamples::IndexSourceLinkContainer source_links;
     auto measurements_ptr = source_linker_result->measurements;
@@ -103,7 +75,7 @@ void eicrecon::CKFTracking_factory::Process(const std::shared_ptr<const JEvent> 
         auto trajectories = m_tracking_algo.process(
                 source_links,
                 *source_linker_result->measurements,
-                acts_track_params);
+                *track_parameters);
 
         // Save the result
         SetData(GetOutputTags()[0], trajectories);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This moves the conversion of the initial track parameters into ActsExamples structures from the CKFTracking factory into the algorithm, for improved modularity and algorithm reuse. No other changes. Diffs should come back clean.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.