### PR TITLE
fix: avoid division by zero in inclusive kinematics DA method

### DIFF
--- a/src/algorithms/reco/InclusiveKinematicsDA.cc
+++ b/src/algorithms/reco/InclusiveKinematicsDA.cc
@@ -137,14 +137,15 @@ namespace eicrecon {
 
     // DIS kinematics calculations
     auto sigma_h = Esum - pzsum;
-    auto ptsum = sqrt(pxsum*pxsum + pysum*pysum);
-    auto theta_h = 2.*atan(sigma_h/ptsum);
 
-    // If no scattered electron was found
+    // If no scattered hadron was found
     if (sigma_h <= 0) {
-      m_log->debug("No scattered electron found");
+      m_log->debug("No scattered hadron found");
       return kinematics;
     }
+
+    auto ptsum = sqrt(pxsum*pxsum + pysum*pysum);
+    auto theta_h = 2.*atan(sigma_h/ptsum);
 
     // Calculate kinematic variables
     const auto y_da = tan(theta_h/2.) / ( tan(theta_e/2.) + tan(theta_h/2.) );


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This avoids a division by zero when only the scattered electron is in the final state, and no other hadrons are present. In that case `Esum` and `pzsum` are both still exactly zero, and `sigma_h` is still exactly zero as well.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/EICrecon/actions/runs/6247530971/job/16961738954?pr=987#step:5:1059)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.