### PR TITLE
960 create a factory to isolate mcparticle collections for beam hadronelectrons and scattered electrons

### DIFF
--- a/src/algorithms/reco/MCParticleIsolator.h
+++ b/src/algorithms/reco/MCParticleIsolator.h
@@ -39,7 +39,7 @@ namespace eicrecon {
 /* 	std::cout << part.getPDG() << " " << m_cfg.pdg << std::endl; */
 	if(part.getGeneratorStatus()==m_cfg.genStatus && part.getPDG()==m_cfg.pdg){
 /* 	  std::cout << "GOOD" << std::endl; */
-	  parts->push_back(part);
+	  parts->push_back(part.clone());
 	}
       }
 

--- a/src/algorithms/reco/MCParticleIsolator.h
+++ b/src/algorithms/reco/MCParticleIsolator.h
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2023 Simon Gardner
+
+#pragma once
+
+#include <spdlog/spdlog.h>
+
+
+// Event Model related classes
+#include <edm4hep/MCParticleCollection.h>
+
+#include "algorithms/interfaces/WithPodConfig.h"
+#include "MCParticleIsolatorConfig.h"
+
+namespace eicrecon {
+
+  /** Selects MC particles with only.
+   *
+   * \ingroup reco
+   */
+  class MCParticleIsolator : public WithPodConfig<MCParticleIsolatorConfig> {
+
+  public:
+
+    void init(std::shared_ptr<spdlog::logger>& logger) {
+        m_log = logger;
+    }
+
+    
+    std::unique_ptr<edm4hep::MCParticleCollection> process(
+        const edm4hep::MCParticleCollection& part_collection
+    ) {
+
+      auto parts = std::make_unique<edm4hep::MCParticleCollection>();
+      //parts->setSubsetCollection();
+
+      for (const auto& part : part_collection) {
+/* 	std::cout << part.getGeneratorStatus() << " " << m_cfg.genStatus << std::endl; */
+/* 	std::cout << part.getPDG() << " " << m_cfg.pdg << std::endl; */
+	if(part.getGeneratorStatus()==m_cfg.genStatus && part.getPDG()==m_cfg.pdg){
+/* 	  std::cout << "GOOD" << std::endl; */
+	  parts->push_back(part);
+	}
+      }
+
+      return std::move(parts);
+    }
+
+  protected:
+
+    std::shared_ptr<spdlog::logger> m_log;
+
+  };
+
+} // namespace eicrecon

--- a/src/algorithms/reco/MCParticleIsolator.h
+++ b/src/algorithms/reco/MCParticleIsolator.h
@@ -26,7 +26,7 @@ namespace eicrecon {
         m_log = logger;
     }
 
