### PR TITLE
feat: new janatop plugin, i.e. janadot without the svg output

### DIFF
--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -1,2 +1,3 @@
-add_subdirectory( eicrecon )
 add_subdirectory(dump_flags)
+add_subdirectory(eicrecon)
+add_subdirectory(janatop)

--- a/src/utilities/eicrecon/eicrecon.cc
+++ b/src/utilities/eicrecon/eicrecon.cc
@@ -45,6 +45,7 @@ std::vector<std::string> EICRECON_DEFAULT_PLUGINS = {
         "LOWQ2",
         "LUMISPECCAL",
         "podio",
+        "janatop",
 };
 
 int main( int narg, char **argv)

--- a/src/utilities/janatop/CMakeLists.txt
+++ b/src/utilities/janatop/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Automatically set plugin name the same as the directory name
+# Don't forget string(REPLACE " " "_" PLUGIN_NAME ${PLUGIN_NAME}) if this dir has spaces in its name
+get_filename_component(PLUGIN_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
+
+# Function creates ${PLUGIN_NAME}_plugin and ${PLUGIN_NAME}_library targets
+# Setting default includes, libraries and installation paths
+plugin_add(${PLUGIN_NAME})
+
+# The macro grabs sources as *.cc *.cpp *.c and headers as *.h *.hh *.hpp
+# Then correctly sets sources for ${_name}_plugin and ${_name}_library targets
+# Adds headers to the correct installation directory
+plugin_glob_all(${PLUGIN_NAME})

--- a/src/utilities/janatop/JEventProcessorJANATOP.h
+++ b/src/utilities/janatop/JEventProcessorJANATOP.h
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2023, Wouter Deconinck
+
+#include <JANA/JEventProcessor.h>
+
+#include <map>
+#include <string>
+
+class JEventProcessorJANATOP : public JEventProcessor
+{
+  private:
+    enum node_type {
+        kDefault,
+        kProcessor,
+        kFactory,
+        kCache,
+        kSource
+    };
+
+    class CallLink {
+      public:
+        std::string caller_name;
+        std::string caller_tag;
+        std::string callee_name;
+        std::string callee_tag;
+
+        bool operator<(const CallLink &link) const {
+            if (this->caller_name != link.caller_name)
+                return this->caller_name < link.caller_name;
+            if (this->callee_name != link.callee_name)
+                return this->callee_name < link.callee_name;
+            if (this->caller_tag != link.caller_tag)
+                return this->caller_tag < link.caller_tag;
+            return this->callee_tag < link.callee_tag;
+        }
+    };
+
+    class CallStats {
+      public:
+        CallStats(void) {
+            from_cache_ms = 0;
+            from_source_ms = 0;
+            from_factory_ms = 0;
+            data_not_available_ms = 0;
+            Nfrom_cache = 0;
+            Nfrom_source = 0;
+            Nfrom_factory = 0;
+            Ndata_not_available = 0;
+        }
+        double from_cache_ms;
+        double from_source_ms;
+        double from_factory_ms;
+        double data_not_available_ms;
+        unsigned int Nfrom_cache;
+        unsigned int Nfrom_source;
+        unsigned int Nfrom_factory;
+        unsigned int Ndata_not_available;
+    };
+
+    class FactoryCallStats{
+      public:
+        FactoryCallStats(void) {
+            type = kDefault;
+            time_waited_on = 0.0;
+            time_waiting = 0.0;
+            Nfrom_factory = 0;
+            Nfrom_source = 0;
+            Nfrom_cache = 0;
+        }
+        node_type type;
+        double time_waited_on;    // time other factories spent waiting on this factory
+        double time_waiting;        // time this factory spent waiting on other factories
+        unsigned int Nfrom_factory;
+        unsigned int Nfrom_source;
+        unsigned int Nfrom_cache;
+    };
+
+  public:
+
+    JEventProcessorJANATOP(): JEventProcessor() {
+        SetTypeName("JEventProcessorJANATOP");
+        auto app = japp;
+    };
+
+    void Init() override { };
+
+    void BeginRun(const std::shared_ptr<const JEvent>& event) override { };
+
+    void Process(const std::shared_ptr<const JEvent>& event) override {
+        // Get the call stack for ths event and add the results to our stats
+        auto stack = event->GetJCallGraphRecorder()->GetCallGraph();
+
+        // Lock mutex in case we are running with multiple threads
+        std::lock_guard<std::mutex> lck(mutex);
+
+        // Loop over the call stack elements and add in the values
+        for (unsigned int i = 0; i < stack.size(); i++) {
+
+            // Keep track of total time each factory spent waiting and being waited on
+            std::string nametag1 = MakeNametag(stack[i].caller_name, stack[i].caller_tag);
+            std::string nametag2 = MakeNametag(stack[i].callee_name, stack[i].callee_tag);
+
+            FactoryCallStats &fcallstats1 = factory_stats[nametag1];
+            FactoryCallStats &fcallstats2 = factory_stats[nametag2];
+
+            auto delta_t_ms = std::chrono::duration_cast<std::chrono::milliseconds>(stack[i].end_time - stack[i].start_time).count();
+            fcallstats1.time_waiting += delta_t_ms;
+            fcallstats2.time_waited_on += delta_t_ms;
+
+            // Get pointer to CallStats object representing this calling pair
+            CallLink link;
+            link.caller_name = stack[i].caller_name;
+            link.caller_tag  = stack[i].caller_tag;
+            link.callee_name = stack[i].callee_name;
+            link.callee_tag  = stack[i].callee_tag;
+            CallStats &stats = call_links[link]; // get pointer to stats object or create if it doesn't exist
+
+            switch(stack[i].data_source){
+                case JCallGraphRecorder::DATA_NOT_AVAILABLE:
+                    stats.Ndata_not_available++;
+                    stats.data_not_available_ms += delta_t_ms;
+                    break;
+                case JCallGraphRecorder::DATA_FROM_CACHE:
+                    fcallstats2.Nfrom_cache++;
+                    stats.Nfrom_cache++;
+                    stats.from_cache_ms += delta_t_ms;
+                    break;
+                case JCallGraphRecorder::DATA_FROM_SOURCE:
+                    fcallstats2.Nfrom_source++;
+                    stats.Nfrom_source++;
+                    stats.from_source_ms += delta_t_ms;
+                    break;
+                case JCallGraphRecorder::DATA_FROM_FACTORY:
+                    fcallstats2.Nfrom_factory++;
+                    stats.Nfrom_factory++;
+                    stats.from_factory_ms += delta_t_ms;
+                    break;
+            }
+        }
+    };
+
+    void EndRun() override { };
+
+    void Finish() override {
+        // In order to get the total time we have to first get a list of
+        // the event processors (i.e. top-level callers). We can tell
+        // this just by looking for callers that never show up as callees
+        std::set<std::string> callers;
+        std::set<std::string> callees;
+        for (auto iter = call_links.begin(); iter != call_links.end(); iter++) {
+            const CallLink &link = iter->first;
+            std::string caller = MakeNametag(link.caller_name, link.caller_tag);
+            std::string callee = MakeNametag(link.callee_name, link.callee_tag);
+            callers.insert(caller);
+            callees.insert(callee);
+        }
+
+        // Loop over list a second time so we can get the total ticks for
+        // the process in order to add the percentage to the label below
+        double total_ms = 0.0;
+        for (auto iter = call_links.begin(); iter != call_links.end(); iter++) {
+            const CallLink &link = iter->first;
+            const CallStats &stats = iter->second;
+            std::string caller = MakeNametag(link.caller_name, link.caller_tag);
+            std::string callee = MakeNametag(link.callee_name, link.callee_tag);
+            if (callees.find(caller) == callees.end()){
+                total_ms += stats.from_factory_ms + stats.from_source_ms + stats.from_cache_ms + stats.data_not_available_ms;
+            }
+        }
+        if (total_ms == 0.0) total_ms = 1.0;
+
+        // Loop over call links
+        std::cout << "Links:" << std::endl;
+        std::vector<std::pair<CallLink, CallStats>> call_links_vector{
+            std::make_move_iterator(std::begin(call_links)),
+            std::make_move_iterator(std::end(call_links))
+        };
+        [[maybe_unused]] auto call_links_compare_time = [](const auto& a, const auto& b) {
+            return ((a.second.from_factory_ms + a.second.from_source_ms + a.second.from_cache_ms)
+                  < (b.second.from_factory_ms + b.second.from_source_ms + b.second.from_cache_ms));
+        };
+        [[maybe_unused]] auto call_links_compare_N = [](const auto& a, const auto& b) {
+            return ((a.second.Nfrom_factory + a.second.Nfrom_source + a.second.Nfrom_cache)
+                  < (b.second.Nfrom_factory + b.second.Nfrom_source + b.second.Nfrom_cache));
+        };
+        std::sort(call_links_vector.begin(), call_links_vector.end(), call_links_compare_time);
+        for (auto iter = call_links_vector.end() - std::min(call_links_vector.size(), 10ul);
+                  iter != call_links_vector.end(); iter++) {
+            const CallLink &link = iter->first;
+            const CallStats &stats = iter->second;
+
+            unsigned int Ntotal = stats.Nfrom_cache + stats.Nfrom_source + stats.Nfrom_factory;
+
+            std::string nametag1 = MakeNametag(link.caller_name, link.caller_tag);
+            std::string nametag2 = MakeNametag(link.callee_name, link.callee_tag);
+
+            double this_ms = stats.from_factory_ms + stats.from_source_ms + stats.from_cache_ms;
+            std::string timestr = MakeTimeString(stats.from_factory_ms);
+            double percent = 100.0 * this_ms / total_ms;
+            char percentstr[32];
+            snprintf(percentstr, 32, "%5.1f%%", percent);
+
+            std::cout << Ntotal << " calls, " << timestr << " (" << percentstr << ") ";
+            std::cout << nametag1 << " -> " << nametag2;
+            std::cout << std::endl;
+        }
+
+        // Loop over factories
+        std::cout << "Factories:" << std::endl;
+        std::vector<std::pair<std::string, FactoryCallStats>> factory_stats_vector{
+            std::make_move_iterator(std::begin(factory_stats)),
+            std::make_move_iterator(std::end(factory_stats))
+        };
+        auto factory_stats_compare = [](const auto& a, const auto& b) {
+            return ((a.second.time_waited_on - a.second.time_waiting)
+                  < (b.second.time_waited_on - b.second.time_waiting));
+        };
+        std::sort(factory_stats_vector.begin(), factory_stats_vector.end(), factory_stats_compare);
+        for (auto fiter = factory_stats_vector.end() - std::min(factory_stats_vector.size(), 10ul);
+                  fiter != factory_stats_vector.end(); fiter++) {
+            FactoryCallStats &fcall_stats = fiter->second;
+            std::string nodename = fiter->first;
+
+            // Get time spent in this factory proper
+            double time_spent_in_factory = fcall_stats.time_waited_on - fcall_stats.time_waiting;
+            std::string timestr = MakeTimeString(time_spent_in_factory);
+            double percent = 100.0 * time_spent_in_factory / total_ms;
+            char percentstr[32];
+            snprintf(percentstr, 32, "%5.1f%%", percent);
+
+            std::cout << timestr << " (" << percentstr << ") ";
+            std::cout << nodename;
+            std::cout << std::endl;
+        }
+    };
+
+  private:
+
+    std::mutex mutex;
+
+    std::map<CallLink, CallStats> call_links;
+    std::map<std::string, FactoryCallStats> factory_stats;
+
+    std::string MakeTimeString(double time_in_ms) {
+        double order = log10(time_in_ms);
+        std::stringstream ss;
+        ss << std::fixed << std::setprecision(2);
+        if (order < 0) {
+            ss << time_in_ms*1000.0 << " us";
+        } else if (order <= 2.0) {
+            ss << time_in_ms << " ms";
+        } else {
+               ss << time_in_ms / 1000.0 << " s";
+        }
+        return ss.str();
+    }
+
+    std::string MakeNametag(const std::string &name, const std::string &tag) {
+        std::string nametag = name;
+        if (tag.size() > 0) nametag += ":" + tag;
+        return nametag;
+    }
+};

--- a/src/utilities/janatop/JEventProcessorJANATOP.h
+++ b/src/utilities/janatop/JEventProcessorJANATOP.h
@@ -216,10 +216,10 @@ class JEventProcessorJANATOP : public JEventProcessor
                   < (b.second.time_waited_on - b.second.time_waiting));
         };
         std::sort(factory_stats_vector.begin(), factory_stats_vector.end(), factory_stats_compare);
