### PR TITLE
fix: move some info logging to debug; remove unneeded fmt::format

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -84,7 +84,7 @@ void CalorimeterHitDigi::init(const dd4hep::Detector* detector, std::shared_ptr<
             // throw::runtime_error(fmt::format("Failed to load ID decoder for {}", m_cfg.readout));
             return;
         }
-        m_log->info("ID mask in {:s}: {:#064b}", m_cfg.readout, id_mask);
+        m_log->debug("ID mask in {:s}: {:#064b}", m_cfg.readout, id_mask);
     }
     id_mask = ~id_inverse_mask;
 }

--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -45,11 +45,11 @@ void CalorimeterHitReco::init(const dd4hep::Detector* detector, std::shared_ptr<
         id_dec = id_spec.decoder();
         if (!m_cfg.sectorField.empty()) {
             sector_idx = id_dec->index(m_cfg.sectorField);
-            m_log->info("Find sector field {}, index = {}", m_cfg.sectorField, sector_idx);
+            m_log->debug("Find sector field {}, index = {}", m_cfg.sectorField, sector_idx);
         }
         if (!m_cfg.layerField.empty()) {
             layer_idx = id_dec->index(m_cfg.layerField);
-            m_log->info("Find layer field {}, index = {}", m_cfg.layerField, sector_idx);
+            m_log->debug("Find layer field {}, index = {}", m_cfg.layerField, sector_idx);
         }
         if (!m_cfg.maskPosFields.empty()) {
             size_t tmp_mask = 0;

--- a/src/algorithms/calorimetry/CalorimeterHitsMerger.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitsMerger.cc
@@ -33,14 +33,13 @@ void CalorimeterHitsMerger::init(const dd4hep::Detector* detector, std::shared_p
             ref_fields.emplace_back(m_cfg.fields[i], ref);
         }
         ref_mask = id_desc.encode(ref_fields);
-        // debug() << fmt::format("Reference id mask for the fields {:#064b}", ref_mask) << endmsg;
     } catch (...) {
         auto mess = fmt::format("Failed to load ID decoder for {}", m_cfg.readout);
         m_log->warn(mess);
 //        throw std::runtime_error(mess);
     }
     id_mask = ~id_mask;
-    m_log->info(fmt::format("ID mask in {:s}: {:#064b}", m_cfg.readout, id_mask));
+    m_log->debug("ID mask in {:s}: {:#064b}", m_cfg.readout, id_mask);
 }
 
 std::unique_ptr<edm4eic::CalorimeterHitCollection> CalorimeterHitsMerger::process(const edm4eic::CalorimeterHitCollection &input) {
@@ -75,7 +74,7 @@ std::unique_ptr<edm4eic::CalorimeterHitCollection> CalorimeterHitsMerger::proces
         // local positions
         auto alignment = volman.lookupDetElement(ref_id).nominal();
         const auto pos = alignment.worldToLocal(dd4hep::Position(gpos.x(), gpos.y(), gpos.z()));
-        m_log->debug( fmt::format("{}, {}", volman.lookupDetElement(ref_id).path(), volman.lookupDetector(ref_id).path()) );
+        m_log->debug("{}, {}", volman.lookupDetElement(ref_id).path(), volman.lookupDetector(ref_id).path());
         // sum energy
         float energy = 0.;
         float energyError = 0.;
@@ -115,7 +114,7 @@ std::unique_ptr<edm4eic::CalorimeterHitCollection> CalorimeterHitsMerger::proces
                         local); // Can do better here? Right now position is mapped on the central hit
     }
 
-    m_log->debug(fmt::format("Size before = {}, after = {}", input.size(), output->size()) );
+    m_log->debug("Size before = {}, after = {}", input.size(), output->size());
 
     return output;
 }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This removes some info logging that should be debug. Also, we don't need to use an explicit fmt::format inside an spdlog logging call.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.