-    
+
     std::unique_ptr<edm4hep::MCParticleCollection> process(
         const edm4hep::MCParticleCollection& part_collection
     ) {
@@ -35,18 +35,18 @@ namespace eicrecon {
       //parts->setSubsetCollection();
 
       for (const auto& part : part_collection) {
-	if(part.getGeneratorStatus()==m_cfg.genStatus){
-	  if(m_cfg.abovePDG){
-	    if(part.getPDG()>=m_cfg.pdg){
-	      parts->push_back(part.clone());
-	    }
-	  }
-	  else{
-	    if(part.getPDG()==m_cfg.pdg){
-	      parts->push_back(part.clone());
-	    }
-	  }
-	}
+        if(part.getGeneratorStatus()==m_cfg.genStatus){
+          if(m_cfg.abovePDG){
+            if(part.getPDG()>=m_cfg.pdg){
+              parts->push_back(part.clone());
+            }
+          }
+          else{
+            if(part.getPDG()==m_cfg.pdg){
+              parts->push_back(part.clone());
+            }
+          }
+        }
       }
 
       return std::move(parts);

--- a/src/algorithms/reco/MCParticleIsolator.h
+++ b/src/algorithms/reco/MCParticleIsolator.h
@@ -35,11 +35,17 @@ namespace eicrecon {
       //parts->setSubsetCollection();
 
       for (const auto& part : part_collection) {
-/* 	std::cout << part.getGeneratorStatus() << " " << m_cfg.genStatus << std::endl; */
-/* 	std::cout << part.getPDG() << " " << m_cfg.pdg << std::endl; */
-	if(part.getGeneratorStatus()==m_cfg.genStatus && part.getPDG()==m_cfg.pdg){
-/* 	  std::cout << "GOOD" << std::endl; */
-	  parts->push_back(part.clone());
+	if(part.getGeneratorStatus()==m_cfg.genStatus){
+	  if(m_cfg.abovePDG){
+	    if(part.getPDG()>=m_cfg.pdg){
+	      parts->push_back(part.clone());
+	    }
+	  }
+	  else{
+	    if(part.getPDG()==m_cfg.pdg){
+	      parts->push_back(part.clone());
+	    }
+	  }
 	}
       }
 

--- a/src/algorithms/reco/MCParticleIsolatorConfig.h
+++ b/src/algorithms/reco/MCParticleIsolatorConfig.h
@@ -5,9 +5,11 @@
 
 namespace eicrecon {
 
+  // Defualt values for beam electron
   struct MCParticleIsolatorConfig {
-    int genStatus;
-    int pdg;
+    int  genStatus{4};
+    int  pdg{11};
+    bool abovePDG{false};
   };
 
 } // eicrecon

--- a/src/algorithms/reco/MCParticleIsolatorConfig.h
+++ b/src/algorithms/reco/MCParticleIsolatorConfig.h
@@ -5,7 +5,7 @@
 
 namespace eicrecon {
 
-  // Defualt values for beam electron
+  // Default values for beam electron
   struct MCParticleIsolatorConfig {
     int  genStatus{4};
     int  pdg{11};

--- a/src/algorithms/reco/MCParticleIsolatorConfig.h
+++ b/src/algorithms/reco/MCParticleIsolatorConfig.h
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2023 Simon Gardner
+
+#pragma once
+
+namespace eicrecon {
+
+  struct MCParticleIsolatorConfig {
+    int genStatus;
+    int pdg;
+  };
+
+} // eicrecon

--- a/src/factories/reco/MCParticleIsolator_factory.h
+++ b/src/factories/reco/MCParticleIsolator_factory.h
@@ -21,7 +21,7 @@ class MCParticleIsolator_factory :
         std::string tag,
         const std::vector<std::string>& input_tags,
         const std::vector<std::string>& output_tags,
-	MCParticleIsolatorConfig cfg)
+        MCParticleIsolatorConfig cfg)
       : JChainMultifactoryT<MCParticleIsolatorConfig>(std::move(tag), input_tags, output_tags, cfg) {
 
       bool owns_data = true; // this produces a subset collection
@@ -35,7 +35,7 @@ class MCParticleIsolator_factory :
 
       // SpdlogMixin logger initialization, sets m_log
       InitLogger(app, GetPrefix(), "info");
-      
+
       auto cfg = GetDefaultConfig();
 
       m_algo.applyConfig(cfg);
@@ -47,7 +47,7 @@ class MCParticleIsolator_factory :
     void Process(const std::shared_ptr<const JEvent> &event) override {
 
       auto particle_collection = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase(GetInputTags()[0]));
-    
+
       try {
         auto particles = m_algo.process(*particle_collection);
         SetCollection<edm4hep::MCParticle>(GetOutputTags()[0], std::move(particles));

--- a/src/factories/reco/MCParticleIsolator_factory.h
+++ b/src/factories/reco/MCParticleIsolator_factory.h
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2023 Simon Gardner
+
+#pragma once
+
+#include <spdlog/logger.h>
+#include <edm4hep/MCParticleCollection.h>
+#include "extensions/jana/JChainMultifactoryT.h"
+#include "extensions/spdlog/SpdlogMixin.h"
+#include "algorithms/reco/MCParticleIsolator.h"
+
+namespace eicrecon {
+
+/// This factory filters an MCParticles collection by pdg and genstatus
+class MCParticleIsolator_factory :
+    public JChainMultifactoryT<MCParticleIsolatorConfig>,
+    public SpdlogMixin {
+
+  public:
+    explicit MCParticleIsolator_factory(
+        std::string tag,
+        const std::vector<std::string>& input_tags,
+        const std::vector<std::string>& output_tags,
+	MCParticleIsolatorConfig cfg)
+      : JChainMultifactoryT<MCParticleIsolatorConfig>(std::move(tag), input_tags, output_tags, cfg) {
+
+      bool owns_data = true; // this produces a subset collection
+      DeclarePodioOutput<edm4hep::MCParticle>(GetOutputTags()[0], owns_data);
+
+    }
+
+    /** One time initialization **/
+    void Init() override {
+      auto app = GetApplication();
+
+      // SpdlogMixin logger initialization, sets m_log
+      InitLogger(app, GetPrefix(), "info");
+      
+      auto cfg = GetDefaultConfig();
+
+      m_algo.applyConfig(cfg);
+
+      m_algo.init(logger());
+    }
+
+    /** Event by event processing **/
+    void Process(const std::shared_ptr<const JEvent> &event) override {
+
+      auto particle_collection = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase(GetInputTags()[0]));
+    
+      try {
+        auto particles = m_algo.process(*particle_collection);
+        SetCollection<edm4hep::MCParticle>(GetOutputTags()[0], std::move(particles));
+      }
+      catch(std::exception &e) {
+        throw JException(e.what());
+      }
+    }
+
+  private:
+    MCParticleIsolator m_algo;
+
+  };
+
+} // eicrecon

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -20,6 +20,7 @@
 #include "GeneratedJets_factory.h"
 #include "ReconstructedJets_factory.h"
 #include "ReconstructedElectrons_factory.h"
+#include "factories/reco/MCParticleIsolator_factory.h"
 
 //
 extern "C" {
@@ -165,6 +166,39 @@ void InitPlugin(JApplication *app) {
             "ReconstructedChargedJets",
             {"ReconstructedChargedParticles"},
             {"ReconstructedChargedJets"},
+            app
+    ));
+
+    app->Add(new JChainMultifactoryGeneratorT<MCParticleIsolator_factory>(
+            "BeamElectronMC",
+            {"MCParticles"},
+            {"BeamElectronMC"},
+            {
+	      .genStatus = 4,
+	      .pdg       = 11,
+	    },
+            app
+    ));
+
+    app->Add(new JChainMultifactoryGeneratorT<MCParticleIsolator_factory>(
+            "BeamProtonMC",
+            {"MCParticles"},
+            {"BeamProtonMC"},
+            {
+	      .genStatus = 4,
+	      .pdg       = 2212,
+	    },
+            app
+    ));
+
+    app->Add(new JChainMultifactoryGeneratorT<MCParticleIsolator_factory>(
+            "ScatteredElectronMC",
+            {"MCParticles"},
+            {"ScatteredElectronMC"},
+            {
+	      .genStatus = 1,
+	      .pdg       = 11,
+	    },
             app
     ));
 

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -174,9 +174,9 @@ void InitPlugin(JApplication *app) {
             {"MCParticles"},
             {"MCBeamElectrons"},
             {
-	      .genStatus = 4,
-	      .pdg       = 11,
-	    },
+              .genStatus = 4,
+              .pdg       = 11,
+            },
             app
     ));
 
@@ -185,10 +185,10 @@ void InitPlugin(JApplication *app) {
             {"MCParticles"},
             {"MCBeamIons"},
             {
-	      .genStatus = 4,
-	      .pdg       = 2212,
-	      .abovePDG  = true,
-	    },
+              .genStatus = 4,
+              .pdg       = 2212,
+              .abovePDG  = true,
+            },
             app
     ));
 
@@ -197,9 +197,9 @@ void InitPlugin(JApplication *app) {
             {"MCParticles"},
             {"MCPrimaryElectrons"},
             {
-	      .genStatus = 1,
-	      .pdg       = 11,
-	    },
+              .genStatus = 1,
+              .pdg       = 11,
+            },
             app
     ));
 

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -170,9 +170,9 @@ void InitPlugin(JApplication *app) {
     ));
 
     app->Add(new JChainMultifactoryGeneratorT<MCParticleIsolator_factory>(
-            "BeamElectronMC",
+            "MCBeamElectrons",
             {"MCParticles"},
-            {"BeamElectronMC"},
+            {"MCBeamElectrons"},
             {
 	      .genStatus = 4,
 	      .pdg       = 11,
@@ -181,20 +181,21 @@ void InitPlugin(JApplication *app) {
     ));
 
     app->Add(new JChainMultifactoryGeneratorT<MCParticleIsolator_factory>(
-            "BeamProtonMC",
+            "MCBeamIons",
             {"MCParticles"},
-            {"BeamProtonMC"},
+            {"MCBeamIons"},
             {
 	      .genStatus = 4,
 	      .pdg       = 2212,
+	      .abovePDG  = true,
 	    },
             app
     ));
 
     app->Add(new JChainMultifactoryGeneratorT<MCParticleIsolator_factory>(
-            "ScatteredElectronMC",
+            "MCPrimaryElectrons",
             {"MCParticles"},
-            {"ScatteredElectronMC"},
+            {"MCPrimaryElectrons"},
             {
 	      .genStatus = 1,
 	      .pdg       = 11,

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -37,9 +37,9 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
     // Get the list of output collections to include/exclude
     std::vector<std::string> output_include_collections={
             "MCParticles",
-	    "MCBeamElectrons",
-	    "MCBeamIons",
-	    "MCPrimaryElectrons",
+            "MCBeamElectrons",
+            "MCBeamIons",
+            "MCPrimaryElectrons",
 
             // All tracking hits combined
             "CentralTrackingRecHits",

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -37,6 +37,9 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
     // Get the list of output collections to include/exclude
     std::vector<std::string> output_include_collections={
             "MCParticles",
+	    "MCBeamElectrons",
+	    "MCBeamIons",
+	    "MCPrimaryElectrons",
 
             // All tracking hits combined
             "CentralTrackingRecHits",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Adds collections to the output for the beam particles and primary event electrons. This would make user analysis code more transparent and easier to produce without (sometimes) having to know details of the hepmc file. This might be the wrong approach in the wrong place for a few reasons. Advice sought if others think this would be useful.

The information is duplicated in the MCParticles branch, currently the object is cloned rather than just pointing to objects in the MCParticles branch allowing for viewing directly in a TBrowser. Not owning the MCParticle is probably a better approach for internal use.

Access directly to these collections would also be useful for users analysing directly in the geant4 output.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #960 )
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
no