### PR TITLE
CalorimeterHitDigi: unified code path for digitization with and without the hit merging

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -59,7 +59,7 @@ void CalorimeterHitDigi::init(const dd4hep::Detector* detector, std::shared_ptr<
     tRes       = m_cfg.tRes / dd4hep::ns;
     stepTDC    = dd4hep::ns / m_cfg.resolutionTDC;
 
-    id_mask = 0;
+    decltype(id_mask) id_inverse_mask = 0;
     // all these are for signal sum at digitization level
     if (!m_cfg.fields.empty()) {
         // sanity checks
@@ -76,7 +76,7 @@ void CalorimeterHitDigi::init(const dd4hep::Detector* detector, std::shared_ptr<
         try {
             auto id_desc = m_detector->readout(m_cfg.readout).idSpec();
             for (auto & field : m_cfg.fields) {
-                id_mask |= id_desc.field(field)->mask();
+                id_inverse_mask |= id_desc.field(field)->mask();
             }
         } catch (...) {
             // a workaround to avoid breaking the whole analysis if a field is not in some configurations
@@ -87,7 +87,7 @@ void CalorimeterHitDigi::init(const dd4hep::Detector* detector, std::shared_ptr<
         }
         m_log->info("ID mask in {:s}: {:#064b}", m_cfg.readout, id_mask);
     }
-    id_mask = ~id_mask;
+    id_mask = ~id_inverse_mask;
 }
 
 

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -59,8 +59,8 @@ void CalorimeterHitDigi::init(const dd4hep::Detector* detector, std::shared_ptr<
     tRes       = m_cfg.tRes / dd4hep::ns;
     stepTDC    = dd4hep::ns / m_cfg.resolutionTDC;
 
+    id_mask = 0;
     // all these are for signal sum at digitization level
-    merge_hits = false;
     if (!m_cfg.fields.empty()) {
         // sanity checks
         if (!m_detector) {
@@ -75,7 +75,6 @@ void CalorimeterHitDigi::init(const dd4hep::Detector* detector, std::shared_ptr<
         // get decoders
         try {
             auto id_desc = m_detector->readout(m_cfg.readout).idSpec();
-            id_mask = 0;
             for (auto & field : m_cfg.fields) {
                 id_mask |= id_desc.field(field)->mask();
             }
@@ -86,64 +85,13 @@ void CalorimeterHitDigi::init(const dd4hep::Detector* detector, std::shared_ptr<
             // throw::runtime_error(fmt::format("Failed to load ID decoder for {}", m_cfg.readout));
             return;
         }
-        id_mask = ~id_mask;
         m_log->info("ID mask in {:s}: {:#064b}", m_cfg.readout, id_mask);
-        // all checks passed
-        merge_hits = true;
     }
+    id_mask = ~id_mask;
 }
 
 
 std::unique_ptr<edm4hep::RawCalorimeterHitCollection> CalorimeterHitDigi::process(const edm4hep::SimCalorimeterHitCollection &simhits)  {
-    if (merge_hits) {
-        return std::move(signal_sum_digi(simhits));
-    } else {
-        return std::move(single_hits_digi(simhits));
-    }
-}
-
-std::unique_ptr<edm4hep::RawCalorimeterHitCollection> CalorimeterHitDigi::single_hits_digi(const edm4hep::SimCalorimeterHitCollection &simhits)  {
-    std::unique_ptr<edm4hep::RawCalorimeterHitCollection> rawhits { std::make_unique<edm4hep::RawCalorimeterHitCollection>() };
-
-     // Create output collections
-    for (const auto &ahit : simhits) {
-        // Note: juggler internal unit of energy is dd4hep::GeV
-        const double eDep    = ahit.getEnergy();
-
-        // apply additional calorimeter noise to corrected energy deposit
-        const double eResRel = (eDep > m_cfg.threshold)
-                               ? m_normDist(generator) * std::sqrt(
-                                    std::pow(m_cfg.eRes[0] / std::sqrt(eDep), 2) +
-                                    std::pow(m_cfg.eRes[1], 2) +
-                                    std::pow(m_cfg.eRes[2] / (eDep), 2)
-                                 )
-                               : 0;
-
-        const double ped    = m_cfg.pedMeanADC + m_normDist(generator) * m_cfg.pedSigmaADC;
-        const long long adc = std::llround(ped + eDep * (m_cfg.corrMeanScale + eResRel) / m_cfg.dyRangeADC * m_cfg.capADC);
-
-        double time = std::numeric_limits<double>::max();
-        for (const auto& c : ahit.getContributions()) {
-            if (c.getTime() <= time) {
-                time = c.getTime();
-            }
-        }
-        if (time > m_cfg.capTime) continue;
-
-        const long long tdc = std::llround((time + m_normDist(generator) * tRes) * stepTDC);
-
-        if (eDep> 1.e-3) m_log->trace("E sim {} \t adc: {} \t time: {}\t maxtime: {} \t tdc: {} \t cell ID {}", eDep, adc, time, m_cfg.capTime, tdc, ahit.getCellID());
-        rawhits->create(
-                ahit.getCellID(),
-                (adc > m_cfg.capADC ? m_cfg.capADC : adc),
-                tdc
-        );
-    }
-
-    return std::move(rawhits);
-}
-
-std::unique_ptr<edm4hep::RawCalorimeterHitCollection> CalorimeterHitDigi::signal_sum_digi(const edm4hep::SimCalorimeterHitCollection &simhits)  {
     auto rawhits = std::make_unique<edm4hep::RawCalorimeterHitCollection>();
 
     // find the hits that belong to the same group (for merging)

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.h
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.h
@@ -37,8 +37,6 @@ namespace eicrecon {
 
     // unitless counterparts of inputs
     double           dyRangeADC{0}, stepTDC{0}, tRes{0};
-    // variables for merging at digitization step
-    bool             merge_hits = false;
 
     uint64_t         id_mask{0};
 
@@ -48,9 +46,6 @@ namespace eicrecon {
 
     std::default_random_engine generator; // TODO: need something more appropriate here
     std::normal_distribution<double> m_normDist; // defaults to mean=0, sigma=1
-
-    std::unique_ptr<edm4hep::RawCalorimeterHitCollection> single_hits_digi(const edm4hep::SimCalorimeterHitCollection &simhits);
-    std::unique_ptr<edm4hep::RawCalorimeterHitCollection> signal_sum_digi(const edm4hep::SimCalorimeterHitCollection &simhits);
 
   };
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This should be easier to maintain. We probably could even refactor merging into
a separate algorithm, if we wanted to.

A side effect of this is that non-merging digitization now reorders hits (the
cell id is used as a key for an std::unordered_map).

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @Chao1009 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
Yes, the hits will be reordered.