### PR TITLE
fix: avoid including Navigator.hpp in tracking.cc

### DIFF
--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -3,10 +3,9 @@
 //
 //
 
-#include <boost/container/small_vector.hpp>
-
 #include <JANA/JApplication.h>
 #include <JANA/JEvent.h>
+#undef alignas
 
 #include "extensions/jana/JChainFactoryGeneratorT.h"
 #include "extensions/jana/JChainMultifactoryGeneratorT.h"

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -3,7 +3,7 @@
 //
 //
 
-#include <Acts/Propagator/Navigator.hpp>
+#include <boost/container/small_vector.hpp>
 
 #include <JANA/JApplication.h>
 #include <JANA/JEvent.h>

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -5,7 +5,6 @@
 
 #include <JANA/JApplication.h>
 #include <JANA/JEvent.h>
-#undef alignas
 
 #include "extensions/jana/JChainFactoryGeneratorT.h"
 #include "extensions/jana/JChainMultifactoryGeneratorT.h"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Because JANA2 redefines `alignas` https://github.com/JeffersonLab/JANA2/blob/master/src/libraries/JANA/Utils/JResourcePool.h#L43-L46, we have been including an Acts header before any JANA headers in tracking.cc, just to get ACTS stuff loaded before JANA breaks it. Instead of loading Navigator (and all its Eigen dependencies) we can also just load the only relevant header: `boost/container/small_vector.hpp`. But really, this should be fixed in JANA, at https://github.com/JeffersonLab/JANA2/issues/238. `alignas` is a [formal part of the C++11 standard](https://en.cppreference.com/w/cpp/language/alignas) and should not be modified.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.