### PR TITLE
fix(ci): run ctest with prefixed LD_LIBRARY_PATH

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -85,8 +85,8 @@ jobs:
       with:
         platform-release: "jug_xl:nightly"
         run: |
-          # Disable LD_LIBRARY_PATH to ensure R(UN)PATH use
-          (cd build && LD_LIBRARY_PATH="" ctest -V)
+          export LD_LIBRARY_PATH=$PWD/lib:$LD_LIBRARY_PATH
+          ctest --test-dir build -V
     - uses: actions/upload-artifact@v3
       with:
         name: install-${{ matrix.CC }}-eic-shell-${{ matrix.CMAKE_BUILD_TYPE }}


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Instead of unsetting `LD_LIBRARY_PATH`, this now sets `LD_LIBRARY_PATH` to start with the install lib directory. This should address the failures in gcc due to failing `dlopen` of `libDD4hepGaudiPluginMgr.so`, and at the same time allow for ctest with sanitizers in the clang builds.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.