### PR TITLE
docs: Doxyfile EXTRACT_ALL = YES

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -485,7 +485,7 @@ NUM_PROC_THREADS       = 1
 # normally produced when WARNINGS is set to YES.
 # The default value is: NO.
 
-EXTRACT_ALL            = NO
+EXTRACT_ALL            = YES
 
 # If the EXTRACT_PRIVATE tag is set to YES, all private members of a class will
 # be included in the documentation.


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This enables include diagrams (and much more documentation diagrams) by not requiring the explicit adding of documentation tags like `\headerfile` etc. It produces for example the following included-by diagram for `ActsGeometryProvider.h`:
![image](https://github.com/eic/EICrecon/assets/4656391/70bda1df-05ae-4c7d-963e-edd2493a2f70)

TODO:
- [x] ~~check artifact size difference~~ not so relevant anymore after we don't publish doxygen on PRs

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [x] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.