### PR TITLE
fix: remove adhoc LFHCAL treatment in CalorimeterHitReco

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -118,7 +118,6 @@ std::unique_ptr<edm4eic::CalorimeterHitCollection> CalorimeterHitReco::process(c
     // number is encountered disable this algorithm. A useful message
     // indicating what is going on is printed below where the
     // error is detector.
-    auto decoder = m_detector->readout(m_cfg.readout).idSpec().decoder();
     if (NcellIDerrors >= MaxCellIDerrors) return std::move(recohits);
 
     for (const auto &rh: rawhits) {

--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -129,6 +129,12 @@ std::unique_ptr<edm4eic::CalorimeterHitCollection> CalorimeterHitReco::process(c
             continue;
         }
 
+        // get layer and sector ID
+        const int lid =
+                id_dec != nullptr && !m_cfg.layerField.empty() ? static_cast<int>(id_dec->get(cellID, layer_idx)) : -1;
+        const int sid =
+                id_dec != nullptr && !m_cfg.sectorField.empty() ? static_cast<int>(id_dec->get(cellID, sector_idx)) : -1;
+
         // convert ADC to energy
         float energy = (((signed) rh.getAmplitude() - (signed) m_cfg.pedMeanADC)) / static_cast<float>(m_cfg.capADC) * m_cfg.dyRangeADC /
                 m_cfg.sampFrac;
@@ -139,11 +145,6 @@ std::unique_ptr<edm4eic::CalorimeterHitCollection> CalorimeterHitReco::process(c
 
         const float time = rh.getTimeStamp() / stepTDC;
         m_log->trace("cellID {}, \t energy: {},  TDC: {}, time: ", cellID, energy, rh.getTimeStamp(), time);
-
-        const int lid =
-                id_dec != nullptr && !m_cfg.layerField.empty() ? static_cast<int>(id_dec->get(cellID, layer_idx)) : -1;
-        const int sid =
-                id_dec != nullptr && !m_cfg.sectorField.empty() ? static_cast<int>(id_dec->get(cellID, sector_idx)) : -1;
 
         dd4hep::Position gpos;
         try {

--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -146,7 +146,7 @@ std::unique_ptr<edm4eic::CalorimeterHitCollection> CalorimeterHitReco::process(c
 
         // convert ADC to energy
         float energy = (((signed) rh.getAmplitude() - (signed) m_cfg.pedMeanADC)) / static_cast<float>(m_cfg.capADC) * m_cfg.dyRangeADC /
-                m_cfg.sampFrac;
+                sampFrac;
 
         const float time = rh.getTimeStamp() / stepTDC;
         m_log->trace("cellID {}, \t energy: {},  TDC: {}, time: ", cellID, energy, rh.getTimeStamp(), time);

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -254,6 +254,7 @@ extern "C" {
               0.037, // 13
             },
             .readout = "LFHCALHits",
+            .layerField = "rlayerz",
           },
           app   // TODO: Remove me once fixed
         ));


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This removes adhoc LFHCAL treatment in CalorimeterHitReco and implements a configurable approach that uses previously implemented layer ID resolution. Instead of `if (m_cfg.readout == "LFHCALHits")`, this now:
- uses the cellID decoder `id_dec` defined on init intsead of a local version,
- doesn't depend on fragile testing `sampFracLayer[0] != 0.` but instead `sampFracLayer.empty()`,
- single place to do the energy reconstruction based on the varying sampFrac,
- single place to do the layer field id decoding.

TODO:
- [x] check diffs in CI: LFHCALRecHits.layer is now filled too

### What kind of change does this PR introduce?
- [x] Bug fix (issue #796)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @FriederikeBock 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.