### PR TITLE
feat: depend on algorithms; demo interface in CaloClusterRecoCoG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,9 @@ add_compile_definitions(HAVE_PODIO)
 # TODO: NWB: Do this correctly in JANA via target_compile_definitions for v2.1.1
 # TODO: NWB: Maybe we want these to be prefixed, e.g. JANA2_HAVE_PODIO
 
+# Algorithms
+find_package(algorithms 1.0.0 REQUIRED Core)
+
 # PODIO, EDM4HEP, EDM4EIC event models
 find_package(Eigen3 REQUIRED)
 find_package(podio REQUIRED)

--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -177,6 +177,20 @@ macro(plugin_glob_all _name)
 endmacro()
 
 
+# Adds algorithms for a plugin
+macro(plugin_add_algorithms _name)
+
+    if(NOT algorithms_FOUND)
+        find_package(algorithms REQUIRED)
+    endif()
+
+    plugin_link_libraries(${_name}
+        algocore
+    )
+
+endmacro()
+
+
 # Adds dd4hep for a plugin
 macro(plugin_add_dd4hep _name)
 

--- a/src/algorithms/calorimetry/CMakeLists.txt
+++ b/src/algorithms/calorimetry/CMakeLists.txt
@@ -12,6 +12,7 @@ plugin_add(${PLUGIN_NAME} WITH_SHARED_LIBRARY WITHOUT_PLUGIN)
 plugin_glob_all(${PLUGIN_NAME})
 
 # Find dependencies
+plugin_add_algorithms(${PLUGIN_NAME} algocalorimetry)
 plugin_add_dd4hep(${PLUGIN_NAME})
 plugin_add_event_model(${PLUGIN_NAME})
 plugin_add_eigen3(${PLUGIN_NAME})

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -7,6 +7,7 @@
  *
  *  Author: Chao Peng (ANL), 09/27/2020
  */
+
 #include <boost/algorithm/string/join.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <edm4eic/CalorimeterHitCollection.h>
@@ -22,9 +23,11 @@
 #include <Evaluator/DD4hepUnits.h>
 #include <cctype>
 #include <exception>
+#include <gsl/pointers>
 #include <limits>
 #include <map>
 #include <optional>
+#include <tuple>
 #include <type_traits>
 #include <vector>
 

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -51,13 +51,12 @@ namespace eicrecon {
     weightFunc = it->second;
   }
 
