### PR TITLE
fix(dRICH): use gas radiator backplane for track propagation filter

### DIFF
--- a/src/global/pid/RichTrack_factory.cc
+++ b/src/global/pid/RichTrack_factory.cc
@@ -70,6 +70,18 @@ void eicrecon::RichTrack_factory::Process(const std::shared_ptr<const JEvent> &e
     }
   }
 
+  // choose the filter surface: all charged particles that pass through the dRICH vessel will pass
+  // through the backplane of the gas radiator
+  std::shared_ptr<Acts::Surface> filter_surface;
+  for(auto& [output_tag, radiator_tracking_planes] : m_tracking_planes) {
+    if(richgeo::ParseRadiatorName(output_tag, m_log) == richgeo::kGas) {
+      filter_surface = radiator_tracking_planes.back();
+      break;
+    }
+  }
+  if(!filter_surface)
+    throw JException("cannot find filter surface for RICH track propagation");
+
   // run track propagator algorithm, for each radiator
   for(auto& [output_tag, radiator_tracking_planes] : m_tracking_planes) {
     try {
@@ -77,7 +89,7 @@ void eicrecon::RichTrack_factory::Process(const std::shared_ptr<const JEvent> &e
       auto result = m_propagation_algo.propagateToSurfaceList(
           trajectories,
           radiator_tracking_planes,
-          radiator_tracking_planes.back(), // `filterSurface`: assumes projectivity to radiator back-plane
+          filter_surface,
           track_point_cut,
           true
           );


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Resolve #990 

We use the `Acts` surface at max $z$ as the "filter surface" to decide whether or not to proceed with track propagation to the sequence of surfaces in the dRICH radiators (see #735). For aerogel, that surface is slightly before the acrylic filter, and for gas that surface is just before the vessel exit window.

This PR resolves #990 by changing the filter surface to be the surface at max $z$ for gas, for _both_ aerogel and gas track propagation attempts. Prior to this PR, a charged particle with $\eta$ less than the max $\eta$ of aerogel would not produce any propagated track points and no `TrackSegment` object would be written out; however, there would still be a `TrackSegment` for the gas radiator, since the track still passes through gas, thus causing the errors reported in #990: this charged particle would have 0 `TrackSegment`s for aerogel, and 1 `TrackSegment` for gas and the merged (gas+aerogel).

With this PR, charged particle with such $\eta$ will still attempt to propagate to the aerogel planes, but all of them will fail* and the output `TrackSegment` will have zero `TrackPoint`s. Since there is still a `TrackSegment` in the output, the errors in #990 no longer appear and IRT proceeds happily**.  

*these failures waste CPU time, so this could be improved further, e.g., by checking _both_ the gas's and aerogel's max $z$ plane

**this PR is a 'quick' solution; perhaps a better, but more difficult solution is refactoring `IrtCherenkovParticleID` (and probably `MergeTracks` and `MergeParticleIDs`) so that it can handle the case of non-equal-sized input `TrackSegment` collections. 

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
yes, stop ignoring such events as described in #990.