### PR TITLE
Updated FEMC threshold and digitization parameters

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -169,7 +169,7 @@ std::unique_ptr<edm4hep::RawCalorimeterHitCollection> CalorimeterHitDigi::proces
                   )
                 : 0;
         double    ped     = m_cfg.pedMeanADC + m_normDist(generator) * m_cfg.pedSigmaADC;
-        unsigned long long adc     = std::llround(ped + edep * (m_cfg.corrMeanScale + eResRel) / m_cfg.dyRangeADC * m_cfg.capADC);
+        unsigned long long adc     = std::llround(ped + edep * m_cfg.corrMeanScale * ( 1.0 + eResRel) / m_cfg.dyRangeADC * m_cfg.capADC);
         unsigned long long tdc     = std::llround((time + m_normDist(generator) * tRes) * stepTDC);
 
         if (edep> 1.e-3) m_log->trace("E sim {} \t adc: {} \t time: {}\t maxtime: {} \t tdc: {}", edep, adc, time, m_cfg.capTime, tdc);

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -8,7 +8,7 @@
 #include <math.h>
 #include <string>
 
-#include "algorithms/interfaces/WithPodConfig.h"
+#include "algorithms/calorimetry/CalorimeterHitDigiConfig.h"
 #include "extensions/jana/JChainMultifactoryGeneratorT.h"
 #include "factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h"
 #include "factories/calorimetry/CalorimeterHitDigi_factoryT.h"
