### PR TITLE
fix: apply the specified time resolutions to tracking reco algorithm

### DIFF
--- a/src/algorithms/tracking/TrackerHitReconstruction.h
+++ b/src/algorithms/tracking/TrackerHitReconstruction.h
@@ -41,6 +41,9 @@ namespace eicrecon {
         /// Get a configuration to be changed
         eicrecon::TrackerHitReconstructionConfig& getConfig() {return m_cfg;}
 
+        /// Set a configuration
+        eicrecon::TrackerHitReconstructionConfig& applyConfig(eicrecon::TrackerHitReconstructionConfig& cfg) {m_cfg = cfg; return m_cfg;}
+
     private:
         /** configuration parameters **/
         eicrecon::TrackerHitReconstructionConfig m_cfg;

--- a/src/global/tracking/TrackerHitReconstruction_factory.cc
+++ b/src/global/tracking/TrackerHitReconstruction_factory.cc
@@ -18,7 +18,9 @@ void TrackerHitReconstruction_factory::Init() {
     auto param_prefix = GetDefaultParameterPrefix();
 
     // Set time resolution
-    app->SetDefaultParameter(param_prefix + ":TimeResolution", m_reco_algo.getConfig().time_resolution, "threshold");
+    auto cfg = GetDefaultConfig();
+    app->SetDefaultParameter(param_prefix + ":TimeResolution", cfg.time_resolution, "threshold");
+    m_reco_algo.applyConfig(cfg);
 
     // Init logger from default or user parameters
     InitLogger(app, param_prefix);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The time resolution specified on the command line or in the tracking.cc file was ignored for the tracker hit reconstruction (only). This fixes that issue so the timeError is set correctly when the hits are sent to ACTS for track fitting.

Changes in the output to be expected:
- timeError in B0, TOF endcap (all others are set to default values),
- potential for different track fit parameters downstream of these collections.

Ref https://github.com/eic/EICrecon/pull/840#issuecomment-1692340071, bullet 1.

TODO:
- [x] Merge #869 first

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @veprbl @kkauder 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, this will cause B0 and TOF time to be as set in tracking.cc, i.e.
```
src/detectors/B0TRK/B0TRK.cc:    hit_reco_cfg.time_resolution = 8;
src/detectors/ECTOF/ECTOF.cc:    hit_reco_cfg.time_resolution = 0.025;
```