### PR TITLE
src/benchmarks: deprecate JEventProcessorSequential::PrefetchT in favor of PODIO collections

### DIFF
--- a/docs/howto/make_plugin.md
+++ b/docs/howto/make_plugin.md
@@ -269,9 +269,6 @@ type, and then pointer for every histogram or tree you wish to create.
 class DaveTestProcessor: public JEventProcessorSequentialRoot {
 private:
 
-    // Data objects we will need from JANA e.g.
-    PrefetchT<edm4hep::Cluster> clusters   = {this, "EcalEndcapNClusters"};
-
     // Declare histogram and tree pointers here. e.g.
     TH1D* hClusterEnergy = nullptr;
 
@@ -325,8 +322,9 @@ void DaveTestProcessor::InitWithGlobalRootLock(){
 // ProcessSequential
 //-------------------------------------------
 void DaveTestProcessor::ProcessSequential(const std::shared_ptr<const JEvent>& event) {
+    const auto &clusters = *static_cast<const edm4eic::ClusterCollection*>(event->GetCollectionBase("EcalEndcapNClusters"));
 
-     for( auto cluster : clusters() ) hClusterEnergy->Fill(  cluster->getEnergy() );
+    for (auto cluster : clusters) hClusterEnergy->Fill(cluster.getEnergy());
 }
 
 //-------------------------------------------

--- a/docs/tutorial/03-end-user-plugin.md
+++ b/docs/tutorial/03-end-user-plugin.md
@@ -64,9 +64,6 @@ The second plugin, JTest, just supplies dummy events, ensuring your plugin is pr
 class myFirstPluginProcessor: public JEventProcessorSequentialRoot {
 private:
 
-    // Data objects we will need from JANA e.g.
-    PrefetchT<edm4hep::SimCalorimeterHit> rawhits   = {this, "EcalBarrelHits"};
-
     // Declare histogram and tree pointers here. e.g.
     TH1D* hEraw = nullptr;
 
@@ -110,8 +107,8 @@ void myFirstPluginProcessor::InitWithGlobalRootLock(){
 // ProcessSequential
 //-------------------------------------------
 void myFirstPluginProcessor::ProcessSequential(const std::shared_ptr<const JEvent>& event) {
-
-     for( auto hit : rawhits() ) hEraw->Fill(  hit->getEnergy() );
+    const auto &rawhits = *static_cast<const edm4hep::SimCalorimeterHitCollection*>(event->GetCollectionBase("EcalBarrelScFiHits"));
+    for (auto hit : rawhits) hEraw->Fill(hit.getEnergy());
 }
 
 //-------------------------------------------

--- a/src/benchmarks/detectors/EcalBarrelScFiCheck/EcalBarrelScFiCheckProcessor.cc
+++ b/src/benchmarks/detectors/EcalBarrelScFiCheck/EcalBarrelScFiCheckProcessor.cc
@@ -6,6 +6,10 @@
 #include "EcalBarrelScFiCheckProcessor.h"
 #include "services/rootfile/RootFile_service.h"
 
+#include <edm4hep/SimCalorimeterHitCollection.h>
+#include <edm4hep/RawCalorimeterHitCollection.h>
+#include <edm4eic/CalorimeterHitCollection.h>
+#include <edm4eic/ProtoClusterCollection.h>
 #include <Evaluator/DD4hepUnits.h>
 
 //-------------------------------------------
@@ -43,41 +47,45 @@ void EcalBarrelScFiCheckProcessor::InitWithGlobalRootLock(){
 // ProcessSequential
 //-------------------------------------------
 void EcalBarrelScFiCheckProcessor::ProcessSequential(const std::shared_ptr<const JEvent>& event) {
+    const auto &EcalBarrelScFiHits          = *static_cast<const edm4hep::SimCalorimeterHitCollection*>(event->GetCollectionBase("EcalBarrelScFiHits"));
+    const auto &EcalBarrelScFiRawHits       = *static_cast<const edm4hep::RawCalorimeterHitCollection*>(event->GetCollectionBase("EcalBarrelScFiRawHits"));
+    const auto &EcalBarrelScFiRecHits       = *static_cast<const edm4eic::CalorimeterHitCollection*>   (event->GetCollectionBase("EcalBarrelScFiRecHits"));
+    const auto &EcalBarrelScFiProtoClusters = *static_cast<const edm4eic::ProtoClusterCollection*>     (event->GetCollectionBase("EcalBarrelScFiProtoClusters"));
 
     // Fill histograms here
 
     // EcalBarrelScFiHits
-    hist1D["EcalBarrelScFiHits_hits_per_event"]->Fill(EcalBarrelScFiHits().size());
-    for( auto hit : EcalBarrelScFiHits()  ){
-        auto row = floor(hit->getPosition().y);
-        auto col = floor(hit->getPosition().x);
+    hist1D["EcalBarrelScFiHits_hits_per_event"]->Fill(EcalBarrelScFiHits.size());
+    for( auto hit : EcalBarrelScFiHits ){
+        auto row = floor(hit.getPosition().y);
+        auto col = floor(hit.getPosition().x);
         hist2D["EcalBarrelScFiHits_occupancy"]->Fill(row, col);
 
-        hist1D["EcalBarrelScFiHits_hit_energy"]->Fill(hit->getEnergy());
+        hist1D["EcalBarrelScFiHits_hit_energy"]->Fill(hit.getEnergy());
     }
 
     // EcalBarrelScFiRawHits
-    hist1D["EcalBarrelScFiRawHits_hits_per_event"]->Fill(EcalBarrelScFiRawHits().size());
-    for( auto hit : EcalBarrelScFiRawHits()  ){
-        hist1D["EcalBarrelScFiRawHits_amplitude"]->Fill( hit->getAmplitude() );
-        hist1D["EcalBarrelScFiRawHits_timestamp"]->Fill( hit->getTimeStamp() );
+    hist1D["EcalBarrelScFiRawHits_hits_per_event"]->Fill(EcalBarrelScFiRawHits.size());
+    for( auto hit : EcalBarrelScFiRawHits  ){
+        hist1D["EcalBarrelScFiRawHits_amplitude"]->Fill( hit.getAmplitude() );
+        hist1D["EcalBarrelScFiRawHits_timestamp"]->Fill( hit.getTimeStamp() );
     }
 
     // EcalBarrelScFiRecHits
-    hist1D["EcalBarrelScFiRecHits_hits_per_event"]->Fill(EcalBarrelScFiRecHits().size());
-    for( auto hit : EcalBarrelScFiRecHits()  ){
-        auto &pos = hit->getPosition();
-        hist1D["EcalBarrelScFiRecHits_hit_energy"]->Fill(hit->getEnergy() / dd4hep::MeV);
-        hist2D["EcalBarrelScFiRecHits_xy"]->Fill( pos.x, pos.y, hit->getEnergy() );
+    hist1D["EcalBarrelScFiRecHits_hits_per_event"]->Fill(EcalBarrelScFiRecHits.size());
+    for( auto hit : EcalBarrelScFiRecHits  ){
+        auto &pos = hit.getPosition();
+        hist1D["EcalBarrelScFiRecHits_hit_energy"]->Fill(hit.getEnergy() / dd4hep::MeV);
+        hist2D["EcalBarrelScFiRecHits_xy"]->Fill( pos.x, pos.y, hit.getEnergy() );
         hist1D["EcalBarrelScFiRecHits_z"]->Fill(pos.z);
-        hist1D["EcalBarrelScFiRecHits_time"]->Fill( hit->getTime() );
+        hist1D["EcalBarrelScFiRecHits_time"]->Fill( hit.getTime() );
     }
 
 
     // EcalBarrelScFiProtoClusters
-    hist1D["EcalBarrelScFiProtoClusters_clusters_per_event"]->Fill(EcalBarrelScFiProtoClusters().size());
-    for (auto proto : EcalBarrelScFiProtoClusters() ){
-        hist1D["EcalBarrelScFiProtoClusters_hits_per_cluster"]->Fill( proto->getHits().size() );
+    hist1D["EcalBarrelScFiProtoClusters_clusters_per_event"]->Fill(EcalBarrelScFiProtoClusters.size());
+    for (auto proto : EcalBarrelScFiProtoClusters ){
+        hist1D["EcalBarrelScFiProtoClusters_hits_per_cluster"]->Fill( proto.getHits().size() );
     }
 }
 

--- a/src/benchmarks/detectors/EcalBarrelScFiCheck/EcalBarrelScFiCheckProcessor.h
+++ b/src/benchmarks/detectors/EcalBarrelScFiCheck/EcalBarrelScFiCheckProcessor.h
@@ -7,18 +7,8 @@
 #include <TH2.h>
 #include <TFile.h>
 
-#include <edm4hep/SimCalorimeterHit.h>
-#include <edm4hep/RawCalorimeterHit.h>
-#include <edm4eic/ProtoCluster.h>
-
 class EcalBarrelScFiCheckProcessor: public JEventProcessorSequentialRoot {
 private:
-
-    // Data objects we will need from JANA e.g.
-    PrefetchT<edm4hep::SimCalorimeterHit> EcalBarrelScFiHits           = {this, "EcalBarrelScFiHits"};
-    PrefetchT<edm4hep::RawCalorimeterHit> EcalBarrelScFiRawHits        = {this, "EcalBarrelScFiRawHits"};
-    PrefetchT<edm4eic::CalorimeterHit>    EcalBarrelScFiRecHits        = {this, "EcalBarrelScFiRecHits"};
-    PrefetchT<edm4eic::ProtoCluster>      EcalBarrelScFiProtoClusters  = {this, "EcalBarrelScFiProtoClusters"};
 
     // Declare histogram and tree pointers
     std::map<std::string, TH1*> hist1D;

--- a/src/benchmarks/reconstruction/TRACKINGcheck/TRACKINGcheckProcessor.cc
+++ b/src/benchmarks/reconstruction/TRACKINGcheck/TRACKINGcheckProcessor.cc
@@ -3,11 +3,13 @@
 // Template for this file generated with eicmkplugin.py
 //
 
-#include "TRACKINGcheckProcessor.h"
+#include <TVector3.h>
+#include <Evaluator/DD4hepUnits.h>
+#include "algorithms/tracking/ActsExamples/EventData/Trajectories.hpp"
+
 #include "services/rootfile/RootFile_service.h"
 
-#include <Evaluator/DD4hepUnits.h>
-#include <TVector3.h>
+#include "TRACKINGcheckProcessor.h"
 
 //-------------------------------------------
 // InitWithGlobalRootLock
@@ -31,13 +33,14 @@ void TRACKINGcheckProcessor::InitWithGlobalRootLock(){
 // ProcessSequential
 //-------------------------------------------
 void TRACKINGcheckProcessor::ProcessSequential(const std::shared_ptr<const JEvent>& event) {
+    auto Trajectories = event->Get<ActsExamples::Trajectories>("CentralCKFActsTrajectories");
 
     // Fill histograms here
 
     // Trajectories
-    hist1D["Trajectories_trajectories_per_event"]->Fill(Trajectories().size());
+    hist1D["Trajectories_trajectories_per_event"]->Fill(Trajectories.size());
 
-    for( const auto *traj : Trajectories() ){
+    for( const auto *traj : Trajectories ){
         for( auto entryIndex : traj->tips() ){
             if( ! traj->hasTrackParameters( entryIndex) ) continue;
             auto trackparams = traj->trackParameters( entryIndex );

--- a/src/benchmarks/reconstruction/TRACKINGcheck/TRACKINGcheckProcessor.h
+++ b/src/benchmarks/reconstruction/TRACKINGcheck/TRACKINGcheckProcessor.h
@@ -7,16 +7,9 @@
 #include <TH2.h>
 #include <TFile.h>
 
-#include <edm4hep/MCParticle.h>
-#include "algorithms/tracking/ActsExamples/EventData/Trajectories.hpp"
-
 
 class TRACKINGcheckProcessor: public JEventProcessorSequentialRoot {
 private:
-
-    // Data objects we will need from JANA
-    PrefetchT<edm4hep::MCParticle>  MCParticles   = {this, "MCParticles" };
-    PrefetchT<ActsExamples::Trajectories>    Trajectories  = {this, "CentralCKFActsTrajectories"};
 
     // Containers for histograms
     std::map<std::string, TH1*> hist1D;

--- a/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.cc
@@ -19,11 +19,10 @@
 #include <DDRec/CellIDPositionConverter.h>
 
 // Include appropriate class headers. e.g.
-#include <edm4hep/SimCalorimeterHit.h>
-#include <edm4hep/MCParticle.h>
-#include <edm4eic/CalorimeterHit.h>
-#include <edm4eic/Cluster.h>
-#include <edm4eic/ProtoCluster.h>
+#include <edm4hep/SimCalorimeterHitCollection.h>
+#include <edm4hep/MCParticleCollection.h>
+#include <edm4eic/CalorimeterHitCollection.h>
+#include <edm4eic/ClusterCollection.h>
 #include <edm4eic/vector_utils.h>
 
 #include <JANA/JApplication.h>
@@ -232,18 +231,18 @@ void femc_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event) 
   // ===============================================================================================
   // process MC particles
   // ===============================================================================================
-  auto mcParticles = event -> Get<edm4hep::MCParticle>("MCParticles");
+  const auto &mcParticles = *static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase("MCParticles"));
   double mceta    = 0;
   double mcphi    = 0;
   double mcp      = 0;
   double mcenergy = 0;
   int iMC         = 0;
-  for (auto mcparticle : mcParticles) {
-    if (mcparticle->getGeneratorStatus() != 1)
+  for (const auto mcparticle : mcParticles) {
+    if (mcparticle.getGeneratorStatus() != 1)
       continue;
-    const auto& mom = mcparticle->getMomentum();
+    const auto& mom = mcparticle.getMomentum();
     // get particle energy
-    mcenergy = mcparticle->getEnergy();
+    mcenergy = mcparticle.getEnergy();
     //determine mceta from momentum
     mceta = -log(tan(atan2(sqrt(mom.x * mom.x + mom.y * mom.y), mom.z) / 2.));
     // determine mcphi from momentum
@@ -270,15 +269,15 @@ void femc_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event) 
   int nCaloHitsSim = 0;
   float sumActiveCaloEnergy = 0;
   float sumPassiveCaloEnergy = 0;
-  auto simHits = event -> Get<edm4hep::SimCalorimeterHit>(nameSimHits.data());
-  for (const auto *caloHit : simHits) {
-    float x         = caloHit->getPosition().x / 10.;
-    float y         = caloHit->getPosition().y / 10.;
-    float z         = caloHit->getPosition().z / 10.;
-    uint64_t cellID = caloHit->getCellID();
-    float energy    = caloHit->getEnergy();
+  const auto &simHits = *static_cast<const edm4hep::SimCalorimeterHitCollection*>(event->GetCollectionBase(nameSimHits));
+  for (const auto caloHit : simHits) {
+    float x         = caloHit.getPosition().x / 10.;
+    float y         = caloHit.getPosition().y / 10.;
+    float z         = caloHit.getPosition().z / 10.;
+    uint64_t cellID = caloHit.getCellID();
+    float energy    = caloHit.getEnergy();
     double time = std::numeric_limits<double>::max();
-    for (const auto& c : caloHit->getContributions()) {
+    for (const auto& c : caloHit.getContributions()) {
         if (c.getTime() <= time) {
             time = c.getTime();
         }
@@ -333,18 +332,18 @@ void femc_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event) 
   // ===============================================================================================
   // read rec hits & fill structs
   // ===============================================================================================
-  auto recHits = event -> Get<edm4eic::CalorimeterHit>(nameRecHits.data());
+  const auto &recHits = *static_cast<const edm4eic::CalorimeterHitCollection*>(event->GetCollectionBase(nameRecHits));
   int nCaloHitsRec = 0;
   std::vector<towersStrct> input_tower_rec;
   std::vector<towersStrct> input_tower_recSav;
   // process rec hits
-  for (const auto *caloHit : recHits) {
-    float x         = caloHit->getPosition().x / 10.;
-    float y         = caloHit->getPosition().y / 10.;
-    float z         = caloHit->getPosition().z / 10.;
-    uint64_t cellID = caloHit->getCellID();
-    float energy    = caloHit->getEnergy();
-    float time      = caloHit->getTime();
+  for (const auto caloHit : recHits) {
+    float x         = caloHit.getPosition().x / 10.;
+    float y         = caloHit.getPosition().y / 10.;
+    float z         = caloHit.getPosition().z / 10.;
+    uint64_t cellID = caloHit.getCellID();
+    float energy    = caloHit.getEnergy();
+    float time      = caloHit.getTime();
 
     auto detector_passive = 0;
     auto detector_layer_x = floor((x+246)/2.5);
@@ -482,7 +481,7 @@ void femc_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event) 
     m_log->info("-----> found {} clusters" , clusters_calo.size());
     hRecNClusters_E_eta->Fill(mcenergy, clusters_calo.size(), mceta);
     int iCl = 0;
-    for (auto& cluster : clusters_calo) {
+    for (const auto cluster : clusters_calo) {
       if (iCl < maxNCluster && enableTreeCluster){
         t_fEMC_cluster_E[iCl]       = (float)cluster.cluster_E;
         t_fEMC_cluster_NCells[iCl]  = (int)cluster.cluster_NTowers;
@@ -490,7 +489,7 @@ void femc_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event) 
         t_fEMC_cluster_Phi[iCl]     = (float)cluster.cluster_Phi;
       }
       hRecClusterEcalib_E_eta->Fill(mcenergy, cluster.cluster_E/mcenergy, mceta);
-      for (auto & cluster_tower : cluster.cluster_towers){
+      for (const auto cluster_tower : cluster.cluster_towers){
         int pSav = 0;
         while(cluster_tower.cellID !=  input_tower_recSav.at(pSav).cellID && pSav < (int)input_tower_recSav.size() ) {
           pSav++;
@@ -522,16 +521,16 @@ void femc_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event) 
   float highestEFr  = 0;
   int iClFHigh      = 0;
 
-  auto fecalClustersF = event -> Get<edm4eic::Cluster>(nameClusters.data());
-  for (auto& cluster : fecalClustersF) {
-    if (cluster->getEnergy() > highestEFr){
+  const auto &fecalClustersF = *static_cast<const edm4eic::ClusterCollection*>(event->GetCollectionBase(nameClusters));
+  for (const auto cluster : fecalClustersF) {
+    if (cluster.getEnergy() > highestEFr){
       iClFHigh    = iClF;
-      highestEFr  = cluster->getEnergy();
+      highestEFr  = cluster.getEnergy();
     }
-    hRecFClusterEcalib_E_eta->Fill(mcenergy, cluster->getEnergy()/mcenergy, mceta);
-    m_log->trace("Island cluster {}:\t {} \t {}", iClF, cluster->getEnergy(), cluster->getNhits());
+    hRecFClusterEcalib_E_eta->Fill(mcenergy, cluster.getEnergy()/mcenergy, mceta);
+    m_log->trace("Island cluster {}:\t {} \t {}", iClF, cluster.getEnergy(), cluster.getNhits());
 
-    for (const auto& hit: cluster->getHits()){
+    for (const auto& hit: cluster.getHits()){
       int pSav = 0;
       while(hit.getCellID() !=  input_tower_recSav.at(pSav).cellID && pSav < (int)input_tower_recSav.size() ) pSav++;
       if (hit.getCellID() == input_tower_recSav.at(pSav).cellID)
@@ -542,10 +541,10 @@ void femc_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event) 
   hRecFNClusters_E_eta->Fill(mcenergy, iClF, mceta);
   // fill hists for highest Island cluster
   iClF          = 0;
-  for (auto& cluster : fecalClustersF) {
+  for (const auto cluster : fecalClustersF) {
     if (iClF == iClFHigh){
-      hRecFClusterEcalib_Ehigh_eta->Fill(mcenergy, cluster->getEnergy()/mcenergy, mceta);
-      hRecFClusterNCells_Ehigh_eta->Fill(mcenergy, cluster->getNhits(), mceta);
+      hRecFClusterEcalib_Ehigh_eta->Fill(mcenergy, cluster.getEnergy()/mcenergy, mceta);
+      hRecFClusterNCells_Ehigh_eta->Fill(mcenergy, cluster.getNhits(), mceta);
     }
     iClF++;
   }

--- a/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
@@ -320,7 +320,7 @@ void lfhcal_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event
     uint64_t cellID = caloHit.getCellID();
     float energy    = caloHit.getEnergy();
     double time = std::numeric_limits<double>::max();
-    for (const auto c : caloHit.getContributions()) {
+    for (const auto& c : caloHit.getContributions()) {
         if (c.getTime() <= time) {
             time = c.getTime();
         }

--- a/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
@@ -19,11 +19,10 @@
 #include <DDRec/CellIDPositionConverter.h>
 
 // Include appropriate class headers. e.g.
-#include <edm4hep/SimCalorimeterHit.h>
-#include <edm4hep/MCParticle.h>
-#include <edm4eic/CalorimeterHit.h>
-#include <edm4eic/Cluster.h>
-#include <edm4eic/ProtoCluster.h>
+#include <edm4hep/SimCalorimeterHitCollection.h>
+#include <edm4hep/MCParticleCollection.h>
+#include <edm4eic/CalorimeterHitCollection.h>
+#include <edm4eic/ClusterCollection.h>
 #include <edm4eic/vector_utils.h>
 
 #include <JANA/JApplication.h>
@@ -275,18 +274,18 @@ void lfhcal_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event
   // ===============================================================================================
   // process MC particles
   // ===============================================================================================
-  auto mcParticles = event -> Get<edm4hep::MCParticle>("MCParticles");
+  const auto &mcParticles = *static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase("MCParticles"));
   double mceta    = 0;
   double mcphi    = 0;
   double mcp      = 0;
   double mcenergy = 0;
   int iMC         = 0;
   for (auto mcparticle : mcParticles) {
-    if (mcparticle->getGeneratorStatus() != 1)
+    if (mcparticle.getGeneratorStatus() != 1)
       continue;
-    const auto& mom = mcparticle->getMomentum();
+    const auto& mom = mcparticle.getMomentum();
     // get particle energy
-    mcenergy = mcparticle->getEnergy();
+    mcenergy = mcparticle.getEnergy();
     //determine mceta from momentum
     mceta = -log(tan(atan2(sqrt(mom.x * mom.x + mom.y * mom.y), mom.z) / 2.));
     // determine mcphi from momentum
@@ -313,15 +312,15 @@ void lfhcal_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event
   int nCaloHitsSim = 0;
   float sumActiveCaloEnergy = 0;
   float sumPassiveCaloEnergy = 0;
-  auto simHits = event -> Get<edm4hep::SimCalorimeterHit>(nameSimHits.data());
-  for (const auto *caloHit : simHits) {
-    float x         = caloHit->getPosition().x / 10.;
-    float y         = caloHit->getPosition().y / 10.;
-    float z         = caloHit->getPosition().z / 10.;
-    uint64_t cellID = caloHit->getCellID();
-    float energy    = caloHit->getEnergy();
+  const auto &simHits = *static_cast<const edm4hep::SimCalorimeterHitCollection*>(event->GetCollectionBase(nameSimHits));
+  for (const auto caloHit : simHits) {
+    float x         = caloHit.getPosition().x / 10.;
+    float y         = caloHit.getPosition().y / 10.;
+    float z         = caloHit.getPosition().z / 10.;
+    uint64_t cellID = caloHit.getCellID();
+    float energy    = caloHit.getEnergy();
     double time = std::numeric_limits<double>::max();
-    for (const auto& c : caloHit->getContributions()) {
+    for (const auto c : caloHit.getContributions()) {
         if (c.getTime() <= time) {
             time = c.getTime();
         }
@@ -392,18 +391,18 @@ void lfhcal_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event
   // ===============================================================================================
   // read rec hits & fill structs
   // ===============================================================================================
-  auto recHits = event -> Get<edm4eic::CalorimeterHit>(nameRecHits.data());
+  const auto &recHits = *static_cast<const edm4eic::CalorimeterHitCollection*>(event->GetCollectionBase(nameRecHits));
   int nCaloHitsRec = 0;
   std::vector<towersStrct> input_tower_rec;
   std::vector<towersStrct> input_tower_recSav;
   // process rec hits
-  for (const auto *caloHit : recHits) {
-    float x         = caloHit->getPosition().x / 10.;
-    float y         = caloHit->getPosition().y / 10.;
-    float z         = caloHit->getPosition().z / 10.;
-    uint64_t cellID = caloHit->getCellID();
-    float energy    = caloHit->getEnergy();
-    float time      = caloHit->getTime();
+  for (const auto caloHit : recHits) {
+    float x         = caloHit.getPosition().x / 10.;
+    float y         = caloHit.getPosition().y / 10.;
+    float z         = caloHit.getPosition().z / 10.;
+    uint64_t cellID = caloHit.getCellID();
+    float energy    = caloHit.getEnergy();
+    float time      = caloHit.getTime();
 
     auto detector_module_x  = m_decoder->get(cellID, 1);
     auto detector_module_y  = m_decoder->get(cellID, 2);
@@ -569,7 +568,7 @@ void lfhcal_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event
     m_log->info("-----> found {} clusters" , clusters_calo.size());
     hRecNClusters_E_eta->Fill(mcenergy, clusters_calo.size(), mceta);
     int iCl = 0;
-    for (auto& cluster : clusters_calo) {
+    for (const auto cluster : clusters_calo) {
       if (iCl < maxNCluster && enableTreeCluster){
         t_lFHCal_cluster_E[iCl]       = (float)cluster.cluster_E;
         t_lFHCal_cluster_NCells[iCl]  = (int)cluster.cluster_NTowers;
@@ -606,15 +605,15 @@ void lfhcal_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event
   float highestEFr  = 0;
   int iClFHigh      = 0;
 
-  auto lfhcalClustersF = event -> Get<edm4eic::Cluster>(nameClusters.data());
-  for (auto& cluster : lfhcalClustersF) {
-    if (cluster->getEnergy() > highestEFr){
+  const auto &lfhcalClustersF = *static_cast<const edm4eic::ClusterCollection*>(event->GetCollectionBase(nameClusters));
+  for (const auto cluster : lfhcalClustersF) {
+    if (cluster.getEnergy() > highestEFr){
       iClFHigh    = iClF;
-      highestEFr  = cluster->getEnergy();
+      highestEFr  = cluster.getEnergy();
     }
-    hRecFClusterEcalib_E_eta->Fill(mcenergy, cluster->getEnergy()/mcenergy, mceta);
-    m_log->trace("Island cluster {}:\t {} \t {}", iClF, cluster->getEnergy(), cluster->getNhits());
-    for (const auto& hit: cluster->getHits()){
+    hRecFClusterEcalib_E_eta->Fill(mcenergy, cluster.getEnergy()/mcenergy, mceta);
+    m_log->trace("Island cluster {}:\t {} \t {}", iClF, cluster.getEnergy(), cluster.getNhits());
+    for (const auto hit : cluster.getHits()){
       int pSav = 0;
       while(hit.getCellID() !=  input_tower_recSav.at(pSav).cellID && pSav < (int)input_tower_recSav.size() ) pSav++;
       if (hit.getCellID() == input_tower_recSav.at(pSav).cellID)
@@ -625,10 +624,10 @@ void lfhcal_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event
   hRecFNClusters_E_eta->Fill(mcenergy, iClF, mceta);
   // fill hists for highest Island cluster
   iClF          = 0;
-  for (auto& cluster : lfhcalClustersF) {
+  for (const auto cluster : lfhcalClustersF) {
     if (iClF == iClFHigh){
-      hRecFClusterEcalib_Ehigh_eta->Fill(mcenergy, cluster->getEnergy()/mcenergy, mceta);
-      hRecFClusterNCells_Ehigh_eta->Fill(mcenergy, cluster->getNhits(), mceta);
+      hRecFClusterEcalib_Ehigh_eta->Fill(mcenergy, cluster.getEnergy()/mcenergy, mceta);
+      hRecFClusterNCells_Ehigh_eta->Fill(mcenergy, cluster.getNhits(), mceta);
     }
     iClF++;
   }
@@ -643,21 +642,21 @@ void lfhcal_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event
 
   if (enableECalCluster){
     try {
-      auto fEMCClustersF = event->Get<edm4eic::Cluster>("EcalEndcapPClusters");
+      const auto &fEMCClustersF = *static_cast<const edm4eic::ClusterCollection*>(event->GetCollectionBase("EcalEndcapPClusters"));
       m_log->info("-----> found fEMCClustersF:" , fEMCClustersF.size());
-      for (auto& cluster : fEMCClustersF) {
+      for (const auto cluster : fEMCClustersF) {
         if (iECl < maxNCluster && enableTreeCluster){
-            t_fEMC_cluster_E[iECl]       = (float)cluster->getEnergy();
-            t_fEMC_cluster_NCells[iECl]  = (int)cluster->getNhits();
-            t_fEMC_cluster_Eta[iECl]     = (-1.) * std::log(std::tan((float)cluster->getIntrinsicTheta() / 2.));
-            t_fEMC_cluster_Phi[iECl]     = (float)cluster->getIntrinsicPhi();
+            t_fEMC_cluster_E[iECl]       = (float)cluster.getEnergy();
+            t_fEMC_cluster_NCells[iECl]  = (int)cluster.getNhits();
+            t_fEMC_cluster_Eta[iECl]     = (-1.) * std::log(std::tan((float)cluster.getIntrinsicTheta() / 2.));
+            t_fEMC_cluster_Phi[iECl]     = (float)cluster.getIntrinsicPhi();
         }
 
-        if (cluster->getEnergy() > highestEEmCl){
+        if (cluster.getEnergy() > highestEEmCl){
           iEClHigh      = iECl;
-          highestEEmCl  = cluster->getEnergy();
+          highestEEmCl  = cluster.getEnergy();
         }
-        hRecFEmClusterEcalib_E_eta->Fill(mcenergy, cluster->getEnergy()/mcenergy, mceta);
+        hRecFEmClusterEcalib_E_eta->Fill(mcenergy, cluster.getEnergy()/mcenergy, mceta);
         iECl++;
       }
       t_fEMC_clusters_N  = iECl;
@@ -665,9 +664,9 @@ void lfhcal_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event
 
       // fill hists for highest Island cluster
       iECl          = 0;
-      for (auto& cluster : fEMCClustersF) {
+      for (const auto cluster : fEMCClustersF) {
         if (iECl == iEClHigh){
-          hRecFEmClusterEcalib_Ehigh_eta->Fill(mcenergy, cluster->getEnergy()/mcenergy, mceta);
+          hRecFEmClusterEcalib_Ehigh_eta->Fill(mcenergy, cluster.getEnergy()/mcenergy, mceta);
         }
         iECl++;
       }

--- a/src/benchmarks/reconstruction/tof_efficiency/TofEfficiency_processor.cc
+++ b/src/benchmarks/reconstruction/tof_efficiency/TofEfficiency_processor.cc
@@ -1,6 +1,9 @@
 #include "TofEfficiency_processor.h"
 #include "services/rootfile/RootFile_service.h"
 
+#include <edm4hep/MCParticleCollection.h>
+#include <edm4eic/TrackSegmentCollection.h>
+#include <edm4eic/TrackerHitCollection.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <TVector3.h>
 
@@ -47,36 +50,40 @@ void TofEfficiency_processor::InitWithGlobalRootLock(){
 // ProcessSequential
 //-------------------------------------------
 void TofEfficiency_processor::ProcessSequential(const std::shared_ptr<const JEvent>& event) {
+    const auto &mcParticles   = *static_cast<const edm4hep::MCParticleCollection*>  (event->GetCollectionBase("MCParticles"));
+    const auto &trackSegments = *static_cast<const edm4eic::TrackSegmentCollection*>(event->GetCollectionBase("CentralTrackSegments"));
+    const auto &barrelHits    = *static_cast<const edm4eic::TrackerHitCollection*>  (event->GetCollectionBase("TOFBarrelRecHit"));
+    const auto &endcapHits    = *static_cast<const edm4eic::TrackerHitCollection*>  (event->GetCollectionBase("TOFEndcapRecHits"));
 
     // List TOF Barrel hits from barrel
     logger()->trace("TOF barrel hits:");
     m_log->trace("   {:>10} {:>10} {:>10} {:>10}", "[x]", "[y]", "[z]", "[time]");
-    for (const auto *hit: barrelHits()) {
-        const auto& pos = hit->getPosition();
+    for (const auto hit: barrelHits) {
+        const auto& pos = hit.getPosition();
         float r=sqrt(pos.x*pos.x+pos.y*pos.y);
         float phi=acos(pos.x/r); if(pos.y<0) phi+=3.1415927;
         m_th2_btof_phiz->Fill(phi, pos.z);
-        m_log->trace("   {:>10.2f} {:>10.2f} {:>10.2f} {:>10.4f}", pos.x, pos.y, pos.z, hit->getTime());
+        m_log->trace("   {:>10.2f} {:>10.2f} {:>10.2f} {:>10.4f}", pos.x, pos.y, pos.z, hit.getTime());
     }
 
     // List TOF endcap hits
     logger()->trace("TOF endcap hits:");
     m_log->trace("   {:>10} {:>10} {:>10} {:>10}", "[x]", "[y]", "[z]", "[time]");
-    for (const auto *hit: endcapHits()) {
-        const auto& pos = hit->getPosition();
+    for (const auto hit: endcapHits) {
+        const auto& pos = hit.getPosition();
         float r=sqrt(pos.x*pos.x+pos.y*pos.y);
         float phi=acos(pos.x/r); if(pos.y<0) phi+=3.1415927;
         m_th2_ftof_rphi->Fill(r, phi);
-        m_log->trace("   {:>10.2f} {:>10.2f} {:>10.2f} {:>10.4f}", pos.x, pos.y, pos.z, hit->getTime());
+        m_log->trace("   {:>10.2f} {:>10.2f} {:>10.2f} {:>10.4f}", pos.x, pos.y, pos.z, hit.getTime());
     }
 
     // Now go through reconstructed tracks points
     logger()->trace("Going over tracks:");
     m_log->trace("   {:>10} {:>10} {:>10} {:>10}", "[x]", "[y]", "[z]", "[length]");
-    for( const auto *track_segment : trackSegments() ){
+    for( const auto track_segment : trackSegments ){
         logger()->trace(" Track trajectory");
 
-        for(auto point: track_segment->getPoints()) {
+        for(const auto point: track_segment.getPoints()) {
             auto &pos = point.position;
             m_log->trace("   {:>10.2f} {:>10.2f} {:>10.2f} {:>10.2f}", pos.x, pos.y, pos.z, point.pathlength);
 
@@ -85,28 +92,28 @@ void TofEfficiency_processor::ProcessSequential(const std::shared_ptr<const JEve
             float hit_x=-1000, hit_y=-1000, hit_z=-1000, hit_t=-1000;
             float hit_px=-1000, hit_py=-1000, hit_pz=-1000, hit_e=-1000;
             if(det==1) {
-                for (const auto *hit: barrelHits()) {
-                    const auto& hitpos = hit->getPosition();
+                for (const auto hit: barrelHits) {
+                    const auto& hitpos = hit.getPosition();
                     float distance=sqrt((hitpos.x-pos.x)*(hitpos.x-pos.x)+(hitpos.y-pos.y)*(hitpos.y-pos.y)+(hitpos.z-pos.z)*(hitpos.z-pos.z));
                     if(distance<distance_closest) {
                         distance_closest=distance;
                         hit_x=hitpos.x;
                         hit_y=hitpos.y;
                         hit_z=hitpos.z;
-                        hit_t=hit->getTime();
+                        hit_t=hit.getTime();
                     }
                 }
             }
             if(det==2) {
-                for (const auto *hit: endcapHits()) {
-                    const auto& hitpos = hit->getPosition();
+                for (const auto hit: endcapHits) {
+                    const auto& hitpos = hit.getPosition();
                     float distance=sqrt((hitpos.x-pos.x)*(hitpos.x-pos.x)+(hitpos.y-pos.y)*(hitpos.y-pos.y)+(hitpos.z-pos.z)*(hitpos.z-pos.z));
                     if(distance<distance_closest) {
                         distance_closest=distance;
                         hit_x=hitpos.x;
                         hit_y=hitpos.y;
                         hit_z=hitpos.z;
-                        hit_t=hit->getTime();
+                        hit_t=hit.getTime();
                     }
                 }
             }

--- a/src/benchmarks/reconstruction/tof_efficiency/TofEfficiency_processor.h
+++ b/src/benchmarks/reconstruction/tof_efficiency/TofEfficiency_processor.h
@@ -8,23 +8,10 @@
 #include <TH2.h>
 #include <TFile.h>
 
-#include "algorithms/tracking/TrackProjector.h"
 #include "extensions/spdlog/SpdlogMixin.h"
-#include <edm4hep/MCParticle.h>
-#include <edm4eic/TrackSegment.h>
-#include <edm4eic/TrackerHit.h>
-
 
 class TofEfficiency_processor: public JEventProcessorSequentialRoot, public eicrecon::SpdlogMixin  {
 private:
-
-    // Data objects we will need from JANA
-    // Since Prefetch<> is used as a fanction, we use function naming scheme for the next
-    PrefetchT<edm4hep::MCParticle>  mcParticles   = {this, "MCParticles" };
-    PrefetchT<edm4eic::TrackSegment> trackSegments = {this, "CentralTrackSegments"};
-    PrefetchT<edm4eic::TrackerHit> barrelHits = {this, "TOFBarrelRecHit"};
-    PrefetchT<edm4eic::TrackerHit> endcapHits = {this, "TOFEndcapRecHits"};
-
 
     // Containers for histograms
     std::map<std::string, TH1*> m_1d_hists;

--- a/src/scripts/eicmkplugin.py
+++ b/src/scripts/eicmkplugin.py
@@ -52,15 +52,10 @@ processor_sequentialroot_header_template = """
 
 // Include appropirate class headers. e.g.
 // #include <edm4hep/SimCalorimeterHit.h>
-// #include "detectors/BEMC/BEMCRawCalorimeterHit.h"
 
 
 class {0}: public JEventProcessorSequentialRoot {{
 private:
-
-    // Data objects we will need from JANA e.g.
-    // PrefetchT<edm4hep::SimCalorimeterHit> rawhits   = {{this, "EcalBarrelHits"}};
-    // PrefetchT<BEMCRawCalorimeterHit>      digihits  = {{this}};
 
     // Declare histogram and tree pointers here. e.g.
     // TH1D* hEraw  = nullptr;
@@ -109,10 +104,11 @@ void {0}::InitWithGlobalRootLock(){{
 // ProcessSequential
 //-------------------------------------------
 void {0}::ProcessSequential(const std::shared_ptr<const JEvent>& event) {{
+    // Data objects we will need from JANA e.g.
+    const auto &rawhits = *static_cast<const edm4hep::SimCalorimeterHitCollection*>(event->GetCollectionBase("EcalBarrelScFiHits"));
 
     // Fill histograms here. e.g.
-    // for( auto hit : rawhits()  ) hEraw->Fill(  hit->getEnergy());
-    // for( auto hit : digihits() ) hEdigi->Fill( hit->getAmplitude(), hit->getEnergy());
+    // for (auto hit : rawhits) hEraw->Fill(hit.getEnergy());
 }}
 
 //-------------------------------------------


### PR DESCRIPTION
PrefetchT relies on compatibility interface that copies PODIO pointer objects into `std::vector<> JFactory::mData` member. We'd like for all of our code to work with PODIO collections directly.