### PR TITLE
fix: don't try to write non-existent collections

### DIFF
--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -59,8 +59,6 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "ForwardMPGDEndcapRecHits",
 
             // Forward & Far forward hits
-            "ForwardOffMTrackerRecHits",
-            "ForwardRomanPotRecHits",
             "B0TrackerRecHits",
 
             //
@@ -120,7 +118,6 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "EcalBarrelImagingClusterAssociations",
             "EcalBarrelScFiRawHits",
             "EcalBarrelScFiRecHits",
-            "EcalBarrelScFiMergedHits",
             "EcalBarrelScFiClusters",
             "EcalBarrelScFiClusterAssociations",
             "EcalLumiSpecRawHits",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This removes collections that are not produced by anything. This just adds noise to the logs, e.g.
```console
[JEventProcessorPODIO] [info] Persisting collection 'EcalLumiSpecTruthClusterAssociations'
[JEventProcessorPODIO] [info] Persisting collection 'EcalLumiSpecTruthClusters'
[JEventProcessorPODIO] [info] Persisting collection 'ForwardMPGDEndcapRecHits'
[JEventProcessorPODIO] [info] Persisting collection 'ForwardOffMRecParticles'
Warning: ocessorPODIO] [warning] Explicitly included collection 'ForwardOffMTrackerRecHits' not present in factory set, omitting.
Warning: ocessorPODIO] [warning] Explicitly included collection 'ForwardRomanPotRecHits' not present in factory set, omitting.
[JEventProcessorPODIO] [info] Persisting collection 'ForwardRomanPotRecParticles'
[JEventProcessorPODIO] [info] Persisting collection 'GeneratedJets'
[JEventProcessorPODIO] [info] Persisting collection 'GeneratedParticles'
[JEventProcessorPODIO] [info] Persisting collection 'HcalBarrelClusterAssociations'
```
(yes, that's what it looks like in https://github.com/eic/EICrecon/actions/runs/6042257250/job/16397942449?pr=829#step:5:456)

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.