### PR TITLE
feat(ci): publish GitHub pages site with PR information (from fork)

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -530,7 +530,7 @@ jobs:
         id: query
         with:
           route: GET /repos/{repo}/pulls?state=open
-          repo: "eic/EICrecon" # FIXME: ${{ github.repository }}
+          repo: ${{ github.repository }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Remap open PRs
@@ -549,7 +549,6 @@ jobs:
     steps:
       - uses: dawidd6/action-download-artifact@v2
         with:
-          repo: eic/EICrecon # FIXME ${{ github.repository }}
           pr: ${{ matrix.pr }}
           path: publishing_docs/pr/${{ matrix.pr }}/
           name: docs

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -579,7 +579,6 @@ jobs:
           apk add tar bash
         # FIXME bash not really required: see https://github.com/actions/upload-pages-artifact/pull/14
       - uses: actions/upload-pages-artifact@v1
-        if: github.ref == 'refs/heads/main'
         with:
           path: publishing_docs/
           retention-days: 7
@@ -587,7 +586,6 @@ jobs:
   deploy-docs:
     needs:
       - collect-docs
-    if: github.ref == 'refs/heads/main'
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -521,6 +521,30 @@ jobs:
           path: publishing_docs/
           if-no-files-found: error
 
+  list-open-prs:
+    runs-on: ubuntu-latest
+    outputs:
+      data: ${{ steps.list-open-prs.outputs.data }}
+    steps:
+      - uses: octokit/graphql-action@v2.x
+        id: list-open-prs
+        with:
+          query: |
+            query release($owner:String!,$repo:String!) {
+              repository(owner:$owner,name:$repo) {
+                pullRequests(state:OPEN, last:10) {
+                  nodes {
+                    number
+                  }
+                }
+              }
+            }
+          owner: ${{ github.event.repository.owner.name }}
+          repo: ${{ github.event.repository.name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: "echo 'open prs: ${{ steps.list-open-prs.outputs.data }}'"
+
   collect-docs:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -495,9 +495,9 @@ jobs:
 
   build-docs:
     runs-on: ubuntu-latest
-    #needs:
-    #  - eicrecon-gun
-    #  - eicrecon-dis
+    needs:
+      - eicrecon-gun
+      - eicrecon-dis
     container:
       image: alpine:latest
       volumes:
@@ -511,10 +511,10 @@ jobs:
           doxygen Doxyfile
           cp -r docs publishing_docs
           mv html publishing_docs/doxygen
-      #- uses: actions/download-artifact@v3
-      #  with:
-      #    name: jana.dot
-      #    path: publishing_docs/dot/
+      - uses: actions/download-artifact@v3
+        with:
+          name: jana.dot
+          path: publishing_docs/dot/
       - uses: actions/upload-artifact@v3
         with:
           name: docs

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -495,9 +495,9 @@ jobs:
 
   build-docs:
     runs-on: ubuntu-latest
-    needs:
-      - eicrecon-gun
-      - eicrecon-dis
+    #needs:
+    #  - eicrecon-gun
+    #  - eicrecon-dis
     container:
       image: alpine:latest
       volumes:
@@ -511,10 +511,10 @@ jobs:
           doxygen Doxyfile
           cp -r docs publishing_docs
           mv html publishing_docs/doxygen
-      - uses: actions/download-artifact@v3
-        with:
-          name: jana.dot
-          path: publishing_docs/dot/
+      #- uses: actions/download-artifact@v3
+      #  with:
+      #    name: jana.dot
+      #    path: publishing_docs/dot/
       - uses: actions/upload-artifact@v3
         with:
           name: docs

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -530,15 +530,33 @@ jobs:
         id: query
         with:
           route: GET /repos/{repo}/pulls?state=open
-          repo: "eic/EICrecon"
+          repo: "eic/EICrecon" # FIXME: ${{ github.repository }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Remap open PRs
         id: remap
         uses: nickofthyme/object-remap@v1
         with:
-          include.*.number: ${{ toJSON(fromJSON(steps.query.outputs.data).*.number) }}
-      - run: "echo 'open prs: ${{ steps.remap.outputs.data }}'"
+          include.*.pr: ${{ toJSON(fromJSON(steps.query.outputs.data).*.number) }}
+
+  collect-open-prs:
+    runs-on: ubuntu-latest
+    needs:
+      - list-open-prs
+    strategy:
+      matrix: ${{ fromJson(needs.list-open-prs.outputs.data) }}
+    steps:
+      - uses: dawidd6/action-download-artifact@v2
+        with:
+          pr: ${{ matrix.pr }}
+          path: publishing_docs/pr/${{ matrix.pr }}/
+          name: docs
+          if_no_artifact_found: warn
+      - uses: actions/upload-artifact@v3
+        with:
+          name: docs
+          path: publishing_docs/
+          if-no-files-found: warn
 
   collect-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -545,6 +545,7 @@ jobs:
       - list-open-prs
     strategy:
       matrix: ${{ fromJson(needs.list-open-prs.outputs.json) }}
+      fail-fast: false
     steps:
       - uses: dawidd6/action-download-artifact@v2
         with:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -524,10 +524,10 @@ jobs:
   list-open-prs:
     runs-on: ubuntu-latest
     outputs:
-      data: ${{ steps.list-open-prs.outputs.data }}
+      data: ${{ steps.remap.outputs.data }}
     steps:
       - uses: octokit/graphql-action@v2.x
-        id: list-open-prs
+        id: query
         with:
           query: |
             query release($owner:String!,$repo:String!) {
@@ -539,11 +539,17 @@ jobs:
                 }
               }
             }
-          owner: ${{ github.event.repository.owner.name }}
-          repo: ${{ github.event.repository.name }}
+          owner: "eic" # ${{ github.event.repository.owner.name }}
+          repo: "EICrecon" # ${{ github.event.repository.name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: "echo 'open prs: ${{ steps.list-open-prs.outputs.data }}'"
+      - run: "echo 'open prs: ${{ steps.query.outputs.data }}'"
+      - name: Remap open PRs
+        id: remap
+        uses: nickofthyme/object-remap@v1
+        with:
+          include.*.number: ${{ toJSON(fromJSON(steps.query.outputs.data).*.number) }}
+      - run: "echo 'open prs: ${{ steps.remap.outputs.data }}'"
 
   collect-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -529,8 +529,7 @@ jobs:
       - uses: octokit/request-action@v2.x
         id: query
         with:
-          route: GET /repos/{repo}/pulls?state=open
-          repo: ${{ github.repository }}
+          route: GET /repos/${{ github.repository }}/pulls?state=open
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Remap open PRs

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -524,7 +524,7 @@ jobs:
   list-open-prs:
     runs-on: ubuntu-latest
     outputs:
-      data: ${{ steps.remap.outputs.data }}
+      json: ${{ steps.remap.outputs.json }}
     steps:
       - uses: octokit/request-action@v2.x
         id: query
@@ -544,7 +544,7 @@ jobs:
     needs:
       - list-open-prs
     strategy:
-      matrix: ${{ fromJson(needs.list-open-prs.outputs.data) }}
+      matrix: ${{ fromJson(needs.list-open-prs.outputs.json) }}
     steps:
       - uses: dawidd6/action-download-artifact@v2
         with:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -532,7 +532,7 @@ jobs:
           query: |
             query release($owner:String!,$repo:String!) {
               repository(owner:$owner,name:$repo) {
-                pullRequests(state:OPEN, last:10) {
+                pullRequests(states:OPEN, last:10) {
                   nodes {
                     number
                   }

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -527,6 +527,7 @@ jobs:
       data: ${{ steps.remap.outputs.data }}
     steps:
       - uses: octokit/request-action@v2.x
+        id: query
         with:
           route: GET /repos/{repo}/pulls?state=open
           repo: "eic/EICrecon"

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -569,6 +569,8 @@ jobs:
 
   get-docs-from-main:
     runs-on: ubuntu-latest
+    needs:
+      - build-docs
     steps:
       - uses: dawidd6/action-download-artifact@v2
         if: github.ref_name != 'main'

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -592,7 +592,6 @@ jobs:
   collect-docs:
     runs-on: ubuntu-latest
     needs:
-      - build-docs
       - get-docs-from-main
       - get-docs-from-open-prs
     container:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -577,7 +577,7 @@ jobs:
           path: publishing_docs/
           name: docs
           workflow_conclusion: "completed"
-          if_no_artifact_found: error
+          if_no_artifact_found: fail
       - uses: actions/download-artifact@v3
         if: github.ref_name == 'main'
         with:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -533,7 +533,6 @@ jobs:
           repo: "eic/EICrecon"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: "echo 'open prs: ${{ steps.query.outputs.data }}'"
       - name: Remap open PRs
         id: remap
         uses: nickofthyme/object-remap@v1

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -559,10 +559,26 @@ jobs:
           path: publishing_docs/
           if-no-files-found: warn
 
+  get-docs-from-main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dawidd6/action-download-artifact@v2
+        with:
+          branch: main
+          path: publishing_docs/
+          name: docs
+          if_no_artifact_found: error
+      - uses: actions/upload-artifact@v3
+        with:
+          name: docs
+          path: publishing_docs/
+          if-no-files-found: error
+
   collect-docs:
     runs-on: ubuntu-latest
     needs:
       - build-docs
+      - get-docs-from-main
       - get-docs-from-open-prs
     container:
       image: alpine:latest

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -534,7 +534,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Remap open PRs
         id: remap
-        uses: nickofthyme/object-remap@v1
+        uses: nickofthyme/object-remap@v2
         with:
           include.*.pr: ${{ toJSON(fromJSON(steps.query.outputs.data).*.number) }}
 

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -548,7 +548,7 @@ jobs:
         id: remap
         uses: nickofthyme/object-remap@v1
         with:
-          include.*.number: ${{ toJSON(fromJSON(steps.query.outputs.data).*.number) }}
+          include.*.number: ${{ toJSON(fromJSON(steps.query.outputs.data).repository.pullRequests.*.number) }}
       - run: "echo 'open prs: ${{ steps.remap.outputs.data }}'"
 
   collect-docs:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -542,17 +542,25 @@ jobs:
   get-docs-from-open-prs:
     runs-on: ubuntu-latest
     needs:
+      - build-docs
       - list-open-prs
     strategy:
       matrix: ${{ fromJson(needs.list-open-prs.outputs.json) }}
       fail-fast: false
     steps:
       - uses: dawidd6/action-download-artifact@v2
+        if: github.event.pull_request.number != matrix.pr
         with:
           pr: ${{ matrix.pr }}
           path: publishing_docs/pr/${{ matrix.pr }}/
           name: docs
           if_no_artifact_found: warn
+      - uses: actions/download-artifact@v3
+        if: github.event.pull_request.number == matrix.pr
+        with:
+          name: docs
+          path: publishing_docs/pr/${{ matrix.pr }}/
+          if-no-files-found: error
       - uses: actions/upload-artifact@v3
         with:
           name: github-pages-staging
@@ -563,11 +571,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: dawidd6/action-download-artifact@v2
+        if: github.ref_name != 'main'
         with:
           branch: main
           path: publishing_docs/
           name: docs
           if_no_artifact_found: error
+      - uses: actions/download-artifact@v3
+        if: github.ref_name == 'main'
+        with:
+          name: docs
+          path: publishing_docs/
+          if-no-files-found: error
       - uses: actions/upload-artifact@v3
         with:
           name: github-pages-staging

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -560,7 +560,6 @@ jobs:
         with:
           name: docs
           path: publishing_docs/pr/${{ matrix.pr }}/
-          if-no-files-found: error
       - uses: actions/upload-artifact@v3
         with:
           name: github-pages-staging
@@ -584,7 +583,6 @@ jobs:
         with:
           name: docs
           path: publishing_docs/
-          if-no-files-found: error
       - uses: actions/upload-artifact@v3
         with:
           name: github-pages-staging

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -514,15 +514,15 @@ jobs:
           doxygen Doxyfile
           cp -r docs publishing_docs
           mv html publishing_docs/doxygen
+      - uses: actions/download-artifact@v3
+        with:
+          name: jana.dot
+          path: publishing_docs/dot/
       - uses: actions/upload-artifact@v3
         with:
           name: docs
           path: publishing_docs/
           if-no-files-found: error
-      - uses: actions/download-artifact@v3
-        with:
-          name: jana.dot
-          path: publishing_docs/dot/
       - run:
           apk add tar bash
         # FIXME bash not really required: see https://github.com/actions/upload-pages-artifact/pull/14

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -577,6 +577,7 @@ jobs:
           branch: main
           path: publishing_docs/
           name: docs
+          workflow_conclusion: "completed"
           if_no_artifact_found: error
       - uses: actions/download-artifact@v3
         if: github.ref_name == 'main'

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -526,7 +526,7 @@ jobs:
     outputs:
       data: ${{ steps.remap.outputs.data }}
     steps:
-      - uses: octokit/graphql-action@v2.x
+      - uses: octokit/request-action@v2.x
         with:
           route: GET /repos/{repo}/pulls?state=open
           repo: "eic/EICrecon"

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -553,7 +553,7 @@ jobs:
           pr: ${{ matrix.pr }}
           path: publishing_docs/pr/${{ matrix.pr }}/
           name: docs
-          if_no_artifact_found: warn
+          if_no_artifact_found: ignore
       - uses: actions/download-artifact@v3
         if: github.event.pull_request.number == matrix.pr
         with:
@@ -563,7 +563,7 @@ jobs:
         with:
           name: github-pages-staging
           path: publishing_docs/
-          if-no-files-found: warn
+          if-no-files-found: ignore
 
   get-docs-from-main:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -527,20 +527,9 @@ jobs:
       data: ${{ steps.remap.outputs.data }}
     steps:
       - uses: octokit/graphql-action@v2.x
-        id: query
         with:
-          query: |
-            query release($owner:String!,$repo:String!) {
-              repository(owner:$owner,name:$repo) {
-                pullRequests(states:OPEN, last:10) {
-                  nodes {
-                    number
-                  }
-                }
-              }
-            }
-          owner: "eic" # ${{ github.event.repository.owner.name }}
-          repo: "EICrecon" # ${{ github.event.repository.name }}
+          route: GET /repos/{repo}/pulls?state=open
+          repo: "eic/EICrecon"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: "echo 'open prs: ${{ steps.query.outputs.data }}'"
@@ -548,7 +537,7 @@ jobs:
         id: remap
         uses: nickofthyme/object-remap@v1
         with:
-          include.*.number: ${{ toJSON(fromJSON(steps.query.outputs.data).repository.pullRequests.*.number) }}
+          include.*.number: ${{ toJSON(fromJSON(steps.query.outputs.data).*.number) }}
       - run: "echo 'open prs: ${{ steps.remap.outputs.data }}'"
 
   collect-docs:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -496,7 +496,7 @@ jobs:
   # build-docs and deploy-docs copy doxygen.yml functionality
   # the difference is that these jobs use resulting artifacts from EICrecon runs
   # to embed into docs
-  build-docs-advanced:
+  build-docs:
     runs-on: ubuntu-latest
     needs:
       - eicrecon-gun
@@ -532,8 +532,8 @@ jobs:
           path: publishing_docs/
           retention-days: 7
 
-  deploy-docs-advanced:
-    needs: build-docs-advanced
+  deploy-docs:
+    needs: build-docs
     if: github.ref == 'refs/heads/main'
     permissions:
       pages: write

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -555,7 +555,7 @@ jobs:
           if_no_artifact_found: warn
       - uses: actions/upload-artifact@v3
         with:
-          name: docs
+          name: github-pages-staging
           path: publishing_docs/
           if-no-files-found: warn
 
@@ -570,7 +570,7 @@ jobs:
           if_no_artifact_found: error
       - uses: actions/upload-artifact@v3
         with:
-          name: docs
+          name: github-pages-staging
           path: publishing_docs/
           if-no-files-found: error
 
@@ -588,7 +588,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v3
         with:
-          name: docs
+          name: github-pages-staging
           path: publishing_docs/
       - run:
           apk add tar bash

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -544,7 +544,7 @@ jobs:
       - build-docs
       - list-open-prs
     strategy:
-      matrix: ${{ fromJson(needs.list-open-prs.outputs.json) }}
+      matrix: ${{ fromJSON(needs.list-open-prs.outputs.json) }}
       fail-fast: false
     steps:
       - uses: dawidd6/action-download-artifact@v2

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -493,9 +493,6 @@ jobs:
           python3 ${{ github.workspace }}/epic-capybara/bara.py ref/rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root
           echo "::endgroup::"
 
-  # build-docs and deploy-docs copy doxygen.yml functionality
-  # the difference is that these jobs use resulting artifacts from EICrecon runs
-  # to embed into docs
   build-docs:
     runs-on: ubuntu-latest
     needs:
@@ -523,6 +520,21 @@ jobs:
           name: docs
           path: publishing_docs/
           if-no-files-found: error
+
+  collect-docs:
+    runs-on: ubuntu-latest
+    needs:
+      - build-docs
+    container:
+      image: alpine:latest
+      volumes:
+        - /home/runner/work/_temp:/home/runner/work/_temp
+      # FIXME hard-coded: see https://github.com/actions/upload-pages-artifact/pull/14
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: docs
+          path: publishing_docs/
       - run:
           apk add tar bash
         # FIXME bash not really required: see https://github.com/actions/upload-pages-artifact/pull/14
@@ -533,7 +545,8 @@ jobs:
           retention-days: 7
 
   deploy-docs:
-    needs: build-docs
+    needs:
+      - collect-docs
     if: github.ref == 'refs/heads/main'
     permissions:
       pages: write

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -539,7 +539,7 @@ jobs:
         with:
           include.*.pr: ${{ toJSON(fromJSON(steps.query.outputs.data).*.number) }}
 
-  collect-open-prs:
+  get-docs-from-open-prs:
     runs-on: ubuntu-latest
     needs:
       - list-open-prs
@@ -549,6 +549,7 @@ jobs:
     steps:
       - uses: dawidd6/action-download-artifact@v2
         with:
+          repo: eic/EICrecon # FIXME ${{ github.repository }}
           pr: ${{ matrix.pr }}
           path: publishing_docs/pr/${{ matrix.pr }}/
           name: docs
@@ -563,6 +564,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-docs
+      - get-docs-from-open-prs
     container:
       image: alpine:latest
       volumes:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,5 @@
-Replaced
+# EICrecon
+
+**JANA based reconstruction for the EPIC detector**
+
+<img src="demo.png" style="max-height: 300px"/>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This modifies the approach we use for publishing the github-pages documentation to allow also publishing from pull requests while maintaining the main branch as reference top level url.

This works by doing some less linear things with artifacts than we usually do. Instead of building docs, then creating the github-pages artifact, and then deploying this, we now pull artifacts from other pipelines. In particular, we pull the docs from the last complete pipeline on main (with error on failure) and from the last successful pipeline on all open PRs (taking care to use the not yet published docs for the current branch, whether main or PR), then stage this all in a github-pages-staging artifact that is added to by multiple jobs, from which we then create the github-pages artifact, and then deploy. This allows us to put the PRs under e.g. `pr/891` etc.

The real reason for this is not that we want to have doxygen and rst docs for all these PRs (though it does make review of docs changes easier). It also allows us to write CI results to these areas, without needing to find another hosting solution. It could accommodate the unit test reports and capybara bokeh dashboards, for example.

Demonstration at:
- https://github.com/wdconinc/EICrecon/pull/5/ (this PR in my fork)
- https://wdconinc.github.io/EICrecon/#/ (docs from main)
- https://wdconinc.github.io/EICrecon/pr/5/#/ (docs from PR 5)

When we list the open PRs, we only have a token that has permission for querying this info in the current repository. That's why I had to demonstrate this in my fork and it only finds PRs against that fork. It is possible that this PR will not get the permissions to be able to identify all open PRs in the eic/EICrecon repository; we'll see.

Current size of docs per PR is about 20 MB. The maximum size of a GitHub Pages site is 1 GB, so we can accommodate 50 open PRs.

TODO:
- [x] relax github-pages environment protection to allow deployment from all branches, not just main

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @veprbl 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.