### PR TITLE
fix: use DD4hep_service in femc_studies and lfhcal_studies

### DIFF
--- a/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.cc
@@ -212,7 +212,9 @@ void femc_studiesProcessor::Init() {
   dd4hep::rec::CellIDPositionConverter cellid_converter(*detector);
   std::cout << "--------------------------\nID specification:\n";
   try {
-    m_decoder = detector->readout("EcalEndcapPHits").idSpec().decoder();
+    auto readout = detector->readout("EcalEndcapPHits");
+    std::cout << "0th: " << &readout << std::endl;
+    m_decoder = readout.idSpec().decoder();
     std::cout << "1st: "<< m_decoder << std::endl;
     std::cout << "full list: " << " " << m_decoder->fieldDescription() << std::endl;
   } catch (...) {

--- a/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.cc
@@ -11,6 +11,7 @@
 
 #include "extensions/spdlog/SpdlogExtensions.h"
 #include "extensions/spdlog/SpdlogMixin.h"
+#include "services/geometry/dd4hep/DD4hep_service.h"
 #include "services/log/Log_service.h"
 #include <spdlog/fmt/ostr.h>
 
@@ -55,6 +56,9 @@ void femc_studiesProcessor::Init() {
 
   // Ask service locator a file to write histograms to
   auto root_file_service = app->GetService<RootFile_service>();
+
+  // Ask service locator for the DD4hep geometry
+  auto dd4hep_service = app->GetService<DD4hep_service>();
 
   // Get TDirectory for histograms root file
   auto globalRootLock = app->GetService<JGlobalRootLock>();
@@ -204,12 +208,12 @@ void femc_studiesProcessor::Init() {
   }
 
   std::cout << __PRETTY_FUNCTION__ << " " << __LINE__ << std::endl;
-  dd4hep::Detector& detector = dd4hep::Detector::getInstance();
-  dd4hep::rec::CellIDPositionConverter cellid_converter(detector);
+  dd4hep::Detector* detector = dd4hep_service->detector();
+  dd4hep::rec::CellIDPositionConverter cellid_converter(*detector);
   std::cout << "--------------------------\nID specification:\n";
   try {
-    m_decoder         = detector.readout("EcalEndcapPHits").idSpec().decoder();
-    std::cout <<"1st: "<< m_decoder << std::endl;
+    m_decoder = detector->readout("EcalEndcapPHits").idSpec().decoder();
+    std::cout << "1st: "<< m_decoder << std::endl;
     std::cout << "full list: " << " " << m_decoder->fieldDescription() << std::endl;
   } catch (...) {
       std::cout <<"2nd: "  << m_decoder << std::endl;

--- a/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.cc
@@ -212,9 +212,7 @@ void femc_studiesProcessor::Init() {
   dd4hep::rec::CellIDPositionConverter cellid_converter(*detector);
   std::cout << "--------------------------\nID specification:\n";
   try {
-    auto readout = detector->readout("EcalEndcapPHits");
-    std::cout << "0th: " << &readout << std::endl;
-    m_decoder = readout.idSpec().decoder();
+    m_decoder = detector->readout("EcalEndcapPHits").idSpec().decoder();
     std::cout << "1st: "<< m_decoder << std::endl;
     std::cout << "full list: " << " " << m_decoder->fieldDescription() << std::endl;
   } catch (...) {

--- a/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
@@ -11,6 +11,7 @@
 
 #include "extensions/spdlog/SpdlogExtensions.h"
 #include "extensions/spdlog/SpdlogMixin.h"
+#include "services/geometry/dd4hep/DD4hep_service.h"
 #include "services/log/Log_service.h"
 #include <spdlog/fmt/ostr.h>
 
@@ -52,6 +53,9 @@ void lfhcal_studiesProcessor::Init() {
   app->SetDefaultParameter(plugin_name + ":LogLevel", log_level_str,
                            "LogLevel: trace, debug, info, warn, err, critical, off");
   m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
+
+  // Ask service locator for the DD4hep geometry
+  auto dd4hep_service = app->GetService<DD4hep_service>();
 
   // Ask service locator a file to write histograms to
   auto root_file_service = app->GetService<RootFile_service>();
@@ -240,11 +244,11 @@ void lfhcal_studiesProcessor::Init() {
   }
 
   std::cout << __PRETTY_FUNCTION__ << " " << __LINE__ << std::endl;
-  dd4hep::Detector& detector = dd4hep::Detector::getInstance();
-  dd4hep::rec::CellIDPositionConverter cellid_converter(detector);
+  dd4hep::Detector* detector = dd4hep_service->detector();
+  dd4hep::rec::CellIDPositionConverter cellid_converter(*detector);
   std::cout << "--------------------------\nID specification:\n";
   try {
-    m_decoder         = detector.readout("LFHCALHits").idSpec().decoder();
+    m_decoder = detector->readout("LFHCALHits").idSpec().decoder();
     std::cout <<"1st: "<< m_decoder << std::endl;
     auto module_index_x = m_decoder->index("moduleIDx");
     auto module_index_y = m_decoder->index("moduleIDy");


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This fixes femc_studies and lfhcal_studies to use the DD4hep_service instead of just a DD4hep::GetInstance() call.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/EICrecon/actions/runs/6252352462/job/16988380711#step:5:176)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.