### PR TITLE
calorimetry_CalorimeterIslandCluster: add test case for adjacencyMatrix code path

### DIFF
--- a/src/tests/algorithms_test/calorimetry_CalorimeterIslandCluster.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterIslandCluster.cc
@@ -2,8 +2,11 @@
 // Copyright (C) 2023, Dmitry Kalinkin
 
 #include <DD4hep/Detector.h>
+#include <DD4hep/IDDescriptor.h>
+#include <DD4hep/Readout.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <edm4eic/CalorimeterHitCollection.h>
@@ -16,6 +19,7 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "algorithms/calorimetry/CalorimeterIslandCluster.h"
@@ -35,17 +39,28 @@ TEST_CASE( "the clustering algorithm runs", "[CalorimeterIslandCluster]" ) {
   cfg.minClusterCenterEdep = 0. * dd4hep::GeV;
 
   auto detector = dd4hep::Detector::make_unique("");
+  dd4hep::Readout readout(std::string("MockCalorimeterHits"));
+  dd4hep::IDDescriptor id_desc("MockCalorimeterHits", "system:8,x:8,y:8");
+  readout.setIDDescriptor(id_desc);
+  detector->add(id_desc);
+  detector->add(readout);
 
   SECTION( "without splitting" ) {
+    bool use_adjacencyMatrix = GENERATE(false, true);
     cfg.splitCluster = false;
-    cfg.localDistXY = {1 * dd4hep::mm, 1 * dd4hep::mm};
+    if (use_adjacencyMatrix) {
+      cfg.adjacencyMatrix = "abs(x_1 - x_2) + abs(y_1 - y_2) == 1";
+      cfg.readout = "MockCalorimeterHits";
+    } else {
+      cfg.localDistXY = {1 * dd4hep::mm, 1 * dd4hep::mm};
+    }
     algo.applyConfig(cfg);
     algo.init(detector.get(), logger);
 
     SECTION( "on a single cell" ) {
       edm4eic::CalorimeterHitCollection hits_coll;
       hits_coll.create(
-        0, // std::uint64_t cellID,
+        id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
         5.0, // float energy,
         0.0, // float energyError,
         0.0, // float time,
@@ -101,7 +116,7 @@ TEST_CASE( "the clustering algorithm runs", "[CalorimeterIslandCluster]" ) {
     SECTION( "on two adjacent cells" ) {
       edm4eic::CalorimeterHitCollection hits_coll;
       hits_coll.create(
-        0, // std::uint64_t cellID,
+        id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
         5.0, // float energy,
         0.0, // float energyError,
         0.0, // float time,
@@ -113,7 +128,7 @@ TEST_CASE( "the clustering algorithm runs", "[CalorimeterIslandCluster]" ) {
         edm4hep::Vector3f(0.0, 0.0, 0.0) // edm4hep::Vector3f local
       );
       hits_coll.create(
-        1, // std::uint64_t cellID,
+        id_desc.encode({{"system", 255}, {"x", 1}, {"y", 0}}), // std::uint64_t cellID,
         6.0, // float energy,
         0.0, // float energyError,
         0.0, // float time,
@@ -133,13 +148,18 @@ TEST_CASE( "the clustering algorithm runs", "[CalorimeterIslandCluster]" ) {
   }
 
   SECTION( "run on three adjacent cells" ) {
-    SECTION( "with splitting" ) {
-      cfg.splitCluster = true;
+    bool use_adjacencyMatrix = GENERATE(false, true);
+    if (use_adjacencyMatrix) {
+      cfg.adjacencyMatrix = "abs(x_1 - x_2) + abs(y_1 - y_2) == 1";
+      cfg.readout = "MockCalorimeterHits";
+    } else {
+      cfg.localDistXY = {1 * dd4hep::mm, 1 * dd4hep::mm};
+    }
+
+    cfg.splitCluster = GENERATE(false, true);
+    if (cfg.splitCluster) {
       cfg.transverseEnergyProfileMetric = "localDistXY";
       cfg.transverseEnergyProfileScale = std::numeric_limits<decltype(cfg.transverseEnergyProfileScale)>::infinity();
-    }
-    SECTION( "without splitting" ) {
-      cfg.splitCluster = false;
     }
     cfg.localDistXY = {1 * dd4hep::mm, 1 * dd4hep::mm};
     algo.applyConfig(cfg);
@@ -147,7 +167,7 @@ TEST_CASE( "the clustering algorithm runs", "[CalorimeterIslandCluster]" ) {
 
     edm4eic::CalorimeterHitCollection hits_coll;
     hits_coll.create(
-      0, // std::uint64_t cellID,
+      id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
       5.0, // float energy,
       0.0, // float energyError,
       0.0, // float time,
@@ -159,7 +179,7 @@ TEST_CASE( "the clustering algorithm runs", "[CalorimeterIslandCluster]" ) {
       edm4hep::Vector3f(0.0, 0.0, 0.0) // edm4hep::Vector3f local
     );
     hits_coll.create(
-      1, // std::uint64_t cellID,
+      id_desc.encode({{"system", 255}, {"x", 1}, {"y", 0}}), // std::uint64_t cellID,
       1.0, // float energy,
       0.0, // float energyError,
       0.0, // float time,
@@ -171,7 +191,7 @@ TEST_CASE( "the clustering algorithm runs", "[CalorimeterIslandCluster]" ) {
       edm4hep::Vector3f(0.9 /* mm */, 0.9 /* mm */, 0.0) // edm4hep::Vector3f local
     );
     hits_coll.create(
-      1, // std::uint64_t cellID,
+      id_desc.encode({{"system", 255}, {"x", 2}, {"y", 0}}), // std::uint64_t cellID,
       6.0, // float energy,
       0.0, // float energyError,
       0.0, // float time,


### PR DESCRIPTION
Distance-based adjacency test is not the only code path. Using adjacencyMatrix is preferred, but was not tested until now. This implements a mock DD4hep detector that just provides the necessary readout encoder/decoder.