### PR TITLE
fix: address memory leaks in TrackProjector

### DIFF
--- a/src/algorithms/tracking/TrackProjector.cc
+++ b/src/algorithms/tracking/TrackProjector.cc
@@ -51,10 +51,10 @@ namespace eicrecon {
     }
 
 
-    std::vector<edm4eic::TrackSegment *> TrackProjector::execute(std::vector<const ActsExamples::Trajectories *> trajectories) {
+    std::unique_ptr<edm4eic::TrackSegmentCollection> TrackProjector::execute(std::vector<const ActsExamples::Trajectories *> trajectories) {
 
         // create output collections
-        std::vector<edm4eic::TrackSegment *> track_segments;
+        auto track_segments = std::make_unique<edm4eic::TrackSegmentCollection>();
         m_log->debug("Track projector event process. Num of input trajectories: {}", std::size(trajectories));
 
         // Loop over the trajectories
@@ -81,7 +81,7 @@ namespace eicrecon {
             m_log->debug("  Num measurement in trajectory {}", m_nMeasurements);
             m_log->debug("  Num state in trajectory {}", m_nStates);
 
-            edm4eic::MutableTrackSegment track_segment;
+            auto track_segment = track_segments->create();
 
             // visit the track points
             mj.visitBackwards(trackTip, [&](auto &&trackstate) {
@@ -201,13 +201,10 @@ namespace eicrecon {
 
             m_log->debug("  Num calibrated state in trajectory {}", m_nCalibrated);
             m_log->debug("------ end of trajectory process ------");
-
-            // Add to output collection
-            track_segments.push_back(new edm4eic::TrackSegment(track_segment));
         }
 
         m_log->debug("END OF Track projector event process");
-        return track_segments;
+        return std::move(track_segments);
     }
 
 

--- a/src/algorithms/tracking/TrackProjector.h
+++ b/src/algorithms/tracking/TrackProjector.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <edm4eic/TrackSegment.h>
+#include <edm4eic/TrackSegmentCollection.h>
 
 #include "algorithms/interfaces/WithPodConfig.h"
 #include <spdlog/logger.h>
@@ -27,7 +27,7 @@ namespace eicrecon {
 
             void init(std::shared_ptr<const ActsGeometryProvider> geo_svc, std::shared_ptr<spdlog::logger> logger);
 
-            std::vector<edm4eic::TrackSegment*> execute(std::vector<const ActsExamples::Trajectories*> trajectories);
+            std::unique_ptr<edm4eic::TrackSegmentCollection> execute(std::vector<const ActsExamples::Trajectories*> trajectories);
 
         private:
             std::shared_ptr<const ActsGeometryProvider> m_geo_provider;

--- a/src/global/tracking/TrackProjector_factory.cc
+++ b/src/global/tracking/TrackProjector_factory.cc
@@ -36,8 +36,8 @@ namespace eicrecon {
         auto trajectories = event->Get<ActsExamples::Trajectories>(input_tag);
 
         try {
-            auto result = m_track_projector_algo.execute(trajectories);
-            Set(result);
+            auto track_segments = m_track_projector_algo.execute(trajectories);
+            SetCollection(std::move(track_segments));
         }
         catch(std::exception &e) {
             throw JException(e.what());


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This converts the TrackProjector to podio collections, thereby fixing major memory leaks in all three because of not deleting of pointers in std::vectors.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: memory leaks)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.