### PR TITLE
fix: avoid undefined unsigned integer behavior in pid size checks

### DIFF
--- a/src/algorithms/pid/IrtCherenkovParticleID.cc
+++ b/src/algorithms/pid/IrtCherenkovParticleID.cc
@@ -134,7 +134,7 @@ std::map<std::string, std::unique_ptr<edm4eic::CherenkovParticleIDCollection>> e
 
   // loop over charged particles ********************************************
   m_log->trace("{:#<70}","### CHARGED PARTICLES ");
-  std::size_t num_charged_particles = in_charged_particle_size_distribution.begin()->second;
+  std::size_t num_charged_particles = in_charged_particle_size_distribution.begin()->first;
   for(long i_charged_particle=0; i_charged_particle<num_charged_particles; i_charged_particle++) {
     m_log->trace("{:-<70}", fmt::format("--- charged particle #{} ", i_charged_particle));
 

--- a/src/algorithms/pid/IrtCherenkovParticleID.cc
+++ b/src/algorithms/pid/IrtCherenkovParticleID.cc
@@ -3,6 +3,8 @@
 
 #include "IrtCherenkovParticleID.h"
 
+#include <fmt/ranges.h>
+
 // AlgorithmInit
 //---------------------------------------------------------------------------
 void eicrecon::IrtCherenkovParticleID::AlgorithmInit(
@@ -117,20 +119,22 @@ std::map<std::string, std::unique_ptr<edm4eic::CherenkovParticleIDCollection>> e
     result.insert({rad_name, std::make_unique<edm4eic::CherenkovParticleIDCollection>()});
 
   // check `in_charged_particles`: each radiator should have the same number of TrackSegments
-  long num_charged_particles = -1;
-  for(const auto& [rad_name,charged_particle_list] : in_charged_particles) {
-    if(num_charged_particles<0) {
-      num_charged_particles = charged_particle_list->size();
-      m_log->trace("number of reconstructed charged particles: {}", charged_particle_list->size());
-    }
-    else if(num_charged_particles != charged_particle_list->size()) {
-      m_log->error("radiators have differing numbers of TrackSegments");
-      return result;
-    }
+  std::unordered_map<std::size_t, std::size_t> in_charged_particle_size_distribution;
+  for(const auto& [rad_name, in_charged_particle] : in_charged_particles) {
+    ++in_charged_particle_size_distribution[in_charged_particle->size()];
+  }
+  if (in_charged_particle_size_distribution.size() != 1) {
+    std::vector<size_t> in_charged_particle_sizes;
+    std::transform(in_charged_particles.begin(), in_charged_particles.end(),
+      std::back_inserter(in_charged_particle_sizes),
+      [](const auto& in_charged_particle) { return in_charged_particle.second->size(); });
+    m_log->error("radiators have differing numbers of TrackSegments {}", fmt::join(in_charged_particle_sizes, ", "));
+    return result;
   }
 
   // loop over charged particles ********************************************
   m_log->trace("{:#<70}","### CHARGED PARTICLES ");
+  std::size_t num_charged_particles = in_charged_particle_size_distribution.begin()->second;
   for(long i_charged_particle=0; i_charged_particle<num_charged_particles; i_charged_particle++) {
     m_log->trace("{:-<70}", fmt::format("--- charged particle #{} ", i_charged_particle));
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This avoids undefined behavior flagged by ubsan in the statement `std::size_t n_tracks = -1;` and in the signed/unsigned integer comparisons in the pid system, which caused at least MergeTracks to always fail. It also adds output on the problematic sizes, e.g.
```
[DRICH:DRICHMergedTracks] [error] cannot merge input track collections with different sizes 3, 5
[DRICH:DRICHIrtCherenkovParticleID] [error] radiators have differing numbers of TrackSegments 3, 5, 0
```

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, should now attempt MergeTracks.