### PR TITLE
956 add configuration options to handle multiple hits in the same silicon tracker cell

### DIFF
--- a/src/algorithms/digi/SiliconTrackerDigi.cc
+++ b/src/algorithms/digi/SiliconTrackerDigi.cc
@@ -24,6 +24,7 @@ SiliconTrackerDigi::process(const edm4hep::SimTrackerHitCollection& sim_hits) {
     // A map of unique cellIDs with temporary structure RawHit
     std::unordered_map<std::uint64_t, edm4eic::MutableRawTrackerHit> cell_hit_map;
 
+    std::uint64_t mapID = 0;
 
     for (const auto& sim_hit : sim_hits) {
 
@@ -49,20 +50,26 @@ SiliconTrackerDigi::process(const edm4hep::SimTrackerHitCollection& sim_hits) {
             continue;
         }
 
-        if (cell_hit_map.count(sim_hit.getCellID()) == 0) {
+	if(m_cfg.sumCellHits==true){
+	  mapID = sim_hit.getCellID();
+	}
+	else{
+	  mapID++;
+	}
+
+        if (cell_hit_map.count(mapID) == 0) {
             // This cell doesn't have hits
-            cell_hit_map[sim_hit.getCellID()] = {
+            cell_hit_map[mapID] = {
                 sim_hit.getCellID(),
                 (std::int32_t) std::llround(sim_hit.getEDep() * 1e6),
                 hit_time_stamp  // ns->ps
             };
         } else {
             // There is previous values in the cell
-            auto& hit = cell_hit_map[sim_hit.getCellID()];
-            m_log->debug("  Hit already exists in cell ID={}, prev. hit time: {}", sim_hit.getCellID(), hit.getTimeStamp());
+            auto& hit = cell_hit_map[mapID];
+            m_log->debug("  Hit already exists in cell ID={}, prev. hit time: {}", mapID, hit.getTimeStamp());
 
             // keep earliest time for hit
-            auto time_stamp = hit.getTimeStamp();
             hit.setTimeStamp(std::min(hit_time_stamp, hit.getTimeStamp()));
 
             // sum deposited energy

--- a/src/algorithms/digi/SiliconTrackerDigi.cc
+++ b/src/algorithms/digi/SiliconTrackerDigi.cc
@@ -50,12 +50,12 @@ SiliconTrackerDigi::process(const edm4hep::SimTrackerHitCollection& sim_hits) {
             continue;
         }
 
-	if(m_cfg.sumCellHits==true){
-	  mapID = sim_hit.getCellID();
-	}
-	else{
-	  mapID++;
-	}
+        if(m_cfg.sumCellHits==true){
+          mapID = sim_hit.getCellID();
+        }
+        else{
+          mapID++;
+        }
 
         if (cell_hit_map.count(mapID) == 0) {
             // This cell doesn't have hits

--- a/src/algorithms/digi/SiliconTrackerDigiConfig.h
+++ b/src/algorithms/digi/SiliconTrackerDigiConfig.h
@@ -12,6 +12,7 @@ namespace eicrecon {
     // NB: be aware of thresholds in npsim! E.g. https://github.com/eic/npsim/pull/9/files
     double threshold  = 0 * dd4hep::keV;
     double timeResolution = 8;   /// TODO 8 of what units??? Same TODO in juggler. Probably [ns]
+    bool   sumCellHits    = true;
   };
 
 } // eicrecon

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -23,6 +23,7 @@ extern "C" {
          {
            .threshold = 1 * dd4hep::keV,
            .timeResolution = 2 * dd4hep::ns,
+	   .sumCellHits = false,
          },
          app
     ));

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -23,7 +23,7 @@ extern "C" {
          {
            .threshold = 1 * dd4hep::keV,
            .timeResolution = 2 * dd4hep::ns,
-	   .sumCellHits = false,
+           .sumCellHits = false,
          },
          app
     ));


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Adds a configuration option to turn off merging of hits in a single cell. A more rigorous approach to identifying when hits should be summed should follow.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #956 )
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
