### PR TITLE
fix: reenable storing geometryId into TrackPoint surface field

### DIFF
--- a/src/algorithms/tracking/TrackProjector.cc
+++ b/src/algorithms/tracking/TrackProjector.cc
@@ -148,7 +148,7 @@ namespace eicrecon {
                 const float pathLength = static_cast<float>(trackstate.pathLength());
                 const float pathLengthError = 0;
 
-                uint64_t surface = 0; // trackstate.referenceSurface().geometryId().value(); FIXME - ASAN is not happy with this
+                uint64_t surface = trackstate.referenceSurface().geometryId().value();
                 uint32_t system = 0;
 
                 // Store track point

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -292,7 +292,7 @@ namespace eicrecon {
         m_log->trace("    loc err = {:.4f}", static_cast<float>(covariance(Acts::eBoundLoc0, Acts::eBoundLoc1)));
 
 #if EDM4EIC_VERSION_MAJOR >= 3
-        uint64_t surface = 0; // targetSurf->geometryId().value(); // FIXME - ASAN is not happy with this
+        uint64_t surface = targetSurf->geometryId().value();
         uint32_t system = 0; // default value...will be set in TrackPropagation factory
 #endif
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This reenables the geometryId call to store the surface field of the TrackPoint. It was previously having issues with ASAN.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #930)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @veprbl 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.