### PR TITLE
fix: Compiler warning in src/tests/algorithms_test/pid_MergeParticleID.cc

### DIFF
--- a/src/tests/algorithms_test/pid_MergeParticleID.cc
+++ b/src/tests/algorithms_test/pid_MergeParticleID.cc
@@ -125,7 +125,7 @@ TEST_CASE("the PID MergeParticleID algorithm runs", "[MergeParticleID]") {
         return obj;
     }
     FAIL("ERROR: cannot find CherenkovParticleID given track");
-    if(coll->empty())
+    if(coll->size() == 0)
       throw std::runtime_error("empty collection used in pid_MergeParticleID::find_cherenkov_pid_for_track");
     return coll->at(0);
   };

--- a/src/tests/algorithms_test/pid_MergeParticleID.cc
+++ b/src/tests/algorithms_test/pid_MergeParticleID.cc
@@ -125,6 +125,9 @@ TEST_CASE("the PID MergeParticleID algorithm runs", "[MergeParticleID]") {
         return obj;
     }
     FAIL("ERROR: cannot find CherenkovParticleID given track");
+    if(coll->size() == 0)
+      throw std::runtime_error("empty collection used in pid_MergeParticleID::find_cherenkov_pid_for_track");
+    return coll->at(0);
   };
 
   // additive weights

--- a/src/tests/algorithms_test/pid_MergeParticleID.cc
+++ b/src/tests/algorithms_test/pid_MergeParticleID.cc
@@ -125,7 +125,7 @@ TEST_CASE("the PID MergeParticleID algorithm runs", "[MergeParticleID]") {
         return obj;
     }
     FAIL("ERROR: cannot find CherenkovParticleID given track");
-    if(coll->size() == 0)
+    if(coll->empty())
       throw std::runtime_error("empty collection used in pid_MergeParticleID::find_cherenkov_pid_for_track");
     return coll->at(0);
   };


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Resolve warning: non-void lambda does not return a value in all control paths.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #927)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no

### Does this PR change default behavior?
no