### PR TITLE
feat: std::optional in cluster reco CoG

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -59,10 +59,11 @@ namespace eicrecon {
         continue;
       }
 
-      auto cl = reconstruct(pcl);
-      if (! cl.has_value()) {
+      auto cl_opt = reconstruct(pcl);
+      if (! cl_opt.has_value()) {
         continue;
       }
+      auto cl = *std::move(cl_opt);
 
       m_log->debug("{} hits: {} GeV, ({}, {}, {})", cl.getNhits(), cl.getEnergy() / dd4hep::GeV, cl.getPosition().x / dd4hep::mm, cl.getPosition().y / dd4hep::mm, cl.getPosition().z / dd4hep::mm);
       clusters->push_back(cl);

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -11,6 +11,7 @@
 #include <boost/range/adaptor/map.hpp>
 #include <fmt/format.h>
 #include <map>
+#include <optional>
 #include <Eigen/Dense>
 
 #include <Evaluator/DD4hepUnits.h>
@@ -59,6 +60,9 @@ namespace eicrecon {
       }
 
       auto cl = reconstruct(pcl);
+      if (! cl.has_value()) {
+        continue;
+      }
 
       m_log->debug("{} hits: {} GeV, ({}, {}, {})", cl.getNhits(), cl.getEnergy() / dd4hep::GeV, cl.getPosition().x / dd4hep::mm, cl.getPosition().y / dd4hep::mm, cl.getPosition().z / dd4hep::mm);
       clusters->push_back(cl);
@@ -141,7 +145,7 @@ namespace eicrecon {
 }
 
 //------------------------------------------------------------------------
-edm4eic::Cluster CalorimeterClusterRecoCoG::reconstruct(const edm4eic::ProtoCluster& pcl) const {
+std::optional<edm4eic::Cluster> CalorimeterClusterRecoCoG::reconstruct(const edm4eic::ProtoCluster& pcl) const {
   edm4eic::MutableCluster cl;
   cl.setNhits(pcl.hits_size());
 
@@ -149,7 +153,7 @@ edm4eic::Cluster CalorimeterClusterRecoCoG::reconstruct(const edm4eic::ProtoClus
 
   // no hits
   if (pcl.hits_size() == 0) {
-    return cl;
+    return {};
   }
 
   // calculate total energy, find the cell with the maximum energy deposit

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
@@ -17,6 +17,7 @@
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <edm4eic/vector_utils.h>
 #include <map>
+#include <optional>
 #include <spdlog/spdlog.h>
 
 #include "algorithms/interfaces/WithPodConfig.h"
@@ -58,7 +59,7 @@ namespace eicrecon {
 
   private:
 
-    edm4eic::Cluster reconstruct(const edm4eic::ProtoCluster& pcl) const;
+    std::optional<edm4eic::Cluster> reconstruct(const edm4eic::ProtoCluster& pcl) const;
 
   };
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
In CalorimeterClusterRecoCoG, we use a helper function which can sometimes decide not to return a cluster. `std:: optional` makes that intent clearer.

See discussion in https://github.com/eic/EICrecon/pull/989#discussion_r1330628992. Suggestion is to merge #989, merge this, then put the actual `return {}` for zero weights in a third PR.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.