### PR TITLE
fix: rm independent geometry reading in RICHGeo

### DIFF
--- a/src/services/geometry/richgeo/IrtGeo.cc
+++ b/src/services/geometry/richgeo/IrtGeo.cc
@@ -10,18 +10,6 @@ richgeo::IrtGeo::IrtGeo(std::string detName_, dd4hep::Detector *det_, std::share
   Bind();
 }
 
-// alternate constructor: use compact file for DD4hep geometry (backward compatibility)
-richgeo::IrtGeo::IrtGeo(std::string detName_, std::string compactFile_, std::shared_ptr<spdlog::logger> log_) :
-  m_detName(detName_), m_log(log_)
-{
-  // build DD4hep detector from compact file
-  m_det = &dd4hep::Detector::getInstance();
-  m_det->fromXML(compactFile_);
-
-  // set IRT and DD4hep geometry handles
-  Bind();
-}
-
 // Bind() -----------------------------------------
 // set IRT and DD4hep geometry handles
 void richgeo::IrtGeo::Bind() {

--- a/src/services/geometry/richgeo/IrtGeo.h
+++ b/src/services/geometry/richgeo/IrtGeo.h
@@ -29,8 +29,6 @@ namespace richgeo {
 
       // constructor: creates IRT-DD4hep bindings using main `Detector` handle `*det_`
       IrtGeo(std::string detName_, dd4hep::Detector *det_, std::shared_ptr<spdlog::logger> log_);
-      // alternate constructor: use compact file for DD4hep geometry (backward compatibility)
-      IrtGeo(std::string detName_, std::string compactFile_, std::shared_ptr<spdlog::logger> log_);
       virtual ~IrtGeo();
 
       // access the full IRT geometry

--- a/src/services/geometry/richgeo/IrtGeoDRICH.h
+++ b/src/services/geometry/richgeo/IrtGeoDRICH.h
@@ -10,8 +10,6 @@ namespace richgeo {
   class IrtGeoDRICH : public IrtGeo {
 
     public:
-      IrtGeoDRICH(std::string compactFile_, std::shared_ptr<spdlog::logger> log_) :
-        IrtGeo("DRICH",compactFile_,log_) { DD4hep_to_IRT(); }
       IrtGeoDRICH(dd4hep::Detector *det_, std::shared_ptr<spdlog::logger> log_) :
         IrtGeo("DRICH",det_,log_) { DD4hep_to_IRT(); }
       ~IrtGeoDRICH();

--- a/src/services/geometry/richgeo/IrtGeoPFRICH.h
+++ b/src/services/geometry/richgeo/IrtGeoPFRICH.h
@@ -10,8 +10,6 @@ namespace richgeo {
   class IrtGeoPFRICH : public IrtGeo {
 
     public:
-      IrtGeoPFRICH(std::string compactFile_, std::shared_ptr<spdlog::logger> log_) :
-        IrtGeo("PFRICH",compactFile_,log_) { DD4hep_to_IRT(); }
       IrtGeoPFRICH(dd4hep::Detector *det_, std::shared_ptr<spdlog::logger> log_) :
         IrtGeo("PFRICH",det_,log_) { DD4hep_to_IRT(); }
       ~IrtGeoPFRICH();

--- a/src/services/geometry/richgeo/RichGeo_service.cc
+++ b/src/services/geometry/richgeo/RichGeo_service.cc
@@ -80,8 +80,6 @@ std::shared_ptr<richgeo::ReadoutGeo> RichGeo_service::GetReadoutGeo(std::string 
 // Destructor --------------------------------------------------------
 RichGeo_service::~RichGeo_service() {
   try {
-    if(m_dd4hepGeo) m_dd4hepGeo->destroyInstance();
-    m_dd4hepGeo = nullptr;
     delete m_irtGeo;
     delete m_actsGeo;
   } catch (...) {}


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This removes the unused (deprecated) IrtGeo interfaces that load their own compact file. This is in particular relevant because RichGeo cleans up the geometry regardless with a `destroyInstance` that is applied on both the DD4hep_service and RichGeo_service geometries. That could potentially cause a race condition when both DD4hep_service and RichGeo_service try to destroy the same geometry instance (it probably is happening already but is caught by the try catch around both instances). This change also allows us to move towards more const correctness in the treatment of DD4hep geometries (i.e. not passing the geometry as a non-const pointer).

### What kind of change does this PR introduce?
- [x] Bug fix (issue: `destroyInstance` in RichGeo_service also applies on DD4hep_service geometry)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @c-dilks @chchatte92 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.