### PR TITLE
fix: use RPATH in build tree, unset LD_LIBRARY_PATH for ctest

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -74,7 +74,8 @@ jobs:
       with:
         platform-release: "jug_xl:nightly"
         run: |
-          (cd build && ctest -V)
+          # Disable LD_LIBRARY_PATH to ensure R(UN)PATH use
+          (cd build && LD_LIBRARY_PATH="" ctest -V)
     - uses: actions/upload-artifact@v3
       with:
         name: install-${{ matrix.CC }}-eic-shell-${{ matrix.CMAKE_BUILD_TYPE }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,9 +82,16 @@ if(NOT DEFINED PLUGIN_LIBRARY_OUTPUT_DIRECTORY)
 endif()
 message(STATUS "${CMAKE_PROJECT_NAME}: PLUGIN_LIBRARY_OUTPUT_DIRECTORY: ${PLUGIN_LIBRARY_OUTPUT_DIRECTORY}")
 
+
+# Use, i.e. don't skip the full RPATH for the build tree,
+# and use relative paths for relocatable build products
+set(CMAKE_SKIP_BUILD_RPATH FALSE)
+set(CMAKE_BUILD_RPATH_USE_ORIGIN TRUE)
+
 # When building, don't use the install RPATH already
 # (but later on when installing)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+set(CMAKE_SKIP_INSTALL_RPATH FALSE)
 set(CMAKE_INSTALL_RPATH
     "${CMAKE_INSTALL_PREFIX}/${PLUGIN_LIBRARY_OUTPUT_DIRECTORY};${CMAKE_INSTALL_PREFIX}/${PLUGIN_OUTPUT_DIRECTORY}"
 )


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This will (hopefully) fix the ctest failures in CI. We were not explicit about how we want rpath to be handled in the build tree (now we are), but more importantly on binaries the rpath settings in CMake set the RUNPATH elf record, which is lower precedence than the entries in LD_LIBRARY_PATH. That means that any executable (such as the test executable) will still defer to LD_LIBRARY_PATH, if set. So, we unset it for ctest.

This doesn't affect our other executable, eicrecon, because that isn't actually linked against anything (or nothing that is internal to our source tree). Instead it uses the dlopen to plugins explicitly in JANA_PLUGIN_PATH. When those are opened, the rpath to their dependencies is respected.

### What kind of change does this PR introduce?
- [x] Bug fix (issue, see also #976)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.