### PR TITLE
fix(ci): don't use pre-filled JANA_PLUGIN_PATH with EICrecon plugins

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -310,7 +310,7 @@ jobs:
         setup: /opt/detector/setup.sh
         run: |
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
-          export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
+          export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins:/usr/local/plugins
           chmod a+x bin/*
           $PWD/bin/eicrecon -Ppodio:output_file=rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -Pplugins=dump_flags,janadot -Pdump_flags:json=${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json -Pjana:warmup_timeout=0 -Pjana:timeout=0
           dot -Tsvg jana.dot > jana.svg
@@ -392,7 +392,7 @@ jobs:
         setup: /opt/detector/setup.sh
         run: |
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
-          export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
+          export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins:/usr/local/plugins
           chmod a+x bin/*
           $PWD/bin/eicrecon -Ppodio:output_file=rec_${{ matrix.particle }}_EcalLumiSpec_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_EcalLumiSpec_${{ matrix.detector_config }}.edm4hep.root -Ppodio:output_include_collections=EcalLumiSpecRawHits,EcalLumiSpecRecHits,EcalLumiSpecClusters,EcalLumiSpecClusterAssociations -PLUMISPECCAL:EcalLumiSpecIslandProtoClusters:splitCluster=1 -Pplugins=dump_flags,janadot -Pdump_flags:json=${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json -Pjana:warmup_timeout=0 -Pjana:timeout=0
     - uses: actions/upload-artifact@v3
@@ -440,7 +440,7 @@ jobs:
         setup: /opt/detector/setup.sh
         run: |
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
-          export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
+          export JANA_PLUGIN_PATH=$PWD/lib/EICrecon/plugins:/usr/local/plugins
           chmod a+x bin/*
           $PWD/bin/eicrecon -Ppodio:output_file=rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root -Pplugins=janadot -Pjana:warmup_timeout=0 -Pjana:timeout=0
           dot -Tsvg jana.dot > jana.svg


### PR DESCRIPTION
### Briefly, what does this PR introduce?
`JANA_PLUGIN_PATH` in eic-shell (and therefore CI environments) is prepopulated with `/usr/local/lib/EICrecon/plugins:/usr/local/plugins`. This means that removing (intentionally or otherwise) a plugin in a PR will still cause it to be found in `/usr/local/lib/EICrecon/plugins`. We need `/usr/local/plugins` though, because that contains the `janadot` plugin to create callgraphs.

There's an issue reported to JANA2 (https://github.com/JeffersonLab/JANA2/issues/136) that points out that installing plugins in a shared namespace at `/usr/local/plugins` may lead to issues and does not conform to the linux FHS. But at least EICrecon plugins are not installed there, otherwise we would have exactly this issue.

### What kind of change does this PR introduce?
- [x] Bug fix (issues, potentially)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.