### PR TITLE
[Backport v1.5] fix: disable DRICH radiator and photon vertex cheat code

### DIFF
--- a/src/detectors/DRICH/DRICH.cc
+++ b/src/detectors/DRICH/DRICH.cc
@@ -87,8 +87,8 @@ extern "C" {
     // - PDG list
     irt_cfg.pdgList.insert(irt_cfg.pdgList.end(), { 11, 211, 321, 2212 });
     // - cheat modes
-    irt_cfg.cheatPhotonVertex  = true;
-    irt_cfg.cheatTrueRadiator  = true;
+    irt_cfg.cheatPhotonVertex  = false;
+    irt_cfg.cheatTrueRadiator  = false;
 
     // Merge PID from radiators
     MergeParticleIDConfig merge_cfg;


### PR DESCRIPTION
# Description
Backport of #967 to `v1.5`.