### PR TITLE
fix: move Eigen out of SpdlogFormatters

### DIFF
--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -19,9 +19,21 @@
 #include <Acts/Plugins/Json/JsonMaterialDecorator.hpp>
 #include <Acts/Plugins/Json/MaterialMapJsonConverter.hpp>
 
-
 #include "extensions/spdlog/SpdlogToActs.h"
 #include "extensions/spdlog/SpdlogFormatters.h"
+
+// Formatter for Eigen matrices
+#if FMT_VERSION >= 90000
+#include <Eigen/Core>
+template <typename T>
+struct fmt::formatter<
+    T,
+    std::enable_if_t<
+        std::is_base_of_v<Eigen::MatrixBase<T>, T>,
+        char
+    >
+> : fmt::ostream_formatter {};
+#endif // FMT_VERSION >= 90000
 
 void draw_surfaces(std::shared_ptr<const Acts::TrackingGeometry> trk_geo, const Acts::GeometryContext geo_ctx,
                    const std::string &fname) {

--- a/src/algorithms/tracking/TrackProjector.cc
+++ b/src/algorithms/tracking/TrackProjector.cc
@@ -37,6 +37,10 @@
 
 #include <cmath>
 
+#if FMT_VERSION >= 90000
+template<> struct fmt::formatter<Acts::GeometryIdentifier> : fmt::ostream_formatter {};
+#endif // FMT_VERSION >= 90000
+
 namespace eicrecon {
 
     void

--- a/src/extensions/spdlog/SpdlogFormatters.h
+++ b/src/extensions/spdlog/SpdlogFormatters.h
@@ -11,41 +11,7 @@
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/Vector3d.h>
 
-#include <Eigen/Core>
-
 #if FMT_VERSION >= 90000
-
-/*
-
-template <typename T, typename = void>
-struct has_output_operator : std::false_type {};
-
-template <typename T>
-struct has_output_operator<T, std::void_t<decltype(std::cout << std::declval<T>())>> : std::true_type {};
-
-template <typename T, typename Char, typename Context>
-struct fmt::formatter<
-    T,
-    std::enable_if_t<
-        !fmt::has_formatter<T, Context>::value &&
-        has_output_operator<T>::value,
-        Char
-    >
-> : fmt::ostream_formatter {};
-
-*/
-
-// handle Eigen CRTP
-template <typename T>
-struct fmt::formatter<
-    T,
-    std::enable_if_t<
-        std::is_base_of_v<Eigen::MatrixBase<T>, T>,
-        char
-    >
-> : fmt::ostream_formatter {};
-
-template<> struct fmt::formatter<Acts::GeometryIdentifier> : fmt::ostream_formatter {};
 
 template<> struct fmt::formatter<edm4eic::Cov2f> : fmt::ostream_formatter {};
 template<> struct fmt::formatter<edm4eic::Cov3f> : fmt::ostream_formatter {};


### PR DESCRIPTION
### Briefly, what does this PR introduce?
One of the largest source of slow builds is the inclusion of `Eigen` headers indirectly in many source files. This removes one of these instances. Rather than including and using `Eigen::MatrixBase<T>` in the SpdlogFormatters header, this moves the 'expensive' formatters to the source files where they are used.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #628 but doesn't fix it all)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.