### PR TITLE
fix(ci): set DD4HEP_PLUGINMGR when running ctest without LD_LIBRARY_PATH

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -86,7 +86,7 @@ jobs:
         platform-release: "jug_xl:nightly"
         run: |
           # Disable LD_LIBRARY_PATH to ensure R(UN)PATH use
-          (cd build && LD_LIBRARY_PATH="" ctest -V)
+          (cd build && LD_LIBRARY_PATH="" DD4HEP_PLUGINMGR="/usr/local/lib/libDD4hepGaudiPluginMgr.so" ctest -V)
     - uses: actions/upload-artifact@v3
       with:
         name: install-${{ matrix.CC }}-eic-shell-${{ matrix.CMAKE_BUILD_TYPE }}


### PR DESCRIPTION
### Briefly, what does this PR introduce?
DD4hep loads a custom plugin manager to load plugins. This is usually found in LD_LIBRARY_PATH, but for ctest we quash LD_LIBRARY_PATH and we have to provide this explicitly through DD4HEP_PLUGINMGR.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/EICrecon/actions/runs/6264334702/job/17010800942?pr=1006#step:9:64)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.