### PR TITLE
fix: IWYU pragmas and iwyu.imp fixes

### DIFF
--- a/.github/iwyu.imp
+++ b/.github/iwyu.imp
@@ -223,5 +223,18 @@
   #{ include: ["<stdlib.h>", "private", "<cstdlib>", "public"] },
   #{ include: ["<unistd.h>", "private", "<cunistd>", "public"] },
 
-  #{ include: ["@<(.*)\.ipp>", "private", "<\1.hpp>", "public"] }
+  #{ include: ["@<Acts/(.*)\.ipp>", "private", "<Acts/\1.hpp>", "public"] }
+  { include: ["<Acts/EventData/MultiTrajectory.ipp>", "private", "<Acts/EventData/MultiTrajectory.hpp>", "public"] },
+  { include: ["<Acts/Geometry/detail/Layer.ipp>", "private", "<Acts/Geometry/Layer.hpp>", "public"] },
+  { include: ["<Acts/Geometry/detail/TrackingVolume.ipp>", "private", "<Acts/Geometry/TrackingVolume.hpp>", "public"] },
+  { include: ["<Acts/Propagator/EigenStepper.ipp>", "private", "<Acts/Propagator/EigenStepper.hpp>", "public"] },
+  { include: ["<Acts/Propagator/Propagator.ipp>", "private", "<Acts/Propagator/Propagator.hpp>", "public"] },
+  { include: ["<Acts/Seeding/SeedFilter.ipp>", "private", "<Acts/Seeding/SeedFilter.hpp>", "public"] },
+  { include: ["<Acts/Seeding/SeedFinderOrthogonal.ipp>", "private", "<Acts/Seeding/SeedFinderOrthogonal.hpp>", "public"] },
+  { include: ["<Acts/Vertexing/FullBilloirVertexFitter.ipp>", "private", "<Acts/Vertexing/FullBilloirVertexFitter.hpp>", "public"] },
+  { include: ["<Acts/Vertexing/HelicalTrackLinearizer.ipp>", "private", "<Acts/Vertexing/HelicalTrackLinearizer.hpp>", "public"] },
+  { include: ["<Acts/Vertexing/ImpactPointEstimator.ipp>", "private", "<Acts/Vertexing/ImpactPointEstimator.hpp>", "public"] },
+  { include: ["<Acts/Vertexing/IterativeVertexFinder.ipp>", "private", "<Acts/Vertexing/IterativeVertexFinder.hpp>", "public"] },
+  { include: ["<Acts/Vertexing/Vertex.ipp>", "private", "<Acts/Vertexing/Vertex.hpp>", "public"] },
+  { include: ["<Acts/Vertexing/ZScanVertexFinder.ipp>", "private", "<Acts/Vertexing/ZScanVertexFinder.hpp>", "public"] }
 ]

--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -238,6 +238,13 @@ macro(plugin_add_irt _name)
         find_package(IRT REQUIRED)
     endif()
 
