### PR TITLE
docs: apk add ttf-freefont for graphviz without boxes

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -510,7 +510,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run Doxygen
         run: |
-          apk add doxygen graphviz
+          apk add doxygen graphviz ttf-freefont
           doxygen Doxyfile
           cp -r docs publishing_docs
           mv html publishing_docs/doxygen


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Since we run doxygen in alpine, and since alpine doesn't come with any fonts installed, we need to install at least one font. `ttf-freefont` is 17 MB, and smaller than `ttf-dejavu`, and it has both serif and sans serif typefaces.

See e.g. https://wdconinc.github.io/EICrecon/doxygen/classACTSGeo__service.html which uses this fix.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #199)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators @ruse-traveler 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.