### PR TITLE
MatchClusters_factory: switch to use PODIO collections as input

### DIFF
--- a/src/algorithms/reco/MatchClusters.cc
+++ b/src/algorithms/reco/MatchClusters.cc
@@ -33,12 +33,12 @@ namespace eicrecon {
         m_log = logger;
     }
 
-    std::tuple<edm4eic::ReconstructedParticleCollection*, edm4eic::MCRecoParticleAssociationCollection*> MatchClusters::execute(
-            std::vector<const edm4hep::MCParticle *> mcparticles,
-            std::vector<const edm4eic::ReconstructedParticle *> inparts,
-            std::vector<const edm4eic::MCRecoParticleAssociation *> inpartsassoc,
-            const std::vector<std::vector<const edm4eic::Cluster*>> &cluster_collections,
-            const std::vector<std::vector<const edm4eic::MCRecoClusterParticleAssociation*>> &cluster_assoc_collections) {
+    MatchClusters::MatchingResults MatchClusters::execute(
+        const edm4hep::MCParticleCollection* mcparticles,
+        const edm4eic::ReconstructedParticleCollection* inparts,
+        const edm4eic::MCRecoParticleAssociationCollection* inpartsassoc,
+        const std::vector<const edm4eic::ClusterCollection*> &cluster_collections,
+        const std::vector<const edm4eic::MCRecoClusterParticleAssociationCollection*> &cluster_assoc_collections) {
 
         m_log->debug("Processing cluster info for new event");
 
@@ -55,19 +55,19 @@ namespace eicrecon {
         // (removing matched clusters from the cluster maps)
         m_log->debug("Step 1/2: Matching clusters to charged particles...");
 
-        for (const auto &inpart: inparts) {
-            m_log->debug(" --> Processing charged particle {}, PDG {}, energy {}", inpart->getObjectID().index,
-                         inpart->getPDG(), inpart->getEnergy());
+        for (const auto inpart: *inparts) {
+            m_log->debug(" --> Processing charged particle {}, PDG {}, energy {}", inpart.getObjectID().index,
+                         inpart.getPDG(), inpart.getEnergy());
 
-            auto outpart = inpart->clone();
+            auto outpart = inpart.clone();
             outparts->push_back(outpart);
 
             int mcID = -1;
 
             // find associated particle
-            for (const auto &assoc: inpartsassoc) {
-                if (assoc->getRecID() == inpart->getObjectID().index) {
-                    mcID = assoc->getSimID();
+            for (const auto &assoc: *inpartsassoc) {
+                if (assoc.getRecID() == inpart.getObjectID().index) {
+                    mcID = assoc.getSimID();
                     break;
                 }
             }
@@ -81,9 +81,9 @@ namespace eicrecon {
 
             if (clusterMap.count(mcID)) {
                 const auto &clus = clusterMap[mcID];
-                m_log->debug("    --> found matching cluster with energy: {}", clus->getEnergy());
+                m_log->debug("    --> found matching cluster with energy: {}", clus.getEnergy());
                 m_log->debug("    --> adding cluster to reconstructed particle");
-                outpart.addToClusters(*clus);
+                outpart.addToClusters(clus);
                 clusterMap.erase(mcID);
             }
 
@@ -93,31 +93,31 @@ namespace eicrecon {
             assoc.setSimID(mcID);
             assoc.setWeight(1.0);
             assoc.setRec(outpart);
-            assoc.setSim(*mcparticles[mcID]);
+            assoc.setSim((*mcparticles)[mcID]);
         }
 
         // 2. Now loop over all remaining clusters and add neutrals. Also add in Hcal energy
         // if a matching cluster is available
         m_log->debug("Step 2/2: Creating neutrals for remaining clusters...");
         for (const auto &[mcID, clus]: clusterMap) {
-            m_log->debug(" --> Processing unmatched cluster with energy: {}", clus->getEnergy());
+            m_log->debug(" --> Processing unmatched cluster with energy: {}", clus.getEnergy());
 
 
             // get mass/PDG from mcparticles, 0 (unidentified) in case the matched particle is charged.
-            const auto &mc = mcparticles[mcID];
-            const double mass = (!mc->getCharge()) ? mc->getMass() : 0;
-            const int32_t pdg = (!mc->getCharge()) ? mc->getPDG() : 0;
+            const auto mc = (*mcparticles)[mcID];
+            const double mass = (!mc.getCharge()) ? mc.getMass() : 0;
+            const int32_t pdg = (!mc.getCharge()) ? mc.getPDG() : 0;
             if (m_log->level() <= spdlog::level::debug) {
-                if (mc->getCharge()) {
+                if (mc.getCharge()) {
                     m_log->debug("   --> associated mcparticle is not a neutral (PDG: {}), "
-                                 "setting the reconstructed particle ID to 0 (unidentified)", mc->getPDG());
+                                 "setting the reconstructed particle ID to 0 (unidentified)", mc.getPDG());
                 }
                 m_log->debug("   --> found matching associated mcparticle with PDG: {}, energy: {}", pdg,
-                             mc->getEnergy());
+                             mc.getEnergy());
             }
 
             // Reconstruct our neutrals and add them to the list
-            const auto outpart = reconstruct_neutral(clus, mass, pdg);
+            const auto outpart = reconstruct_neutral(&clus, mass, pdg);
             m_log->debug(" --> Reconstructed neutral particle with PDG: {}, energy: {}", outpart.getPDG(),
                          outpart.getEnergy());
 
@@ -129,7 +129,7 @@ namespace eicrecon {
             assoc.setSimID(mcID);
             assoc.setWeight(1.0);
             assoc.setRec(outpart);
-            assoc.setSim(*mcparticles[mcID]);
+            assoc.setSim((*mcparticles)[mcID]);
         }
 
         return {outparts, outpartsassoc};
@@ -139,16 +139,16 @@ namespace eicrecon {
 
     // get a map of mcID --> cluster
     // input: cluster_collections --> list of handles to all cluster collections
-    std::map<int, const edm4eic::Cluster*> MatchClusters::indexedClusters(
-            const std::vector<std::vector<const edm4eic::Cluster*>> &cluster_collections,
-            const std::vector<std::vector<const edm4eic::MCRecoClusterParticleAssociation*>> &associations_collections) {
-        std::map<int, const edm4eic::Cluster*> matched = {};
+    std::map<int, edm4eic::Cluster> MatchClusters::indexedClusters(
+            const std::vector<const edm4eic::ClusterCollection*> &cluster_collections,
+            const std::vector<const edm4eic::MCRecoClusterParticleAssociationCollection*> &associations_collections) {
+        std::map<int, edm4eic::Cluster> matched = {};
 
         // loop over cluster collections
         for (const auto &clusters: cluster_collections) {
 
             // loop over clusters
-            for (const auto &cluster: clusters) {
+            for (const auto cluster: *clusters) {
 
                 int mcID = -1;
 
@@ -156,9 +156,9 @@ namespace eicrecon {
                 for (const auto &associations: associations_collections) {
 
                     // find associated particle
-                    for (const auto &assoc: associations) {
-                        if (assoc->getRec() == *cluster) {
-                            mcID = assoc->getSimID();
+                    for (const auto assoc: *associations) {
+                        if (assoc.getRec() == cluster) {
+                            mcID = assoc.getSimID();
                             break;
                         }
                     }
@@ -169,7 +169,7 @@ namespace eicrecon {
                     }
                 }
 
-                m_log->trace(" --> Found cluster with mcID {} and energy {}", mcID, cluster->getEnergy());
+                m_log->trace(" --> Found cluster with mcID {} and energy {}", mcID, cluster.getEnergy());
 
                 if (mcID < 0) {
                     m_log->trace("   --> WARNING: no valid MC truth link found, skipping cluster...");
@@ -180,7 +180,7 @@ namespace eicrecon {
                 if (duplicate) {
                     m_log->trace("   --> WARNING: this is a duplicate mcID, keeping the higher energy cluster");
 
-                    if (cluster->getEnergy() < matched[mcID]->getEnergy()) {
+                    if (cluster.getEnergy() < matched[mcID].getEnergy()) {
                         continue;
                     }
                 }

--- a/src/algorithms/reco/MatchClusters.h
+++ b/src/algorithms/reco/MatchClusters.h
@@ -37,11 +37,11 @@ namespace eicrecon {
         void init(std::shared_ptr<spdlog::logger> logger);
 
         MatchingResults execute(
-            std::vector<const edm4hep::MCParticle *> mcparticles,
-            std::vector<const edm4eic::ReconstructedParticle *> inparts,
-            std::vector<const edm4eic::MCRecoParticleAssociation *> inpartsassoc,
-            const std::vector<std::vector<const edm4eic::Cluster*>> &cluster_collections,
-            const std::vector<std::vector<const edm4eic::MCRecoClusterParticleAssociation*>> &cluster_assoc_collections);
+            const edm4hep::MCParticleCollection* mcparticles,
+            const edm4eic::ReconstructedParticleCollection* inparts,
+            const edm4eic::MCRecoParticleAssociationCollection* inpartsassoc,
+            const std::vector<const edm4eic::ClusterCollection*> &cluster_collections,
+            const std::vector<const edm4eic::MCRecoClusterParticleAssociationCollection*> &cluster_assoc_collections);
 
     private:
 
@@ -49,9 +49,9 @@ namespace eicrecon {
 
         // get a map of mcID --> cluster
         // input: cluster_collections --> list of handles to all cluster collections
-        std::map<int, const edm4eic::Cluster*> indexedClusters(
-                const std::vector<std::vector<const edm4eic::Cluster*>> &cluster_collections,
-                const std::vector<std::vector<const edm4eic::MCRecoClusterParticleAssociation*>> &associations_collections);
+        std::map<int, edm4eic::Cluster> indexedClusters(
+                const std::vector<const edm4eic::ClusterCollection*> &cluster_collections,
+                const std::vector<const edm4eic::MCRecoClusterParticleAssociationCollection*> &associations_collections);
 
         // reconstruct a neutral cluster
         // (for now assuming the vertex is at (0,0,0))

--- a/src/global/reco/MatchClusters_factory.cc
+++ b/src/global/reco/MatchClusters_factory.cc
@@ -10,8 +10,8 @@
 
 #include "MatchClusters_factory.h"
 
-#include <edm4hep/MCParticle.h>
-#include <edm4eic/Cluster.h>
+#include <edm4hep/MCParticleCollection.h>
+#include <edm4eic/ClusterCollection.h>
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 
 #include "extensions/spdlog/SpdlogExtensions.h"
@@ -46,35 +46,31 @@ namespace eicrecon {
     }
 
     void MatchClusters_factory::Process(const std::shared_ptr<const JEvent> &event) {
-
         // TODO make input tags changeable
-        auto mc_particles = event->Get<edm4hep::MCParticle>("MCParticles");
-        auto charged_particles = event->Get<edm4eic::ReconstructedParticle>("ReconstructedChargedParticles");
-        auto charged_particle_assocs = event->Get<edm4eic::MCRecoParticleAssociation>("ReconstructedChargedParticleAssociations");
+        auto mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase("MCParticles"));
+        auto charged_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase("ReconstructedChargedParticles"));
+        auto charged_particle_assocs = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase("ReconstructedChargedParticleAssociations"));
 
-        using ClustersVector = std::vector<const edm4eic::Cluster*>;
-        using ClustersAssocVector = std::vector<const edm4eic::MCRecoClusterParticleAssociation*>;
-
-        std::vector<ClustersVector> input_cluster_vectors;
-        std::vector<ClustersAssocVector> input_cluster_assoc;
+        std::vector<const edm4eic::ClusterCollection*> cluster_collections;
+        std::vector<const edm4eic::MCRecoClusterParticleAssociationCollection*> cluster_assoc_collections;
 
         for(auto &input_tag: GetInputTags()) {
-            auto clusters = event->Get<edm4eic::Cluster>(input_tag);
-            input_cluster_vectors.push_back(clusters);
+            auto clusters = static_cast<const edm4eic::ClusterCollection*>(event->GetCollectionBase(input_tag));
+            cluster_collections.push_back(clusters);
 
-            m_log->debug("Clusters '{}' len: {}", input_tag,  clusters.size());
-            for(const auto *cluster: clusters) {
-                m_log->debug("  {} {}", cluster->getObjectID().collectionID, cluster->getEnergy());
+            m_log->debug("Clusters '{}' len: {}", input_tag,  clusters->size());
+            for(const auto cluster : *clusters) {
+                m_log->debug("  {} {}", cluster.getObjectID().collectionID, cluster.getEnergy());
             }
         }
 
         for(auto &input_tag: m_input_assoc_tags) {
-            auto assocs = event->Get<edm4eic::MCRecoClusterParticleAssociation>(input_tag);
-            input_cluster_assoc.push_back(assocs);
+            auto assocs = static_cast<const edm4eic::MCRecoClusterParticleAssociationCollection*>(event->GetCollectionBase(input_tag));
+            cluster_assoc_collections.push_back(assocs);
 
-            m_log->debug("Associations '{}' len: {}", input_tag, assocs.size());
-            for(const auto *assoc: assocs) {
-                m_log->debug("  {} {} {} {}", assoc->getRecID(), assoc->getSimID(), assoc->getRec().getEnergy(), assoc->getSim().getEnergy());
+            m_log->debug("Associations '{}' len: {}", input_tag, assocs->size());
+            for(const auto assoc : *assocs) {
+                m_log->debug("  {} {} {} {}", assoc.getRecID(), assoc.getSimID(), assoc.getRec().getEnergy(), assoc.getSim().getEnergy());
             }
         }
 
@@ -82,8 +78,8 @@ namespace eicrecon {
         auto [matched_particles, matched_assocs] = m_match_algo.execute(mc_particles,
                                                                               charged_particles,
                                                                               charged_particle_assocs,
-                                                                              input_cluster_vectors,
-                                                                              input_cluster_assoc);
+                                                                              cluster_collections,
+                                                                              cluster_assoc_collections);
 
         SetCollection<edm4eic::ReconstructedParticle>(GetOutputTags()[0], std::unique_ptr<edm4eic::ReconstructedParticleCollection>(matched_particles));
         SetCollection<edm4eic::MCRecoParticleAssociation>(GetOutputTags()[1], std::unique_ptr<edm4eic::MCRecoParticleAssociationCollection>(matched_assocs));


### PR DESCRIPTION
One of the few factories with incomplete porting to GetCollection/SetCollection instead of Get/Set with STL vectors.