### PR TITLE
fix: avoid division by zero by not setting weighted position if sum of weights is zero

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -199,10 +199,10 @@ std::optional<edm4eic::Cluster> CalorimeterClusterRecoCoG::reconstruct(const edm
   }
   if (tw == 0.) {
     m_log->warn("zero total weights encountered, you may want to adjust your weighting parameter.");
-  } else {
-    cl.setPosition(v / tw);
-    cl.setPositionError({}); // @TODO: Covariance matrix
+    return {};
   }
+  cl.setPosition(v / tw);
+  cl.setPositionError({}); // @TODO: Covariance matrix
 
   // Optionally constrain the cluster to the hit eta values
   if (m_cfg.enableEtaBounds) {

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -199,9 +199,10 @@ std::optional<edm4eic::Cluster> CalorimeterClusterRecoCoG::reconstruct(const edm
   }
   if (tw == 0.) {
     m_log->warn("zero total weights encountered, you may want to adjust your weighting parameter.");
+  } else {
+    cl.setPosition(v / tw);
+    cl.setPositionError({}); // @TODO: Covariance matrix
   }
-  cl.setPosition(v / tw);
-  cl.setPositionError({}); // @TODO: Covariance matrix
 
   // Optionally constrain the cluster to the hit eta values
   if (m_cfg.enableEtaBounds) {


### PR DESCRIPTION
### Briefly, what does this PR introduce?
In the center of gravity weighting, when all cluster hits have zero weight (logWeightBase is set too low, e.g. ZDC Ecal), then none of the hits are added in the weighted sum and the sum of weights is zero. Normalizing by the sum of weights leads to division by zero on a zero position at that point. Instead of division by zero we just leave the position unset (i.e. still at zero).

### What kind of change does this PR introduce?
- [x] Bug fix (issue: division by zero)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.