-  ClustersWithAssociations CalorimeterClusterRecoCoG::process(
-            const edm4eic::ProtoClusterCollection* proto,
-            const edm4hep::SimCalorimeterHitCollection* mchits) {
+  void CalorimeterClusterRecoCoG::process(
+      const CalorimeterClusterRecoCoG::Input& input,
+      const CalorimeterClusterRecoCoG::Output& output) const {
 
-    // output collections
-    auto clusters = std::make_unique<edm4eic::ClusterCollection>();
-    auto associations = std::make_unique<edm4eic::MCRecoClusterParticleAssociationCollection>();
+    const auto [proto, mchits] = input;
+    auto [clusters, associations] = output;
 
     for (const auto& pcl : *proto) {
 
@@ -148,8 +147,6 @@ namespace eicrecon {
         m_log->debug("No mcHitCollection was provided, so no truth association will be performed.");
       }
     }
-
-    return std::make_pair(std::move(clusters), std::move(associations));
 }
 
 //------------------------------------------------------------------------

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
@@ -64,7 +64,7 @@ namespace eicrecon {
         public WithPodConfig<CalorimeterClusterRecoCoGConfig> {
 
   public:
-    CalorimeterClusterRecoCoG(std::string_view name = {})
+    CalorimeterClusterRecoCoG(std::string_view name)
       : CalorimeterClusterRecoCoGAlgorithm{name,
                             {"inputProtoClusterCollection", "mcHits"},
                             {"outputClusterCollection", "outputAssociations"},

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
@@ -59,14 +59,23 @@ namespace eicrecon {
     >
   >;
 
-  class CalorimeterClusterRecoCoG : public WithPodConfig<CalorimeterClusterRecoCoGConfig> {
+  class CalorimeterClusterRecoCoG
+      : public CalorimeterClusterRecoCoGAlgorithm,
+        public WithPodConfig<CalorimeterClusterRecoCoGConfig> {
+
+  public:
+    CalorimeterClusterRecoCoG(std::string_view name = {})
+      : CalorimeterClusterRecoCoGAlgorithm{name,
+                            {"inputProtoClusterCollection", "mcHits"},
+                            {"outputClusterCollection", "outputAssociations"},
+                            "Reconstruct a cluster with the Center of Gravity method. For "
+                            "simulation results it optionally creates a Cluster <-> MCParticle "
+                            "association provided both optional arguments are provided."} {}
 
   public:
     void init(const dd4hep::Detector* detector, std::shared_ptr<spdlog::logger>& logger);
 
-    ClustersWithAssociations process(
-            const edm4eic::ProtoClusterCollection* proto,
-            const edm4hep::SimCalorimeterHitCollection* mchits);
+    void process(const Input&, const Output&) const final;
 
   private:
     const dd4hep::Detector* m_detector;

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <algorithms/algorithm.h>
 #include <DD4hep/Detector.h>
 #include <edm4eic/ClusterCollection.h>
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
@@ -45,6 +46,17 @@ namespace eicrecon {
   using ClustersWithAssociations = std::pair<
     std::unique_ptr<edm4eic::ClusterCollection>,
     std::unique_ptr<edm4eic::MCRecoClusterParticleAssociationCollection>
+  >;
+
+  using CalorimeterClusterRecoCoGAlgorithm = algorithms::Algorithm<
+    algorithms::Input<
+      edm4eic::ProtoClusterCollection,
+      std::optional<edm4hep::SimCalorimeterHitCollection>
+    >,
+    algorithms::Output<
+      edm4eic::ClusterCollection,
+      std::optional<edm4eic::MCRecoClusterParticleAssociationCollection>
+    >
   >;
 
   class CalorimeterClusterRecoCoG : public WithPodConfig<CalorimeterClusterRecoCoGConfig> {

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
@@ -10,8 +10,8 @@
 
 #pragma once
 
-#include <algorithms/algorithm.h>
 #include <DD4hep/Detector.h>
+#include <algorithms/algorithm.h>
 #include <edm4eic/ClusterCollection.h>
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <edm4eic/ProtoClusterCollection.h>
@@ -24,6 +24,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "CalorimeterClusterRecoCoGConfig.h"

--- a/src/factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h
+++ b/src/factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h
@@ -23,7 +23,8 @@ class CalorimeterClusterRecoCoG_factoryT :
         const std::vector<std::string>& input_tags,
         const std::vector<std::string>& output_tags,
         CalorimeterClusterRecoCoGConfig cfg)
-    : JChainMultifactoryT<CalorimeterClusterRecoCoGConfig>(std::move(tag), input_tags, output_tags, cfg) {
+    : JChainMultifactoryT<CalorimeterClusterRecoCoGConfig>(std::move(tag), input_tags, output_tags, cfg),
+      m_algo(tag) {
 
       DeclarePodioOutput<edm4eic::Cluster>(GetOutputTags()[0]);
       DeclarePodioOutput<edm4eic::MCRecoClusterParticleAssociation>(GetOutputTags()[1]);

--- a/src/factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h
+++ b/src/factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h
@@ -23,7 +23,7 @@ class CalorimeterClusterRecoCoG_factoryT :
         const std::vector<std::string>& input_tags,
         const std::vector<std::string>& output_tags,
         CalorimeterClusterRecoCoGConfig cfg)
-    : JChainMultifactoryT<CalorimeterClusterRecoCoGConfig>(std::move(tag), input_tags, output_tags, cfg),
+    : JChainMultifactoryT<CalorimeterClusterRecoCoGConfig>(tag, input_tags, output_tags, cfg),
       m_algo(tag) {
 
       DeclarePodioOutput<edm4eic::Cluster>(GetOutputTags()[0]);

--- a/src/factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h
+++ b/src/factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h
@@ -68,9 +68,16 @@ class CalorimeterClusterRecoCoG_factoryT :
         auto mchits = static_cast<const edm4hep::SimCalorimeterHitCollection*>(event->GetCollectionBase(GetInputTags()[1]));
 
         try {
-            auto clusters_with_assocs = m_algo.process(proto, mchits);
-            SetCollection<edm4eic::Cluster>(GetOutputTags()[0], std::move(clusters_with_assocs.first));
-            SetCollection<edm4eic::MCRecoClusterParticleAssociation>(GetOutputTags()[1], std::move(clusters_with_assocs.second));
+            auto clusters = std::make_unique<edm4eic::ClusterCollection>();
+            auto assocs = std::make_unique<edm4eic::MCRecoClusterParticleAssociationCollection>();
+
+            decltype(m_algo)::Input input{proto, mchits};
+            decltype(m_algo)::Output output{clusters.get(), assocs.get()};
+
+            m_algo.process(input, output);
+
+            SetCollection<edm4eic::Cluster>(GetOutputTags()[0], std::move(clusters));
+            SetCollection<edm4eic::MCRecoClusterParticleAssociation>(GetOutputTags()[1], std::move(assocs));
         }
         catch(std::exception &e) {
             throw JException(e.what());


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This adds support for [algorithms](https://github.com/eic/algorithms) in EICrecon. It depends on getting the updated algorithms@main into eic-shell, to get the addition of `find_package(algorithms)` support. This does not add any 'real' algorithms support but demonstrates the accessibility of the interface in CalorimeterClusterRecoCoG.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @sly2j 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.