### PR TITLE
fix: resolve CKFTracking memory leak

### DIFF
--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -179,6 +179,7 @@ namespace eicrecon {
                 const auto& trackTips = multiTrajectory->tips();
                 if (trackTips.empty()) {
                     m_log->debug("Empty multiTrajectory.");
+                    delete multiTrajectory;
                     continue;
                 }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
When there are no track tips, we should delete the ActsExamples::Trajectories before moving on to the next one.

Fixes:
```
Direct leak of 128928 byte(s) in 1343 object(s) allocated from:
    #0 0x556fe8256ded in operator new(unsigned long) (/home/wdconinc/git/EICrecon/.worktree/main/bin/eicrecon+0xeaded) (BuildId: 7089f1e0b4fe65f89c79d38a99df5a0d1554ba34)
    #1 0x7f0f0594cb83 in eicrecon::CKFTracking::process(boost::container::flat_multiset<std::reference_wrapper<ActsExamples::IndexSourceLink const>, ActsExamples::detail::CompareGeometryId, void> const&, std::vector<std::variant<Acts::Measurement<Acts::BoundIndices, 1ul>, Acts::Measurement<Acts::BoundIndices, 2ul>, Acts::Measurement<Acts::BoundIndices, 3ul>, Acts::Measurement<Acts::BoundIndices, 4ul>, Acts::Measurement<Acts::BoundIndices, 5ul>, Acts::Measurement<Acts::BoundIndices, 6ul> >, std::allocator<std::variant<Acts::Measurement<Acts::BoundIndices, 1ul>, Acts::Measurement<Acts::BoundIndices, 2ul>, Acts::Measurement<Acts::BoundIndices, 3ul>, Acts::Measurement<Acts::BoundIndices, 4ul>, Acts::Measurement<Acts::BoundIndices, 5ul>, Acts::Measurement<Acts::BoundIndices, 6ul> > > > const&, edm4eic::TrackParametersCollection const&) /home/wdconinc/git/EICrecon/.worktree/main/src/algorithms/tracking/CKFTracking.cc:170:41
    #2 0x7f0f0514f9c3 in eicrecon::CKFTracking_factory::Process(std::shared_ptr<JEvent const> const&) /home/wdconinc/git/EICrecon/.worktree/main/src/global/tracking/CKFTracking_factory.cc:74:84
    #3 0x7f0f0524d104 in JMultifactoryHelperPodio<edm4eic::TrackParameters>::Process(std::shared_ptr<JEvent const> const&) /opt/software/linux-debian12-x86_64_v2/gcc-12.2.0/jana2-2.1.1-txdpt66ozlvvdquuovpy44emsmsnuip4/include/JANA/JMultifactory.h:228:20
    #4 0x7f0f0cec0cf7 in JFactory::Create(std::shared_ptr<JEvent const> const&) (/usr/._local/jhttvx4bcm3wdo7jmamfg6pazkythsai/lib/libJANA.so+0x59cf7) (BuildId: e11aaf0447ef572861e6577e3cfce0750b7aa2c3)
```

### What kind of change does this PR introduce?
- [x] Bug fix (issue: memory leak)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.