### PR TITLE
fix: use subset collection when collecting hits in TrackSeeding

### DIFF
--- a/src/global/tracking/TrackSeeding_factory.cc
+++ b/src/global/tracking/TrackSeeding_factory.cc
@@ -63,6 +63,7 @@ void eicrecon::TrackSeeding_factory::Process(const std::shared_ptr<const JEvent>
     // Collect all hits
     // FIXME Collection is better done with a TrackerHitCollector factory
     edm4eic::TrackerHitCollection total_hits;
+    total_hits.setSubsetCollection();
 
     for(auto input_tag: GetInputTags()) {
         auto hits = static_cast<const edm4eic::TrackerHitCollection*>(event->GetCollectionBase(input_tag));


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This fixes a regression introduced in #983 that caused realistic track seeding to fail. Essentially, you cannot just add an object from one podio collection into another podio collection "by reference", i.e. without cloning. You can do that with pointers in std::vector, which was done here before #983. We can achieve the same behavior in podio, but we have to be more intentional about it and define a subset collection.

Of course, podio complains loudly when you try to add an object from one collection into another collection. It emits an exception: `Object already in a collection. Cannot add it to a second collection`. But JANA2 eats that exception and doesn't even print it :angry:

TODO:
- [x] check diffs

### What kind of change does this PR introduce?
- [x] Bug fix (issue: no track seeding results after #983)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @ShujieL 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, CentralTrackSeedingResults and dependents are restored.