### PR TITLE
treewide: deprecate simID and recID in Association types for EDM4eic 4.0.0

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -14,6 +14,7 @@
 #include <Eigen/Dense>
 
 #include <Evaluator/DD4hepUnits.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4hep/MCParticle.h>
 
 #include "CalorimeterClusterRecoCoG.h"
@@ -124,8 +125,10 @@ namespace eicrecon {
 
         // set association
         auto clusterassoc = associations->create();
+#if EDM4EIC_VERSION_MAJOR < 4
         clusterassoc.setRecID(cl->getObjectID().index); // if not using collection, this is always set to -1
         clusterassoc.setSimID(mcp.getObjectID().index);
+#endif
         clusterassoc.setWeight(1.0);
         clusterassoc.setRec(*cl);
         clusterassoc.setSim(mcp);

--- a/src/algorithms/calorimetry/EnergyPositionClusterMerger.h
+++ b/src/algorithms/calorimetry/EnergyPositionClusterMerger.h
@@ -9,6 +9,7 @@
 #include <spdlog/spdlog.h>
 
 // Event Model related classes
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/ClusterCollection.h>
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <edm4eic/vector_utils.h>
@@ -145,45 +146,55 @@ namespace eicrecon {
                     // we must write an association
                     if (ea != energy_assoc.end() && pa != pos_assoc.end()) {
                         // we have two associations
-                        if (pa->getSimID() == ea->getSimID()) {
+                        if (pa->getSim().getObjectID().index == ea->getSim().getObjectID().index) {
                             // both associations agree on the MCParticles entry
                             auto clusterassoc = merged_assoc->create();
+#if EDM4EIC_VERSION_MAJOR < 4
                             clusterassoc.setRecID(new_clus.getObjectID().index);
-                            clusterassoc.setSimID(ea->getSimID());
+                            clusterassoc.setSimID(ea->getSim().getObjectID().index);
+#endif
                             clusterassoc.setWeight(1.0);
                             clusterassoc.setRec(new_clus);
                             clusterassoc.setSim(ea->getSim());
                         } else {
                             // both associations disagree on the MCParticles entry
-                            m_log->debug("   --> Two associations added to {} and {}", ea->getSimID(), pa->getSimID());
+                            m_log->debug("   --> Two associations added to {} and {}", ea->getSim().getObjectID().index, pa->getSim().getObjectID().index);
                             auto clusterassoc1 = merged_assoc->create();
+#if EDM4EIC_VERSION_MAJOR < 4
                             clusterassoc1.setRecID(new_clus.getObjectID().index);
-                            clusterassoc1.setSimID(ea->getSimID());
+                            clusterassoc1.setSimID(ea->getSim().getObjectID().index);
+#endif
                             clusterassoc1.setWeight(0.5);
                             clusterassoc1.setRec(new_clus);
                             clusterassoc1.setSim(ea->getSim());
                             auto clusterassoc2 = merged_assoc->create();
+#if EDM4EIC_VERSION_MAJOR < 4
                             clusterassoc2.setRecID(new_clus.getObjectID().index);
-                            clusterassoc2.setSimID(pa->getSimID());
+                            clusterassoc2.setSimID(pa->getSim().getObjectID().index);
+#endif
                             clusterassoc2.setWeight(0.5);
                             clusterassoc2.setRec(new_clus);
                             clusterassoc2.setSim(pa->getSim());
                         }
                     } else if (ea != energy_assoc.end()) {
                         // no position association
-                        m_log->debug("   --> Only added energy cluster association to {}", ea->getSimID());
+                        m_log->debug("   --> Only added energy cluster association to {}", ea->getSim().getObjectID().index);
                         auto clusterassoc = merged_assoc->create();
+#if EDM4EIC_VERSION_MAJOR < 4
                         clusterassoc.setRecID(new_clus.getObjectID().index);
-                        clusterassoc.setSimID(ea->getSimID());
+                        clusterassoc.setSimID(ea->getSim().getObjectID().index);
+#endif
                         clusterassoc.setWeight(1.0);
                         clusterassoc.setRec(new_clus);
                         clusterassoc.setSim(ea->getSim());
                     } else if (pa != pos_assoc.end()) {
                         // no energy association
-                        m_log->debug("   --> Only added position cluster association to {}", pa->getSimID());
+                        m_log->debug("   --> Only added position cluster association to {}", pa->getSim().getObjectID().index);
                         auto clusterassoc = merged_assoc->create();
+#if EDM4EIC_VERSION_MAJOR < 4
                         clusterassoc.setRecID(new_clus.getObjectID().index);
-                        clusterassoc.setSimID(pa->getSimID());
+                        clusterassoc.setSimID(pa->getSim().getObjectID().index);
+#endif
                         clusterassoc.setWeight(1.0);
                         clusterassoc.setRec(new_clus);
                         clusterassoc.setSim(pa->getSim());

--- a/src/algorithms/calorimetry/ImagingClusterReco.h
+++ b/src/algorithms/calorimetry/ImagingClusterReco.h
@@ -20,6 +20,7 @@
 #include "algorithms/calorimetry/ClusterTypes.h"
 
 // Event Model related classes
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
 #include <edm4eic/CalorimeterHitCollection.h>
@@ -120,8 +121,10 @@ namespace eicrecon {
 
                 // set association
                 auto clusterassoc = associations->create();
+#if EDM4EIC_VERSION_MAJOR < 4
                 clusterassoc.setRecID(cl.getObjectID().index);
                 clusterassoc.setSimID(mcp.getObjectID().index);
+#endif
                 clusterassoc.setWeight(1.0);
                 clusterassoc.setRec(cl);
                 clusterassoc.setSim(mcp);

--- a/src/algorithms/calorimetry/TruthEnergyPositionClusterMerger.h
+++ b/src/algorithms/calorimetry/TruthEnergyPositionClusterMerger.h
@@ -9,6 +9,7 @@
 
 // Event Model related classes
 #include <edm4hep/MCParticle.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/Cluster.h>
 #include <edm4eic/MCRecoClusterParticleAssociation.h>
 #include <edm4eic/vector_utils.h>
@@ -109,8 +110,10 @@ namespace eicrecon {
 
                 // set association
                 auto clusterassoc = merged_assoc->create();
+#if EDM4EIC_VERSION_MAJOR < 4
                 clusterassoc.setRecID(new_clus.getObjectID().index);
                 clusterassoc.setSimID(mcID);
+#endif
                 clusterassoc.setWeight(1.0);
                 clusterassoc.setRec(new_clus);
                 clusterassoc.setSim(mcparticles[mcID]);
@@ -126,8 +129,10 @@ namespace eicrecon {
 
                 // set association
                 auto clusterassoc = merged_assoc->create();
+#if EDM4EIC_VERSION_MAJOR < 4
                 clusterassoc.setRecID(new_clus.getObjectID().index);
                 clusterassoc.setSimID(mcID);
+#endif
                 clusterassoc.setWeight(1.0);
                 clusterassoc.setRec(new_clus);
                 clusterassoc.setSim(mcparticles[mcID]);
@@ -157,8 +162,10 @@ namespace eicrecon {
 
             // set association
             auto clusterassoc = merged_assoc->create();
+#if EDM4EIC_VERSION_MAJOR < 4
             clusterassoc.setRecID(new_clus.getObjectID().index);
             clusterassoc.setSimID(mcID);
+#endif
             clusterassoc.setWeight(1.0);
             clusterassoc.setRec(new_clus);
             clusterassoc.setSim(mc);
@@ -182,7 +189,7 @@ namespace eicrecon {
             // find associated particle
             for (const auto &assoc: associations) {
                 if (assoc.getRec() == cluster) {
-                    mcID = assoc.getSimID();
+                    mcID = assoc.getSim().getObjectID().index;
                     break;
                 }
             }

--- a/src/algorithms/pid/ParticlesWithPID.cc
+++ b/src/algorithms/pid/ParticlesWithPID.cc
@@ -3,6 +3,7 @@
 
 #include "ParticlesWithPID.h"
 
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/vector_utils.h>
 #include <edm4hep/utils/vector_utils.h>
 
@@ -161,8 +162,10 @@ namespace eicrecon {
             // Also write MC <--> truth particle association if match was found
             if (best_match >= 0) {
                 auto rec_assoc = out_colls.assocs->create();
+#if EDM4EIC_VERSION_MAJOR < 4
                 rec_assoc.setRecID(rec_part.getObjectID().index);
                 rec_assoc.setSimID((*mc_particles)[best_match].getObjectID().index);
+#endif
                 rec_assoc.setWeight(1);
                 rec_assoc.setRec(rec_part);
                 auto sim = (*mc_particles)[best_match];
@@ -180,7 +183,7 @@ namespace eicrecon {
                                  mcpart.getPDG());
 
                     m_log->debug(" Assoc: id={} SimId={} RecId={}",
-                                 rec_assoc.getObjectID().index, rec_assoc.getSimID(), rec_assoc.getSimID());
+                                 rec_assoc.getObjectID().index, rec_assoc.getSim().getObjectID().index, rec_assoc.getRec().getObjectID().index);
 
                     m_log->trace(" Assoc PDGs: sim.PDG | rec.PDG | rec.particleIDUsed.PDG = {:^6} | {:^6} | {:^6}",
                                  rec_assoc.getSim().getPDG(),

--- a/src/algorithms/reco/ElectronReconstruction.cc
+++ b/src/algorithms/reco/ElectronReconstruction.cc
@@ -32,7 +32,7 @@ namespace eicrecon {
             auto sim = clu_assoc.getSim(); // McParticle
             auto clu = clu_assoc.getRec(); // RecoCluster
 
-            m_log->trace( "SimId={}, CluId={}", clu_assoc.getSimID(), clu_assoc.getRecID() );
+            m_log->trace( "SimId={}, CluId={}", sim.getObjectID().index, clu.getObjectID().index );
             m_log->trace( "MCParticle: Energy={} GeV, p={} GeV, E/p = {} for PDG: {}", clu.getEnergy(), edm4eic::magnitude(sim.getMomentum()), clu.getEnergy() / edm4eic::magnitude(sim.getMomentum()), sim.getPDG() );
 
 
@@ -40,7 +40,7 @@ namespace eicrecon {
             // i.e. take (MC Particle <-> RC Cluster) + ( MC Particle <-> RC Particle ) = ( RC Particle <-> RC Cluster )
             auto reco_part_assoc = rcassoc->begin();
             for (; reco_part_assoc != rcassoc->end(); ++reco_part_assoc) {
-              if (reco_part_assoc->getSimID() == (unsigned) clu_assoc.getSimID()) {
+              if (reco_part_assoc->getSim().getObjectID().index == (unsigned) sim.getObjectID().index) {
                 break;
               }
             }
@@ -57,7 +57,7 @@ namespace eicrecon {
               }
 
             } else {
-              m_log->debug( "Could not find reconstructed particle for SimId={}", clu_assoc.getSimID() );
+              m_log->debug( "Could not find reconstructed particle for SimId={}", sim.getObjectID().index );
             }
 
           } // loop on MC particle to cluster associations in collection

--- a/src/algorithms/reco/InclusiveKinematicsDA.cc
+++ b/src/algorithms/reco/InclusiveKinematicsDA.cc
@@ -74,10 +74,10 @@ namespace eicrecon {
     //const auto ef_assoc = std::find_if(
     //  rcassoc->begin(),
     //  rcassoc.end(),
-    //  [&ef_coll](const auto& a){ return a.getSimID() == ef_coll[0].getObjectID().index; });
+    //  [&ef_coll](const auto& a){ return a.getSim().getObjectID().index == ef_coll[0].getObjectID().index; });
     auto ef_assoc = rcassoc.begin();
     for (; ef_assoc != rcassoc.end(); ++ef_assoc) {
-      if (ef_assoc->getSimID() == (unsigned) ef_coll[0].getObjectID().index) {
+      if (ef_assoc->getSim().getObjectID().index == (unsigned) ef_coll[0].getObjectID().index) {
         break;
       }
     }

--- a/src/algorithms/reco/InclusiveKinematicsElectron.cc
+++ b/src/algorithms/reco/InclusiveKinematicsElectron.cc
@@ -123,10 +123,10 @@ namespace eicrecon {
     //const auto ef_assoc = std::find_if(
     //  rcassoc.begin(),
     //  rcassoc.end(),
-    //  [&ef_coll](const auto& a){ return a.getSimID() == ef_coll[0].getObjectID().index; });
+    //  [&ef_coll](const auto& a){ return a.getSim().getObjectID().index == ef_coll[0].getObjectID().index; });
     auto ef_assoc = rcassoc.begin();
     for (; ef_assoc != rcassoc.end(); ++ef_assoc) {
-      if (ef_assoc->getSimID() == (unsigned) ef_coll[0].getObjectID().index) {
+      if (ef_assoc->getSim().getObjectID().index == (unsigned) ef_coll[0].getObjectID().index) {
         break;
       }
     }

--- a/src/algorithms/reco/InclusiveKinematicsJB.cc
+++ b/src/algorithms/reco/InclusiveKinematicsJB.cc
@@ -74,10 +74,10 @@ namespace eicrecon {
     //const auto ef_assoc = std::find_if(
     //  rcassoc.begin(),
     //  rcassoc.end(),
-    //  [&ef_coll](const auto& a){ return a.getSimID() == ef_coll[0].getObjectID().index; });
+    //  [&ef_coll](const auto& a){ return a.getSim().getObjectID().index == ef_coll[0].getObjectID().index; });
     auto ef_assoc = rcassoc.begin();
     for (; ef_assoc != rcassoc.end(); ++ef_assoc) {
-      if (ef_assoc->getSimID() == (unsigned) ef_coll[0].getObjectID().index) {
+      if (ef_assoc->getSim().getObjectID().index == (unsigned) ef_coll[0].getObjectID().index) {
         break;
       }
     }

--- a/src/algorithms/reco/InclusiveKinematicsSigma.cc
+++ b/src/algorithms/reco/InclusiveKinematicsSigma.cc
@@ -75,10 +75,10 @@ namespace eicrecon {
     //const auto ef_assoc = std::find_if(
     //  rcassoc.begin(),
     //  rcassoc.end(),
-    //  [&ef_coll](const auto& a){ return a.getSimID() == ef_coll[0].getObjectID().index; });
+    //  [&ef_coll](const auto& a){ return a.getSim().getObjectID().index == ef_coll[0].getObjectID().index; });
     auto ef_assoc = rcassoc.begin();
     for (; ef_assoc != rcassoc.end(); ++ef_assoc) {
-      if (ef_assoc->getSimID() == (unsigned) ef_coll[0].getObjectID().index) {
+      if (ef_assoc->getSim().getObjectID().index == (unsigned) ef_coll[0].getObjectID().index) {
         break;
       }
     }

--- a/src/algorithms/reco/InclusiveKinematicseSigma.cc
+++ b/src/algorithms/reco/InclusiveKinematicseSigma.cc
@@ -75,10 +75,10 @@ namespace eicrecon {
     //const auto ef_assoc = std::find_if(
     //  rcassoc.begin(),
     //  rcassoc.end(),
-    //  [&ef_coll](const auto& a){ return a.getSimID() == ef_coll[0].getObjectID().index; });
+    //  [&ef_coll](const auto& a){ return a.getSim().getObjectID().index == ef_coll[0].getObjectID().index; });
     auto ef_assoc = rcassoc.begin();
     for (; ef_assoc != rcassoc.end(); ++ef_assoc) {
-      if (ef_assoc->getSimID() == (unsigned) ef_coll[0].getObjectID().index) {
+      if (ef_assoc->getSim().getObjectID().index == (unsigned) ef_coll[0].getObjectID().index) {
         break;
       }
     }

--- a/src/algorithms/reco/MatchClusters.cc
+++ b/src/algorithms/reco/MatchClusters.cc
@@ -18,6 +18,7 @@
 
 // Event Model related classes
 #include <edm4hep/MCParticleCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/ClusterCollection.h>
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <edm4eic/MCRecoParticleAssociationCollection.h>
@@ -66,8 +67,8 @@ namespace eicrecon {
 
             // find associated particle
             for (const auto &assoc: inpartsassoc) {
-                if (assoc->getRecID() == inpart->getObjectID().index) {
-                    mcID = assoc->getSimID();
+                if (assoc->getRec().getObjectID().index == inpart->getObjectID().index) {
+                    mcID = assoc->getSim().getObjectID().index;
                     break;
                 }
             }
@@ -89,8 +90,10 @@ namespace eicrecon {
 
             // create truth associations
             auto assoc = outpartsassoc->create();
+#if EDM4EIC_VERSION_MAJOR < 4
             assoc.setRecID(outpart.getObjectID().index);
             assoc.setSimID(mcID);
+#endif
             assoc.setWeight(1.0);
             assoc.setRec(outpart);
             assoc.setSim(*mcparticles[mcID]);
@@ -125,8 +128,10 @@ namespace eicrecon {
 
             // Create truth associations
             auto assoc = outpartsassoc->create();
+#if EDM4EIC_VERSION_MAJOR < 4
             assoc.setRecID(outpart.getObjectID().index);
             assoc.setSimID(mcID);
+#endif
             assoc.setWeight(1.0);
             assoc.setRec(outpart);
             assoc.setSim(*mcparticles[mcID]);
@@ -158,7 +163,7 @@ namespace eicrecon {
                     // find associated particle
                     for (const auto &assoc: associations) {
                         if (assoc->getRec() == *cluster) {
-                            mcID = assoc->getSimID();
+                            mcID = assoc->getSim().getObjectID().index;
                             break;
                         }
                     }

--- a/src/global/reco/MatchClusters_factory.cc
+++ b/src/global/reco/MatchClusters_factory.cc
@@ -74,7 +74,7 @@ namespace eicrecon {
 
             m_log->debug("Associations '{}' len: {}", input_tag, assocs.size());
             for(const auto *assoc: assocs) {
-                m_log->debug("  {} {} {} {}", assoc->getRecID(), assoc->getSimID(), assoc->getRec().getEnergy(), assoc->getSim().getEnergy());
+                m_log->debug("  {} {} {} {}", assoc->getRec().getObjectID().index, assoc->getSim().getObjectID().index, assoc->getRec().getEnergy(), assoc->getSim().getEnergy());
             }
         }
 

--- a/src/tests/tracking_test/TrackingTest_processor.cc
+++ b/src/tests/tracking_test/TrackingTest_processor.cc
@@ -141,7 +141,7 @@ void TrackingTest_processor::ProcessTrackingMatching(const std::shared_ptr<const
         auto sim = assoc.getSim();
         auto rec = assoc.getRec();
 
-        m_log->debug("  {:<6} {:<6} {:>8.2f} {:>8.2f} {:>8.2f} {:>8.2f}", assoc.getSimID(), assoc.getRecID(), sim.getPDG(), rec.getPDG());
+        m_log->debug("  {:<6} {:<6} {:>8.2f} {:>8.2f} {:>8.2f} {:>8.2f}", assoc.getSim().getObjectID().index, assoc.getRec().getObjectID().index, sim.getPDG(), rec.getPDG());
     }
 
 //    m_log->debug("Particles [objID] [PDG] [simE] [recE] [simPDG] [recPDG]");


### PR DESCRIPTION
This prepares EICrecon for the changes in https://github.com/eic/EDM4eic/pull/51. `simID` and `recID` fields will be filled while they are available. After, the same values (plus the collection IDs) will be still accessible from the `sim` and `rec` relations.