### PR TITLE
fix(dRICH): `CentralCKFTrajectories` -> `CentralCKFActsTrajectories`

### DIFF
--- a/src/detectors/DRICH/DRICH.cc
+++ b/src/detectors/DRICH/DRICH.cc
@@ -109,7 +109,7 @@ extern "C" {
     // charged particle tracks
     app->Add(new JChainMultifactoryGeneratorT<RichTrack_factory>(
           "DRICHTracks",
-          {"CentralCKFTrajectories"},
+          {"CentralCKFActsTrajectories"},
           {"DRICHAerogelTracks", "DRICHGasTracks"},
           track_cfg,
           app

--- a/src/detectors/DRICH/README.md
+++ b/src/detectors/DRICH/README.md
@@ -30,7 +30,7 @@ flowchart TB
   subgraph Inputs
     direction LR
     SimHits(<strong>DRICHHits</strong><br/>MC dRICH photon hits<br/>edm4hep::SimTrackerHit):::col
-    Trajectories(<strong>CentralCKFTrajectories</strong><br/>ActsExamples::Trajectories):::col
+    Trajectories(<strong>CentralCKFActsTrajectories</strong><br/>ActsExamples::Trajectories):::col
     MCParts(<strong>MCParticles</strong><br/>MC True Particles<br/>edm4hep::MCParticles):::col
   end
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Fix dRICH track propagation by using `CentralCKFActsTrajectories` instead of `CentralCKFTrajectories`

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
yes, should restore functionality to dRICH