### PR TITLE
fix(ci): avoid API rate exceeding in get-docs-from-open-prs with max-parallel: 4

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -617,6 +617,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.list-open-prs.outputs.json) }}
       fail-fast: false
+      max-parallel: 4
     steps:
       - uses: dawidd6/action-download-artifact@v2
         if: github.event.pull_request.number != matrix.pr


### PR DESCRIPTION
### Briefly, what does this PR introduce?
We have been seeing API rate limit failures (e.g. https://github.com/eic/EICrecon/actions/runs/6239863253/job/17007468298?pr=982#step:2:21) likely due to the spinning up of many jobs at the same time. This effectively spreads the rate to a more managable average instead of peaking in short time, and should (hopefully) resolve these issues.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/EICrecon/actions/runs/6239863253/job/17007468298?pr=982#step:2:21)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.