### PR TITLE
ACTSGeo_service.cc: rename geom const materials-map -> material-map

### DIFF
--- a/src/services/geometry/acts/ACTSGeo_service.cc
+++ b/src/services/geometry/acts/ACTSGeo_service.cc
@@ -34,7 +34,7 @@ std::shared_ptr<const ActsGeometryProvider> ACTSGeo_service::actsGeoProvider() {
             // Get material map from user parameter
             std::string material_map_file;
             try {
-              material_map_file = m_dd4hepGeo->constant<std::string>("materials-map");
+              material_map_file = m_dd4hepGeo->constant<std::string>("material-map");
             } catch (const std::runtime_error& e) {
               material_map_file = "calibrations/materials-map.cbor";
             }


### PR DESCRIPTION
The https://github.com/eic/epic/pull/494 is not merged at this time. Let's update that one to provide both constants, but going forward use proper meaning one.