### PR TITLE
CMakeLists.txt: relax EDM4eic version requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ add_compile_definitions(HAVE_PODIO)
 find_package(Eigen3 REQUIRED)
 find_package(podio REQUIRED)
 find_package(EDM4HEP REQUIRED)
-find_package(EDM4EIC 2.1 REQUIRED)
+find_package(EDM4EIC 2.1...99 REQUIRED)
 
 # DD4Hep is required for the most of the part
 find_package(DD4hep REQUIRED)


### PR DESCRIPTION
Fixes
```
 CMake Error at CMakeLists.txt:99 (find_package):
   Could not find a configuration file for package "EDM4EIC" that is
   compatible with requested version "2.1".
   The following configuration files were considered but not accepted:
     prefix/lib/EDM4EIC/EDM4EICConfig.cmake, version: 3.0.1
```
https://cmake.org/cmake/help/latest/command/find_package.html#find-package-version-format