+    # FIXME: IRTConfig.cmake sets INTERFACE_INCLUDE_DIRECTORIES to <prefix>/include/IRT
+    # instead of <prefix>/include, allowing for short-form #include <CherenkovDetector.h>
+    get_target_property(IRT_INTERFACE_INCLUDE_DIRECTORIES IRT INTERFACE_INCLUDE_DIRECTORIES)
+    list(TRANSFORM IRT_INTERFACE_INCLUDE_DIRECTORIES REPLACE "/IRT$" "")
+    list(REMOVE_DUPLICATES IRT_INTERFACE_INCLUDE_DIRECTORIES)
+    set_target_properties(IRT PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${IRT_INTERFACE_INCLUDE_DIRECTORIES}")
+
     plugin_link_libraries(${PLUGIN_NAME} IRT)
 
 endmacro()

--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -26,7 +26,7 @@
 #include <Acts/Definitions/Units.hpp>
 
 #include "extensions/spdlog/SpdlogToActs.h"
-#include "extensions/spdlog/SpdlogFormatters.h"
+#include "extensions/spdlog/SpdlogFormatters.h" // IWYU pragma: keep
 
 #include "DD4hepBField.h"
 

--- a/src/algorithms/tracking/TrackParamTruthInit.cc
+++ b/src/algorithms/tracking/TrackParamTruthInit.cc
@@ -13,7 +13,7 @@
 #include <spdlog/fmt/ostr.h>
 #include <Acts/Surfaces/PerigeeSurface.hpp>
 
-#include "extensions/spdlog/SpdlogFormatters.h"
+#include "extensions/spdlog/SpdlogFormatters.h" // IWYU pragma: keep
 
 
 void eicrecon::TrackParamTruthInit::init(const std::shared_ptr<spdlog::logger> &logger) {

--- a/src/algorithms/tracking/TrackProjector.cc
+++ b/src/algorithms/tracking/TrackProjector.cc
@@ -34,7 +34,7 @@
 #include <spdlog/fmt/ostr.h>
 #include "TrackProjectorConfig.h"
 #include "TrackProjector.h"
-#include "extensions/spdlog/SpdlogFormatters.h"
+#include "extensions/spdlog/SpdlogFormatters.h" // IWYU pragma: keep
 
 #include <cmath>
 

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -4,7 +4,7 @@
 
 #include "TrackSeeding.h"
 
-#include <Acts/Utilities/KDTree.hpp> // FIXME KDTree missing in SeedFinderOrthogonal.hpp until Acts v23.0.0
+#include <Acts/Utilities/KDTree.hpp> // IWYU pragma: keep FIXME KDTree missing in SeedFinderOrthogonal.hpp until Acts v23.0.0
 #include <Acts/Seeding/Seed.hpp>
 #include <Acts/Seeding/SeedFilter.hpp>
 #include <Acts/Seeding/SeedFilterConfig.hpp>

--- a/src/algorithms/tracking/TrackSeeding.h
+++ b/src/algorithms/tracking/TrackSeeding.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <cstddef> // FIXME size_t missing in SeedConfirmationRangeConfig.hpp until Acts 27.2.0 (maybe even later)
+#include <cstddef> // IWYU pragma: keep FIXME size_t missing in SeedConfirmationRangeConfig.hpp until Acts 27.2.0 (maybe even later)
 #include <vector>
 
 #include <Acts/Definitions/Units.hpp>

--- a/src/extensions/spdlog/SpdlogFormatters.h
+++ b/src/extensions/spdlog/SpdlogFormatters.h
@@ -2,6 +2,7 @@
 
 // IWYU pragma: always_keep
 // since IWYU otherwise removes this headers from output that need it
+// FIXME: this is only valid as of iwyu v21; until then use keep on includes
 
 #include <system_error>
 #include <type_traits>

--- a/src/extensions/spdlog/SpdlogFormatters.h
+++ b/src/extensions/spdlog/SpdlogFormatters.h
@@ -1,5 +1,8 @@
 #pragma once
 
+// IWYU pragma: always_keep
+// since IWYU otherwise removes this headers from output that need it
+
 #include <system_error>
 #include <type_traits>
 

--- a/src/tests/tracking_test/TrackingTest_processor.cc
+++ b/src/tests/tracking_test/TrackingTest_processor.cc
@@ -3,7 +3,7 @@
 #include "algorithms/tracking/ActsExamples/EventData/Trajectories.hpp"
 #include "extensions/spdlog/SpdlogExtensions.h"
 
-#include "datamodel_glue.h"
+#include "datamodel_glue.h" // IWYU pragma: keep (templated JEvent::GetCollection<T> needs PodioTypeMap)
 
 #include <JANA/JApplication.h>
 #include <JANA/JEvent.h>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This adds some fixes to the IWYU treatment which is now enabled.
- IWYU always_keep on SpdlogFormatters.h ([iwyu fails to detect usage](https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/WhyIWYUIsDifficult.md#who-is-responsible-for-dependent-template-types)),
- IWYU keep SpdlogFormatters.h while always_keep not available yet,
- IWYU keep known missing std headers in Acts,
- IWYU import fixes to avoid duplicate symbols due to inclusion of ipp AND hpp files,
- IRT include directories fix to avoid short-form include suggestions.

TODO:
- [x] verify that within this branch, after repeating `iwyu_tool | fix_include` until stable, we are left with a compilable source tree, see #1080 

### What kind of change does this PR introduce?
- [x] Bug fix (issue: full-project IWYU results in non-compilable code)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.