### PR TITLE
fix: replace GetCollectionBase with GetCollection<T>

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 
 # Check and print what JANA2 is used
-find_package(JANA 2.0.8 REQUIRED)
+find_package(JANA 2.1.0 REQUIRED)
 message(STATUS "${CMAKE_PROJECT_NAME}: JANA2 CMake   : ${JANA_DIR}")
 message(STATUS "${CMAKE_PROJECT_NAME}: JANA2 includes: ${JANA_INCLUDE_DIR}")
 message(STATUS "${CMAKE_PROJECT_NAME}: JANA2 library : ${JANA_LIBRARY}")

--- a/src/factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h
+++ b/src/factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h
@@ -65,9 +65,8 @@ class CalorimeterClusterRecoCoG_factoryT :
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override {
 
-        // TODO: NWB: We are using GetCollectionBase because GetCollection is temporarily out of commission due to JFactoryPodioTFixed
-        auto proto = static_cast<const edm4eic::ProtoClusterCollection*>(event->GetCollectionBase(GetInputTags()[0]));
-        auto mchits = static_cast<const edm4hep::SimCalorimeterHitCollection*>(event->GetCollectionBase(GetInputTags()[1]));
+        auto proto = event->GetCollection<edm4eic::ProtoCluster>(GetInputTags()[0]);
+        auto mchits = event->GetCollection<edm4hep::SimCalorimeterHit>(GetInputTags()[1]);
 
         try {
             auto clusters_with_assocs = m_algo.process(proto, mchits);

--- a/src/factories/calorimetry/CalorimeterHitDigi_factoryT.h
+++ b/src/factories/calorimetry/CalorimeterHitDigi_factoryT.h
@@ -62,7 +62,7 @@ namespace eicrecon {
     }
 
     void Process(const std::shared_ptr<const JEvent> &event) override {
-        auto hits = static_cast<const edm4hep::SimCalorimeterHitCollection*>(event->GetCollectionBase(GetInputTags()[0]));
+        auto hits = event->GetCollection<edm4hep::SimCalorimeterHit>(GetInputTags()[0]);
 
         try {
             auto raw_hits = m_algo.process(*hits);

--- a/src/factories/calorimetry/CalorimeterHitReco_factoryT.h
+++ b/src/factories/calorimetry/CalorimeterHitReco_factoryT.h
@@ -64,7 +64,7 @@ class CalorimeterHitReco_factoryT :
     }
 
     void Process(const std::shared_ptr<const JEvent> &event) override {
-        auto raw_hits = static_cast<const edm4hep::RawCalorimeterHitCollection*>(event->GetCollectionBase(GetInputTags()[0]));
+        auto raw_hits = event->GetCollection<edm4hep::RawCalorimeterHit>(GetInputTags()[0]);
 
         try {
             auto rec_hits = m_algo.process(*raw_hits);

--- a/src/factories/calorimetry/CalorimeterHitsMerger_factoryT.h
+++ b/src/factories/calorimetry/CalorimeterHitsMerger_factoryT.h
@@ -53,7 +53,7 @@ class CalorimeterHitsMerger_factoryT :
     }
 
     void Process(const std::shared_ptr<const JEvent> &event) override {
-        auto raw_hits = static_cast<const edm4eic::CalorimeterHitCollection*>(event->GetCollectionBase(GetInputTags()[0]));
+        auto raw_hits = event->GetCollection<edm4eic::CalorimeterHit>(GetInputTags()[0]);
 
         try {
             auto rec_hits = m_algo.process(*raw_hits);

--- a/src/factories/calorimetry/CalorimeterIslandCluster_factoryT.h
+++ b/src/factories/calorimetry/CalorimeterIslandCluster_factoryT.h
@@ -70,7 +70,7 @@ class CalorimeterIslandCluster_factoryT :
     }
 
     void Process(const std::shared_ptr<const JEvent> &event) override {
-        auto hits = static_cast<const edm4eic::CalorimeterHitCollection*>(event->GetCollectionBase(GetInputTags()[0]));
+        auto hits = event->GetCollection<edm4eic::CalorimeterHit>(GetInputTags()[0]);
 
         try {
             auto proto_clusters = m_algo.process(*hits);

--- a/src/factories/calorimetry/CalorimeterTruthClustering_factoryT.h
+++ b/src/factories/calorimetry/CalorimeterTruthClustering_factoryT.h
@@ -38,8 +38,8 @@ class CalorimeterTruthClustering_factoryT :
     }
 
     void Process(const std::shared_ptr<const JEvent> &event) override {
-        auto rc_hits = static_cast<const edm4eic::CalorimeterHitCollection*>(event->GetCollectionBase(GetInputTags()[0]));
-        auto mc_hits = static_cast<const edm4hep::SimCalorimeterHitCollection*>(event->GetCollectionBase(GetInputTags()[1]));
+        auto rc_hits = event->GetCollection<edm4eic::CalorimeterHit>(GetInputTags()[0]);
+        auto mc_hits = event->GetCollection<edm4hep::SimCalorimeterHit>(GetInputTags()[1]);
 
         try {
             auto clusters = m_algo.process(*rc_hits, *mc_hits);

--- a/src/factories/calorimetry/EnergyPositionClusterMerger_factoryT.h
+++ b/src/factories/calorimetry/EnergyPositionClusterMerger_factoryT.h
@@ -56,11 +56,10 @@ class EnergyPositionClusterMerger_factoryT :
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override {
 
-        // TODO: NWB: We are using GetCollectionBase because GetCollection is temporarily out of commission due to JFactoryPodioTFixed
-        auto energy_clusters = static_cast<const edm4eic::ClusterCollection*>(event->GetCollectionBase(GetInputTags()[0]));
-        auto energy_assocs = static_cast<const edm4eic::MCRecoClusterParticleAssociationCollection*>(event->GetCollectionBase(GetInputTags()[1]));
-        auto position_clusters = static_cast<const edm4eic::ClusterCollection*>(event->GetCollectionBase(GetInputTags()[2]));
-        auto position_assocs = static_cast<const edm4eic::MCRecoClusterParticleAssociationCollection*>(event->GetCollectionBase(GetInputTags()[3]));
+        auto energy_clusters = event->GetCollection<edm4eic::Cluster>(GetInputTags()[0]);
+        auto energy_assocs = event->GetCollection<edm4eic::MCRecoClusterParticleAssociation>(GetInputTags()[1]);
+        auto position_clusters = event->GetCollection<edm4eic::Cluster>(GetInputTags()[2]);
+        auto position_assocs = event->GetCollection<edm4eic::MCRecoClusterParticleAssociation>(GetInputTags()[3]);
 
         try {
             auto clusters = m_algo.process(*energy_clusters, *energy_assocs, *position_clusters, *position_assocs);

--- a/src/factories/calorimetry/ImagingClusterReco_factoryT.h
+++ b/src/factories/calorimetry/ImagingClusterReco_factoryT.h
@@ -55,9 +55,8 @@ class ImagingClusterReco_factoryT :
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override {
 
-        // TODO: NWB: We are using GetCollectionBase because GetCollection is temporarily out of commission due to JFactoryPodioTFixed
-        auto proto = static_cast<const edm4eic::ProtoClusterCollection*>(event->GetCollectionBase(GetInputTags()[0]));
-        auto mchits = static_cast<const edm4hep::SimCalorimeterHitCollection*>(event->GetCollectionBase(GetInputTags()[1]));
+        auto proto = event->GetCollection<edm4eic::ProtoCluster>(GetInputTags()[0]);
+        auto mchits = event->GetCollection<edm4hep::SimCalorimeterHit>(GetInputTags()[1]);
 
         try {
             auto clusters = m_algo.process(*proto, *mchits);

--- a/src/factories/calorimetry/ImagingTopoCluster_factoryT.h
+++ b/src/factories/calorimetry/ImagingTopoCluster_factoryT.h
@@ -58,7 +58,7 @@ namespace eicrecon {
 
     void Process(const std::shared_ptr<const JEvent> &event) override {
         // Get input collection
-        auto* hits = static_cast<const edm4eic::CalorimeterHitCollection*>(event->GetCollectionBase(GetInputTags()[0]));
+        auto* hits = event->GetCollection<edm4eic::CalorimeterHit>(GetInputTags()[0]);
 
         // Call Process for generic algorithm
         auto proto = m_algo.process(*hits);

--- a/src/factories/calorimetry/TruthEnergyPositionClusterMerger_factoryT.h
+++ b/src/factories/calorimetry/TruthEnergyPositionClusterMerger_factoryT.h
@@ -47,12 +47,11 @@ class TruthEnergyPositionClusterMerger_factoryT :
     // Process
     void Process(const std::shared_ptr<const JEvent> &event) override {
 
-        // TODO: NWB: We are using GetCollectionBase because GetCollection is temporarily out of commission due to JFactoryPodioTFixed
-        auto mcparticles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase(GetInputTags()[0]));
-        auto energy_clusters = static_cast<const edm4eic::ClusterCollection*>(event->GetCollectionBase(GetInputTags()[1]));
-        auto energy_assocs = static_cast<const edm4eic::MCRecoClusterParticleAssociationCollection*>(event->GetCollectionBase(GetInputTags()[2]));
-        auto position_clusters = static_cast<const edm4eic::ClusterCollection*>(event->GetCollectionBase(GetInputTags()[3]));
-        auto position_assocs = static_cast<const edm4eic::MCRecoClusterParticleAssociationCollection*>(event->GetCollectionBase(GetInputTags()[4]));
+        auto mcparticles = event->GetCollection<edm4hep::MCParticle>(GetInputTags()[0]);
+        auto energy_clusters = event->GetCollection<edm4eic::Cluster>(GetInputTags()[1]);
+        auto energy_assocs = event->GetCollection<edm4eic::MCRecoClusterParticleAssociation>(GetInputTags()[2]);
+        auto position_clusters = event->GetCollection<edm4eic::Cluster>(GetInputTags()[3]);
+        auto position_assocs = event->GetCollection<edm4eic::MCRecoClusterParticleAssociation>(GetInputTags()[4]);
 
         try {
             auto clusters = m_algo.process(*mcparticles, *energy_clusters, *energy_assocs, *position_clusters, *position_assocs);

--- a/src/factories/digi/SiliconTrackerDigi_factoryT.h
+++ b/src/factories/digi/SiliconTrackerDigi_factoryT.h
@@ -49,7 +49,7 @@ namespace eicrecon {
     }
 
     void Process(const std::shared_ptr<const JEvent> &event) override {
-        auto hits = static_cast<const edm4hep::SimTrackerHitCollection*>(event->GetCollectionBase(GetInputTags()[0]));
+        auto hits = event->GetCollection<edm4hep::SimTrackerHit>(GetInputTags()[0]);
 
         try {
             auto raw_hits = m_algo.process(*hits);

--- a/src/factories/fardetectors/MatrixTransferStatic_factoryT.h
+++ b/src/factories/fardetectors/MatrixTransferStatic_factoryT.h
@@ -53,7 +53,7 @@ namespace eicrecon {
         /** Event by event processing **/
         void Process(const std::shared_ptr<const JEvent> &event) override {
 
-          auto inputhits = static_cast<const edm4hep::SimTrackerHitCollection*>(event->GetCollectionBase(GetInputTags()[0]));
+          auto inputhits = event->GetCollection<edm4hep::SimTrackerHit>(GetInputTags()[0]);
 
           try {
             auto outputTracks = m_reco_algo.produce(*inputhits);

--- a/src/factories/tracking/TrackerHitCollector_factory.cc
+++ b/src/factories/tracking/TrackerHitCollector_factory.cc
@@ -22,7 +22,7 @@ namespace eicrecon {
         std::vector<const edm4eic::TrackerHitCollection*> hit_collections;
         for (const auto& input_tag : GetInputTags()) {
             try {
-                hit_collections.emplace_back(static_cast<const edm4eic::TrackerHitCollection*>(event->GetCollectionBase(input_tag)));
+                hit_collections.emplace_back(event->GetCollection<edm4eic::TrackerHit>(input_tag));
             }
             catch(std::exception &e) {
                 // ignore missing collections, but print them in debug mode

--- a/src/factories/tracking/TrackerHitCollector_factory.h
+++ b/src/factories/tracking/TrackerHitCollector_factory.h
@@ -49,7 +49,7 @@ class TrackerHitCollector_factory :
         // not that much benefit to that approach since it requires searching through
         // a std::vector of names.
         try {
-          hit_collections.emplace_back(static_cast<const edm4eic::TrackerHitCollection*>(event->GetCollectionBase(input_tag)));
+          hit_collections.emplace_back(event->GetCollection<edm4eic::TrackerHit>(input_tag));
         }
         catch(std::exception &e) {
           // ignore missing collections, but notify them in debug mode

--- a/src/factories/tracking/TrackerHitReconstruction_factoryT.h
+++ b/src/factories/tracking/TrackerHitReconstruction_factoryT.h
@@ -52,7 +52,7 @@ namespace eicrecon {
     }
 
     void Process(const std::shared_ptr<const JEvent> &event) override {
-        auto raw_hits = static_cast<const edm4eic::RawTrackerHitCollection*>(event->GetCollectionBase(GetInputTags()[0]));
+        auto raw_hits = event->GetCollection<edm4eic::RawTrackerHit>(GetInputTags()[0]);
 
         try {
             auto rec_hits = m_algo.process(*raw_hits);

--- a/src/global/digi/PhotoMultiplierHitDigi_factory.cc
+++ b/src/global/digi/PhotoMultiplierHitDigi_factory.cc
@@ -80,7 +80,7 @@ void eicrecon::PhotoMultiplierHitDigi_factory::BeginRun(const std::shared_ptr<co
 
 void eicrecon::PhotoMultiplierHitDigi_factory::Process(const std::shared_ptr<const JEvent> &event) {
 
-  const auto *sim_hits = static_cast<const edm4hep::SimTrackerHitCollection*>(event->GetCollectionBase(GetInputTags()[0]));
+  const auto *sim_hits = event->GetCollection<edm4hep::SimTrackerHit>(GetInputTags()[0]);
 
   try {
     auto result = m_digi_algo.AlgorithmProcess(sim_hits);

--- a/src/global/pid/IrtCherenkovParticleID_factory.cc
+++ b/src/global/pid/IrtCherenkovParticleID_factory.cc
@@ -70,7 +70,7 @@ void eicrecon::IrtCherenkovParticleID_factory::Process(const std::shared_ptr<con
     if(radiator_id >= 0 && radiator_id < richgeo::nRadiators)
       charged_particles.insert({
           richgeo::RadiatorName(radiator_id),
-          static_cast<const edm4eic::TrackSegmentCollection*>(event->GetCollectionBase(input_tag))
+          event->GetCollection<edm4eic::TrackSegment>(input_tag)
           });
     else m_log->error("Unknown input RICH track collection '{}'", input_tag);
   }
@@ -79,7 +79,7 @@ void eicrecon::IrtCherenkovParticleID_factory::Process(const std::shared_ptr<con
   if(GetInputTags()[tag_num].find("Merge") != std::string::npos)
     charged_particles.insert({
         "Merged",
-        static_cast<const edm4eic::TrackSegmentCollection*>(event->GetCollectionBase(GetInputTags()[tag_num++]))
+        event->GetCollection<edm4eic::TrackSegment>(GetInputTags()[tag_num++])
         });
   else {
     m_log->critical("input tag {} should be merged tracks", tag_num);
@@ -87,8 +87,8 @@ void eicrecon::IrtCherenkovParticleID_factory::Process(const std::shared_ptr<con
   }
 
   // get input hit collections
-  const auto *raw_hits   = static_cast<const edm4eic::RawTrackerHitCollection*>(event->GetCollectionBase(GetInputTags()[tag_num++]));
-  const auto *hit_assocs = static_cast<const edm4eic::MCRecoTrackerHitAssociationCollection*>(event->GetCollectionBase(GetInputTags()[tag_num++]));
+  const auto *raw_hits   = event->GetCollection<edm4eic::RawTrackerHit>(GetInputTags()[tag_num++]);
+  const auto *hit_assocs = event->GetCollection<edm4eic::MCRecoTrackerHitAssociation>(GetInputTags()[tag_num++]);
 
   try {
     // run the IrtCherenkovParticleID algorithm

--- a/src/global/pid/MergeCherenkovParticleID_factory.cc
+++ b/src/global/pid/MergeCherenkovParticleID_factory.cc
@@ -48,7 +48,7 @@ void eicrecon::MergeCherenkovParticleID_factory::Process(const std::shared_ptr<c
   std::vector<const edm4eic::CherenkovParticleIDCollection*> cherenkov_pids;
   for(auto& input_tag : GetInputTags())
     cherenkov_pids.push_back(
-        static_cast<const edm4eic::CherenkovParticleIDCollection*>(event->GetCollectionBase(input_tag))
+        event->GetCollection<edm4eic::CherenkovParticleID>(input_tag)
         );
 
   // call the MergeParticleID algorithm

--- a/src/global/pid/MergeTrack_factory.cc
+++ b/src/global/pid/MergeTrack_factory.cc
@@ -36,7 +36,7 @@ void eicrecon::MergeTrack_factory::Process(const std::shared_ptr<const JEvent> &
   std::vector<const edm4eic::TrackSegmentCollection*> in_track_collections;
   for(auto& input_tag : GetInputTags())
     in_track_collections.push_back(
-        static_cast<const edm4eic::TrackSegmentCollection*>(event->GetCollectionBase(input_tag))
+        event->GetCollection<edm4eic::TrackSegment>(input_tag)
         );
 
   // call the MergeTracks algorithm

--- a/src/global/pid/ParticlesWithPID_factory.cc
+++ b/src/global/pid/ParticlesWithPID_factory.cc
@@ -21,10 +21,10 @@ void eicrecon::ParticlesWithPID_factory::Init() {
 }
 
 void eicrecon::ParticlesWithPID_factory::Process(const std::shared_ptr<const JEvent> &event) {
-    auto mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase(GetInputTags().at(0)));
-    auto trajectories = static_cast<const edm4eic::TrajectoryCollection*>(event->GetCollectionBase(GetInputTags().at(1)));
+    auto mc_particles = event->GetCollection<edm4hep::MCParticle>(GetInputTags().at(0));
+    auto trajectories = event->GetCollection<edm4eic::Trajectory>(GetInputTags().at(1));
     std::vector<const edm4eic::CherenkovParticleIDCollection*> cherenkov_pids;
-    cherenkov_pids.push_back(static_cast<const edm4eic::CherenkovParticleIDCollection*>(event->GetCollectionBase(GetInputTags().at(2)))); // DRICH
+    cherenkov_pids.push_back(event->GetCollection<edm4eic::CherenkovParticleID>(GetInputTags().at(2))); // DRICH
 
     try {
         auto result = m_matching_algo.process(mc_particles, trajectories, cherenkov_pids);

--- a/src/global/reco/ChargedParticleSelector_factory.h
+++ b/src/global/reco/ChargedParticleSelector_factory.h
@@ -41,7 +41,7 @@ class ChargedParticleSelector_factory :
 
     /** Event by event processing **/
     void Process(const std::shared_ptr<const JEvent> &event) override {
-      auto particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase(GetInputTags()[0]));
+      auto particles = event->GetCollection<edm4hep::MCParticle>(GetInputTags()[0]);
 
       try {
         auto charged_particles = m_algo.process(*particles);

--- a/src/global/reco/GeneratedJets_factory.cc
+++ b/src/global/reco/GeneratedJets_factory.cc
@@ -59,7 +59,7 @@ namespace eicrecon {
     void GeneratedJets_factory::Process(const std::shared_ptr<const JEvent> &event) {
 
         // grab input collection
-        auto input = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase(GetInputTags()[0]));
+        auto input = event->GetCollection<edm4hep::MCParticle>(GetInputTags()[0]);
 
         // extract particle momenta
         std::vector<const edm4hep::LorentzVectorE*> momenta;

--- a/src/global/reco/InclusiveKinematicsDA_factory.cc
+++ b/src/global/reco/InclusiveKinematicsDA_factory.cc
@@ -25,9 +25,9 @@ namespace eicrecon {
     }
 
     void InclusiveKinematicsDA_factory::Process(const std::shared_ptr<const JEvent> &event) {
-        const auto* mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase(GetInputTags()[0]));
-        const auto* rc_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase(GetInputTags()[1]));
-        const auto* rc_particles_assoc = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase(GetInputTags()[2]));
+        const auto* mc_particles = event->GetCollection<edm4hep::MCParticle>(GetInputTags()[0]);
+        const auto* rc_particles = event->GetCollection<edm4eic::ReconstructedParticle>(GetInputTags()[1]);
+        const auto* rc_particles_assoc = event->GetCollection<edm4eic::MCRecoParticleAssociation>(GetInputTags()[2]);
 
         auto inclusive_kinematics = m_inclusive_kinematics_algo.execute(
             *mc_particles,

--- a/src/global/reco/InclusiveKinematicsElectron_factory.cc
+++ b/src/global/reco/InclusiveKinematicsElectron_factory.cc
@@ -25,9 +25,9 @@ namespace eicrecon {
     }
 
     void InclusiveKinematicsElectron_factory::Process(const std::shared_ptr<const JEvent> &event) {
-        const auto* mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase(GetInputTags()[0]));
-        const auto* rc_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase(GetInputTags()[1]));
-        const auto* rc_particles_assoc = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase(GetInputTags()[2]));
+        const auto* mc_particles = event->GetCollection<edm4hep::MCParticle>(GetInputTags()[0]);
+        const auto* rc_particles = event->GetCollection<edm4eic::ReconstructedParticle>(GetInputTags()[1]);
+        const auto* rc_particles_assoc = event->GetCollection<edm4eic::MCRecoParticleAssociation>(GetInputTags()[2]);
 
         auto inclusive_kinematics = m_inclusive_kinematics_algo.execute(
             *mc_particles,

--- a/src/global/reco/InclusiveKinematicsJB_factory.cc
+++ b/src/global/reco/InclusiveKinematicsJB_factory.cc
@@ -25,9 +25,9 @@ namespace eicrecon {
     }
 
     void InclusiveKinematicsJB_factory::Process(const std::shared_ptr<const JEvent> &event) {
-        const auto* mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase(GetInputTags()[0]));
-        const auto* rc_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase(GetInputTags()[1]));
-        const auto* rc_particles_assoc = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase(GetInputTags()[2]));
+        const auto* mc_particles = event->GetCollection<edm4hep::MCParticle>(GetInputTags()[0]);
+        const auto* rc_particles = event->GetCollection<edm4eic::ReconstructedParticle>(GetInputTags()[1]);
+        const auto* rc_particles_assoc = event->GetCollection<edm4eic::MCRecoParticleAssociation>(GetInputTags()[2]);
 
         auto inclusive_kinematics = m_inclusive_kinematics_algo.execute(
             *mc_particles,

--- a/src/global/reco/InclusiveKinematicsSigma_factory.cc
+++ b/src/global/reco/InclusiveKinematicsSigma_factory.cc
@@ -25,9 +25,9 @@ namespace eicrecon {
     }
 
     void InclusiveKinematicsSigma_factory::Process(const std::shared_ptr<const JEvent> &event) {
-        const auto* mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase(GetInputTags()[0]));
-        const auto* rc_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase(GetInputTags()[1]));
-        const auto* rc_particles_assoc = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase(GetInputTags()[2]));
+        const auto* mc_particles = event->GetCollection<edm4hep::MCParticle>(GetInputTags()[0]);
+        const auto* rc_particles = event->GetCollection<edm4eic::ReconstructedParticle>(GetInputTags()[1]);
+        const auto* rc_particles_assoc = event->GetCollection<edm4eic::MCRecoParticleAssociation>(GetInputTags()[2]);
 
         auto inclusive_kinematics = m_inclusive_kinematics_algo.execute(
             *mc_particles,

--- a/src/global/reco/InclusiveKinematicsTruth_factory.cc
+++ b/src/global/reco/InclusiveKinematicsTruth_factory.cc
@@ -23,7 +23,7 @@ namespace eicrecon {
     }
 
     void InclusiveKinematicsTruth_factory::Process(const std::shared_ptr<const JEvent> &event) {
-        const auto* mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase(GetInputTags()[0]));
+        const auto* mc_particles = event->GetCollection<edm4hep::MCParticle>(GetInputTags()[0]);
 
         auto inclusive_kinematics = m_inclusive_kinematics_algo.execute(
             *mc_particles

--- a/src/global/reco/InclusiveKinematicseSigma_factory.cc
+++ b/src/global/reco/InclusiveKinematicseSigma_factory.cc
@@ -25,9 +25,9 @@ namespace eicrecon {
     }
 
     void InclusiveKinematicseSigma_factory::Process(const std::shared_ptr<const JEvent> &event) {
-        const auto* mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase(GetInputTags()[0]));
-        const auto* rc_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase(GetInputTags()[1]));
-        const auto* rc_particles_assoc = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase(GetInputTags()[2]));
+        const auto* mc_particles = event->GetCollection<edm4hep::MCParticle>(GetInputTags()[0]);
+        const auto* rc_particles = event->GetCollection<edm4eic::ReconstructedParticle>(GetInputTags()[1]);
+        const auto* rc_particles_assoc = event->GetCollection<edm4eic::MCRecoParticleAssociation>(GetInputTags()[2]);
 
         auto inclusive_kinematics = m_inclusive_kinematics_algo.execute(
             *mc_particles,

--- a/src/global/reco/MC2SmearedParticle_factory.cc
+++ b/src/global/reco/MC2SmearedParticle_factory.cc
@@ -33,7 +33,7 @@ namespace eicrecon {
 
     void MC2SmearedParticle_factory::Process(const std::shared_ptr<const JEvent> &event) {
         // Collect all hits from different tags
-        const auto mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase(GetInputTags()[0]));
+        const auto mc_particles = event->GetCollection<edm4hep::MCParticle>(GetInputTags()[0]);
         auto reco_particles = m_smearing_algo.produce(mc_particles);
 
         // Set the result

--- a/src/global/reco/ReconstructedElectrons_factory.h
+++ b/src/global/reco/ReconstructedElectrons_factory.h
@@ -54,16 +54,16 @@ namespace eicrecon {
           }
           m_log->trace( "Adding cluster associations from: {}", input_tag );
           in_clu_assoc.push_back(
-            static_cast<const edm4eic::MCRecoClusterParticleAssociationCollection*>(event->GetCollectionBase(input_tag))
+            event->GetCollection<edm4eic::MCRecoClusterParticleAssociation>(input_tag)
           );
         }
 
         // Step 2. Get MC, RC, and MC-RC association info
         // This is needed as a bridge to get RecoCluster - RC Particle associations
 
-        auto mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase("MCParticles"));
-        auto rc_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase("ReconstructedChargedParticles"));
-        auto rc_particles_assoc = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase("ReconstructedChargedParticleAssociations"));
+        auto mc_particles = event->GetCollection<edm4hep::MCParticle>("MCParticles");
+        auto rc_particles = event->GetCollection<edm4eic::ReconstructedParticle>("ReconstructedChargedParticles");
+        auto rc_particles_assoc = event->GetCollection<edm4eic::MCRecoParticleAssociation>("ReconstructedChargedParticleAssociations");
 
         // Step 3. Pass everything to "the algorithm"
         // in the future, select appropriate algorithm (truth, fully reco, etc.)

--- a/src/global/reco/ReconstructedJets_factory.cc
+++ b/src/global/reco/ReconstructedJets_factory.cc
@@ -59,7 +59,7 @@ namespace eicrecon {
     void ReconstructedJets_factory::Process(const std::shared_ptr<const JEvent> &event) {
 
         // grab input collection
-        auto input = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase(GetInputTags()[0]));
+        auto input = event->GetCollection<edm4eic::ReconstructedParticle>(GetInputTags()[0]);
 
         // extract particle momenta
         std::vector<const edm4hep::LorentzVectorE*> momenta;

--- a/src/global/tracking/CKFTracking_factory.cc
+++ b/src/global/tracking/CKFTracking_factory.cc
@@ -53,7 +53,7 @@ void eicrecon::CKFTracking_factory::Init() {
 
 void eicrecon::CKFTracking_factory::Process(const std::shared_ptr<const JEvent> &event) {
     // Collect all inputs
-    auto seed_track_parameters = static_cast<const edm4eic::TrackParametersCollection*>(event->GetCollectionBase(GetInputTags()[0]));
+    auto seed_track_parameters = event->GetCollection<edm4eic::TrackParameters>(GetInputTags()[0]);
     auto source_linker_result = event->GetSingle<eicrecon::TrackerSourceLinkerResult>(GetInputTags()[1]);
 
     if(!source_linker_result) {

--- a/src/global/tracking/TrackParamTruthInit_factory.cc
+++ b/src/global/tracking/TrackParamTruthInit_factory.cc
@@ -44,7 +44,7 @@ void eicrecon::TrackParamTruthInit_factory::ChangeRun(const std::shared_ptr<cons
 }
 
 void eicrecon::TrackParamTruthInit_factory::Process(const std::shared_ptr<const JEvent> &event) {
-    auto mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase(GetInputTags()[0]));
+    auto mc_particles = event->GetCollection<edm4hep::MCParticle>(GetInputTags()[0]);
 
     try {
         auto output = m_seeding_algo.produce(mc_particles);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Back in the early JMultifactory days, we were not able to use `GetCollection<T>`, so we ended up with many `static_cast<const T::collection_t*>(GetCollectionBase())` workarounds. As of JANA 2.1.0 (https://github.com/JeffersonLab/JANA2/pull/215) we can now use the `GetCollection<T>` syntax.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators
  - @nathanwbrei Is there a particular reason for the difference between `event->GetCollection` defined on JEvent, but `SetCollection` as a JMultifactory method?

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.