### PR TITLE
fix: support fmt v10 and C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ add_compile_definitions(HAVE_PODIO)
 # PODIO, EDM4HEP, EDM4EIC event models
 find_package(Eigen3 REQUIRED)
 find_package(podio REQUIRED)
-find_package(EDM4HEP REQUIRED)
+find_package(EDM4HEP 0.7.1 REQUIRED)
 find_package(EDM4EIC 2.1 REQUIRED)
 
 # Guidelines Support Library

--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -29,7 +29,7 @@ macro(plugin_add _name)
     find_package(spdlog REQUIRED)
 
     # include fmt by default
-    find_package(fmt REQUIRED)
+    find_package(fmt 9.0.0 REQUIRED)
 
     # include gsl by default
     find_package(Microsoft.GSL CONFIG)

--- a/src/algorithms/pid/IrtCherenkovParticleID.cc
+++ b/src/algorithms/pid/IrtCherenkovParticleID.cc
@@ -52,7 +52,7 @@ void eicrecon::IrtCherenkovParticleID::AlgorithmInit(
   for(auto [rad_name,irt_rad] : m_irt_det->Radiators()) {
     if(rad_name!="Filter") {
       m_pid_radiators.insert({ std::string(rad_name), irt_rad });
-      m_log->debug("- {}", rad_name);
+      m_log->debug("- {}", rad_name.Data());
     }
   }
 

--- a/src/algorithms/pid/ParticlesWithPID.cc
+++ b/src/algorithms/pid/ParticlesWithPID.cc
@@ -259,7 +259,7 @@ namespace eicrecon {
             // get averge momentum direction of the track's TrackPoints
             decltype(edm4eic::TrackPoint::momentum) in_track_p{0.0, 0.0, 0.0};
             for (const auto& in_track_point : in_track.getPoints())
-                in_track_p = in_track_p + ( in_track_point.momentum ); // FIXME / in_track.points_size() );
+                in_track_p = in_track_p + ( in_track_point.momentum / in_track.points_size() );
             auto in_track_eta = edm4hep::utils::eta(in_track_p);
             auto in_track_phi = edm4hep::utils::angleAzimuthal(in_track_p);
 

--- a/src/extensions/spdlog/SpdlogExtensions.h
+++ b/src/extensions/spdlog/SpdlogExtensions.h
@@ -52,7 +52,7 @@ namespace eicrecon {
                 break;
         }
 
-        auto err_msg = fmt::format("ParseLogLevel don't know this log level: '{}'", input);
+        auto err_msg = fmt::format("ParseLogLevel don't know this log level: '{}'", fmt::underlying(input));
         throw JException(err_msg);
     }
 }

--- a/src/extensions/spdlog/SpdlogToActs.h
+++ b/src/extensions/spdlog/SpdlogToActs.h
@@ -39,7 +39,7 @@ inline Acts::Logging::Level SpdlogToActsLevel(spdlog::level::level_enum input) {
   try {
     return kSpdlogToActsLevel.left.at(input);
   } catch (...) {
-    auto err_msg = fmt::format("SpdlogToActsLevel don't know this log level: '{}'", input);
+    auto err_msg = fmt::format("SpdlogToActsLevel don't know this log level: '{}'", fmt::underlying(input));
     throw JException(err_msg);
   }
 }
@@ -48,7 +48,7 @@ inline spdlog::level::level_enum ActsToSpdlogLevel(Acts::Logging::Level input) {
   try {
     return kSpdlogToActsLevel.right.at(input);
   } catch (...) {
-    auto err_msg = fmt::format("ActsToSpdlogLevel don't know this log level: '{}'", input);
+    auto err_msg = fmt::format("ActsToSpdlogLevel don't know this log level: '{}'", fmt::underlying(input));
     throw JException(err_msg);
   }
 }

