### PR TITLE
fix: unused header cleanup

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -13,7 +13,6 @@
 #include <map>
 #include <Eigen/Dense>
 
-#include <JANA/JEvent.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <edm4hep/MCParticle.h>
 

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
@@ -10,8 +10,6 @@
 
 #pragma once
 
-#include <random>
-
 #include <DD4hep/Detector.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
 #include <edm4eic/ProtoClusterCollection.h>

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -13,7 +13,6 @@
 
 #include "CalorimeterHitDigi.h"
 
-#include <JANA/JEvent.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <fmt/format.h>
 using namespace dd4hep;

--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -7,7 +7,6 @@
 
 #include "CalorimeterHitReco.h"
 
-#include <JANA/JEvent.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <fmt/format.h>
 #include <cctype>

--- a/src/algorithms/calorimetry/CalorimeterHitReco.h
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.h
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <random>
-
 #include <DD4hep/Detector.h>
 #include <DDRec/CellIDPositionConverter.h>
 

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -18,7 +18,6 @@
 #include <edm4hep/Vector2f.h>
 #include <edm4hep/Vector3f.h>
 
-#include <JANA/JEvent.h>
 #include <edm4hep/SimCalorimeterHit.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <fmt/format.h>

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.h
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.h
@@ -6,8 +6,7 @@
 #include <random>
 #include <memory>
 
-#include "services/geometry/dd4hep/JDD4hep_service.h"
-
+#include <DD4hep/Detector.h>
 #include <Evaluator/DD4hepUnits.h>
 
 #include <edm4hep/Vector2f.h>

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.h
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <random>
 #include <memory>
 
 #include <DD4hep/Detector.h>

--- a/src/algorithms/calorimetry/CalorimeterTruthClustering.cc
+++ b/src/algorithms/calorimetry/CalorimeterTruthClustering.cc
@@ -3,7 +3,6 @@
 
 #include "CalorimeterTruthClustering.h"
 
-#include <JANA/JEvent.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <fmt/format.h>
 #include <edm4hep/MCParticle.h>

--- a/src/algorithms/calorimetry/CalorimeterTruthClustering.h
+++ b/src/algorithms/calorimetry/CalorimeterTruthClustering.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <random>
-
 #include <DD4hep/Detector.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <edm4eic/CalorimeterHitCollection.h>

--- a/src/algorithms/calorimetry/CalorimeterTruthClustering.h
+++ b/src/algorithms/calorimetry/CalorimeterTruthClustering.h
@@ -6,7 +6,7 @@
 
 #include <random>
 
-#include "services/geometry/dd4hep/JDD4hep_service.h"
+#include <DD4hep/Detector.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <edm4eic/CalorimeterHitCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>

--- a/src/algorithms/digi/PhotoMultiplierHitDigi.cc
+++ b/src/algorithms/digi/PhotoMultiplierHitDigi.cc
@@ -15,8 +15,6 @@
 
 #include "PhotoMultiplierHitDigi.h"
 
-#include <JANA/JEvent.h>
-
 //------------------------
 // AlgorithmInit
 //------------------------

--- a/src/algorithms/digi/PhotoMultiplierHitDigi.h
+++ b/src/algorithms/digi/PhotoMultiplierHitDigi.h
@@ -15,12 +15,12 @@
 
 #pragma once
 
-#include "services/geometry/dd4hep/JDD4hep_service.h"
 #include <TRandomGen.h>
 #include <edm4hep/SimTrackerHitCollection.h>
 #include <edm4eic/RawTrackerHitCollection.h>
 #include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
 #include <spdlog/spdlog.h>
+#include <DD4hep/Detector.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <cstddef>
 #include <functional>

--- a/src/algorithms/digi/PhotoMultiplierHitDigi.h
+++ b/src/algorithms/digi/PhotoMultiplierHitDigi.h
@@ -21,6 +21,7 @@
 #include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
 #include <spdlog/spdlog.h>
 #include <DD4hep/Detector.h>
