### PR TITLE
fix(ci): get-docs-from-main for last *success* workflow, not merely completed

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -649,7 +649,6 @@ jobs:
           branch: main
           path: publishing_docs/
           name: docs
-          workflow_conclusion: "completed"
           if_no_artifact_found: fail
       - uses: actions/download-artifact@v3
         if: github.ref_name == 'main'


### PR DESCRIPTION
### Briefly, what does this PR introduce?
We have seen some pipelines fail because get-docs-from-main fails to get the correct artifact from main becuase the pipeline it tries to get the artifact from has not completed successfully, e.g. https://github.com/eic/EICrecon/actions/runs/6239677941/job/16939205041 (merge queue) failed because https://github.com/eic/EICrecon/actions/runs/6238746274 (main) failed. We can avoid this merge queue (and PR) failure scenario by requiring that the main artifact is pulled from the lastest successful main workflow.

### What kind of change does this PR introduce?
- [x] Bug fix (issue https://github.com/eic/EICrecon/actions/runs/6239677941/job/16939205041)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.