### PR TITLE
linux-eic-shell.yml: remove last reference to brycecanyon

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -405,7 +405,7 @@ jobs:
       matrix:
         CC: [gcc]
         particle: [e]
-        detector_config: [brycecanyon]
+        detector_config: [craterlake]
     steps:
     - uses: actions/download-artifact@v3
       with:


### PR DESCRIPTION
The brycecanyon test now fails, because the simulation is gone.