### PR TITLE
fix: address memory leaks in IterativeVertexFinder

### DIFF
--- a/src/algorithms/tracking/IterativeVertexFinder.h
+++ b/src/algorithms/tracking/IterativeVertexFinder.h
@@ -15,7 +15,7 @@
 
 #include <edm4eic/TrackParameters.h>
 #include <edm4eic/Trajectory.h>
-#include <edm4eic/Vertex.h>
+#include <edm4eic/VertexCollection.h>
 #include <spdlog/logger.h>
 
 #include <Acts/Definitions/Common.hpp>
@@ -29,7 +29,7 @@ class IterativeVertexFinder
 public:
   void init(std::shared_ptr<const ActsGeometryProvider> geo_svc,
             std::shared_ptr<spdlog::logger> log);
-  std::vector<edm4eic::Vertex*>
+  std::unique_ptr<edm4eic::VertexCollection>
   produce(std::vector<const ActsExamples::Trajectories*> trajectories);
 
 private:

--- a/src/global/tracking/IterativeVertexFinder_factory.cc
+++ b/src/global/tracking/IterativeVertexFinder_factory.cc
@@ -54,8 +54,8 @@ void eicrecon::IterativeVertexFinder_factory::Process(const std::shared_ptr<cons
   m_log->debug("Process method");
 
   try {
-    auto result = m_vertexing_algo.produce(trajectories);
-    Set(result); // Set() - is what factory produced
+    auto vertices = m_vertexing_algo.produce(trajectories);
+    SetCollection(std::move(vertices));
   } catch (std::exception& e) {
     throw JException(e.what());
   }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This converts the IterativeVertexFinder to podio collections, thereby fixing major memory leaks in all three because of not deleting of pointers in std::vectors.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: memory leak)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.