### PR TITLE
fix: trigger compilation error when `alignas` is a macro

### DIFF
--- a/src/utilities/eicrecon/eicrecon_cli.h
+++ b/src/utilities/eicrecon/eicrecon_cli.h
@@ -6,6 +6,11 @@
 
 #include <JANA/JApplication.h>
 
+#ifdef alignas
+// FIXME may be removed when minimum version in CMakeLists.txt includes the PR below
+#error JANA defines alignas macro; for patch see https://github.com/JeffersonLab/JANA2/pull/239
+#enfif
+
 namespace jana {
 
     enum Flag {

--- a/src/utilities/eicrecon/eicrecon_cli.h
+++ b/src/utilities/eicrecon/eicrecon_cli.h
@@ -9,7 +9,7 @@
 #ifdef alignas
 // FIXME may be removed when minimum version in CMakeLists.txt includes the PR below
 #error JANA defines alignas macro; for patch see https://github.com/JeffersonLab/JANA2/pull/239
-#enfif
+#endif
 
 namespace jana {
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
When `alignas` is overridden as a macro, we want to fail compilation. This allows us to ensure that this code is only used with patched JANA2 versions or future releases which don't define `alignas` as a macro.

### What kind of change does this PR introduce?
- [x] Bug fix (issue https://github.com/JeffersonLab/JANA2/issues/238)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.