### PR TITLE
fix: move NoConfig to WithPodConfig.h, as default template argument

### DIFF
--- a/src/algorithms/interfaces/WithPodConfig.h
+++ b/src/algorithms/interfaces/WithPodConfig.h
@@ -6,13 +6,21 @@
 namespace eicrecon {
 
     /**
+     * This struct might be used for factories that has no underlying config class,
+     * for example:
+     *    WithPodConfig<NoConfig>
+     */
+    struct NoConfig {
+    };
+
+    /**
      * Small helper class that brings common functions interface for classes that have POD type config
      * @tparam ConfigT
      *
      * @example:
      *
      */
-    template<typename ConfigT>
+    template<typename ConfigT = NoConfgi>
     class WithPodConfig {
     public:
         using ConfigType = ConfigT;

--- a/src/algorithms/interfaces/WithPodConfig.h
+++ b/src/algorithms/interfaces/WithPodConfig.h
@@ -20,7 +20,7 @@ namespace eicrecon {
      * @example:
      *
      */
-    template<typename ConfigT = NoConfgi>
+    template<typename ConfigT = NoConfig>
     class WithPodConfig {
     public:
         using ConfigType = ConfigT;

--- a/src/extensions/jana/JChainFactoryGeneratorT.h
+++ b/src/extensions/jana/JChainFactoryGeneratorT.h
@@ -36,7 +36,7 @@ public:
     void GenerateFactories(JFactorySet *factory_set) override {
 
         FactoryT *factory;
-        if constexpr(std:: is_base_of<NoConfig,FactoryConfigType>()) {
+        if constexpr(std::is_base_of<eicrecon::NoConfig,FactoryConfigType>()) {
             factory = new FactoryT(m_default_input_tags);
         } else {
             factory = new FactoryT(m_default_input_tags, m_default_cfg);

--- a/src/extensions/jana/JChainFactoryT.h
+++ b/src/extensions/jana/JChainFactoryT.h
@@ -16,12 +16,6 @@
 #include "services/io/podio/JFactoryPodioT.h"
 
 
-/// This struct might be used for factories that has no underlying config class
-/// @example:
-///    JChainFactoryT<OutputType, NoConfig>
-struct NoConfig {
-};
-
 template <typename OutT, typename ConfigT = NoConfig, template <typename> typename BaseT = eicrecon::JFactoryPodioT>
 class JChainFactoryT : public BaseT<OutT> {
 public:

--- a/src/extensions/jana/JChainFactoryT.h
+++ b/src/extensions/jana/JChainFactoryT.h
@@ -13,10 +13,11 @@
 #include <string>
 #include <vector>
 
+#include "algorithms/interfaces/WithPodConfig.h"
 #include "services/io/podio/JFactoryPodioT.h"
 
 
-template <typename OutT, typename ConfigT = NoConfig, template <typename> typename BaseT = eicrecon::JFactoryPodioT>
+template <typename OutT, typename ConfigT = eicrecon::NoConfig, template <typename> typename BaseT = eicrecon::JFactoryPodioT>
 class JChainFactoryT : public BaseT<OutT> {
 public:
 

--- a/src/extensions/jana/JChainMultifactoryGeneratorT.h
+++ b/src/extensions/jana/JChainMultifactoryGeneratorT.h
@@ -46,7 +46,7 @@ public:
         }
 
         FactoryT *factory;
-        if constexpr(std:: is_base_of<NoConfig,FactoryConfigType>()) {
+        if constexpr(std:: is_base_of<eicrecon::NoConfig,FactoryConfigType>()) {
             factory = new FactoryT(m_tag, m_input_tags, m_output_tags);
         } else {
             factory = new FactoryT(m_tag, m_input_tags, m_output_tags, m_default_cfg);

--- a/src/extensions/jana/JChainMultifactoryT.h
+++ b/src/extensions/jana/JChainMultifactoryT.h
@@ -21,10 +21,11 @@
 
 #include "datamodel_glue.h"
 #include <JANA/JMultifactory.h>
+#include "algorithms/interfaces/WithPodConfig.h"
 #include "extensions/jana/JChainFactoryT.h"  // Just to pull in struct NoConfig
 
 
-template <typename ConfigT = NoConfig>
+template <typename ConfigT = eicrecon::NoConfig>
 class JChainMultifactoryT : public JMultifactory {
 public:
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Instead of defining `NoConfig` in `JChainFactoryT.h`, it makes more sense to define it where the config interfaces are defined.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: discussion in #945)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.