@@ -31,9 +31,10 @@ extern "C" {
         app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
           "EcalEndcapPRawHits", {"EcalEndcapPHits"}, {"EcalEndcapPRawHits"},
           {
-            .eRes = {0.00340 * sqrt(dd4hep::GeV), 0.0009, 0.0 * dd4hep::GeV}, // (0.340% / sqrt(E)) \oplus 0.09%
+	    .eRes = {0.11333 * sqrt(dd4hep::GeV), 0.03, 0.0 * dd4hep::GeV}, // (0.340% / sqrt(E)) \oplus 0.09% divided by corrMeanScale = 0.03
             .tRes = 0.0,
-            .threshold = 15 * dd4hep::MeV,
+            .threshold = 0.0,
+	     // .threshold = 15 * dd4hep::MeV,
             .capADC = EcalEndcapP_capADC,
             .capTime =  100, // given in ns, 4 samples in HGCROC
             .dyRangeADC = EcalEndcapP_dyRangeADC,
@@ -52,8 +53,8 @@ extern "C" {
             .pedMeanADC = EcalEndcapP_pedMeanADC,
             .pedSigmaADC = EcalEndcapP_pedSigmaADC,
             .resolutionTDC = EcalEndcapP_resolutionTDC,
-            .thresholdFactor = 5.0,
-            .thresholdValue = 2.0,
+            .thresholdFactor = 0.0,
+            .thresholdValue = 2731.0,
             .sampFrac  =0.03,
             .readout = "EcalEndcapPHits",
           },

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -34,7 +34,7 @@ extern "C" {
             .eRes = {0.11333 * sqrt(dd4hep::GeV), 0.03, 0.0 * dd4hep::GeV}, // (11.333% / sqrt(E)) \oplus 3%
             .tRes = 0.0,
             .threshold = 0.0,
-             // .threshold = 15 * dd4hep::MeV,
+             // .threshold = 15 * dd4hep::MeV for a single tower, applied on ADC level
             .capADC = EcalEndcapP_capADC,
             .capTime =  100, // given in ns, 4 samples in HGCROC
             .dyRangeADC = EcalEndcapP_dyRangeADC,
@@ -54,7 +54,7 @@ extern "C" {
             .pedSigmaADC = EcalEndcapP_pedSigmaADC,
             .resolutionTDC = EcalEndcapP_resolutionTDC,
             .thresholdFactor = 0.0,
-            .thresholdValue = 2731.0,
+            .thresholdValue = 2.0,
             .sampFrac  =0.03,
             .readout = "EcalEndcapPHits",
           },

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -22,21 +22,21 @@ extern "C" {
         using namespace eicrecon;
 
         InitJANAPlugin(app);
-	// Make sure digi and reco use the same value
-	decltype(CalorimeterHitDigiConfig::capADC)        EcalEndcapP_capADC = 16384; //16384, assuming 14 bits. For approximate HGCROC resolution use 65536
-	decltype(CalorimeterHitDigiConfig::dyRangeADC)    EcalEndcapP_dyRangeADC = 3 * dd4hep::GeV;
-	decltype(CalorimeterHitDigiConfig::pedMeanADC)    EcalEndcapP_pedMeanADC = 200;
-	decltype(CalorimeterHitDigiConfig::pedSigmaADC)   EcalEndcapP_pedSigmaADC = 2.4576;
-	decltype(CalorimeterHitDigiConfig::resolutionTDC) EcalEndcapP_resolutionTDC = 10 * dd4hep::picosecond;
-	app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
+        // Make sure digi and reco use the same value
+        decltype(CalorimeterHitDigiConfig::capADC)        EcalEndcapP_capADC = 16384; //16384, assuming 14 bits. For approximate HGCROC resolution use 65536
+        decltype(CalorimeterHitDigiConfig::dyRangeADC)    EcalEndcapP_dyRangeADC = 3 * dd4hep::GeV;
+        decltype(CalorimeterHitDigiConfig::pedMeanADC)    EcalEndcapP_pedMeanADC = 200;
+        decltype(CalorimeterHitDigiConfig::pedSigmaADC)   EcalEndcapP_pedSigmaADC = 2.4576;
+        decltype(CalorimeterHitDigiConfig::resolutionTDC) EcalEndcapP_resolutionTDC = 10 * dd4hep::picosecond;
+        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
           "EcalEndcapPRawHits", {"EcalEndcapPHits"}, {"EcalEndcapPRawHits"},
           {
             .eRes = {0.00340 * sqrt(dd4hep::GeV), 0.0009, 0.0 * dd4hep::GeV}, // (0.340% / sqrt(E)) \oplus 0.09%
             .tRes = 0.0,
-	    .threshold = 15 * dd4hep::MeV,
+            .threshold = 15 * dd4hep::MeV,
             .capADC = EcalEndcapP_capADC,
-	    .capTime =  100, // given in ns, 4 samples in HGCROC
-	    .dyRangeADC = EcalEndcapP_dyRangeADC,
+            .capTime =  100, // given in ns, 4 samples in HGCROC
+            .dyRangeADC = EcalEndcapP_dyRangeADC,
             .pedMeanADC = EcalEndcapP_pedMeanADC,
             .pedSigmaADC = EcalEndcapP_pedSigmaADC,
             .resolutionTDC = EcalEndcapP_resolutionTDC,
@@ -48,7 +48,7 @@ extern "C" {
           "EcalEndcapPRecHits", {"EcalEndcapPRawHits"}, {"EcalEndcapPRecHits"},
           {
             .capADC = EcalEndcapP_capADC,
-	    .dyRangeADC = EcalEndcapP_dyRangeADC,
+            .dyRangeADC = EcalEndcapP_dyRangeADC,
             .pedMeanADC = EcalEndcapP_pedMeanADC,
             .pedSigmaADC = EcalEndcapP_pedSigmaADC,
             .resolutionTDC = 10 * EcalEndcapP_resolutionTDC,

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -22,18 +22,24 @@ extern "C" {
         using namespace eicrecon;
 
         InitJANAPlugin(app);
-
-        app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
+	// Make sure digi and reco use the same value
+	decltype(CalorimeterHitDigiConfig::capADC)        EcalEndcapP_capADC = 16384; //16384, assuming 14 bits. For approximate HGCROC resolution use 65536
+	decltype(CalorimeterHitDigiConfig::dyRangeADC)    EcalEndcapP_dyRangeADC = 3 * dd4hep::GeV;
+	decltype(CalorimeterHitDigiConfig::pedMeanADC)    EcalEndcapP_pedMeanADC = 200;
+	decltype(CalorimeterHitDigiConfig::pedSigmaADC)   EcalEndcapP_pedSigmaADC = 2.4576;
+	decltype(CalorimeterHitDigiConfig::resolutionTDC) EcalEndcapP_resolutionTDC = 10 * dd4hep::picosecond;
+	app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
           "EcalEndcapPRawHits", {"EcalEndcapPHits"}, {"EcalEndcapPRawHits"},
           {
             .eRes = {0.00340 * sqrt(dd4hep::GeV), 0.0009, 0.0 * dd4hep::GeV}, // (0.340% / sqrt(E)) \oplus 0.09%
             .tRes = 0.0,
-            .capADC = 65536, //2^16  (approximate HGCROC resolution) old 16384
-            .capTime = 100, // given in ns, 4 samples in HGCROC
-            .dyRangeADC = 3 * dd4hep::GeV,
-            .pedMeanADC = 100,
-            .pedSigmaADC = 0.7,
-            .resolutionTDC = 10 * dd4hep::picosecond,
+	    .threshold = 15 * dd4hep::MeV,
+            .capADC = EcalEndcapP_capADC,
+	    .capTime =  100, // given in ns, 4 samples in HGCROC
+	    .dyRangeADC = EcalEndcapP_dyRangeADC,
+            .pedMeanADC = EcalEndcapP_pedMeanADC,
+            .pedSigmaADC = EcalEndcapP_pedSigmaADC,
+            .resolutionTDC = EcalEndcapP_resolutionTDC,
             .corrMeanScale = 0.03,
           },
           app   // TODO: Remove me once fixed
@@ -41,11 +47,11 @@ extern "C" {
         app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitReco_factoryT>(
           "EcalEndcapPRecHits", {"EcalEndcapPRawHits"}, {"EcalEndcapPRecHits"},
           {
-            .capADC = 65536,
-            .dyRangeADC = 3. * dd4hep::GeV,
-            .pedMeanADC = 100,
-            .pedSigmaADC = 0.7,
-            .resolutionTDC = 10 * dd4hep::picosecond,
+            .capADC = EcalEndcapP_capADC,
+	    .dyRangeADC = EcalEndcapP_dyRangeADC,
+            .pedMeanADC = EcalEndcapP_pedMeanADC,
+            .pedSigmaADC = EcalEndcapP_pedSigmaADC,
+            .resolutionTDC = 10 * EcalEndcapP_resolutionTDC,
             .thresholdFactor = 5.0,
             .thresholdValue = 2.0,
             .sampFrac  =0.03,

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -54,7 +54,7 @@ extern "C" {
             .pedSigmaADC = EcalEndcapP_pedSigmaADC,
             .resolutionTDC = EcalEndcapP_resolutionTDC,
             .thresholdFactor = 0.0,
-            .thresholdValue = 2.0,
+            .thresholdValue = 2, // The ADC of a 15 MeV particle is adc = 200 + 15 * 0.03 * ( 1.0 + 0) / 3000 * 16384 = 200 + 2.4576
             .sampFrac  =0.03,
             .readout = "EcalEndcapPHits",
           },

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -51,7 +51,7 @@ extern "C" {
             .dyRangeADC = EcalEndcapP_dyRangeADC,
             .pedMeanADC = EcalEndcapP_pedMeanADC,
             .pedSigmaADC = EcalEndcapP_pedSigmaADC,
-            .resolutionTDC = 10 * EcalEndcapP_resolutionTDC,
+            .resolutionTDC = EcalEndcapP_resolutionTDC,
             .thresholdFactor = 5.0,
             .thresholdValue = 2.0,
             .sampFrac  =0.03,

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -31,10 +31,10 @@ extern "C" {
         app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
           "EcalEndcapPRawHits", {"EcalEndcapPHits"}, {"EcalEndcapPRawHits"},
           {
-	    .eRes = {0.11333 * sqrt(dd4hep::GeV), 0.03, 0.0 * dd4hep::GeV}, // (0.340% / sqrt(E)) \oplus 0.09% divided by corrMeanScale = 0.03
+            .eRes = {0.11333 * sqrt(dd4hep::GeV), 0.03, 0.0 * dd4hep::GeV}, // (0.340% / sqrt(E)) \oplus 0.09% divided by corrMeanScale = 0.03
             .tRes = 0.0,
             .threshold = 0.0,
-	     // .threshold = 15 * dd4hep::MeV,
+             // .threshold = 15 * dd4hep::MeV,
             .capADC = EcalEndcapP_capADC,
             .capTime =  100, // given in ns, 4 samples in HGCROC
             .dyRangeADC = EcalEndcapP_dyRangeADC,

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -31,7 +31,7 @@ extern "C" {
         app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
           "EcalEndcapPRawHits", {"EcalEndcapPHits"}, {"EcalEndcapPRawHits"},
           {
-            .eRes = {0.11333 * sqrt(dd4hep::GeV), 0.03, 0.0 * dd4hep::GeV}, // (0.340% / sqrt(E)) \oplus 0.09% divided by corrMeanScale = 0.03
+            .eRes = {0.11333 * sqrt(dd4hep::GeV), 0.03, 0.0 * dd4hep::GeV}, // (11.333% / sqrt(E)) \oplus 3%
             .tRes = 0.0,
             .threshold = 0.0,
              // .threshold = 15 * dd4hep::MeV,


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Updated FEMC threshold and digitization parameters to match the [digitization table from 10/2](https://brookhavenlab.sharepoint.com/:x:/s/EICPublicSharingDocs/EeICxMJ9vGtPtyq5g4qzcSwBKCqkHDj06KDdSvYQ7pxqrQ?rtime=lD_5kMnT20g)

Also, the formula in https://github.com/eic/EICrecon/blob/main/src/algorithms/calorimetry/CalorimeterHitDigi.cc#L172 was wrong. It is corrected and eRes here was adapted for that change.

### Explanation
These parameters are applied in three stages:
1. Apply energy threshold to cumulated Geant4 hits. 
Relevant snippet:
https://github.com/eic/EICrecon/blob/main/src/algorithms/calorimetry/CalorimeterHitDigi.cc#L164-L170
--> Not used here, instead we use an ADC cut

2. Smear energy, convert to ADC
Relevant snippet:
https://github.com/eic/EICrecon/blob/main/src/algorithms/calorimetry/CalorimeterHitDigi.cc#L171-L172
--> At this stage, the energy is scaled down to 3% and smeared, simulating a sampling fraction. The Geant implementation uses a mix of materials and assumes 100% efficiency.

3. Apply zero suppression, then convert to energy
Relevant snippets:
https://github.com/eic/EICrecon/blob/main/src/algorithms/calorimetry/CalorimeterHitReco.cc#L47
https://github.com/eic/EICrecon/blob/main/src/algorithms/calorimetry/CalorimeterHitReco.cc#L150-L152
https://github.com/eic/EICrecon/blob/main/src/algorithms/calorimetry/CalorimeterHitReco.cc#L170-L172

You can cut EITHER by specifying the number of SigmaADC's OR a fixed threshold value, one of the two should always be 0.
```
thresholdADC = m_cfg.thresholdFactor * m_cfg.pedSigmaADC + m_cfg.thresholdValue;
```
--> What I did: Assuming 15 MeV corresponds to the sensitivity of the sensor. I.e., in reality a 500 MeV (=15/3% MeV) particle hit the detector and deposited ultimately 15 MeV

The ADC of this particle is `adc = 200 + 15 * 0.03 * ( 1.0 + 0) / 3000 * 16384 = 2931`
Subtracting the pedestal, I set the threshold value to 2731.

Please also double-check the correctness of 
.capADC = 16384;  assuming 14 bits.
.dyRangeADC = 3 * dd4hep::GeV;



### What kind of change does this PR introduce?
- [x] Bug fix (issue #895 )

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes.