### PR TITLE
fix: use localDistXY in HcalEndcapN

### DIFF
--- a/src/detectors/EHCAL/EHCAL.cc
+++ b/src/detectors/EHCAL/EHCAL.cc
@@ -64,8 +64,7 @@ extern "C" {
           "HcalEndcapNIslandProtoClusters", {"HcalEndcapNRecHits"}, {"HcalEndcapNIslandProtoClusters"},
           {
             .sectorDist = 5.0 * dd4hep::cm,
-            .localDistXY = {15*dd4hep::mm, 15*dd4hep::mm},
-            .dimScaledLocalDistXY = {15.0*dd4hep::mm, 15.0*dd4hep::mm},
+            .localDistXY = {15*dd4hep::cm, 15*dd4hep::cm},
             .splitCluster = true,
             .minClusterHitEdep = 0.0 * dd4hep::MeV,
             .minClusterCenterEdep = 30.0 * dd4hep::MeV,


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Fix the division by 0 bug #988, where segment dimensions are 0. Switched to localDistXY. Needs testing and adjustment of the max dist values.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #988)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.