### PR TITLE
fix: link DIRC/DRICH detectors against digi_library with PhotoMultiplierDigi_factory

### DIFF
--- a/src/detectors/DIRC/CMakeLists.txt
+++ b/src/detectors/DIRC/CMakeLists.txt
@@ -14,3 +14,8 @@ plugin_glob_all(${PLUGIN_NAME})
 # Find dependencies
 plugin_add_event_model(${PLUGIN_NAME})
 plugin_add_dd4hep(${PLUGIN_NAME})
+
+# Add libraries
+plugin_link_libraries(${PLUGIN_NAME}
+    digi_library
+)

--- a/src/detectors/DRICH/CMakeLists.txt
+++ b/src/detectors/DRICH/CMakeLists.txt
@@ -16,3 +16,8 @@ plugin_add_irt(${PLUGIN_NAME})
 plugin_add_event_model(${PLUGIN_NAME})
 plugin_add_dd4hep(${PLUGIN_NAME})
 plugin_add_acts(${PLUGIN_NAME})
+
+# Add libraries
+plugin_link_libraries(${PLUGIN_NAME}
+    digi_library
+)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Link the DIRC and DRICH detector plugins against the src/global/digi library to resolve PhotoMultiplierDigi factory.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #884)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @veprbl 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.