### PR TITLE
labeler.yml: fix calorimetry tag for EHCAL

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,7 +15,7 @@
   - "src/detectors/B0ECAL/**"
   - "src/detectors/BEMC/**"
   - "src/detectors/BHCAL/**"
-  - "src/detectors/EEMC/**"
+  - "src/detectors/EHCAL/**"
   - "src/detectors/EEMC/**"
   - "src/detectors/FEMC/**"
   - "src/detectors/FHCAL/**"


### PR DESCRIPTION
EEMC went in twice - must have been an editing mistake.