### PR TITLE
fix: correct number of arguments for fmt string in processors

### DIFF
--- a/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.cc
@@ -553,7 +553,7 @@ void femc_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event) 
   if (enableTree){
     t_fEMC_towers_N = (int)input_tower_recSav.size();
     for (int iCell = 0; iCell < (int)input_tower_recSav.size(); iCell++){
-      m_log->trace("{} \t {} \t {} \t {} \t {} \t {}", input_tower_recSav.at(iCell).cellIDx, input_tower_recSav.at(iCell).cellIDy , input_tower_recSav.at(iCell).energy, input_tower_recSav.at(iCell).tower_clusterIDA, input_tower_recSav.at(iCell).tower_clusterIDB  );
+      m_log->trace("{} \t {} \t {} \t {} \t {}", input_tower_recSav.at(iCell).cellIDx, input_tower_recSav.at(iCell).cellIDy , input_tower_recSav.at(iCell).energy, input_tower_recSav.at(iCell).tower_clusterIDA, input_tower_recSav.at(iCell).tower_clusterIDB  );
 
       t_fEMC_towers_cellE[iCell]      = (float)input_tower_recSav.at(iCell).energy;
       t_fEMC_towers_cellT[iCell]      = (float)input_tower_recSav.at(iCell).time;

--- a/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
@@ -671,7 +671,7 @@ void lfhcal_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event
   if (enableTree){
     t_lFHCal_towers_N = (int)input_tower_recSav.size();
     for (int iCell = 0; iCell < (int)input_tower_recSav.size(); iCell++){
-      m_log->trace("{} \t {} \t {} \t {} \t {} \t {} \t {}", input_tower_recSav.at(iCell).cellIDx, input_tower_recSav.at(iCell).cellIDy, input_tower_recSav.at(iCell).cellIDz , input_tower_recSav.at(iCell).energy, input_tower_recSav.at(iCell).tower_clusterIDA, input_tower_recSav.at(iCell).tower_clusterIDB  );
+      m_log->trace("{} \t {} \t {} \t {} \t {} \t {}", input_tower_recSav.at(iCell).cellIDx, input_tower_recSav.at(iCell).cellIDy, input_tower_recSav.at(iCell).cellIDz , input_tower_recSav.at(iCell).energy, input_tower_recSav.at(iCell).tower_clusterIDA, input_tower_recSav.at(iCell).tower_clusterIDB  );
 
       t_lFHCal_towers_cellE[iCell]      = (float)input_tower_recSav.at(iCell).energy;
       t_lFHCal_towers_cellT[iCell]      = (float)input_tower_recSav.at(iCell).time;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
In C++20 / fmt-10.1.0 the format string is constexpr and parsed on compilation time. That means that format string mismatches with the number of arguments are now compilation errors. This fixes (the only) two such cases.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: incomplete C++20 / fmt-10 support)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.