### PR TITLE
treewide: avoid including some internal headers from libstdc++

### DIFF
--- a/.github/iwyu.imp
+++ b/.github/iwyu.imp
@@ -225,6 +225,11 @@
   #{ include: ["<stdlib.h>", "private", "<cstdlib>", "public"] },
   #{ include: ["<unistd.h>", "private", "<cunistd>", "public"] },
 
+  { include: ["<bits/std_abs.h>", "private", "<math.h>", "public"] },
+  { include: ["<bits/utility.h>", "private", "<tuple>", "public"] },
+  # https://github.com/include-what-you-use/include-what-you-use/issues/166
+  { include: ["<ext/alloc_traits.h>", "private", "<vector>", "public"] },
+
   #{ include: ["@<Acts/(.*)\.ipp>", "private", "<Acts/\1.hpp>", "public"] }
   { include: ["<Acts/EventData/MultiTrajectory.ipp>", "private", "<Acts/EventData/MultiTrajectory.hpp>", "public"] },
   { include: ["<Acts/Geometry/detail/Layer.ipp>", "private", "<Acts/Geometry/Layer.hpp>", "public"] },

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -28,6 +28,7 @@
 #include <limits>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <type_traits>
 #include <unordered_map>
 #include <utility>

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -18,9 +18,7 @@
 #include <DD4hep/config.h>
 #include <DDSegmentation/BitFieldCoder.h>
 #include <Evaluator/DD4hepUnits.h>
-#include <bits/utility.h>
 #include <edm4hep/CaloHitContributionCollection.h>
-#include <ext/alloc_traits.h>
 #include <fmt/core.h>
 #include <podio/RelationRange.h>
 #include <algorithm>

--- a/src/algorithms/calorimetry/CalorimeterHitsMerger.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitsMerger.cc
@@ -25,6 +25,7 @@
 #include <cstddef>
 #include <exception>
 #include <string>
+#include <tuple>
 #include <type_traits>
 #include <unordered_map>
 #include <utility>

--- a/src/algorithms/calorimetry/CalorimeterHitsMerger.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitsMerger.cc
@@ -19,7 +19,6 @@
 #include <DDSegmentation/BitFieldCoder.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <Math/GenVector/DisplacementVector3D.h>
-#include <bits/utility.h>
 #include <fmt/core.h>
 #include <algorithm>
 #include <cmath>

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -9,7 +9,6 @@
 #include <Evaluator/DD4hepUnits.h>
 #include <TInterpreter.h>
 #include <TInterpreterValue.h>
-#include <bits/utility.h>
 #include <edm4hep/Vector2f.h>
 #include <edm4hep/Vector3f.h>
 #include <fmt/format.h>

--- a/src/algorithms/digi/PhotoMultiplierHitDigi.cc
+++ b/src/algorithms/digi/PhotoMultiplierHitDigi.cc
@@ -16,7 +16,6 @@
 #include "PhotoMultiplierHitDigi.h"
 
 #include <Evaluator/DD4hepUnits.h>
-#include <bits/std_abs.h>
 #include <edm4hep/Vector3d.h>
 #include <fmt/core.h>
 #include <math.h>

--- a/src/algorithms/fardetectors/MatrixTransferStatic.cc
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.cc
@@ -13,7 +13,6 @@
 #include <Math/GenVector/DisplacementVector3D.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <ext/alloc_traits.h>
 #include <cmath>
 #include <vector>
 

--- a/src/algorithms/pid/ParticlesWithPID.cc
+++ b/src/algorithms/pid/ParticlesWithPID.cc
@@ -8,7 +8,7 @@
 #include <edm4eic/TrackSegmentCollection.h>
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
-#include <edm4hep/utils/vector_utils_legacy.h>
+#include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>

--- a/src/algorithms/pid/ParticlesWithPID.cc
+++ b/src/algorithms/pid/ParticlesWithPID.cc
@@ -3,7 +3,6 @@
 
 #include "ParticlesWithPID.h"
 
-#include <bits/std_abs.h>
 #include <edm4eic/TrackParametersCollection.h>
 #include <edm4eic/TrackPoint.h>
 #include <edm4eic/TrackSegmentCollection.h>

--- a/src/algorithms/tracking/TrackParamTruthInit.cc
+++ b/src/algorithms/tracking/TrackParamTruthInit.cc
@@ -6,7 +6,6 @@
 
 #include <Acts/Definitions/Units.hpp>
 #include <TParticlePDG.h>
-#include <bits/std_abs.h>
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
 #include <fmt/core.h>

--- a/src/algorithms/tracking/TrackProjector.cc
+++ b/src/algorithms/tracking/TrackProjector.cc
@@ -5,7 +5,6 @@
 #include <Acts/EventData/MultiTrajectoryHelpers.hpp>
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
 #include <Acts/Geometry/GeometryIdentifier.hpp>
-#include <bits/std_abs.h>
 #include <edm4eic/Cov2f.h>
 #include <edm4eic/Cov3f.h>
 #include <edm4eic/EDM4eicVersion.h>

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -11,7 +11,6 @@
 #include <Acts/Propagator/EigenStepper.hpp>
 #include <Acts/Propagator/Propagator.hpp>
 #include <Acts/Utilities/Logger.hpp>
-#include <bits/std_abs.h>
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -17,8 +17,6 @@
 #include <Acts/Surfaces/PerigeeSurface.hpp>
 #include <Acts/Surfaces/Surface.hpp>
 #include <Acts/Utilities/Result.hpp>
-#include <bits/std_abs.h>
-#include <bits/utility.h>
 #include <boost/container/small_vector.hpp>
 #include <boost/container/vector.hpp>
 #include <Eigen/Core>

--- a/src/detectors/DIRC/DIRC.cc
+++ b/src/detectors/DIRC/DIRC.cc
@@ -4,7 +4,6 @@
 //
 
 #include <JANA/JApplication.h>
-#include <ext/alloc_traits.h>
 #include <stddef.h>
 #include <algorithm>
 #include <string>

--- a/src/services/geometry/richgeo/ActsGeo.cc
+++ b/src/services/geometry/richgeo/ActsGeo.cc
@@ -11,7 +11,6 @@
 #include <DD4hep/Objects.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <Math/GenVector/DisplacementVector3D.h>
-#include <bits/std_abs.h>
 #include <ctype.h>
 #include <edm4hep/Vector3f.h>
 #include <fmt/core.h>

--- a/src/services/geometry/richgeo/IrtGeoPFRICH.cc
+++ b/src/services/geometry/richgeo/IrtGeoPFRICH.cc
@@ -17,7 +17,6 @@
 #include <TGeoNode.h>
 #include <TRef.h>
 #include <TVector3.h>
-#include <bits/std_abs.h>
 #include <fmt/core.h>
 #include <math.h>
 #include <stdint.h>

--- a/src/services/geometry/richgeo/ReadoutGeo.cc
+++ b/src/services/geometry/richgeo/ReadoutGeo.cc
@@ -15,7 +15,6 @@
 #include <Math/GenVector/Cartesian3D.h>
 #include <Math/GenVector/DisplacementVector3D.h>
 #include <TGeoMatrix.h>
-#include <bits/std_abs.h>
 #include <ctype.h>
 #include <fmt/core.h>
 #include <algorithm>


### PR DESCRIPTION
Those are not portable across versions and to different libraries.

Avoids build errors like:
```
src/algorithms/calorimetry/CalorimeterHitDigi.cc:21:10: fatal error: bits/utility.h: No such file or directory
   21 | #include <bits/utility.h>
      |          ^~~~~~~~~~~~~~~~
compilation terminated.
```