### PR TITLE
Implement jet PODIO relations

### DIFF
--- a/src/global/reco/ReconstructedJets_factory.cc
+++ b/src/global/reco/ReconstructedJets_factory.cc
@@ -55,23 +55,11 @@ namespace eicrecon {
     void ReconstructedJets_factory::Process(const std::shared_ptr<const JEvent> &event) {
 
         // grab input collection
+        // TODO: Need to exclude the scattered electron
         auto input = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase(GetInputTags()[0]));
 
-        // extract particle momenta
-        std::vector<const edm4hep::LorentzVectorE*> momenta;
-        for (const auto& particle : *input) {
-
-            // TODO: Need to exclude the scattered electron
-            const auto& momentum = particle.getMomentum();
-            const auto& energy = particle.getEnergy();
-            momenta.push_back(new edm4hep::LorentzVectorE(momentum.x, momentum.y, momentum.z, energy));
-        }  // end particle loop
-
         // run algorithm
-        auto rec_jets = m_jet_algo.process(momenta);
-        for (const auto &momentum : momenta) {
-            delete momentum;
-        }
+        auto rec_jets = m_jet_algo.process(*input);
 
         // set output collection
         SetCollection<edm4eic::ReconstructedParticle>(GetOutputTags()[0], std::move(rec_jets));


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This PR rewrites the jet reconstruction algorithms and factories in order to accommodate PODIO relations between the jets and their constituents. [Previously,](https://wiki.bnl.gov/EPIC/index.php?title=JetsHF) the constituents' kinematics were stored in the same output collection as the jets and could be identified via their `type` member. Now, only jets are stored in the output collection and their constituents are identified via standard PODIO relations.

Note that in the rewrite, the jet algorithm now processes a generic EDM4EIC or EDM4HEP collection rather than a list of 4-momenta.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #902 )
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [X ] Documentation has been added / updated (the Jet/HF wiki page will be updated on merging)
- [X ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

Yes. Any code making use of the generated and reconstructed jet collections will need to be updated to

1. stop checking the jet `type` for if the object is a jet or constituent;
2. refer to constituents via PODIO relations.

### Does this PR change default behavior?

Yes. Only jets will be stored in the output collections.
