### PR TITLE
fix: use xyz_g[3] in richgeo/ReadoutGeo.cc

### DIFF
--- a/src/services/geometry/richgeo/ReadoutGeo.cc
+++ b/src/services/geometry/richgeo/ReadoutGeo.cc
@@ -119,7 +119,7 @@ dd4hep::Position richgeo::ReadoutGeo::GetSensorLocalPosition(CellIDType cellID, 
   auto context = m_cellid_converter->findContext(cellID);
 
   // transformation vector buffers
-  double xyz_l[3], xyz_e[3], xyz_g[2];
+  double xyz_l[3], xyz_e[3], xyz_g[3];
   double pv_g[3], pv_l[3];
 
   // get sensor position w.r.t. its parent


### PR DESCRIPTION
This fixes the memory overrun in e.g. https://github.com/eic/EICrecon/actions/runs/6176955368/job/16769656988.

Fixes: c9ceddc0275c911065d9c3658a51d646264ca63e ('feat: SiPM pixel gap cuts')