-        for (auto fiter = factory_stats_vector.end() - std::min(factory_stats_vector.size(), 10ul);
-                  fiter != factory_stats_vector.end(); fiter++) {
-            FactoryCallStats &fcall_stats = fiter->second;
-            std::string nodename = fiter->first;
+        for (auto iter = factory_stats_vector.end() - std::min(factory_stats_vector.size(), 10ul);
+                  iter != factory_stats_vector.end(); iter++) {
+            FactoryCallStats &fcall_stats = iter->second;
+            std::string nodename = iter->first;
 
             // Get time spent in this factory proper
             double time_spent_in_factory = fcall_stats.time_waited_on - fcall_stats.time_waiting;

--- a/src/utilities/janatop/janadot.cc
+++ b/src/utilities/janatop/janadot.cc
@@ -1,0 +1,17 @@
+// Copyright 2022, Dmitry Romanov
+// Subject to the terms in the LICENSE file found in the top-level directory.
+//
+//
+
+#include <JANA/JApplication.h>
+#include <JANA/JFactoryGenerator.h>
+
+#include "JEventProcessorJANATOP.h"
+
+extern "C" {
+    void InitPlugin(JApplication *app) {
+        InitJANAPlugin(app);
+        app->Add(new JEventProcessorJANATOP());
+        app->GetJParameterManager()->SetParameter("RECORD_CALL_STACK", true);
+    }
+}


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This plugin produces a final table with top link requests and top factory consumers. This will allow us to figure out where our CPU time is going (in particular the factory consumers list shows that). I don't know yet if the top link requests is so useful or interpretable...

Example output:
```console
[INFO] All workers have stopped.
[INFO] Merging threads ...
[INFO] JArrow: Finalized JEventProcessor 'JEventProcessorPODIO'
Links:
20 calls, 2.68 s (  3.0%) JEventProcessorPODIO -> edm4eic::ReconstructedParticle:GeneratedJets
20 calls, 0.00 us (  3.1%) JEventProcessorPODIO -> edm4eic::TrackSegment:CalorimeterTrackProjections
10 calls, 3.08 s (  3.4%) edm4eic::MCRecoClusterParticleAssociation:LFHCALClusterAssociations -> edm4eic::ProtoCluster:LFHCALIslandProtoClusters
20 calls, 3.14 s (  3.5%) JEventProcessorPODIO -> edm4eic::MCRecoClusterParticleAssociation:LFHCALClusterAssociations
20 calls, 3.25 s (  3.6%) JEventProcessorPODIO -> edm4eic::MCRecoClusterParticleAssociation:EcalBarrelClusterAssociations
20 calls, 5.81 s (  6.5%) JEventProcessorPODIO -> edm4eic::TrackParameters:CentralCKFSeededTrackParameters
20 calls, 6.54 s (  7.3%) JEventProcessorPODIO -> edm4eic::TrackParameters:CentralCKFTrackParameters
20 calls, 14.01 s ( 15.6%) JEventProcessorPODIO -> edm4eic::MCRecoClusterParticleAssociation:B0ECalClusterAssociations
10 calls, 41.16 s ( 45.8%) edm4eic::CherenkovParticleID:DRICHAerogelIrtCherenkovParticleID -> edm4eic::TrackSegment:DRICHAerogelTracks
20 calls, 41.23 s ( 45.9%) JEventProcessorPODIO -> edm4eic::CherenkovParticleID:DRICHAerogelIrtCherenkovParticleID
Factories:
2.56 s (  2.8%) edm4eic::ReconstructedParticle:GeneratedChargedJets
2.57 s (  2.9%) edm4eic::ReconstructedParticle:ReconstructedChargedJets
2.62 s (  2.9%) edm4eic::ReconstructedParticle:ReconstructedJets
2.68 s (  3.0%) edm4eic::ReconstructedParticle:GeneratedJets
2.75 s (  3.1%) edm4eic::TrackSegment:CalorimeterTrackProjections
3.04 s (  3.4%) edm4eic::ProtoCluster:LFHCALIslandProtoClusters
3.96 s (  4.4%) edm4eic::TrackParameters:CentralCKFSeededTrackParameters
6.54 s (  7.3%) edm4eic::TrackParameters:CentralCKFTrackParameters
14.00 s ( 15.6%) edm4eic::MCRecoClusterParticleAssociation:B0ECalClusterAssociations
41.16 s ( 45.8%) edm4eic::TrackSegment:DRICHAerogelTracks
[INFO] JArrow: Finalized JEventProcessor 'JEventProcessorJANATOP'
[INFO] Event processing ended.
```

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.