### PR TITLE
feat: fill Acts::GeometryIdentfier extra field with DD4hep detector ID

### DIFF
--- a/src/algorithms/tracking/ActsGeometryProvider.h
+++ b/src/algorithms/tracking/ActsGeometryProvider.h
@@ -98,9 +98,6 @@ private:
     /// ACTS Tracking Geometry
     std::shared_ptr<const Acts::TrackingGeometry> m_trackingGeo{nullptr};
 
-    /// ACTS Material Decorator
-    std::shared_ptr<const Acts::IMaterialDecorator> m_materialDeco{nullptr};
-
     /// ACTS surface lookup container for hit surfaces that generate smeared hits
     VolumeSurfaceMap m_surfaces;
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This sets up the Acts::GeometryIdentifierHook to get the DD4hep detector ID on geometry conversion.

Also: makes the material decorator local instead of class member.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.