### PR TITLE
fix: disable timeouts entirely (by default)

### DIFF
--- a/src/utilities/eicrecon/eicrecon_cli.cpp
+++ b/src/utilities/eicrecon/eicrecon_cli.cpp
@@ -258,8 +258,8 @@ namespace jana {
 
         // If the user hasn't specified a timeout (on cmd line or in config file), set the timeout to something reasonably high
         if (para_mgr->FindParameter("jana:timeout") == nullptr) {
-            para_mgr->SetParameter("jana:timeout", 180); // seconds
-            para_mgr->SetParameter("jana:warmup_timeout", 180); // seconds
+            para_mgr->SetParameter("jana:timeout", 0); // seconds, 0 to disable
+            para_mgr->SetParameter("jana:warmup_timeout", 0); // seconds, 0 to disable
         }
 
         auto app = new JApplication(para_mgr);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This disables jana event and warmup timeouts entirely. It doesn't solve the exit code in #875, but it would just have just hung instead.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #875)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @veprbl not sure where you encountered the issue exactly, but would this have resulted in at least foregrounding the issue better?

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.