### PR TITLE
fix(ci): ignore when clang-tidy doesn't produce any fixes

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -121,6 +121,7 @@ jobs:
       with:
         name: clang-tidy-fixes.yml
         path: clang_tidy_fixes.yml
+        if-no-files-found: ignore
     - uses: platisd/clang-tidy-pr-comments@1.4.0
       if: ${{ github.event_name == 'pull_request' }}
       with:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Instead of generating a warning, we should just ignore when clang-tidy doesn't produce any fixes. This is an expected condition when no source files are modified. There is no failure scenario where clang-tidy-diff/run-clang-tidy itself runs succesfully but no output file is written; that's actually a success scenario since it means no fixes are necessary (though it's more likely caused by `No relevant changes found` as in https://github.com/eic/EICrecon/actions/runs/6065496614/job/16455346295#step:7:102).

### What kind of change does this PR introduce?
- [x] Bug fix (issue: unnecessary warnings from clang-tidy)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.