### PR TITLE
ci: don't fail when if_no_artifact_found: warn

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -341,12 +341,12 @@ jobs:
         name: rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
         if_no_artifact_found: warn
     - uses: actions/checkout@v3
-      if: steps.download_previous_artifact.outputs.found_artifact == true
+      if: steps.download_previous_artifact.outputs.found_artifact == 'true'
       with:
         repository: 'eic/epic-capybara'
         path: epic-capybara
     - uses: eic/run-cvmfs-osg-eic-shell@main
-      if: steps.download_previous_artifact.outputs.found_artifact == true
+      if: steps.download_previous_artifact.outputs.found_artifact == 'true'
       with:
         platform-release: "jug_xl:nightly"
         setup: /opt/detector/setup.sh

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -448,17 +448,21 @@ jobs:
           *.dot
           *.svg
         if-no-files-found: error
-    - uses: actions/checkout@v3
-      with:
-        repository: 'eic/epic-capybara'
-        path: epic-capybara
-    - uses: dawidd6/action-download-artifact@v2
+    - name: Download previous artifact
+      id: download_previous_artifact
+      uses: dawidd6/action-download-artifact@v2
       with:
         branch: ${{ github.event.pull_request.base.ref || github.ref_name }}
         path: ref/
         name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root
         if_no_artifact_found: warn
+    - uses: actions/checkout@v3
+      if: steps.download_previous_artifact.outputs.found_artifact == 'true'
+      with:
+        repository: 'eic/epic-capybara'
+        path: epic-capybara
     - uses: eic/run-cvmfs-osg-eic-shell@main
+      if: steps.download_previous_artifact.outputs.found_artifact == 'true'
       with:
         platform-release: "jug_xl:nightly"
         setup: /opt/detector/setup.sh

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -332,17 +332,21 @@ jobs:
           *.dot
           *.svg
         if-no-files-found: error
-    - uses: dawidd6/action-download-artifact@v2
+    - name: Download previous artifact
+      id: download_previous_artifact
+      uses: dawidd6/action-download-artifact@v2
       with:
         branch: ${{ github.event.pull_request.base.ref || github.ref_name }}
         path: ref/
         name: rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
         if_no_artifact_found: warn
     - uses: actions/checkout@v3
+      if: steps.download_previous_artifact.outputs.found_artifact == true
       with:
         repository: 'eic/epic-capybara'
         path: epic-capybara
     - uses: eic/run-cvmfs-osg-eic-shell@main
+      if: steps.download_previous_artifact.outputs.found_artifact == true
       with:
         platform-release: "jug_xl:nightly"
         setup: /opt/detector/setup.sh


### PR DESCRIPTION
### Briefly, what does this PR introduce?
We set `if_no_artifact_found: warn` on the action-download-artifact (when the default is `fail`), but then we fail anyway because the next step can't find the file. If we don't want to fail, we shouldn't run the next step.

TODO:
- [x] apply to all

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/EICrecon/actions/runs/5893882391/job/15987488862)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.