### PR TITLE
Adjust reconstruction parameters for Barrel ECal

### DIFF
--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -49,7 +49,7 @@ extern "C" {
             .dyRangeADC = 1500. * dd4hep::MeV,
             .pedMeanADC = 100,
             .resolutionTDC = 10 * dd4hep::picosecond,
-            .thresholdValue = 5.0, // 16384 ADC counts/1500 MeV * 0.5 MeV (desired threshold) = 5.46 
+            .thresholdValue = 5.0, // 16384 ADC counts/1500 MeV * 0.5 MeV (desired threshold) = 5.46
             .sampFrac = 0.10200085,
             .readout = "EcalBarrelScFiHits",
             .layerField = "layer",

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -114,8 +114,8 @@ extern "C" {
             .capADC = 8192,
             .dyRangeADC = 3 * dd4hep::MeV,
             .pedMeanADC = 14,
-            .thresholdValue = 41, // 8192 ADC counts/3 MeV * 0.015 MeV (desired threshold) = 41
             .resolutionTDC = 3.25 * dd4hep::nanosecond,
+            .thresholdValue = 41, // 8192 ADC counts/3 MeV * 0.015 MeV (desired threshold) = 41
             .sampFrac = 0.00619766,
             .readout = "EcalBarrelImagingHits",
             .layerField = "layer",

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -136,7 +136,7 @@ extern "C" {
             .minClusterHitEdep    = 0,
             .minClusterCenterEdep = 0,
             .minClusterEdep       = 100 * dd4hep::MeV,
-            .minClusterNhits      = 10, 
+            .minClusterNhits      = 10,
           },
           app   // TODO: Remove me once fixed
         ));

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -71,8 +71,8 @@ extern "C" {
             .sectorDist = 50. * dd4hep::mm,
             .localDistXZ = {40 * dd4hep::mm, 40 * dd4hep::mm},
             .splitCluster = false,
-            .minClusterHitEdep = 1.0 * dd4hep::MeV,
-            .minClusterCenterEdep = 10.0 * dd4hep::MeV,
+            .minClusterHitEdep = 5.0 * dd4hep::MeV,
+            .minClusterCenterEdep = 100.0 * dd4hep::MeV,
           },
           app   // TODO: Remove me once fixed
         ));
@@ -136,7 +136,7 @@ extern "C" {
             .minClusterHitEdep    = 0,
             .minClusterCenterEdep = 0,
             .minClusterEdep       = 100 * dd4hep::MeV,
-            .minClusterNhits      = 10, // From Maria Z. comment in PR
+            .minClusterNhits      = 10, 
           },
           app   // TODO: Remove me once fixed
         ));

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -3,17 +3,20 @@
 //
 //
 
-#include "extensions/jana/JChainMultifactoryGeneratorT.h"
+#include <Evaluator/DD4hepUnits.h>
+#include <JANA/JApplication.h>
+#include <math.h>
+#include <string>
 
+#include "algorithms/interfaces/WithPodConfig.h"
+#include "extensions/jana/JChainMultifactoryGeneratorT.h"
 #include "factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h"
 #include "factories/calorimetry/CalorimeterHitDigi_factoryT.h"
 #include "factories/calorimetry/CalorimeterHitReco_factoryT.h"
-#include "factories/calorimetry/CalorimeterHitsMerger_factoryT.h"
-#include "factories/calorimetry/CalorimeterTruthClustering_factoryT.h"
 #include "factories/calorimetry/CalorimeterIslandCluster_factoryT.h"
-#include "factories/calorimetry/ImagingTopoCluster_factoryT.h"
-#include "factories/calorimetry/ImagingClusterReco_factoryT.h"
 #include "factories/calorimetry/EnergyPositionClusterMerger_factoryT.h"
