### PR TITLE
fix: address memory leaks in TrackSeeding

### DIFF
--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -112,38 +112,38 @@ void eicrecon::TrackSeeding::configure() {
       std::pow(m_seedFinderConfig.highland / m_seedFinderConfig.pTPerHelixRadius,2);
 }
 
-std::vector<edm4eic::TrackParameters*> eicrecon::TrackSeeding::produce(std::vector<const edm4eic::TrackerHit*> trk_hits) {
+std::unique_ptr<edm4eic::TrackParametersCollection> eicrecon::TrackSeeding::produce(const edm4eic::TrackerHitCollection& trk_hits) {
 
   std::vector<const eicrecon::SpacePoint*> spacePoints = getSpacePoints(trk_hits);
 
   Acts::SeedFinderOrthogonal<eicrecon::SpacePoint> finder(m_seedFinderConfig);
   eicrecon::SeedContainer seeds = finder.createSeeds(spacePoints);
 
-  std::vector<edm4eic::TrackParameters*> result = makeTrackParams(seeds);
+  std::unique_ptr<edm4eic::TrackParametersCollection> trackparams = makeTrackParams(seeds);
 
   for (auto& sp: spacePoints) {
     delete sp;
   }
 
-  return result;
+  return std::move(trackparams);
 }
 
-std::vector<const eicrecon::SpacePoint*> eicrecon::TrackSeeding::getSpacePoints(std::vector<const edm4eic::TrackerHit*>& trk_hits)
+std::vector<const eicrecon::SpacePoint*> eicrecon::TrackSeeding::getSpacePoints(const edm4eic::TrackerHitCollection& trk_hits)
 {
   std::vector<const eicrecon::SpacePoint*> spacepoints;
 
   for(const auto hit : trk_hits)
     {
-      const eicrecon::SpacePoint* sp = new SpacePoint(*hit);
+      const eicrecon::SpacePoint* sp = new SpacePoint(hit);
       spacepoints.push_back(sp);
     }
 
   return spacepoints;
 }
 
-std::vector<edm4eic::TrackParameters*> eicrecon::TrackSeeding::makeTrackParams(SeedContainer& seeds)
+std::unique_ptr<edm4eic::TrackParametersCollection> eicrecon::TrackSeeding::makeTrackParams(SeedContainer& seeds)
 {
-  std::vector<edm4eic::TrackParameters*> trackparams;
+  auto trackparams = std::make_unique<edm4eic::TrackParametersCollection>();
 
   for(auto& seed : seeds)
     {
@@ -208,23 +208,20 @@ std::vector<edm4eic::TrackParameters*> eicrecon::TrackSeeding::makeTrackParams(S
           localpos = local.value();
         }
 
-      auto *params = new edm4eic::TrackParameters{
-        -1, // type --> seed(-1)
-        {(float)localpos(0), (float)localpos(1)}, // 2d location on surface
-        {0.1,0.1}, //covariance of location
-        theta, //theta [rad]
-        (float)phi, // phi [rad]
-        qOverP, // Q/p [e/GeV]
-        {0.05,0.05,0.05}, // covariance on theta/phi/q/p
-        10, // time in ns
-        0.1, // error on time
-        (float)charge // charge
-      };
-
-      trackparams.push_back(params);
+      auto trackparam = trackparams->create();
+      trackparam.setType(-1); // type --> seed(-1)
+      trackparam.setLoc({(float)localpos(0), (float)localpos(1)}); // 2d location on surface
+      trackparam.setLocError({0.1,0.1}); //covariance of location
+      trackparam.setTheta(theta); //theta [rad]
+      trackparam.setPhi((float)phi); // phi [rad]
+      trackparam.setQOverP(qOverP); // Q/p [e/GeV]
+      trackparam.setMomentumError({0.05,0.05,0.05}); // covariance on theta/phi/q/p
+      trackparam.setTime(10); // time in ns
+      trackparam.setTimeError(0.1); // error on time
+      trackparam.setCharge((float)charge); // charge
     }
 
-  return trackparams;
+  return std::move(trackparams);
 }
 std::pair<float, float> eicrecon::TrackSeeding::findPCA(std::tuple<float,float,float>& circleParams) const
 {

--- a/src/algorithms/tracking/TrackSeeding.h
+++ b/src/algorithms/tracking/TrackSeeding.h
@@ -31,7 +31,7 @@ namespace eicrecon {
             public eicrecon::WithPodConfig<eicrecon::OrthogonalTrackSeedingConfig> {
     public:
         void init(std::shared_ptr<const ActsGeometryProvider> geo_svc, std::shared_ptr<spdlog::logger> log);
-        std::vector<edm4eic::TrackParameters*> produce(std::vector<const edm4eic::TrackerHit*> trk_hits);
+        std::unique_ptr<edm4eic::TrackParametersCollection> produce(const edm4eic::TrackerHitCollection& trk_hits);
 
     private:
         void configure();
@@ -47,8 +47,8 @@ namespace eicrecon {
 
         int determineCharge(std::vector<std::pair<float,float>>& positions) const;
         std::pair<float,float> findPCA(std::tuple<float,float,float>& circleParams) const;
-        std::vector<const eicrecon::SpacePoint*> getSpacePoints(std::vector<const edm4eic::TrackerHit*>& trk_hits);
-        std::vector<edm4eic::TrackParameters*> makeTrackParams(SeedContainer& seeds);
+        std::vector<const eicrecon::SpacePoint*> getSpacePoints(const edm4eic::TrackerHitCollection& trk_hits);
+        std::unique_ptr<edm4eic::TrackParametersCollection> makeTrackParams(SeedContainer& seeds);
 
         std::tuple<float,float,float> circleFit(std::vector<std::pair<float,float>>& positions) const;
         std::tuple<float,float> lineFit(std::vector<std::pair<float,float>>& positions) const;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This converts the TrackSeeding to podio collections, thereby fixing major memory leaks in all three because of not deleting of pointers in std::vectors.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: memory leaks)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.