### PR TITLE
Added LowQ2 plugin with hit digitization

### DIFF
--- a/src/detectors/CMakeLists.txt
+++ b/src/detectors/CMakeLists.txt
@@ -14,10 +14,11 @@ add_subdirectory(ECGEM)     # EndCap GEM
 add_subdirectory(ECTRK)     # EndCap tracker
 add_subdirectory(MPGD)      # MPDG tracker
 add_subdirectory(RPOTS)     # Roman Pots
-add_subdirectory(FOFFMTRK)   # OffMom tracker
+add_subdirectory(FOFFMTRK)  # OffMom tracker
 add_subdirectory(ECTOF)     # Endcap TOF
 add_subdirectory(BTOF)      # Barrel TOF
 add_subdirectory(B0TRK)     # B0 tracker
+add_subdirectory(LOWQ2)     # LOWQ2 Tagger
 add_subdirectory(LUMISPECCAL)  # Lumi spectrometer calorimeter
 
 # PID detectors

--- a/src/detectors/LOWQ2/CMakeLists.txt
+++ b/src/detectors/LOWQ2/CMakeLists.txt
@@ -19,4 +19,3 @@ plugin_add_event_model(${PLUGIN_NAME})
 
 # Add include directories (works same as target_include_directories)
 plugin_include_directories(${PLUGIN_NAME} SYSTEM PUBLIC ${podio_INCLUDE_DIR} ${EDM4EIC_INCLUDE_DIR})
-

--- a/src/detectors/LOWQ2/CMakeLists.txt
+++ b/src/detectors/LOWQ2/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
-
 project(LOWQ2)
 
 # Automatically set plugin name the same as the directory name
@@ -22,5 +20,3 @@ plugin_add_event_model(${PLUGIN_NAME})
 # Add include directories (works same as target_include_directories)
 plugin_include_directories(${PLUGIN_NAME} SYSTEM PUBLIC ${podio_INCLUDE_DIR} ${EDM4EIC_INCLUDE_DIR})
 
-# Add libraries (works same as target_include_directories)
-#file(COPY trainedTaggerRegressionModel.dat DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/detectors/LOWQ2/CMakeLists.txt
+++ b/src/detectors/LOWQ2/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(LOWQ2)
+
+# Automatically set plugin name the same as the directory name
+# Don't forget string(REPLACE " " "_" PLUGIN_NAME ${PLUGIN_NAME}) if this dir has spaces in its name
+get_filename_component(PLUGIN_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
+
+# Function creates ${PLUGIN_NAME}_plugin and ${PLUGIN_NAME}_library targets
+# Setting default includes, libraries and installation paths
+plugin_add(${PLUGIN_NAME} )
+
+# The macro grabs sources as *.cc *.cpp *.c and headers as *.h *.hh *.hpp
+# Then correctly sets sources for ${_name}_plugin and ${_name}_library targets
+# Adds headers to the correct installation directory
+plugin_glob_all(${PLUGIN_NAME})
+
+# Find dependencies
+plugin_add_dd4hep(${PLUGIN_NAME})
+plugin_add_event_model(${PLUGIN_NAME})
+
+# Add include directories (works same as target_include_directories)
+plugin_include_directories(${PLUGIN_NAME} SYSTEM PUBLIC ${podio_INCLUDE_DIR} ${EDM4EIC_INCLUDE_DIR})
+
+# Add libraries (works same as target_include_directories)
+#file(COPY trainedTaggerRegressionModel.dat DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -1,0 +1,33 @@
+// Copyright 2023, Simon Gardner
+// Subject to the terms in the LICENSE file found in the top-level directory.
+//
+//
+
+#include <JANA/JApplication.h>
+#include <JANA/JEvent.h>
+
+#include "extensions/jana/JChainMultifactoryGeneratorT.h"
+#include "factories/digi/SiliconTrackerDigi_factoryT.h"
+
+
+extern "C" {
+  void InitPlugin(JApplication *app) {
+    InitJANAPlugin(app);
+
+    using namespace eicrecon;
+
+    // Digitization of silicon hits
+    app->Add(new JChainMultifactoryGeneratorT<SiliconTrackerDigi_factoryT>(
+         "TaggerTrackerRawHits",
+         {"TaggerTrackerHits"},
+         {"TaggerTrackerRawHits"},
+         {
+           .threshold = 1 * dd4hep::keV,
+           .timeResolution = 2 * dd4hep::ns,
+         },
+         app
+    ));
+
+
+  }
+}

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -66,8 +66,8 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "BackwardMPGDEndcapRecHits",
             "ForwardMPGDEndcapRecHits",
 
-	    // LOWQ2 hits
-	    "TaggerTrackerRawHits",
+            // LOWQ2 hits
+            "TaggerTrackerRawHits",
 
             // Forward & Far forward hits
             "B0TrackerRecHits",

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -66,6 +66,9 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "BackwardMPGDEndcapRecHits",
             "ForwardMPGDEndcapRecHits",
 
+	    // LOWQ2 hits
+	    "TaggerTrackerRawHits",
+
             // Forward & Far forward hits
             "B0TrackerRecHits",
 

--- a/src/utilities/dump_flags/DumpFlags_processor.h
+++ b/src/utilities/dump_flags/DumpFlags_processor.h
@@ -71,6 +71,7 @@ private:
             "HCAL",
             "MPGD",
             "RPOTS",
+            "LOWQ2",
             "ZDC",
             "Tracking",
             "Reco",

--- a/src/utilities/eicrecon/eicrecon.cc
+++ b/src/utilities/eicrecon/eicrecon.cc
@@ -42,6 +42,7 @@ std::vector<std::string> EICRECON_DEFAULT_PLUGINS = {
         "FOFFMTRK",
         "BTOF",
         "ECTOF",
+        "LOWQ2",
         "LUMISPECCAL",
         "podio",
 };


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Adds a basic LowQ2 plugin which only digitizes the simulated hits using the standard silicon digitization factory

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no

### Does this PR change default behavior?
Adds digitized lowq2 tagger hits to output 