### PR TITLE
feat: enable ubsan by default in CI, with print_stacktrace=1 and suppressions

### DIFF
--- a/.github/ubsan.supp
+++ b/.github/ubsan.supp
@@ -1,2 +1,3 @@
 implicit-integer-sign-change:JsonMaterialDecorator
 implicit-integer-sign-change:/usr/local/include/eigen3/Eigen/src/Core/arch/SSE/PacketMath.h
+implicit-integer-sign-change:TObject

--- a/.github/ubsan.supp
+++ b/.github/ubsan.supp
@@ -1,0 +1,2 @@
+implicit-integer-sign-change:JsonMaterialDecorator
+implicit-integer-sign-change:/usr/local/include/eigen3/Eigen/src/Core/arch/SSE/PacketMath.h

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -18,6 +18,7 @@ concurrency:
 env:
   ASAN_OPTIONS: suppressions=${{ github.workspace }}/.github/asan.supp:malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:detect_stack_use_after_return=1:detect_odr_violation=1:new_delete_type_mismatch=0:intercept_tls_get_addr=0
   LSAN_OPTIONS: suppressions=${{ github.workspace }}/.github/lsan.supp
+  UBSAN_OPTIONS: suppressions=${{ github.workspace }}.github/ubsan.supp:print_stacktrace=1
 
 jobs:
   build:
@@ -69,7 +70,7 @@ jobs:
         platform-release: "jug_xl:nightly"
         run: |
           # install this repo
-          CC="${{ matrix.CC }}" CXX="${{ matrix.CXX }}" CXXFLAGS="${{ matrix.CXXFLAGS }}" cmake -B build -S . -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }} -DUSE_ASAN=ON -DUSE_TSAN=OFF -DUSE_UBSAN=OFF
+          CC="${{ matrix.CC }}" CXX="${{ matrix.CXX }}" CXXFLAGS="${{ matrix.CXXFLAGS }}" cmake -B build -S . -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }} -DUSE_ASAN=ON -DUSE_TSAN=OFF -DUSE_UBSAN=ON
           cmake --build build -- -j 2 install
           ccache --show-stats --verbose
     - name: Check dynamic library loader paths

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   ASAN_OPTIONS: suppressions=${{ github.workspace }}/.github/asan.supp:malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:detect_stack_use_after_return=1:detect_odr_violation=1:new_delete_type_mismatch=0:intercept_tls_get_addr=0
   LSAN_OPTIONS: suppressions=${{ github.workspace }}/.github/lsan.supp
-  UBSAN_OPTIONS: suppressions=${{ github.workspace }}.github/ubsan.supp:print_stacktrace=1
+  UBSAN_OPTIONS: suppressions=${{ github.workspace }}/.github/ubsan.supp:print_stacktrace=1
 
 jobs:
   build:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,13 +171,14 @@ endif()
 # Undefined behavior sanitizer
 option(USE_UBSAN "Compile with undefined behavior sanitizer" OFF)
 if (${USE_UBSAN})
-    foreach (sanitizer undefined nullability implicit-conversion)
+    foreach (sanitizer undefined float-divide-by-zero unsigned-integer-overflow implicit-conversion local-bounds nullability)
         check_cxx_compiler_flag("-fsanitize=${sanitizer}" CXX_COMPILER_HAS_sanitize_${sanitizer})
         if (CXX_COMPILER_HAS_sanitize_${sanitizer})
-            add_compile_options(-fsanitize=${sanitizer} -g -O1)
+            add_compile_options(-fsanitize=${sanitizer})
             add_link_options(-fsanitize=${sanitizer})
         endif()
     endforeach()
+    add_compile_options(-g -O1)
 endif()
 
 # Compress debug symbols if supported


### PR DESCRIPTION
This enables ubsan by default in CI, with some more undefined behaviors (float-divide-by-zero, unsigned-integer-overflow, local-bounds). It has two suppressions already, but more will no doubt be needed to limit the output to what we control. There is no way to have an exitcode != 0 when undefined behavior is found, so this depends a bit on people checking the output periodically.

TODO:
- [x] #989 