+#include <DDRec/CellIDPositionConverter.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <cstddef>
 #include <functional>

--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -47,7 +47,6 @@
 #include <functional>
 #include <stdexcept>
 #include <vector>
-#include <random>
 #include <stdexcept>
 #include <unordered_map>
 

--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -44,12 +44,6 @@
 
 #include <spdlog/fmt/ostr.h>
 
-#include <functional>
-#include <stdexcept>
-#include <vector>
-#include <stdexcept>
-#include <unordered_map>
-
 namespace eicrecon {
 
     using namespace Acts::UnitLiterals;

--- a/src/algorithms/tracking/CKFTracking.h
+++ b/src/algorithms/tracking/CKFTracking.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <functional>
-#include <random>
 #include <stdexcept>
 #include <vector>
 

--- a/src/algorithms/tracking/CKFTracking.h
+++ b/src/algorithms/tracking/CKFTracking.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <functional>
-#include <stdexcept>
 #include <vector>
 
 #include <boost/container/flat_map.hpp>

--- a/src/algorithms/tracking/CKFTrackingFunction.cc
+++ b/src/algorithms/tracking/CKFTrackingFunction.cc
@@ -21,7 +21,6 @@
 #include "DD4hepBField.h"
 
 
-#include <random>
 #include <stdexcept>
 
 namespace eicrecon{

--- a/src/algorithms/tracking/CKFTrackingFunction.cc
+++ b/src/algorithms/tracking/CKFTrackingFunction.cc
@@ -8,20 +8,9 @@
 #include <Acts/TrackFitting/GainMatrixSmoother.hpp>
 #include <Acts/TrackFitting/GainMatrixUpdater.hpp>
 
-#if 0
-#include <Acts/Propagator/EigenStepper.hpp>
-#include <Acts/Propagator/Navigator.hpp>
-#include <Acts/Propagator/Propagator.hpp>
-#include <Acts/TrackFitting/GainMatrixSmoother.hpp>
-#include <Acts/TrackFitting/GainMatrixUpdater.hpp>
-#endif
-
 #include "CKFTracking.h"
 
 #include "DD4hepBField.h"
-
-
-#include <stdexcept>
 
 namespace eicrecon{
   using Updater  = Acts::GainMatrixUpdater;

--- a/src/algorithms/tracking/IterativeVertexFinder.h
+++ b/src/algorithms/tracking/IterativeVertexFinder.h
@@ -7,7 +7,6 @@
 #include "ActsGeometryProvider.h"
 #include "IterativeVertexFinderConfig.h"
 #include <functional>
-#include <random>
 #include <stdexcept>
 #include <vector>
 

--- a/src/algorithms/tracking/IterativeVertexFinder.h
+++ b/src/algorithms/tracking/IterativeVertexFinder.h
@@ -6,8 +6,6 @@
 
 #include "ActsGeometryProvider.h"
 #include "IterativeVertexFinderConfig.h"
-#include <functional>
-#include <stdexcept>
 #include <vector>
 
 #include "DD4hepBField.h"

--- a/src/algorithms/tracking/IterativeVertexFinderConfig.h
+++ b/src/algorithms/tracking/IterativeVertexFinderConfig.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <Acts/Vertexing/IterativeVertexFinder.hpp>
-#include <Acts/Vertexing/VertexingOptions.hpp>
-
 namespace eicrecon {
 
 struct IterativeVertexFinderConfig {

--- a/src/algorithms/tracking/TrackSeeding.h
+++ b/src/algorithms/tracking/TrackSeeding.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <functional>
-#include <random>
 #include <stdexcept>
 #include <vector>
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Unused headers in source files, but even more importantly in other headers, slows down compilation unnecessarily and potentially moves necessary includes behind a smokescreen. For example, by including `JDD4hep_service.h` in an algorithm, you may indirectly include `DD4hep/Detector.h`, but this should be done manifestly in the places that need it.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #628, again)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.