### PR TITLE
fix: use edm4hep vector_utils instead of edm4eic; remove MaterialWiper (prep for Acts v26)

### DIFF
--- a/.github/iwyu.imp
+++ b/.github/iwyu.imp
@@ -215,6 +215,8 @@
   { include: ["<edm4hep/TrackerPulse.h>", "private", "<edm4hep/TrackerPulseCollection.h>", "public"] },
   { include: ["<edm4hep/Vertex.h>", "private", "<edm4hep/VertexCollection.h>", "public"] },
 
+  { include: ["<edm4hep/utils/vector_utils_legacy.h>", "private", "<edm4hep/utils/vector_utils.h>", "public"] },
+
   #{ include: ["<assert.h>", "private", "<cassert>", "public"] },
   #{ include: ["<limits.h>", "private", "<climits>", "public"] },
   #{ include: ["<math.h>",   "private", "<cmath>",   "public"] },

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -10,10 +10,10 @@
 #include <boost/algorithm/string/join.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <edm4eic/CalorimeterHitCollection.h>
-#include <edm4eic/vector_utils_legacy.h>
 #include <edm4hep/CaloHitContributionCollection.h>
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3f.h>
+#include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
@@ -140,7 +140,7 @@ namespace eicrecon {
         m_log->debug("cluster has largest energy in cellID: {}", pclhit->getCellID());
         m_log->debug("pcl hit with highest energy {} at index {}", pclhit->getEnergy(), pclhit->getObjectID().index);
         m_log->debug("corresponding mc hit energy {} at index {}", mchit->getEnergy(), mchit->getObjectID().index);
-        m_log->debug("from MCParticle index {}, PDG {}, {}", mcp.getObjectID().index, mcp.getPDG(), edm4eic::magnitude(mcp.getMomentum()));
+        m_log->debug("from MCParticle index {}, PDG {}, {}", mcp.getObjectID().index, mcp.getPDG(), edm4hep::utils::magnitude(mcp.getMomentum()));
 
         // set association
         auto clusterassoc = associations->create();
@@ -185,7 +185,7 @@ std::optional<edm4eic::Cluster> CalorimeterClusterRecoCoG::reconstruct(const edm
     totalE += energy;
     if (energy > maxE) {
     }
-    const float eta = edm4eic::eta(hit.getPosition());
+    const float eta = edm4hep::utils::eta(hit.getPosition());
     if (eta < minHitEta) {
       minHitEta = eta;
     }
@@ -218,14 +218,14 @@ std::optional<edm4eic::Cluster> CalorimeterClusterRecoCoG::reconstruct(const edm
 
   // Optionally constrain the cluster to the hit eta values
   if (m_cfg.enableEtaBounds) {
-    const bool overflow  = (edm4eic::eta(cl.getPosition()) > maxHitEta);
-    const bool underflow = (edm4eic::eta(cl.getPosition()) < minHitEta);
+    const bool overflow  = (edm4hep::utils::eta(cl.getPosition()) > maxHitEta);
+    const bool underflow = (edm4hep::utils::eta(cl.getPosition()) < minHitEta);
     if (overflow || underflow) {
       const double newEta   = overflow ? maxHitEta : minHitEta;
-      const double newTheta = edm4eic::etaToAngle(newEta);
-      const double newR     = edm4eic::magnitude(cl.getPosition());
-      const double newPhi   = edm4eic::angleAzimuthal(cl.getPosition());
-      cl.setPosition(edm4eic::sphericalToVector(newR, newTheta, newPhi));
+      const double newTheta = edm4hep::utils::etaToAngle(newEta);
+      const double newR     = edm4hep::utils::magnitude(cl.getPosition());
+      const double newPhi   = edm4hep::utils::angleAzimuthal(cl.getPosition());
+      cl.setPosition(edm4hep::utils::sphericalToVector(newR, newTheta, newPhi));
       m_log->debug("Bound cluster position to contributing hits due to {}", (overflow ? "overflow" : "underflow"));
     }
   }
@@ -234,8 +234,8 @@ std::optional<edm4eic::Cluster> CalorimeterClusterRecoCoG::reconstruct(const edm
 
   // best estimate on the cluster direction is the cluster position
   // for simple 2D CoG clustering
-  cl.setIntrinsicTheta(edm4eic::anglePolar(cl.getPosition()));
-  cl.setIntrinsicPhi(edm4eic::angleAzimuthal(cl.getPosition()));
+  cl.setIntrinsicTheta(edm4hep::utils::anglePolar(cl.getPosition()));
+  cl.setIntrinsicPhi(edm4hep::utils::angleAzimuthal(cl.getPosition()));
   // TODO errors
 
   //_______________________________________
@@ -260,7 +260,7 @@ std::optional<edm4eic::Cluster> CalorimeterClusterRecoCoG::reconstruct(const edm
       float w = weightFunc(hit.getEnergy(), cl.getEnergy(), m_cfg.logWeightBase, 0);
 
       // theta, phi
-      Eigen::Vector2f pos2D( edm4eic::anglePolar( hit.getPosition() ), edm4eic::angleAzimuthal( hit.getPosition() ) );
+      Eigen::Vector2f pos2D( edm4hep::utils::anglePolar( hit.getPosition() ), edm4hep::utils::angleAzimuthal( hit.getPosition() ) );
       // x, y, z
       Eigen::Vector3f pos3D( hit.getPosition().x, hit.getPosition().y, hit.getPosition().z );
 

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -58,10 +58,10 @@ static edm4hep::Vector2f globalDistRPhi(const CaloHit &h1, const CaloHit &h2) {
   using vector_type = decltype(edm4hep::Vector2f::a);
   return {
     static_cast<vector_type>(
-      edm4eic::magnitude(h1.getPosition()) - edm4eic::magnitude(h2.getPosition())
+      edm4hep::utils::magnitude(h1.getPosition()) - edm4hep::utils::magnitude(h2.getPosition())
     ),
     static_cast<vector_type>(
-      Phi_mpi_pi(edm4eic::angleAzimuthal(h1.getPosition()) - edm4eic::angleAzimuthal(h2.getPosition()))
+      Phi_mpi_pi(edm4hep::utils::angleAzimuthal(h1.getPosition()) - edm4hep::utils::angleAzimuthal(h2.getPosition()))
     )
   };
 }
@@ -69,10 +69,10 @@ static edm4hep::Vector2f globalDistEtaPhi(const CaloHit &h1, const CaloHit &h2) 
   using vector_type = decltype(edm4hep::Vector2f::a);
   return {
     static_cast<vector_type>(
-      edm4eic::eta(h1.getPosition()) - edm4eic::eta(h2.getPosition())
+      edm4hep::utils::eta(h1.getPosition()) - edm4hep::utils::eta(h2.getPosition())
     ),
     static_cast<vector_type>(
-      Phi_mpi_pi(edm4eic::angleAzimuthal(h1.getPosition()) - edm4eic::angleAzimuthal(h2.getPosition()))
+      Phi_mpi_pi(edm4hep::utils::angleAzimuthal(h1.getPosition()) - edm4hep::utils::angleAzimuthal(h2.getPosition()))
     )
   };
 }
@@ -184,7 +184,7 @@ void CalorimeterIslandCluster::init(const dd4hep::Detector* detector, std::share
             } else {
               // sector may have rotation (barrel), so z is included
               // (EDM4hep units are mm, so convert sectorDist to mm)
-              return (edm4eic::magnitude(h1.getPosition() - h2.getPosition()) <= m_cfg.sectorDist / dd4hep::mm);
+              return (edm4hep::utils::magnitude(h1.getPosition() - h2.getPosition()) <= m_cfg.sectorDist / dd4hep::mm);
             }
           };
 

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.h
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.h
@@ -7,8 +7,8 @@
 #include <DD4hep/IDDescriptor.h>
 #include <edm4eic/CalorimeterHitCollection.h>
 #include <edm4eic/ProtoClusterCollection.h>
-#include <edm4eic/vector_utils_legacy.h>
 #include <edm4hep/Vector2f.h>
+#include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
 #include <spdlog/logger.h>
 #include <algorithm>
@@ -177,7 +177,7 @@ namespace eicrecon {
       // calculate weights for local maxima
       for (std::size_t cidx : maxima) {
         double energy   = hits[cidx].getEnergy();
-        double dist     = edm4eic::magnitude(transverseEnergyProfileMetric(hits[cidx], hits[idx]));
+        double dist     = edm4hep::utils::magnitude(transverseEnergyProfileMetric(hits[cidx], hits[idx]));
         weights[j]      = std::exp(-dist * transverseEnergyProfileScaleUnits / m_cfg.transverseEnergyProfileScale) * energy;
         j += 1;
       }

--- a/src/algorithms/calorimetry/EnergyPositionClusterMerger.h
+++ b/src/algorithms/calorimetry/EnergyPositionClusterMerger.h
@@ -9,7 +9,7 @@
 #include <spdlog/spdlog.h>
 #include <edm4eic/ClusterCollection.h>
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
-#include <edm4eic/vector_utils.h>
+#include <edm4hep/utils/vector_utils.h>
 
 #include "algorithms/interfaces/WithPodConfig.h"
 #include "EnergyPositionClusterMergerConfig.h"
@@ -84,12 +84,12 @@ namespace eicrecon {
                 // 1. stop if not within tolerance
                 //    (make sure to handle rollover of phi properly)
                 const double de_rel = std::abs((pc.getEnergy() - ec.getEnergy()) / ec.getEnergy());
-                const double deta = std::abs(edm4eic::eta(pc.getPosition())
-                                           - edm4eic::eta(ec.getPosition()));
+                const double deta = std::abs(edm4hep::utils::eta(pc.getPosition())
+                                           - edm4hep::utils::eta(ec.getPosition()));
                 // check the tolerance for sin(dphi/2) to avoid the hemisphere problem and allow
                 // for phi rollovers
-                const double dphi = edm4eic::angleAzimuthal(pc.getPosition())
-                                  - edm4eic::angleAzimuthal(ec.getPosition());
+                const double dphi = edm4hep::utils::angleAzimuthal(pc.getPosition())
+                                  - edm4hep::utils::angleAzimuthal(ec.getPosition());
                 const double dsphi = std::abs(sin(0.5 * dphi));
                 if ((m_cfg.energyRelTolerance > 0 && de_rel > m_cfg.energyRelTolerance) ||
                     (m_cfg.etaTolerance > 0 && deta > m_cfg.etaTolerance) ||
@@ -193,11 +193,11 @@ namespace eicrecon {
 
                 m_log->debug("  Matched position cluster {} with energy cluster {}", pc.getObjectID().index, ec.getObjectID().index);
                 m_log->debug("  - Position cluster: (E: {}, phi: {}, z: {})", pc.getEnergy(),
-                             edm4eic::angleAzimuthal(pc.getPosition()), pc.getPosition().z);
+                             edm4hep::utils::angleAzimuthal(pc.getPosition()), pc.getPosition().z);
                 m_log->debug("  - Energy cluster: (E: {}, phi: {}, z: {})", ec.getEnergy(),
-                             edm4eic::angleAzimuthal(ec.getPosition()), ec.getPosition().z);
+                             edm4hep::utils::angleAzimuthal(ec.getPosition()), ec.getPosition().z);
                 m_log->debug("  ---> Merged cluster: (E: {}, phi: {}, z: {})", new_clus.getEnergy(),
-                             edm4eic::angleAzimuthal(new_clus.getPosition()), new_clus.getPosition().z);
+                             edm4hep::utils::angleAzimuthal(new_clus.getPosition()), new_clus.getPosition().z);
 
 
             } else {

--- a/src/algorithms/calorimetry/ImagingClusterReco.h
+++ b/src/algorithms/calorimetry/ImagingClusterReco.h
@@ -197,7 +197,7 @@ namespace eicrecon {
         // Calculate radius as the standard deviation of the hits versus the cluster center
         double radius = 0.;
         for (const auto &[hit, weight]: hits) {
-            radius += std::pow(edm4eic::magnitude(hit.getPosition() - layer.getPosition()), 2);
+            radius += std::pow(edm4hep::utils::magnitude(hit.getPosition() - layer.getPosition()), 2);
         }
         layer.addToShapeParameters(std::sqrt(radius / layer.getNhits()));
         // TODO Skewedness
@@ -228,9 +228,9 @@ namespace eicrecon {
             const double energyWeight = hit.getEnergy() * weight;
             time += hit.getTime() * energyWeight;
             timeError += std::pow(hit.getTimeError() * energyWeight, 2);
-            meta += edm4eic::eta(hit.getPosition()) * energyWeight;
-            mphi += edm4eic::angleAzimuthal(hit.getPosition()) * energyWeight;
-            r = std::min(edm4eic::magnitude(hit.getPosition()), r);
+            meta += edm4hep::utils::eta(hit.getPosition()) * energyWeight;
+            mphi += edm4hep::utils::angleAzimuthal(hit.getPosition()) * energyWeight;
+            r = std::min(edm4hep::utils::magnitude(hit.getPosition()), r);
             cluster.addToHits(hit);
         }
         cluster.setEnergy(energy);
@@ -238,15 +238,15 @@ namespace eicrecon {
         cluster.setTime(time / energy);
         cluster.setTimeError(std::sqrt(timeError) / energy);
         cluster.setNhits(hits.size());
-        cluster.setPosition(edm4eic::sphericalToVector(r, edm4eic::etaToAngle(meta / energy), mphi / energy));
+        cluster.setPosition(edm4hep::utils::sphericalToVector(r, edm4hep::utils::etaToAngle(meta / energy), mphi / energy));
 
         // shower radius estimate (eta-phi plane)
         double radius = 0.;
         for (const auto &hit: hits) {
             radius += std::pow(
               std::hypot(
-                (edm4eic::eta(hit.getPosition()) - edm4eic::eta(cluster.getPosition())),
-                (edm4eic::angleAzimuthal(hit.getPosition()) - edm4eic::angleAzimuthal(cluster.getPosition()))
+                (edm4hep::utils::eta(hit.getPosition()) - edm4hep::utils::eta(cluster.getPosition())),
+                (edm4hep::utils::angleAzimuthal(hit.getPosition()) - edm4hep::utils::angleAzimuthal(cluster.getPosition()))
               ),
               2.0
             );

--- a/src/algorithms/calorimetry/ImagingTopoCluster.h
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.h
@@ -23,7 +23,7 @@
 // Event Model related classes
 #include <edm4eic/CalorimeterHitCollection.h>
 #include <edm4eic/ProtoClusterCollection.h>
-#include <edm4eic/vector_utils.h>
+#include <edm4hep/utils/vector_utils.h>
 
 #include "algorithms/interfaces/WithPodConfig.h"
 #include "ImagingTopoClusterConfig.h"
@@ -155,8 +155,8 @@ namespace eicrecon {
             return (std::abs(h1.getLocal().x - h2.getLocal().x) <= localDistXY[0]) &&
                    (std::abs(h1.getLocal().y - h2.getLocal().y) <= localDistXY[1]);
         } else if (ldiff <= m_cfg.neighbourLayersRange) {
-            return (std::abs(edm4eic::eta(h1.getPosition()) - edm4eic::eta(h2.getPosition())) <= layerDistEtaPhi[0]) &&
-                   (std::abs(edm4eic::angleAzimuthal(h1.getPosition()) - edm4eic::angleAzimuthal(h2.getPosition())) <=
+            return (std::abs(edm4hep::utils::eta(h1.getPosition()) - edm4hep::utils::eta(h2.getPosition())) <= layerDistEtaPhi[0]) &&
+                   (std::abs(edm4hep::utils::angleAzimuthal(h1.getPosition()) - edm4hep::utils::angleAzimuthal(h2.getPosition())) <=
                     layerDistEtaPhi[1]);
         }
 

--- a/src/algorithms/calorimetry/TruthEnergyPositionClusterMerger.h
+++ b/src/algorithms/calorimetry/TruthEnergyPositionClusterMerger.h
@@ -11,7 +11,7 @@
 #include <edm4hep/MCParticle.h>
 #include <edm4eic/Cluster.h>
 #include <edm4eic/MCRecoClusterParticleAssociation.h>
-#include <edm4eic/vector_utils.h>
+#include <edm4hep/utils/vector_utils.h>
 
 #include "algorithms/interfaces/WithPodConfig.h"
 
@@ -149,7 +149,7 @@ namespace eicrecon {
             new_clus.setTime(eclus.getTime());
             new_clus.setNhits(eclus.getNhits());
             // FIXME use nominal dd4hep::radius of 110cm, and use start vertex theta and phi
-            new_clus.setPosition(edm4eic::sphericalToVector(78.5 * dd4hep::cm / dd4hep::mm, theta, phi));
+            new_clus.setPosition(edm4hep::utils::sphericalToVector(78.5 * dd4hep::cm / dd4hep::mm, theta, phi));
             new_clus.addToClusters(eclus);
 
             m_log->debug(" --> Processing energy cluster {}, mcID: {}, energy: {}", eclus.getObjectID().index, mcID, eclus.getEnergy() );

--- a/src/algorithms/fardetectors/MatrixTransferStatic.cc
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.cc
@@ -11,8 +11,8 @@
 #include <DD4hep/VolumeManager.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <Math/GenVector/DisplacementVector3D.h>
-#include <edm4eic/vector_utils_legacy.h>
 #include <edm4hep/Vector3f.h>
+#include <edm4hep/utils/vector_utils.h>
 #include <ext/alloc_traits.h>
 #include <cmath>
 #include <vector>
@@ -158,7 +158,7 @@ std::unique_ptr<edm4eic::ReconstructedParticleCollection> eicrecon::MatrixTransf
       edm4eic::MutableReconstructedParticle reconTrack;
       reconTrack.setType(0);
       reconTrack.setMomentum(prec);
-      reconTrack.setEnergy(std::hypot(edm4eic::magnitude(reconTrack.getMomentum()), m_cfg.partMass));
+      reconTrack.setEnergy(std::hypot(edm4hep::utils::magnitude(reconTrack.getMomentum()), m_cfg.partMass));
       reconTrack.setReferencePoint(refPoint);
       reconTrack.setCharge(m_cfg.partCharge);
       reconTrack.setMass(m_cfg.partMass);

--- a/src/algorithms/reco/ElectronReconstruction.cc
+++ b/src/algorithms/reco/ElectronReconstruction.cc
@@ -3,7 +3,7 @@
 #include "ElectronReconstruction.h"
 
 #include <edm4eic/ClusterCollection.h>
-#include <edm4eic/vector_utils_legacy.h>
+#include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
 #include <exception>
 
@@ -38,7 +38,7 @@ namespace eicrecon {
             auto clu = clu_assoc.getRec(); // RecoCluster
 
             m_log->trace( "SimId={}, CluId={}", clu_assoc.getSimID(), clu_assoc.getRecID() );
-            m_log->trace( "MCParticle: Energy={} GeV, p={} GeV, E/p = {} for PDG: {}", clu.getEnergy(), edm4eic::magnitude(sim.getMomentum()), clu.getEnergy() / edm4eic::magnitude(sim.getMomentum()), sim.getPDG() );
+            m_log->trace( "MCParticle: Energy={} GeV, p={} GeV, E/p = {} for PDG: {}", clu.getEnergy(), edm4hep::utils::magnitude(sim.getMomentum()), clu.getEnergy() / edm4hep::utils::magnitude(sim.getMomentum()), sim.getPDG() );
 
 
             // Find the Reconstructed particle associated to the MC Particle that is matched with this reco cluster
@@ -53,8 +53,8 @@ namespace eicrecon {
             // if we found a reco particle then test for electron compatibility
             if ( reco_part_assoc != rcassoc->end() ){
               auto reco_part = reco_part_assoc->getRec();
-              double EoverP = clu.getEnergy() / edm4eic::magnitude(reco_part.getMomentum());
-              m_log->trace( "ReconstructedParticle: Energy={} GeV, p={} GeV, E/p = {} for PDG (from truth): {}", clu.getEnergy(), edm4eic::magnitude(reco_part.getMomentum()), EoverP, sim.getPDG() );
+              double EoverP = clu.getEnergy() / edm4hep::utils::magnitude(reco_part.getMomentum());
+              m_log->trace( "ReconstructedParticle: Energy={} GeV, p={} GeV, E/p = {} for PDG (from truth): {}", clu.getEnergy(), edm4hep::utils::magnitude(reco_part.getMomentum()), EoverP, sim.getPDG() );
 
               // Apply the E/p cut here to select electons
               if ( EoverP >= min_energy_over_momentum && EoverP <= max_energy_over_momentum ) {

--- a/src/algorithms/reco/InclusiveKinematicsTruth.cc
+++ b/src/algorithms/reco/InclusiveKinematicsTruth.cc
@@ -10,9 +10,9 @@
 #include <Math/GenVector/LorentzVector.h>
 #include <Math/Vector4Dfwd.h>
 #include <edm4eic/InclusiveKinematicsCollection.h>
-#include <edm4eic/vector_utils_legacy.h>
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3f.h>
+#include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
 
 using ROOT::Math::PxPyPzEVector;
@@ -50,7 +50,7 @@ namespace eicrecon {
       return kinematics;
     }
     const auto ei_p = ei_coll[0].getMomentum();
-    const auto ei_p_mag = edm4eic::magnitude(ei_p);
+    const auto ei_p_mag = edm4hep::utils::magnitude(ei_p);
     const auto ei_mass = m_electron;
     const PxPyPzEVector ei(ei_p.x, ei_p.y, ei_p.z, std::hypot(ei_p_mag, ei_mass));
 
@@ -61,7 +61,7 @@ namespace eicrecon {
       return kinematics;
     }
     const auto pi_p = pi_coll[0].getMomentum();
-    const auto pi_p_mag = edm4eic::magnitude(pi_p);
+    const auto pi_p_mag = edm4hep::utils::magnitude(pi_p);
     const auto pi_mass = pi_coll[0].getPDG() == 2212 ? m_proton : m_neutron;
     const PxPyPzEVector pi(pi_p.x, pi_p.y, pi_p.z, std::hypot(pi_p_mag, pi_mass));
 
@@ -76,7 +76,7 @@ namespace eicrecon {
       return kinematics;
     }
     const auto ef_p = ef_coll[0].getMomentum();
-    const auto ef_p_mag = edm4eic::magnitude(ef_p);
+    const auto ef_p_mag = edm4hep::utils::magnitude(ef_p);
     const auto ef_mass = m_electron;
     const PxPyPzEVector ef(ef_p.x, ef_p.y, ef_p.z, std::hypot(ef_p_mag, ef_mass));
 

--- a/src/algorithms/reco/MatchClusters.cc
+++ b/src/algorithms/reco/MatchClusters.cc
@@ -9,9 +9,9 @@
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <edm4eic/MCRecoParticleAssociationCollection.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
-#include <edm4eic/vector_utils_legacy.h>
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3f.h>
+#include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
 #include <podio/ObjectID.h>
 #include <spdlog/common.h>
@@ -195,7 +195,7 @@ namespace eicrecon {
         const float energy = cluster->getEnergy();
         const float p = energy < mass ? 0 : std::sqrt(energy * energy - mass * mass);
         const auto position = cluster->getPosition();
-        const auto momentum = p * (position / edm4eic::magnitude(position));
+        const auto momentum = p * (position / edm4hep::utils::magnitude(position));
         // setup our particle
         edm4eic::MutableReconstructedParticle part;
         part.setMomentum(momentum);

--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -135,9 +135,6 @@ void ActsGeometryProvider::initialize(const dd4hep::Detector* dd4hep_geo,
         Acts::MaterialMapJsonConverter::Config jsonGeoConvConfig;
         // Set up the json-based decorator
         materialDeco = std::make_shared<const Acts::JsonMaterialDecorator>(jsonGeoConvConfig, material_file,acts_init_log_level);
-    } else {
-        m_init_log->warn("no ACTS materials map has been loaded");
-        materialDeco = std::make_shared<const Acts::MaterialWiper>();
     }
 
     // Geometry identifier hook to write detector ID to extra field

--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -33,7 +33,6 @@
 #include <type_traits>
 #include <vector>
 
-#include "ActsExamples/Geometry/MaterialWiper.hpp"
 #include "ActsGeometryProvider.h"
 #include "extensions/spdlog/SpdlogToActs.h"
 

--- a/src/algorithms/tracking/TrackProjector.cc
+++ b/src/algorithms/tracking/TrackProjector.cc
@@ -12,8 +12,8 @@
 #include <edm4eic/TrackParametersCollection.h>
 #include <edm4eic/TrackPoint.h>
 #include <edm4eic/TrackSegmentCollection.h>
-#include <edm4eic/vector_utils_legacy.h>
 #include <edm4hep/Vector3f.h>
+#include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
 #include <fmt/ostream.h>
 #include <spdlog/logger.h>
@@ -112,7 +112,7 @@ namespace eicrecon {
                         static_cast<float>(covariance(Acts::eBoundLoc0, Acts::eBoundLoc1))
                 };
                 const decltype(edm4eic::TrackPoint::positionError) positionError{0, 0, 0};
-                const decltype(edm4eic::TrackPoint::momentum) momentum = edm4eic::sphericalToVector(
+                const decltype(edm4eic::TrackPoint::momentum) momentum = edm4hep::utils::sphericalToVector(
                         static_cast<float>(1.0 / std::abs(parameter[Acts::eBoundQOverP])),
                         static_cast<float>(parameter[Acts::eBoundTheta]),
                         static_cast<float>(parameter[Acts::eBoundPhi])

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -13,8 +13,8 @@
 #include <Acts/Utilities/Logger.hpp>
 #include <bits/std_abs.h>
 #include <edm4eic/EDM4eicVersion.h>
-#include <edm4eic/vector_utils_legacy.h>
 #include <edm4hep/Vector3f.h>
+#include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -141,7 +141,7 @@ namespace eicrecon {
           if(track_segment.points_size()>0) {
             auto pos0 = point->position;
             auto pos1 = std::prev(track_segment.points_end())->position;
-            auto dist = edm4eic::magnitude(pos0-pos1);
+            auto dist = edm4hep::utils::magnitude(pos0-pos1);
             length += dist;
             m_log->trace("               dist to previous point: {}", dist);
           }
@@ -240,7 +240,7 @@ namespace eicrecon {
         m_log->trace("    pos z = {}", position.z);
 
         // Momentum
-        const decltype(edm4eic::TrackPoint::momentum) momentum = edm4eic::sphericalToVector(
+        const decltype(edm4eic::TrackPoint::momentum) momentum = edm4hep::utils::sphericalToVector(
                 static_cast<float>(1.0 / std::abs(parameter[Acts::eBoundQOverP])),
                 static_cast<float>(parameter[Acts::eBoundTheta]),
                 static_cast<float>(parameter[Acts::eBoundPhi])


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This includes two commits (one full, one partial) from #1072 that can be applied even with Acts 21.1.1 and would simplify #1072. Main impact:
- use edm4hep vector_utils,
- avoid unnecessary MaterialWiper.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.