### PR TITLE
fix: avoid undefined behavior in signed integer 0 bitwise complement

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -101,7 +101,7 @@ void CalorimeterHitReco::init(const dd4hep::Detector* detector, std::shared_ptr<
         local_mask = id_spec.get_mask(fields);
         // use all fields if nothing provided
         if (fields.empty()) {
-            local_mask = ~0;
+            local_mask = ~static_cast<size_t>(0);
         }
     }
 

--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -101,7 +101,7 @@ void CalorimeterHitReco::init(const dd4hep::Detector* detector, std::shared_ptr<
         local_mask = id_spec.get_mask(fields);
         // use all fields if nothing provided
         if (fields.empty()) {
-            local_mask = ~static_cast<size_t>(0);
+            local_mask = ~static_cast<decltype(local_mask)>(0);
         }
     }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This addresses an ubsan error because 0 is a signed integer. In other places, we avoid this by expliclitly using a `static_cast<size_t>(0)` (another option could be a literal, `0ull`).

### What kind of change does this PR introduce?
- [x] Bug fix (issue: ubsan report)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.