### PR TITLE
Update BHCal energy thresholds

### DIFF
--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -23,6 +23,7 @@ extern "C" {
           {
             .eRes = {},
             .tRes = 0.0 * dd4hep::ns,
+            .threshold = 5.0 * dd4hep::MeV,
             .capADC = 65536,
             .capTime = 100, // given in ns, 4 samples in HGCROC
             .dyRangeADC = 1.0 * dd4hep::GeV,
@@ -74,7 +75,7 @@ extern "C" {
             .localDistXY = {15*dd4hep::mm, 15*dd4hep::mm},
             .dimScaledLocalDistXY = {50.0*dd4hep::mm, 50.0*dd4hep::mm},
             .splitCluster = false,
-            .minClusterHitEdep = 3.0 * dd4hep::MeV,
+            .minClusterHitEdep = 5.0 * dd4hep::MeV,
             .minClusterCenterEdep = 30.0 * dd4hep::MeV,
             .transverseEnergyProfileMetric = "globalDistEtaPhi",
             .transverseEnergyProfileScale = 1.,


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This PR updates the BHCal minimum energy thresholds applied during digitizaiton and clustering based on discussions from the calorimeter and background working groups (see [this spreadsheet](https://docs.google.com/spreadsheets/d/1s8oXj36SqIh7TJeHFH89gQ_ayU1_SVEpWQNkx6sETKs/edit?pli=1#gid=238482234)).

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [X] Other: Updating default values

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [X] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No.

### Does this PR change default behavior?

Yes. Only tiles with at least 5 MeV deposited in them will be digitized and passed on to reconstruction.