### PR TITLE
fix: don't abuse ActsGeoProvider as a DD4hep service

### DIFF
--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -96,25 +96,6 @@ void ActsGeometryProvider::initialize(const dd4hep::Detector *dd4hep_geo,
 
     m_detector = dd4hep_geo;
 
-    // create a list of all surfaces in the detector:
-//  dd4hep::rec::SurfaceManager surfMan( *m_detector ) ;
-//
-//  m_log->debug(" surface manager ");
-//  const auto* const sM = surfMan.map("tracker") ;
-//  if (sM != nullptr) {
-//      m_log->debug(" surface map  size: {}", sM->size());
-//    // setup  dd4hep surface map
-//    //for( dd4hep::rec::SurfaceMap::const_iterator it = sM->begin() ; it != sM->end() ; ++it ){
-//    for( const auto& [id, s] :   *sM) {
-//      //dd4hep::rec::Surface* surf = s ;
-//      m_surfaceMap[ id ] = dynamic_cast<dd4hep::rec::Surface*>(s) ;
-//        //m_log->debug(" surface : {}", *s );
-////      m_detPlaneMap[id] = std::shared_ptr<genfit::DetPlane>(
-////          new genfit::DetPlane({s->origin().x(), s->origin().y(), s->origin().z()}, {s->u().x(), s->u().y(), s->u().z()},
-////                               {s->v().x(), s->v().y(), s->v().z()}));
-//    }
-//  }
-
     // Load ACTS materials maps
     if (!material_file.empty()) {
         m_init_log->info("loading materials map from file: '{}'", material_file);

--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -19,8 +19,12 @@
 #include <Acts/Plugins/Json/MaterialMapJsonConverter.hpp>
 #include <Acts/Utilities/Logger.hpp>
 
+#include <DD4hep/Detector.h>
+
 #include "extensions/spdlog/SpdlogToActs.h"
 #include "extensions/spdlog/SpdlogFormatters.h"
+
+#include "DD4hepBField.h"
 
 // Formatter for Eigen matrices
 #if FMT_VERSION >= 90000
@@ -174,8 +178,7 @@ void ActsGeometryProvider::initialize(const dd4hep::Detector* detector,
     // Load ACTS magnetic field
     init_log->info("Loading magnetic field...");
     m_magneticField = std::make_shared<const eicrecon::BField::DD4hepBField>(detector);
-    Acts::MagneticFieldContext m_fieldctx{eicrecon::BField::BFieldVariant(m_magneticField)};
-    auto bCache = m_magneticField->makeCache(m_fieldctx);
+    auto bCache = m_magneticField->makeCache(m_magneticFieldCtx);
     for (int z: {0, 500, 1000, 1500, 2000, 3000, 4000}) {
         auto b = m_magneticField->getField({0.0, 0.0, double(z)}, bCache).value();
         init_log->debug("B(z = {:>5} [mm]) = {} T", z, b.transpose());

--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -72,7 +72,7 @@ void draw_surfaces(std::shared_ptr<const Acts::TrackingGeometry> trk_geo, const 
 }
 
 
-void ActsGeometryProvider::initialize(dd4hep::Detector *dd4hep_geo,
+void ActsGeometryProvider::initialize(const dd4hep::Detector *dd4hep_geo,
                                       std::string material_file,
                                       std::shared_ptr<spdlog::logger> log,
                                       std::shared_ptr<spdlog::logger> init_log) {
@@ -94,10 +94,10 @@ void ActsGeometryProvider::initialize(dd4hep::Detector *dd4hep_geo,
     // Surfaces conversion log level
     uint printoutLevel = (uint) m_init_log->level();
 
-    m_dd4hepDetector = dd4hep_geo;
+    m_detector = dd4hep_geo;
 
     // create a list of all surfaces in the detector:
-//  dd4hep::rec::SurfaceManager surfMan( *m_dd4hepDetector ) ;
+//  dd4hep::rec::SurfaceManager surfMan( *m_detector ) ;
 //
 //  m_log->debug(" surface manager ");
 //  const auto* const sM = surfMan.map("tracker") ;
@@ -139,7 +139,7 @@ void ActsGeometryProvider::initialize(dd4hep::Detector *dd4hep_geo,
 
     try {
         m_trackingGeo = Acts::convertDD4hepDetector(
-                m_dd4hepDetector->world(),
+                m_detector->world(),
                 acts_init_log_level,
                 bTypePhi,
                 bTypeR,
@@ -181,7 +181,7 @@ void ActsGeometryProvider::initialize(dd4hep::Detector *dd4hep_geo,
 
             // more verbose output is lower enum value
             m_init_log->debug(" det_element->identifier() = {} ", det_element->identifier());
-            auto volman = m_dd4hepDetector->volumeManager();
+            auto volman = m_detector->volumeManager();
             auto *vol_ctx = volman.lookupContext(det_element->identifier());
             auto vol_id = vol_ctx->identifier;
 
@@ -200,7 +200,7 @@ void ActsGeometryProvider::initialize(dd4hep::Detector *dd4hep_geo,
 
     // Load ACTS magnetic field
     m_init_log->info("Loading magnetic field...");
-    m_magneticField = std::make_shared<const eicrecon::BField::DD4hepBField>(m_dd4hepDetector);
+    m_magneticField = std::make_shared<const eicrecon::BField::DD4hepBField>(m_detector);
     Acts::MagneticFieldContext m_fieldctx{eicrecon::BField::BFieldVariant(m_magneticField)};
     auto bCache = m_magneticField->makeCache(m_fieldctx);
     for (int z: {0, 500, 1000, 1500, 2000, 3000, 4000}) {

--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -7,8 +7,6 @@
 
 #include <TGeoManager.h>
 
-#include <DD4hep/Printout.h>
-
 #include "ActsExamples/Geometry/MaterialWiper.hpp"
 
 #include <Acts/Geometry/TrackingGeometry.hpp>

--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -72,7 +72,7 @@ void draw_surfaces(std::shared_ptr<const Acts::TrackingGeometry> trk_geo, const 
 }
 
 
-void ActsGeometryProvider::initialize(const dd4hep::Detector *dd4hep_geo,
+void ActsGeometryProvider::initialize(const dd4hep::Detector* detector,
                                       std::string material_file,
                                       std::shared_ptr<spdlog::logger> log,
                                       std::shared_ptr<spdlog::logger> init_log) {
@@ -93,8 +93,6 @@ void ActsGeometryProvider::initialize(const dd4hep::Detector *dd4hep_geo,
 
     // Surfaces conversion log level
     uint printoutLevel = (uint) m_init_log->level();
-
-    m_detector = dd4hep_geo;
 
     // Load ACTS materials maps
     std::shared_ptr<const Acts::IMaterialDecorator> materialDeco{nullptr};
@@ -121,7 +119,7 @@ void ActsGeometryProvider::initialize(const dd4hep::Detector *dd4hep_geo,
 
     try {
         m_trackingGeo = Acts::convertDD4hepDetector(
-                m_detector->world(),
+                detector->world(),
                 acts_init_log_level,
                 bTypePhi,
                 bTypeR,
@@ -163,7 +161,7 @@ void ActsGeometryProvider::initialize(const dd4hep::Detector *dd4hep_geo,
 
             // more verbose output is lower enum value
             m_init_log->debug(" det_element->identifier() = {} ", det_element->identifier());
-            auto volman = m_detector->volumeManager();
+            auto volman = detector->volumeManager();
             auto *vol_ctx = volman.lookupContext(det_element->identifier());
             auto vol_id = vol_ctx->identifier;
 
@@ -182,7 +180,7 @@ void ActsGeometryProvider::initialize(const dd4hep::Detector *dd4hep_geo,
 
     // Load ACTS magnetic field
     m_init_log->info("Loading magnetic field...");
-    m_magneticField = std::make_shared<const eicrecon::BField::DD4hepBField>(m_detector);
+    m_magneticField = std::make_shared<const eicrecon::BField::DD4hepBField>(detector);
     Acts::MagneticFieldContext m_fieldctx{eicrecon::BField::BFieldVariant(m_magneticField)};
     auto bCache = m_magneticField->makeCache(m_fieldctx);
     for (int z: {0, 500, 1000, 1500, 2000, 3000, 4000}) {

--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -97,15 +97,16 @@ void ActsGeometryProvider::initialize(const dd4hep::Detector *dd4hep_geo,
     m_detector = dd4hep_geo;
 
     // Load ACTS materials maps
+    std::shared_ptr<const Acts::IMaterialDecorator> materialDeco{nullptr};
     if (!material_file.empty()) {
         m_init_log->info("loading materials map from file: '{}'", material_file);
         // Set up the converter first
         Acts::MaterialMapJsonConverter::Config jsonGeoConvConfig;
         // Set up the json-based decorator
-        m_materialDeco = std::make_shared<const Acts::JsonMaterialDecorator>(jsonGeoConvConfig, material_file,acts_init_log_level);
+        materialDeco = std::make_shared<const Acts::JsonMaterialDecorator>(jsonGeoConvConfig, material_file,acts_init_log_level);
     } else {
         m_init_log->warn("no ACTS materials map has been loaded");
-        m_materialDeco = std::make_shared<const Acts::MaterialWiper>();
+        materialDeco = std::make_shared<const Acts::MaterialWiper>();
     }
 
     // Convert DD4hep geometry to ACTS
@@ -130,7 +131,7 @@ void ActsGeometryProvider::initialize(const dd4hep::Detector *dd4hep_geo,
                 defaultLayerThickness,
                 sortDetElementsByID,
                 m_trackingGeoCtx,
-                m_materialDeco);
+                materialDeco);
     }
     catch(std::exception &ex) {
         m_init_log->error("Error during DD4Hep -> ACTS geometry conversion. See error reason below...");

--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -145,7 +145,7 @@ void ActsGeometryProvider::initialize(const dd4hep::Detector* detector,
         draw_surfaces(m_trackingGeo, m_trackingGeoCtx, "tracking_geometry.obj");
 
         m_init_log->debug("visiting all the surfaces  ");
-        m_trackingGeo->visitSurfaces([this](const Acts::Surface *surface) {
+        m_trackingGeo->visitSurfaces([this,detector](const Acts::Surface *surface) {
             // for now we just require a valid surface
             if (surface == nullptr) {
                 m_init_log->info("no surface??? ");

--- a/src/algorithms/tracking/ActsGeometryProvider.h
+++ b/src/algorithms/tracking/ActsGeometryProvider.h
@@ -23,7 +23,6 @@
 
 // Forward declarations
 namespace Acts {
-    class IMaterialDecorator;
     class Surface;
     class TrackingGeometry;
 }

--- a/src/algorithms/tracking/ActsGeometryProvider.h
+++ b/src/algorithms/tracking/ActsGeometryProvider.h
@@ -64,11 +64,6 @@ public:
     ///  ACTS general logger that is used for running ACTS
     std::shared_ptr<spdlog::logger> getActsRelatedLogger() const { return m_log; }
 
-    /// Logger that is used for geometry initialization
-    /// By default its level the same as ACTS general logger (m_log)
-    /// But it might be customized to solely printout geometry information
-    std::shared_ptr<spdlog::logger> getActsInitRelatedLogger()  const { return m_init_log; }
-
 private:
 
     /** DD4hep detector interface class.

--- a/src/algorithms/tracking/ActsGeometryProvider.h
+++ b/src/algorithms/tracking/ActsGeometryProvider.h
@@ -79,9 +79,6 @@ private:
      */
     const dd4hep::Detector *m_detector = nullptr;
 
-    /// DD4hep surface map
-    std::map<int64_t, dd4hep::rec::Surface *> m_surfaceMap;
-
     /// ACTS Logging Level
     Acts::Logging::Level acts_log_level = Acts::Logging::INFO;
 

--- a/src/algorithms/tracking/ActsGeometryProvider.h
+++ b/src/algorithms/tracking/ActsGeometryProvider.h
@@ -41,7 +41,7 @@ public:
     ActsGeometryProvider() {}
     using VolumeSurfaceMap = std::unordered_map<uint64_t, const Acts::Surface *>;
 
-    virtual void initialize(const dd4hep::Detector* dd4hep_geo,
+    virtual void initialize(const dd4hep::Detector* detector,
                             std::string material_file,
                             std::shared_ptr<spdlog::logger> log,
                             std::shared_ptr<spdlog::logger> init_log) final;
@@ -61,12 +61,6 @@ public:
     std::shared_ptr<spdlog::logger> getActsRelatedLogger() const { return m_log; }
 
 private:
-
-    /** DD4hep detector interface class.
-     * This is the main dd4hep detector handle.
-     * <a href="https://dd4hep.web.cern.ch/dd4hep/reference/classdd4hep_1_1Detector.html">See DD4hep Detector documentation</a>
-     */
-    const dd4hep::Detector *m_detector = nullptr;
 
     /// ACTS Logging Level
     Acts::Logging::Level acts_log_level = Acts::Logging::INFO;

--- a/src/algorithms/tracking/ActsGeometryProvider.h
+++ b/src/algorithms/tracking/ActsGeometryProvider.h
@@ -9,17 +9,13 @@
 //
 #pragma once
 
+#include <spdlog/spdlog.h>
+
 // ACTS
-#include <Acts/Definitions/Units.hpp>
 #include <Acts/Geometry/GeometryContext.hpp>
-#include <Acts/Utilities/Logger.hpp>
 
 // DD4Hep
-#include <DD4hep/DD4hepUnits.h>
-
 #include "DD4hepBField.h"
-
-#include <spdlog/spdlog.h>
 
 // Forward declarations
 namespace Acts {
@@ -57,13 +53,7 @@ public:
 
     const Acts::GeometryContext& getActsGeometryContext() const {return m_trackingGeoCtx;}
 
-    ///  ACTS general logger that is used for running ACTS
-    std::shared_ptr<spdlog::logger> getActsRelatedLogger() const { return m_log; }
-
 private:
-
-    /// ACTS Logging Level
-    Acts::Logging::Level acts_log_level = Acts::Logging::INFO;
 
     /// ACTS Tracking Geometry Context
     Acts::GeometryContext m_trackingGeoCtx;
@@ -76,13 +66,4 @@ private:
 
     /// Acts magnetic field
     std::shared_ptr<const eicrecon::BField::DD4hepBField> m_magneticField = nullptr;
-
-    ///  ACTS general logger that is used for running ACTS
-    std::shared_ptr<spdlog::logger> m_log;
-
-    /// Logger that is used for geometry initialization
-    /// By default its level the same as ACTS general logger (m_log)
-    /// But it might be customized to solely printout geometry information
-    std::shared_ptr<spdlog::logger> m_init_log;
-
 };

--- a/src/algorithms/tracking/ActsGeometryProvider.h
+++ b/src/algorithms/tracking/ActsGeometryProvider.h
@@ -26,12 +26,8 @@ namespace Acts {
     class Surface;
     class TrackingGeometry;
 }
-
 namespace dd4hep {
     class Detector;
-}
-namespace dd4hep::rec {
-    class CellIDPositionConverter;
 }
 
 /** Draw the surfaces and save to obj file.
@@ -83,12 +79,6 @@ private:
 
     /// ACTS surface lookup container for hit surfaces that generate smeared hits
     VolumeSurfaceMap m_surfaces;
-
-    /** DD4hep CellID tool.
-     *  Use to lookup geometry information for a hit with cellid number (int64_t).
-     *  <a href="https://dd4hep.web.cern.ch/dd4hep/reference/classdd4hep_1_1rec_1_1CellIDPositionConverter.html">See DD4hep CellIDPositionConverter documentation</a>
-     */
-    std::shared_ptr<const dd4hep::rec::CellIDPositionConverter> m_cellid_converter = nullptr;
 
     /// Acts magnetic field
     std::shared_ptr<const eicrecon::BField::DD4hepBField> m_magneticField = nullptr;

--- a/src/algorithms/tracking/ActsGeometryProvider.h
+++ b/src/algorithms/tracking/ActsGeometryProvider.h
@@ -33,7 +33,6 @@ namespace dd4hep {
 }
 namespace dd4hep::rec {
     class CellIDPositionConverter;
-    class Surface;
 }
 
 /** Draw the surfaces and save to obj file.

--- a/src/algorithms/tracking/ActsGeometryProvider.h
+++ b/src/algorithms/tracking/ActsGeometryProvider.h
@@ -87,9 +87,6 @@ private:
     /// ACTS Tracking Geometry
     std::shared_ptr<const Acts::TrackingGeometry> m_trackingGeo{nullptr};
 
-    /// ACTS Material Decorator
-    std::shared_ptr<const Acts::IMaterialDecorator> m_materialDeco{nullptr};
-
     /// ACTS surface lookup container for hit surfaces that generate smeared hits
     VolumeSurfaceMap m_surfaces;
 

--- a/src/algorithms/tracking/ActsGeometryProvider.h
+++ b/src/algorithms/tracking/ActsGeometryProvider.h
@@ -47,12 +47,10 @@ public:
     ActsGeometryProvider() {}
     using VolumeSurfaceMap = std::unordered_map<uint64_t, const Acts::Surface *>;
 
-    virtual void initialize(dd4hep::Detector* dd4hep_geo,
+    virtual void initialize(const dd4hep::Detector* dd4hep_geo,
                             std::string material_file,
                             std::shared_ptr<spdlog::logger> log,
                             std::shared_ptr<spdlog::logger> init_log) final;
-
-    dd4hep::Detector*  dd4hepDetector() const {return m_dd4hepDetector; }
 
     /** Gets the ACTS tracking geometry.
      */
@@ -60,14 +58,8 @@ public:
 
     std::shared_ptr<const Acts::MagneticFieldProvider> getFieldProvider() const  { return m_magneticField; }
 
-    double centralMagneticField() const  {
-        return m_dd4hepDetector->field().magneticField({0, 0, 0}).z() * (Acts::UnitConstants::T / dd4hep::tesla);
-    }
-
     const VolumeSurfaceMap &surfaceMap() const  { return m_surfaces; }
 
-
-    std::map<int64_t, dd4hep::rec::Surface *> getDD4hepSurfaceMap() const { return m_surfaceMap; }
 
     const Acts::GeometryContext& getActsGeometryContext() const {return m_trackingGeoCtx;}
 
@@ -85,7 +77,7 @@ private:
      * This is the main dd4hep detector handle.
      * <a href="https://dd4hep.web.cern.ch/dd4hep/reference/classdd4hep_1_1Detector.html">See DD4hep Detector documentation</a>
      */
-    dd4hep::Detector *m_dd4hepDetector = nullptr;
+    const dd4hep::Detector *m_detector = nullptr;
 
     /// DD4hep surface map
     std::map<int64_t, dd4hep::rec::Surface *> m_surfaceMap;

--- a/src/algorithms/tracking/ActsGeometryProvider.h
+++ b/src/algorithms/tracking/ActsGeometryProvider.h
@@ -13,12 +13,11 @@
 
 // ACTS
 #include <Acts/Geometry/GeometryContext.hpp>
-
-// DD4Hep
-#include "DD4hepBField.h"
+#include <Acts/MagneticField/MagneticFieldContext.hpp>
 
 // Forward declarations
 namespace Acts {
+    class MagneticFieldProvider;
     class Surface;
     class TrackingGeometry;
 }
@@ -52,11 +51,13 @@ public:
 
 
     const Acts::GeometryContext& getActsGeometryContext() const {return m_trackingGeoCtx;}
+    const Acts::MagneticFieldContext& getActsMagneticFieldContext() const {return m_magneticFieldCtx;}
 
 private:
 
     /// ACTS Tracking Geometry Context
     Acts::GeometryContext m_trackingGeoCtx;
+    Acts::MagneticFieldContext m_magneticFieldCtx;
 
     /// ACTS Tracking Geometry
     std::shared_ptr<const Acts::TrackingGeometry> m_trackingGeo{nullptr};
@@ -65,5 +66,5 @@ private:
     VolumeSurfaceMap m_surfaces;
 
     /// Acts magnetic field
-    std::shared_ptr<const eicrecon::BField::DD4hepBField> m_magneticField = nullptr;
+    std::shared_ptr<const Acts::MagneticFieldProvider> m_magneticField = nullptr;
 };

--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -118,7 +118,7 @@ namespace eicrecon {
         //// Construct a perigee surface as the target surface
         auto pSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>(Acts::Vector3{0., 0., 0.});
 
-        auto logLevel = eicrecon::SpdlogToActsLevel(m_geoSvc->getActsRelatedLogger()->level());
+        auto logLevel = eicrecon::SpdlogToActsLevel(m_log->level());
 
         ACTS_LOCAL_LOGGER(Acts::getDefaultLogger("CKFTracking Logger", logLevel));
 

--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -28,8 +28,6 @@
 #include "extensions/spdlog/SpdlogToActs.h"
 #include "extensions/spdlog/SpdlogFormatters.h"
 
-#include "DD4hepBField.h"
-
 #include "ActsExamples/EventData/GeometryContainers.hpp"
 #include "ActsExamples/EventData/Measurement.hpp"
 #include "ActsExamples/EventData/Index.hpp"
@@ -58,8 +56,8 @@ namespace eicrecon {
 
         m_geoSvc = geo_svc;
 
-        m_BField = std::static_pointer_cast<const eicrecon::BField::DD4hepBField>(m_geoSvc->getFieldProvider());
-        m_fieldctx = eicrecon::BField::BFieldVariant(m_BField);
+        m_BField = m_geoSvc->getFieldProvider();
+        m_fieldctx = m_geoSvc->getActsMagneticFieldContext();
 
         // eta bins, chi2 and #sourclinks per surface cutoffs
         m_sourcelinkSelectorCfg = {

--- a/src/algorithms/tracking/CKFTracking.h
+++ b/src/algorithms/tracking/CKFTracking.h
@@ -5,7 +5,6 @@
 
 #include <vector>
 
-#include "DD4hepBField.h"
 #include "ActsExamples/EventData/GeometryContainers.hpp"
 #include "ActsExamples/EventData/Index.hpp"
 #include "ActsExamples/EventData/IndexSourceLink.hpp"
@@ -26,7 +25,7 @@
 
 #include "algorithms/interfaces/WithPodConfig.h"
 
-class ActsGeometryProvider;
+#include "ActsGeometryProvider.h"
 
 namespace eicrecon {
 
@@ -81,7 +80,7 @@ namespace eicrecon {
         std::shared_ptr<CKFTrackingFunction> m_trackFinderFunc;
         std::shared_ptr<const ActsGeometryProvider> m_geoSvc;
 
-        std::shared_ptr<const eicrecon::BField::DD4hepBField> m_BField = nullptr;
+        std::shared_ptr<const Acts::MagneticFieldProvider> m_BField = nullptr;
         Acts::GeometryContext m_geoctx;
         Acts::CalibrationContext m_calibctx;
         Acts::MagneticFieldContext m_fieldctx;

--- a/src/algorithms/tracking/CKFTrackingFunction.cc
+++ b/src/algorithms/tracking/CKFTrackingFunction.cc
@@ -10,8 +10,6 @@
 
 #include "CKFTracking.h"
 
-#include "DD4hepBField.h"
-
 namespace eicrecon{
   using Updater  = Acts::GainMatrixUpdater;
   using Smoother = Acts::GainMatrixSmoother;

--- a/src/algorithms/tracking/DD4hepBField.h
+++ b/src/algorithms/tracking/DD4hepBField.h
@@ -19,14 +19,7 @@
 #include <DD4hep/DD4hepUnits.h>
 
 
-
-
 namespace eicrecon::BField {
-
-  ///// The Context to be handed around
-  //struct ScalableBFieldContext {
-  //  double scalor = 1.;
-  //};
 
   /** Use the dd4hep magnetic field in acts.
    *

--- a/src/algorithms/tracking/DD4hepBField.h
+++ b/src/algorithms/tracking/DD4hepBField.h
@@ -35,7 +35,7 @@ namespace eicrecon::BField {
    */
   class DD4hepBField final : public Acts::MagneticFieldProvider {
   public:
-      dd4hep::Detector* m_det;
+    const dd4hep::Detector* m_det;
 
   public:
     struct Cache {
@@ -51,7 +51,7 @@ namespace eicrecon::BField {
     *
     * @param [in] DD4hep detector instance
     */
-    explicit DD4hepBField(dd4hep::Detector* det) : m_det(det) {}
+    explicit DD4hepBField(const dd4hep::Detector* det) : m_det(det) {}
 
     /**  retrieve magnetic field value.
      *

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -60,7 +60,7 @@ std::vector<edm4eic::Vertex*> eicrecon::IterativeVertexFinder::produce(
 
   Acts::EigenStepper<> stepper(m_BField);
   auto propagator = std::make_shared<Propagator>(stepper);
-  auto logLevel   = eicrecon::SpdlogToActsLevel(m_geoSvc->getActsRelatedLogger()->level());
+  auto logLevel   = eicrecon::SpdlogToActsLevel(m_log->level());
 
   ACTS_LOCAL_LOGGER(Acts::getDefaultLogger("CKFTracking Logger", logLevel));
   Acts::PropagatorOptions opts(m_geoctx, m_fieldctx, Acts::LoggerWrapper{logger()});

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -39,9 +39,8 @@ void eicrecon::IterativeVertexFinder::init(std::shared_ptr<const ActsGeometryPro
 
   m_geoSvc = geo_svc;
 
-  m_BField =
-      std::dynamic_pointer_cast<const eicrecon::BField::DD4hepBField>(m_geoSvc->getFieldProvider());
-  m_fieldctx = eicrecon::BField::BFieldVariant(m_BField);
+  m_BField = m_geoSvc->getFieldProvider();
+  m_fieldctx = m_geoSvc->getActsMagneticFieldContext();
 }
 
 std::vector<edm4eic::Vertex*> eicrecon::IterativeVertexFinder::produce(

--- a/src/algorithms/tracking/IterativeVertexFinder.h
+++ b/src/algorithms/tracking/IterativeVertexFinder.h
@@ -8,7 +8,6 @@
 #include "IterativeVertexFinderConfig.h"
 #include <vector>
 
-#include "DD4hepBField.h"
 #include "ActsExamples/EventData/GeometryContainers.hpp"
 #include "ActsExamples/EventData/Track.hpp"
 #include "ActsExamples/EventData/Trajectories.hpp"
@@ -36,7 +35,7 @@ private:
   std::shared_ptr<spdlog::logger> m_log;
   std::shared_ptr<const ActsGeometryProvider> m_geoSvc;
 
-  std::shared_ptr<const eicrecon::BField::DD4hepBField> m_BField = nullptr;
+  std::shared_ptr<const Acts::MagneticFieldProvider> m_BField = nullptr;
   Acts::GeometryContext m_geoctx;
   Acts::MagneticFieldContext m_fieldctx;
   IterativeVertexFinderConfig m_cfg;

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -28,8 +28,8 @@ void eicrecon::TrackSeeding::init(std::shared_ptr<const ActsGeometryProvider> ge
 
     m_geoSvc = geo_svc;
 
-    m_BField = std::dynamic_pointer_cast<const eicrecon::BField::DD4hepBField>(m_geoSvc->getFieldProvider());
-    m_fieldctx = eicrecon::BField::BFieldVariant(m_BField);
+    m_BField = m_geoSvc->getFieldProvider();
+    m_fieldctx = m_geoSvc->getActsMagneticFieldContext();
 
     configure();
 }

--- a/src/algorithms/tracking/TrackSeeding.h
+++ b/src/algorithms/tracking/TrackSeeding.h
@@ -22,7 +22,6 @@
 #include "OrthogonalTrackSeedingConfig.h"
 
 #include "ActsGeometryProvider.h"
-#include "DD4hepBField.h"
 #include "SpacePoint.h"
 
 
@@ -39,7 +38,7 @@ namespace eicrecon {
         std::shared_ptr<spdlog::logger> m_log;
         std::shared_ptr<const ActsGeometryProvider> m_geoSvc;
 
-        std::shared_ptr<const eicrecon::BField::DD4hepBField> m_BField = nullptr;
+        std::shared_ptr<const Acts::MagneticFieldProvider> m_BField = nullptr;
         Acts::MagneticFieldContext m_fieldctx;
 
         Acts::SeedFilterConfig m_seedFilterConfig;

--- a/src/algorithms/tracking/TrackerSourceLinker.cc
+++ b/src/algorithms/tracking/TrackerSourceLinker.cc
@@ -23,15 +23,15 @@
 
 #include <utility>
 
-
-void eicrecon::TrackerSourceLinker::init(std::shared_ptr<const dd4hep::rec::CellIDPositionConverter> cellid_converter,
+void eicrecon::TrackerSourceLinker::init(const dd4hep::Detector* detector,
                                          std::shared_ptr<const ActsGeometryProvider> acts_context,
                                          std::shared_ptr<spdlog::logger> logger) {
-    m_cellid_converter = std::move(cellid_converter);
+    m_detector = detector;
+    m_cellid_converter = std::make_shared<const dd4hep::rec::CellIDPositionConverter>(const_cast<dd4hep::Detector&>(*detector));
+    m_detid_b0tracker = m_detector->constant<int>("B0Tracker_Station_1_ID");
+
     m_log = std::move(logger);
     m_acts_context = std::move(acts_context);
-    m_dd4hepGeo = m_acts_context->dd4hepDetector();
-    m_detid_b0tracker = m_dd4hepGeo->constant<int>("B0Tracker_Station_1_ID");
 }
 
 
@@ -106,7 +106,7 @@ eicrecon::TrackerSourceLinkerResult *eicrecon::TrackerSourceLinker::produce(std:
         }
 
         if (m_log->level() <= spdlog::level::trace) {
-            auto volman         = m_acts_context->dd4hepDetector()->volumeManager();
+            auto volman         = m_detector->volumeManager();
             auto alignment      = volman.lookupDetElement(vol_id).nominal();
             auto local_position = (alignment.worldToLocal({hit_pos.x / mm_conv, hit_pos.y / mm_conv, hit_pos.z / mm_conv})) * mm_conv;
             double surf_center_x = surface->center(Acts::GeometryContext()).transpose()[0];

--- a/src/algorithms/tracking/TrackerSourceLinker.h
+++ b/src/algorithms/tracking/TrackerSourceLinker.h
@@ -21,7 +21,7 @@ namespace eicrecon {
 
     class TrackerSourceLinker {
     public:
-        void init(std::shared_ptr<const dd4hep::rec::CellIDPositionConverter> cellid_converter,
+        void init(const dd4hep::Detector* detector,
                   std::shared_ptr<const ActsGeometryProvider> acts_context,
                   std::shared_ptr<spdlog::logger> logger);
 
@@ -35,7 +35,7 @@ namespace eicrecon {
 
         std::shared_ptr<const ActsGeometryProvider> m_acts_context;
 
-        dd4hep::Detector* m_dd4hepGeo;
+        const dd4hep::Detector* m_detector;
 
         /// Detector-specific information
         int m_detid_b0tracker;

--- a/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.h
+++ b/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.h
@@ -78,7 +78,7 @@ public:
 
     int nEventsWithCaloHits = 0;
     std::shared_ptr<spdlog::logger> m_log;
-    dd4hep::BitFieldCoder* m_decoder;
+    dd4hep::DDSegmentation::BitFieldCoder* m_decoder;
     std::string nameSimHits         = "EcalEndcapPHits";
     std::string nameRecHits         = "EcalEndcapPRecHits";
     std::string nameClusters        = "EcalEndcapPClusters";

--- a/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.h
+++ b/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.h
@@ -95,7 +95,7 @@ public:
     int nEventsWithCaloHits = 0;
     bool isLFHCal = true;
     std::shared_ptr<spdlog::logger> m_log;
-    dd4hep::BitFieldCoder* m_decoder;
+    dd4hep::DDSegmentation::BitFieldCoder* m_decoder;
     std::string nameSimHits         = "LFHCALHits";
     std::string nameRecHits         = "LFHCALRecHits";
     std::string nameClusters        = "LFHCALClusters";

--- a/src/global/tracking/TrackerSourceLinker_factory.cc
+++ b/src/global/tracking/TrackerSourceLinker_factory.cc
@@ -42,8 +42,7 @@ namespace eicrecon {
         auto dd4hp_service = GetApplication()->GetService<JDD4hep_service>();
 
         // Initialize algorithm
-        auto cellid_converter = std::make_shared<const dd4hep::rec::CellIDPositionConverter>(*dd4hp_service->detector());
-        m_source_linker.init(cellid_converter, acts_service->actsGeoProvider(), m_log);
+        m_source_linker.init(dd4hp_service->detector(), acts_service->actsGeoProvider(), m_log);
     }
 
 

--- a/src/services/geometry/acts/ACTSGeo_service.cc
+++ b/src/services/geometry/acts/ACTSGeo_service.cc
@@ -64,7 +64,7 @@ std::shared_ptr<const ActsGeometryProvider> ACTSGeo_service::actsGeoProvider() {
 
 
 void ACTSGeo_service::acquire_services(JServiceLocator * srv_locator) {
-
+    // Log service
     auto log_service = srv_locator->get<Log_service>();
 
     // ACTS general log level:
@@ -81,7 +81,7 @@ void ACTSGeo_service::acquire_services(JServiceLocator * srv_locator) {
     m_init_log->set_level(eicrecon::ParseLogLevel(init_log_level_str));
     m_init_log->info("Acts INIT log level is set to {} ({})", log_level_str, m_init_log->level());
 
-    // DD4Hep geometry
+    // DD4hep geometry
     auto dd4hep_service = srv_locator->get<JDD4hep_service>();
     m_dd4hepGeo = dd4hep_service->detector();
 }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR simplifies the ActsGeometryProvider to prevent it from feature-creeping as a service:
- it should not provide the DD4hep geometry (not even incidentally),
- it should not act as a service if it lives in algorithms,
- it should present Acts interfaces, not custom eicrecon interfaces (I'm looking at you, DD4hepBField!).

Ultimately, the Acts geometry (as the DD4hep geometry or RICH geometry) is a service provided to algorithms, and the ActsGeo_service should provide this to algorithms (via factories). That allows algorithms to focus on 'algorithming'. The only reason for ActsGeometryProvider is to be the interface definition of how the Acts geometry is provided to algorithms, i.e. a struct that is used in the algorithm's init.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.