### PR TITLE
fix: make sure Microsoft.GSL::GSL is provided to plugins/libraries

### DIFF
--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -31,6 +31,9 @@ macro(plugin_add _name)
     # include fmt by default
     find_package(fmt REQUIRED)
 
+    # include gsl by default
+    find_package(Microsoft.GSL CONFIG)
+
     # Define plugin
     if(${_name}_WITH_PLUGIN)
         add_library(${_name}_plugin SHARED ${PLUGIN_SOURCES})
@@ -41,6 +44,7 @@ macro(plugin_add _name)
         set_target_properties(${_name}_plugin PROPERTIES PREFIX "" OUTPUT_NAME "${_name}" SUFFIX ".so")
         target_link_libraries(${_name}_plugin ${JANA_LIB} spdlog::spdlog)
         target_link_libraries(${_name}_plugin ${JANA_LIB} fmt::fmt)
+        target_link_libraries(${_name}_plugin Microsoft.GSL::GSL)
 
         # Install plugin
         install(TARGETS ${_name}_plugin DESTINATION ${PLUGIN_OUTPUT_DIRECTORY})
@@ -61,6 +65,7 @@ macro(plugin_add _name)
         target_include_directories(${_name}_library SYSTEM PUBLIC ${JANA_INCLUDE_DIR} )
         target_link_libraries(${_name}_library ${JANA_LIB} spdlog::spdlog)
         target_link_libraries(${_name}_library ${JANA_LIB} fmt::fmt)
+        target_link_libraries(${_name}_library Microsoft.GSL::GSL)
 
         # Install plugin
         install(TARGETS ${_name}_library DESTINATION ${PLUGIN_LIBRARY_OUTPUT_DIRECTORY})


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Hotfix. Depending on Microsoft.GSL through just a top-level find_package(Microsoft.GSL CONFIG) doesn't work in the eic-shell nightlies, where GSL is in a completely different prefix, e.g. https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/2013019.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/2013019)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.