### PR TITLE
Revert "CKFTracking: disable RTTI type checks until EICrecon conforms to ODR (#551)"

### DIFF
--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -58,7 +58,7 @@ namespace eicrecon {
 
         m_geoSvc = geo_svc;
 
-        m_BField = std::static_pointer_cast<const eicrecon::BField::DD4hepBField>(m_geoSvc->getFieldProvider());
+        m_BField = std::dynamic_pointer_cast<const eicrecon::BField::DD4hepBField>(m_geoSvc->getFieldProvider());
         m_fieldctx = eicrecon::BField::BFieldVariant(m_BField);
 
         // eta bins, chi2 and #sourclinks per surface cutoffs


### PR DESCRIPTION
I don't have a proof of ODR compliance at this time, but, at least, this issue was recently resolved (likely by #940).

This reverts commit f375494b06e6dfc93d92652b6cee271de526bdfb.

Closes: #340