### PR TITLE
Create TrackerHit before populating to prepare for potential future datamodel change

### DIFF
--- a/src/algorithms/tracking/TrackerHitReconstruction.cc
+++ b/src/algorithms/tracking/TrackerHitReconstruction.cc
@@ -55,15 +55,15 @@ std::unique_ptr<edm4eic::TrackerHitCollection> TrackerHitReconstruction::process
         //      - XYZ segmentation: xx -> sigma_x, yy-> sigma_y, zz -> sigma_z, tt -> 0
         //    This is properly in line with how we get the local coordinates for the hit
         //    in the TrackerSourceLinker.
-	auto rec_hit = rec_hits->create();
-	
+        auto rec_hit = rec_hits->create();
+
         rec_hit.setCellID(raw_hit.getCellID()); // Raw DD4hep cell ID
-	rec_hit.setPosition(edm4hep::Vector3f{static_cast<float>(pos.x() / mm), static_cast<float>(pos.y() / mm), static_cast<float>(pos.z() / mm)}); // mm
-	rec_hit.setPositionError(edm4eic::CovDiag3f{get_variance(dim[0] / mm), get_variance(dim[1] / mm), std::size(dim) > 2 ? get_variance(dim[2] / mm) : 0.});  // variance (see note above)
-	rec_hit.setTime(static_cast<float>((double)(raw_hit.getTimeStamp()) / 1000.0)); // ns
-	rec_hit.setTimeError(m_cfg.timeResolution);                                     // in ns
-	rec_hit.setEdep(static_cast<float>(raw_hit.getCharge() / 1.0e6));   // Collected energy (GeV)
-	rec_hit.setEdepError(0.0F);                                       // Error on the energy
+        rec_hit.setPosition(edm4hep::Vector3f{static_cast<float>(pos.x() / mm), static_cast<float>(pos.y() / mm), static_cast<float>(pos.z() / mm)}); // mm
+        rec_hit.setPositionError(edm4eic::CovDiag3f{get_variance(dim[0] / mm), get_variance(dim[1] / mm), std::size(dim) > 2 ? get_variance(dim[2] / mm) : 0.});  // variance (see note above)
+        rec_hit.setTime(static_cast<float>((double)(raw_hit.getTimeStamp()) / 1000.0)); // ns
+        rec_hit.setTimeError(m_cfg.timeResolution);                                     // in ns
+        rec_hit.setEdep(static_cast<float>(raw_hit.getCharge() / 1.0e6));   // Collected energy (GeV)
+        rec_hit.setEdepError(0.0F);                                       // Error on the energy
 
     }
 

--- a/src/algorithms/tracking/TrackerHitReconstruction.cc
+++ b/src/algorithms/tracking/TrackerHitReconstruction.cc
@@ -55,15 +55,15 @@ std::unique_ptr<edm4eic::TrackerHitCollection> TrackerHitReconstruction::process
         //      - XYZ segmentation: xx -> sigma_x, yy-> sigma_y, zz -> sigma_z, tt -> 0
         //    This is properly in line with how we get the local coordinates for the hit
         //    in the TrackerSourceLinker.
-        rec_hits->create(
-            raw_hit.getCellID(), // Raw DD4hep cell ID
-            edm4hep::Vector3f{static_cast<float>(pos.x() / mm), static_cast<float>(pos.y() / mm), static_cast<float>(pos.z() / mm)}, // mm
-            edm4eic::CovDiag3f{get_variance(dim[0] / mm), get_variance(dim[1] / mm), // variance (see note above)
-            std::size(dim) > 2 ? get_variance(dim[2] / mm) : 0.},
-                static_cast<float>((double)(raw_hit.getTimeStamp()) / 1000.0), // ns
-            m_cfg.timeResolution,                            // in ns
-            static_cast<float>(raw_hit.getCharge() / 1.0e6),   // Collected energy (GeV)
-            0.0F);                                       // Error on the energy
+	auto rec_hit = rec_hits->create();
+	
+        rec_hit.setCellID(raw_hit.getCellID()); // Raw DD4hep cell ID
+	rec_hit.setPosition(edm4hep::Vector3f{static_cast<float>(pos.x() / mm), static_cast<float>(pos.y() / mm), static_cast<float>(pos.z() / mm)}); // mm
+	rec_hit.setPositionError(edm4eic::CovDiag3f{get_variance(dim[0] / mm), get_variance(dim[1] / mm), std::size(dim) > 2 ? get_variance(dim[2] / mm) : 0.});  // variance (see note above)
+	rec_hit.setTime(static_cast<float>((double)(raw_hit.getTimeStamp()) / 1000.0)); // ns
+	rec_hit.setTimeError(m_cfg.timeResolution);                                     // in ns
+	rec_hit.setEdep(static_cast<float>(raw_hit.getCharge() / 1.0e6));   // Collected energy (GeV)
+	rec_hit.setEdepError(0.0F);                                       // Error on the energy
 
     }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Creates TrackerHit objects with a default constructor before populating them so that there will not be a required simultaneous change in the data model and EICrecon. Leading towards #957 

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No