+#include "factories/calorimetry/ImagingClusterReco_factoryT.h"
+#include "factories/calorimetry/ImagingTopoCluster_factoryT.h"
 #include "factories/calorimetry/TruthEnergyPositionClusterMerger_factoryT.h"
 
 

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -31,10 +31,10 @@ extern "C" {
            {
              .eRes = {0.0 * sqrt(dd4hep::GeV), 0.0, 0.0 * dd4hep::GeV},
              .tRes = 0.0 * dd4hep::ns,
-             .capADC = 16384,
-             .dyRangeADC = 750 * dd4hep::MeV,
-             .pedMeanADC = 20,
-             .pedSigmaADC = 0.3,
+             .capADC = 16384, // 14bit ADC
+             .dyRangeADC = 1500 * dd4hep::MeV,
+             .pedMeanADC = 100,
+             .pedSigmaADC = 1,
              .resolutionTDC = 10 * dd4hep::picosecond,
              .corrMeanScale = 1.0,
              .readout = "EcalBarrelScFiHits",
@@ -46,12 +46,10 @@ extern "C" {
           "EcalBarrelScFiRecHits", {"EcalBarrelScFiRawHits"}, {"EcalBarrelScFiRecHits"},
           {
             .capADC = 16384,
-            .dyRangeADC = 750. * dd4hep::MeV,
-            .pedMeanADC = 20,
-            .pedSigmaADC = 0.3,
+            .dyRangeADC = 1500. * dd4hep::MeV,
+            .pedMeanADC = 100,
             .resolutionTDC = 10 * dd4hep::picosecond,
-            .thresholdFactor = 36.0488,
-            .thresholdValue = 0.0,
+            .thresholdValue = 5.0, // 16384 ADC counts/1500 MeV * 0.5 MeV (desired threshold) = 5.46 
             .sampFrac = 0.10200085,
             .readout = "EcalBarrelScFiHits",
             .layerField = "layer",
@@ -103,8 +101,8 @@ extern "C" {
              .tRes = 0.0 * dd4hep::ns,
              .capADC = 8192,
              .dyRangeADC = 3 * dd4hep::MeV,
-             .pedMeanADC = 100,
-             .pedSigmaADC = 14,
+             .pedMeanADC = 14, // Noise floor at 5 keV: 8192 / 3 * 0.005
+             .pedSigmaADC = 5, // Upper limit for sigma for AstroPix
              .resolutionTDC = 3.25 * dd4hep::nanosecond,
              .corrMeanScale = 1.0,
            },
@@ -115,10 +113,9 @@ extern "C" {
           {
             .capADC = 8192,
             .dyRangeADC = 3 * dd4hep::MeV,
-            .pedMeanADC = 100,
-            .pedSigmaADC = 14,
+            .pedMeanADC = 14,
+            .thresholdValue = 41, // 8192 ADC counts/3 MeV * 0.015 MeV (desired threshold) = 41
             .resolutionTDC = 3.25 * dd4hep::nanosecond,
-            .thresholdFactor = 3.0,
             .sampFrac = 0.00619766,
             .readout = "EcalBarrelImagingHits",
             .layerField = "layer",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adjusts the Barrel ECal parameters as following:

Dynamic range of SciFi/Pb Calo: 750 MeV ->1500 MeV (both in Digi and Reco)
Pedestal sigma of SciFi/Pb Calo: 1 channel (Digi)
Pedestal of SciFi/Pb Calo: 100 channels (Digi and Reco)
Energy threshold in RecoHits: ~ 5MeV = ~ 5 ADC counts (set through `thresholdValue`)

Pedestal of AstroPix Calo: 14 channels (Digi and Reco) ~ 5 keV noise floor
Pedestal sigma of AstroPix Calo: ~5 channels (Digi) (~3x smaller then noise floor)
Energy threshold in RecoHits: ~ 15keV = ~ 41 ADC counts (set through `thresholdValue`)

It has been also spotted that the SciFi/Pb clustering parameters were not corrected for the sampling fraction, which was causing lots of very small energy clusters being reconstructed. This has been corrected in:
minClusterHitEdep = 5.0 * dd4hep::MeV,
minClusterCenterEdep = 100.0 * dd4hep::MeV,
 
### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: Parameter Adjustment

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @sly2j 

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?

Yes, reconstruction and digi parameters for barrel Ecal slightly adjusted to better match actual AstroPix and GlueX-like calorimeter parameters