--- a/src/services/geometry/acts/ACTSGeo_service.cc
+++ b/src/services/geometry/acts/ACTSGeo_service.cc
@@ -72,14 +72,14 @@ void ACTSGeo_service::acquire_services(JServiceLocator * srv_locator) {
     std::string log_level_str = log_service->getDefaultLevelStr();
     m_app->SetDefaultParameter("acts:LogLevel", log_level_str, "log_level: trace, debug, info, warn, error, critical, off");
     m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
-    m_log->info("Acts GENERAL log level is set to {} ({})", log_level_str, m_log->level());
+    m_log->info("Acts GENERAL log level is set to {} ({})", log_level_str, fmt::underlying(m_log->level()));
 
     // ACTS init log level (geometry conversion):
     m_init_log = log_service->logger("acts_init");
     std::string init_log_level_str = eicrecon::LogLevelToString(m_log->level());  // set general acts log level, if not given by user
     m_app->SetDefaultParameter("acts:InitLogLevel", init_log_level_str, "log_level: trace, debug, info, warn, error, critical, off");
     m_init_log->set_level(eicrecon::ParseLogLevel(init_log_level_str));
-    m_init_log->info("Acts INIT log level is set to {} ({})", log_level_str, m_init_log->level());
+    m_init_log->info("Acts INIT log level is set to {} ({})", log_level_str, fmt::underlying(m_init_log->level()));
 
     // DD4Hep geometry
     auto dd4hep_service = srv_locator->get<DD4hep_service>();

--- a/src/services/geometry/richgeo/IrtGeo.cc
+++ b/src/services/geometry/richgeo/IrtGeo.cc
@@ -59,7 +59,7 @@ void richgeo::IrtGeo::SetReadoutIDToPositionLambda() {
 void richgeo::IrtGeo::SetRefractiveIndexTable() {
   m_log->debug("{:-^60}"," Refractive Index Tables ");
   for(auto rad_obj : m_irtDetector->Radiators()) {
-    m_log->debug("{}:", rad_obj.first);
+    m_log->debug("{}:", rad_obj.first.Data());
     auto *const rad = rad_obj.second;
     const auto *rindex_matrix = m_det->material(rad->GetAlternativeMaterialName()).property("RINDEX");
     for(unsigned row=0; row<rindex_matrix->GetRows(); row++) {

--- a/src/services/geometry/richgeo/RichGeo.h
+++ b/src/services/geometry/richgeo/RichGeo.h
@@ -26,21 +26,6 @@ namespace richgeo {
       dd4hep::Direction surface_offset; // surface centroid = volume centroid + `surface_offset`
   };
 
-  // logging
-  // -----------------------------------------------------------------------
-  /* print an error using `spdlog`, if available, otherwise use `std::cerr`
-   * - this should only be called by static `richgeo` methods here, where we are not guaranteed to
-   *   have an instance of `spdlog::logger` available
-   */
-  template <typename... VALS>
-    static void PrintError(std::shared_ptr<spdlog::logger> m_log, std::string fmt_message, VALS... values) {
-      auto message = fmt::format(fmt_message, values...);
-      if(m_log!=nullptr)
-        m_log->error(message);
-      else
-        std::cerr << "ERROR: " << message << std::endl;
-    }
-
   // radiators
   // -----------------------------------------------------------------------
   /* in many places in the reconstruction, we need to track which radiator
@@ -53,37 +38,40 @@ namespace richgeo {
   };
 
   // return radiator name associated with index
-  static std::string RadiatorName(int num, std::shared_ptr<spdlog::logger> m_log=nullptr) {
+  static std::string RadiatorName(int num, std::shared_ptr<spdlog::logger> m_log = nullptr) {
     if(num==kAerogel)  return "Aerogel";
     else if(num==kGas) return "Gas";
     else {
-      PrintError(m_log, "unknown radiator number {}", num);
+      if (m_log) m_log->error("unknown radiator number {}", num);
+      else std::cerr << "ERROR: unknown radiator number " << num << std::endl;
       return "UNKNOWN_RADIATOR";
     }
   }
 
   // return radiator index associated with name
-  static int RadiatorNum(std::string name, std::shared_ptr<spdlog::logger> m_log=nullptr) {
+  static int RadiatorNum(std::string name, std::shared_ptr<spdlog::logger> m_log = nullptr) {
     if(name=="Aerogel")  return kAerogel;
     else if(name=="Gas") return kGas;
     else {
-      PrintError(m_log, "unknown radiator name {}", name);
+      if (m_log) m_log->error("unknown radiator name {}", name);
+      else std::cerr << "ERROR: unknown radiator name " << name << std::endl;
       return -1;
     }
   }
 
-  static int RadiatorNum(const char * name) {
-    return RadiatorNum(std::string(name));
+  static int RadiatorNum(const char * name, std::shared_ptr<spdlog::logger> m_log = nullptr) {
+    return RadiatorNum(std::string(name), m_log);
   }
 
   // search string `input` for a radiator name; return corresponding index
-  static int ParseRadiatorName(std::string input, std::shared_ptr<spdlog::logger> m_log=nullptr) {
+  static int ParseRadiatorName(std::string input, std::shared_ptr<spdlog::logger> m_log = nullptr) {
     if      (input.find("aerogel")!=std::string::npos) return kAerogel;
     else if (input.find("Aerogel")!=std::string::npos) return kAerogel;
     else if (input.find("gas")!=std::string::npos)     return kGas;
     else if (input.find("Gas")!=std::string::npos)     return kGas;
     else {
-      PrintError(m_log, "failed to parse '{}' for radiator name", input);
+      if (m_log) m_log->error("failed to parse '{}' for radiator name", input);
+      else std::cerr << "ERROR: failed to parse '" << input << "' for radiator name" << std::endl;
       return -1;
     }
   }

--- a/src/services/geometry/richgeo/RichGeo_service.cc
+++ b/src/services/geometry/richgeo/RichGeo_service.cc
@@ -12,7 +12,7 @@ void RichGeo_service::acquire_services(JServiceLocator *srv_locator) {
   std::string log_level_str = "info";
   m_app->SetDefaultParameter("richgeo:LogLevel", log_level_str, "Log level for RichGeo_service");
   m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
-  m_log->debug("RichGeo log level is set to {} ({})", log_level_str, m_log->level());
+  m_log->debug("RichGeo log level is set to {} ({})", log_level_str, fmt::underlying(m_log->level()));
 
   // DD4Hep geometry service
   auto dd4hep_service = srv_locator->get<DD4hep_service>();

--- a/src/tests/tracking_test/TrackingTest_processor.cc
+++ b/src/tests/tracking_test/TrackingTest_processor.cc
@@ -134,7 +134,7 @@ void TrackingTest_processor::ProcessTrackingMatching(const std::shared_ptr<const
         auto sim = assoc.getSim();
         auto rec = assoc.getRec();
 
-        m_log->debug("  {:<6} {:<6} {:>8.2f} {:>8.2f} {:>8.2f} {:>8.2f}", assoc.getSimID(), assoc.getRecID(), sim.getPDG(), rec.getPDG());
+        m_log->debug("  {:<6} {:<6} {:>8d} {:>8d}", assoc.getSimID(), assoc.getRecID(), sim.getPDG(), rec.getPDG());
     }
 
 //    m_log->debug("Particles [objID] [PDG] [simE] [recE] [simPDG] [recPDG]");


### PR DESCRIPTION
### Briefly, what does this PR introduce?
These are the first commits in #1072 which should be entirely compatible with the current version of Acts v21.1.1, fmt v9, and C++17.

Note: this adds C++20 compatibility in EICrecon code (C++20 adds constexpr support for several fmt functions, which imposes conditions on the inputs we pass to them), but it does not mean that this PR allows one to compile EIC with C++20. The Acts dependency of v21.1.1 only allows C++17 support.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: not compatible with EICrecon)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.