### PR TITLE
fix: address clang-tidy clang-analyzer warnings

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -31,16 +31,14 @@ void CalorimeterHitReco::init(const dd4hep::Detector* detector, std::shared_ptr<
     }
 
     // First, try and get the IDDescriptor. This will throw an exception if it fails.
+    IDDescriptor id_spec;
     try {
-        auto id_spec = m_detector->readout(m_cfg.readout).idSpec();
+        id_spec = m_detector->readout(m_cfg.readout).idSpec();
     } catch(...) {
         m_log->warn("Failed to get idSpec for {}", m_cfg.readout);
         return;
     }
-
-    // Get id_spec again, but here it should always succeed.
-    // TODO: This is a bit of a hack so should be cleaned up.
-    auto id_spec = m_detector->readout(m_cfg.readout).idSpec();
+    // Next, try and get the readout fields. This will throw a different exception.
     try {
         id_dec = id_spec.decoder();
         if (!m_cfg.sectorField.empty()) {

--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -91,9 +91,6 @@ void ActsGeometryProvider::initialize(dd4hep::Detector *dd4hep_geo,
     // Set ACTS logging level
     auto acts_init_log_level = eicrecon::SpdlogToActsLevel(m_init_log->level());
 
-    // Surfaces conversion log level
-    uint printoutLevel = (uint) m_init_log->level();
-
     m_dd4hepDetector = dd4hep_geo;
 
     // create a list of all surfaces in the detector:

--- a/src/benchmarks/reconstruction/TRACKINGcheck/TRACKINGcheckProcessor.cc
+++ b/src/benchmarks/reconstruction/TRACKINGcheck/TRACKINGcheckProcessor.cc
@@ -43,7 +43,6 @@ void TRACKINGcheckProcessor::ProcessSequential(const std::shared_ptr<const JEven
             auto trackparams = traj->trackParameters( entryIndex );
 
             auto pos = trackparams.position(Acts::GeometryContext());
-            auto mom = trackparams.momentum();
             auto t = trackparams.time();
 
             hist1D["Trajectories_time"]->Fill( t );

--- a/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
@@ -416,7 +416,7 @@ void lfhcal_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event
 
     // calc cell IDs
     long cellIDx = -1;
-    lonh cellIDy = -1;
+    long cellIDy = -1;
     if (isLFHCal){
       cellIDx = 54*2 - detector_module_x * 2 + detector_layer_x;
       cellIDy = 54*2 - detector_module_y * 2 + detector_layer_y;

--- a/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
@@ -250,12 +250,9 @@ void lfhcal_studiesProcessor::Init() {
   try {
     m_decoder = detector->readout("LFHCALHits").idSpec().decoder();
     std::cout <<"1st: "<< m_decoder << std::endl;
-    auto module_index_x = m_decoder->index("moduleIDx");
-    auto module_index_y = m_decoder->index("moduleIDy");
     iLx = m_decoder->index("towerx");
     iLy = m_decoder->index("towery");
     iLz = m_decoder->index("layerz");
-    auto rlayer_index_z = m_decoder->index("rlayerz");
     iPassive = m_decoder->index("passive");
     std::cout << "full list: " << " " << m_decoder->fieldDescription() << std::endl;
   } catch (...) {
@@ -411,23 +408,18 @@ void lfhcal_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event
     auto detector_layer_x = m_decoder->get(cellID, iLx);
     auto detector_layer_y = m_decoder->get(cellID, iLy);
     int detector_layer_rz = -1;
-    int detector_module_t  = 0;
     if (isLFHCal){
       detector_layer_rz   = m_decoder->get(cellID, 7);
-      detector_module_t   = m_decoder->get(cellID, 3);
     }
-    auto detector_layer_z = m_decoder->get(cellID, iLz);
 
     if (detector_passive > 0) continue;
 
     // calc cell IDs
     int cellIDx = -1;
     int cellIDy = -1;
-    int cellIDz = -1;
     if (isLFHCal){
       cellIDx = 54*2 - detector_module_x * 2 + detector_layer_x;
       cellIDy = 54*2 - detector_module_y * 2 + detector_layer_y;
-      cellIDz = detector_layer_rz;
     }
 
     hPosCaloHitsXY->Fill(x, y);

--- a/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
@@ -415,8 +415,8 @@ void lfhcal_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event
     if (detector_passive > 0) continue;
 
     // calc cell IDs
-    int cellIDx = -1;
-    int cellIDy = -1;
+    long cellIDx = -1;
+    lonh cellIDy = -1;
     if (isLFHCal){
       cellIDx = 54*2 - detector_module_x * 2 + detector_layer_x;
       cellIDy = 54*2 - detector_module_y * 2 + detector_layer_y;

--- a/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
@@ -345,8 +345,8 @@ void lfhcal_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event
     long cellIDy = -1;
     long cellIDz = -1;
     if (isLFHCal){
-      cellIDx = 54*2 - detector_module_x * 2 + detector_layer_x;
-      cellIDy = 54*2 - detector_module_y * 2 + detector_layer_y;
+      cellIDx = 54ll*2 - detector_module_x * 2 + detector_layer_x;
+      cellIDy = 54ll*2 - detector_module_y * 2 + detector_layer_y;
       cellIDz = detector_layer_rz*10+detector_layer_z;
     }
     nCaloHitsSim++;
@@ -418,8 +418,8 @@ void lfhcal_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event
     long cellIDx = -1;
     long cellIDy = -1;
     if (isLFHCal){
-      cellIDx = 54*2 - detector_module_x * 2 + detector_layer_x;
-      cellIDy = 54*2 - detector_module_y * 2 + detector_layer_y;
+      cellIDx = 54ll*2 - detector_module_x * 2 + detector_layer_x;
+      cellIDy = 54ll*2 - detector_module_y * 2 + detector_layer_y;
     }
 
     hPosCaloHitsXY->Fill(x, y);

--- a/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
@@ -329,7 +329,7 @@ void lfhcal_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event
     auto detector_passive = m_decoder->get(cellID, iPassive);
     auto detector_layer_x = m_decoder->get(cellID, iLx);
     auto detector_layer_y = m_decoder->get(cellID, iLy);
-    int detector_layer_rz = -1;
+    long detector_layer_rz = -1;
     if (isLFHCal)
       detector_layer_rz = m_decoder->get(cellID, 7);
     auto detector_layer_z = m_decoder->get(cellID, iLz);
@@ -341,9 +341,9 @@ void lfhcal_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event
 
     if (detector_passive > 0) continue;
     // calc cell IDs
-    int cellIDx = -1;
-    int cellIDy = -1;
-    int cellIDz = -1;
+    long cellIDx = -1;
+    long cellIDy = -1;
+    long cellIDz = -1;
     if (isLFHCal){
       cellIDx = 54*2 - detector_module_x * 2 + detector_layer_x;
       cellIDy = 54*2 - detector_module_y * 2 + detector_layer_y;

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -279,6 +279,7 @@ void JEventProcessorPODIO::Process(const std::shared_ptr<const JEvent> &event) {
     //            all). See also below, at "TODO: NWB:".
     for (const auto& coll_name : m_collections_to_write) {
         try {
+            [[maybe_unused]]
             const auto* coll_ptr = event->GetCollectionBase(coll_name);
         }
         catch(std::exception &e) {

--- a/src/tests/tracking_test/TrackingTest_processor.cc
+++ b/src/tests/tracking_test/TrackingTest_processor.cc
@@ -105,9 +105,6 @@ void TrackingTest_processor::ProcessTrackingResults(const std::shared_ptr<const 
 
     auto mc_particles = event->Get<edm4hep::MCParticle>("MCParticles");
 
-    const auto *particles = event->GetSingle<edm4eic::ReconstructedParticle>("ReconstructedParticles");
-    const auto *track_params = event->GetSingle<edm4eic::TrackParameters>("outputTrackParameters");
-
     m_log->debug("MC particles N={}: ", mc_particles.size());
     m_log->debug("   {:<5} {:<6} {:<7} {:>8} {:>8} {:>8} {:>8}","[i]", "status", "[PDG]",  "[px]", "[py]", "[pz]", "[P]");
     for(size_t i=0; i < mc_particles.size(); i++) {
@@ -130,12 +127,8 @@ void TrackingTest_processor::ProcessTrackingResults(const std::shared_ptr<const 
 
 void TrackingTest_processor::ProcessTrackingMatching(const std::shared_ptr<const JEvent> &event) {
     m_log->debug("Associations [simId] [recID] [simE] [recE] [simPDG] [recPDG]");
-    // auto prt_with_assoc = event->GetSingle<edm4hep::ReconstructedParticle>("ChargedParticlesWithAssociations");
 
-    const auto *particles = event->GetCollection<edm4eic::ReconstructedParticle>("ReconstructedChargedParticles");
     const auto *associations = event->GetCollection<edm4eic::MCRecoParticleAssociation>("ReconstructedChargedParticleAssociations");
-
-
 
     for(auto assoc: *associations) {
         auto sim = assoc.getSim();
@@ -145,6 +138,7 @@ void TrackingTest_processor::ProcessTrackingMatching(const std::shared_ptr<const
     }
 
 //    m_log->debug("Particles [objID] [PDG] [simE] [recE] [simPDG] [recPDG]");
+//    auto prt_with_assoc = event->GetSingle<edm4hep::ReconstructedParticle>("ChargedParticlesWithAssociations");
 //    for(auto part: prt_with_assoc->particles()) {
 //
 //        // auto sim = assoc->getSim();
@@ -171,5 +165,4 @@ void TrackingTest_processor::ProcessGloablMatching(const std::shared_ptr<const J
         m_log->debug("  {:<6} {:<6}  {:>8.2f} {:>8.2f}", part->getObjectID().index, part->getPDG(), part->getCharge(), part->getEnergy());
     }
 
-    const auto *final_generated_particles = event->GetSingle<edm4eic::ReconstructedParticle>("GeneratedParticles");
 }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This addresses nearly all issues highlighted in #757. Mainly essentially unused variables that the compiler didn't already flag because of conditional assignment patterns.

This doesn't fix the warning about the bypassing of virtual dispatch in the RichGeoDRICH and RichGeoPFRICH constructors. Maybe prefixing the class names makes it clear we don't want dispatch and shuts up the warning, but needs testing. (cc @chchatte92 @c-dilks )

### What kind of change does this PR introduce?
- [x] Bug fix (issue #757)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
  - These are all tests not available in the clang-tidy-14 we're using.
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.