### PR TITLE
fix: change "no matching CherenkovParticleID" log level `warn` -> `trace`

### DIFF
--- a/src/algorithms/pid/ParticlesWithPID.cc
+++ b/src/algorithms/pid/ParticlesWithPID.cc
@@ -278,7 +278,7 @@ namespace eicrecon {
 
         // check if at least one match was found
         if (prox_match_list.size() == 0) {
-            m_log->warn("no matching CherenkovParticleID found for this particle");
+            m_log->trace("  => no matching CherenkovParticleID found for this particle");
             return false;
         }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Reduce noisy log messages in `ParticleWithPID`

### What kind of change does this PR introduce?
- [x] Bug fix (not really a bug, but a nuisance)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
no