### PR TITLE
fix: disable DRICH radiator and photon vertex cheat code

### DIFF
--- a/src/detectors/DRICH/DRICH.cc
+++ b/src/detectors/DRICH/DRICH.cc
@@ -87,8 +87,8 @@ extern "C" {
     // - PDG list
     irt_cfg.pdgList.insert(irt_cfg.pdgList.end(), { 11, 211, 321, 2212 });
     // - cheat modes
-    irt_cfg.cheatPhotonVertex  = true;
-    irt_cfg.cheatTrueRadiator  = true;
+    irt_cfg.cheatPhotonVertex  = false;
+    irt_cfg.cheatTrueRadiator  = false;
 
     // Merge PID from radiators
     MergeParticleIDConfig merge_cfg;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This disables the cheatTrueRadiator and cheatPhotonVertex codes in the DRICH IrtCherenkovParticleID_factory configuration. This should reduce the number of warnings about non-optical photon hits on the DRICH sensors.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #689)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @chchatte92 @c-dilks 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes. No more cheating.