### PR TITLE
Changed kinematic calculations to use edm4eic vector utils in ParticlesWithPID

### DIFF
--- a/src/algorithms/pid/ParticlesWithPID.cc
+++ b/src/algorithms/pid/ParticlesWithPID.cc
@@ -79,9 +79,9 @@ namespace eicrecon {
                     continue;
                 }
 
-                const auto p_mag = std::hypot(p.x, p.y, p.z);
-                const auto p_phi = std::atan2(p.y, p.x);
-                const auto p_eta = std::atanh(p.z / p_mag);
+                const auto p_mag = edm4eic::magnitude(p);
+                const auto p_phi = edm4eic::angleAzimuthal(p);
+                const auto p_eta = edm4eic::eta(p);
                 const double dp_rel = std::abs((edm4eic::magnitude(mom) - p_mag) / p_mag);
                 // check the tolerance for sin(dphi/2) to avoid the hemisphere problem and allow
                 // for phi rollovers
@@ -91,6 +91,12 @@ namespace eicrecon {
                 bool is_matching = dp_rel < m_cfg.momentumRelativeTolerance &&
                                    deta < m_cfg.etaTolerance &&
                                    dsphi < sinPhiOver2Tolerance;
+
+		// Matching kinematics with the static variables doesn't work at low angles and within beam divergence
+                // TODO - Maybe reconsider variables used or divide into regions
+                if ((p_eta < -5) && (edm4eic::eta(mom) < -5)) {
+		  is_matching = true;
+                }
 
                 m_log->trace("    Decision: {}  dp: {:.4f} < {}  &&  d_eta: {:.6f} < {}  && d_sin_phi: {:.4e} < {:.4e} ",
                              is_matching? "Matching":"Ignoring",

--- a/src/algorithms/pid/ParticlesWithPID.cc
+++ b/src/algorithms/pid/ParticlesWithPID.cc
@@ -94,11 +94,11 @@ namespace eicrecon {
 
                 // Matching kinematics with the static variables doesn't work at low angles and within beam divergence
                 // TODO - Maybe reconsider variables used or divide into regions
-		// Backward going
+                // Backward going
                 if ((p_eta < -5) && (edm4eic::eta(mom) < -5)) {
                   is_matching = true;
                 }
-		// Forward going
+                // Forward going
                 if ((p_eta >  5) && (edm4eic::eta(mom) >  5)) {
                   is_matching = true;
                 }

--- a/src/algorithms/pid/ParticlesWithPID.cc
+++ b/src/algorithms/pid/ParticlesWithPID.cc
@@ -94,7 +94,12 @@ namespace eicrecon {
 
                 // Matching kinematics with the static variables doesn't work at low angles and within beam divergence
                 // TODO - Maybe reconsider variables used or divide into regions
+		// Backward going
                 if ((p_eta < -5) && (edm4eic::eta(mom) < -5)) {
+                  is_matching = true;
+                }
+		// Forward going
+                if ((p_eta >  5) && (edm4eic::eta(mom) >  5)) {
                   is_matching = true;
                 }
 

--- a/src/algorithms/pid/ParticlesWithPID.cc
+++ b/src/algorithms/pid/ParticlesWithPID.cc
@@ -92,10 +92,10 @@ namespace eicrecon {
                                    deta < m_cfg.etaTolerance &&
                                    dsphi < sinPhiOver2Tolerance;
 
-		// Matching kinematics with the static variables doesn't work at low angles and within beam divergence
+                // Matching kinematics with the static variables doesn't work at low angles and within beam divergence
                 // TODO - Maybe reconsider variables used or divide into regions
                 if ((p_eta < -5) && (edm4eic::eta(mom) < -5)) {
-		  is_matching = true;
+                  is_matching = true;
                 }
 
                 m_log->trace("    Decision: {}  dp: {:.4f} < {}  &&  d_eta: {:.6f} < {}  && d_sin_phi: {:.4e} < {:.4e} ",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The std::hypot method used to define p_mag in ParticlesWithPID.cc by default returns a float. This is insufficient precision when looking at particles travelling very close to the beam axis.

This PR changes to using the edm4eic vector utils methods which return doubles.

Additionally the eta and phi tolerance values provided to match the MC and reconstructed particles do not make sense for the particles along the beamline so if both are below -5 they are assumed to match.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
no