### PR TITLE
Bhcal threshold

### DIFF
--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -27,6 +27,13 @@ extern "C" {
 
         InitJANAPlugin(app);
 
+
+        // Make sure digi and reco use the same value
+        decltype(CalorimeterHitDigiConfig::capADC)        EcalBarrelScFi_capADC = 16384; //16384,  14bit ADC
+        decltype(CalorimeterHitDigiConfig::dyRangeADC)    EcalBarrelScFi_dyRangeADC = 1500 * dd4hep::MeV;
+        decltype(CalorimeterHitDigiConfig::pedMeanADC)    EcalBarrelScFi_pedMeanADC = 100;
+        decltype(CalorimeterHitDigiConfig::pedSigmaADC)   EcalBarrelScFi_pedSigmaADC = 1;
+        decltype(CalorimeterHitDigiConfig::resolutionTDC) EcalBarrelScFi_resolutionTDC = 10 * dd4hep::picosecond;
         app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
            "EcalBarrelScFiRawHits",
            {"EcalBarrelScFiHits"},
@@ -34,11 +41,12 @@ extern "C" {
            {
              .eRes = {0.0 * sqrt(dd4hep::GeV), 0.0, 0.0 * dd4hep::GeV},
              .tRes = 0.0 * dd4hep::ns,
-             .capADC = 16384, // 14bit ADC
-             .dyRangeADC = 1500 * dd4hep::MeV,
-             .pedMeanADC = 100,
-             .pedSigmaADC = 1,
-             .resolutionTDC = 10 * dd4hep::picosecond,
+             .threshold = 0.0*dd4hep::keV, // threshold is set in ADC in reco
+             .capADC        = EcalBarrelScFi_capADC,
+             .dyRangeADC    = EcalBarrelScFi_dyRangeADC,
+             .pedMeanADC    = EcalBarrelScFi_pedMeanADC,
+             .pedSigmaADC   = EcalBarrelScFi_pedSigmaADC,
+             .resolutionTDC = EcalBarrelScFi_resolutionTDC,
              .corrMeanScale = 1.0,
              .readout = "EcalBarrelScFiHits",
              .fields = {"fiber", "z"},
@@ -48,10 +56,12 @@ extern "C" {
         app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitReco_factoryT>(
           "EcalBarrelScFiRecHits", {"EcalBarrelScFiRawHits"}, {"EcalBarrelScFiRecHits"},
           {
-            .capADC = 16384,
-            .dyRangeADC = 1500. * dd4hep::MeV,
-            .pedMeanADC = 100,
-            .resolutionTDC = 10 * dd4hep::picosecond,
+            .capADC        = EcalBarrelScFi_capADC,
+            .dyRangeADC    = EcalBarrelScFi_dyRangeADC,
+            .pedMeanADC    = EcalBarrelScFi_pedMeanADC,
+            .pedSigmaADC   = EcalBarrelScFi_pedSigmaADC, // not needed; use only thresholdValue
+            .resolutionTDC = EcalBarrelScFi_resolutionTDC,
+            .thresholdFactor = 0.0, // use only thresholdValue
             .thresholdValue = 5.0, // 16384 ADC counts/1500 MeV * 0.5 MeV (desired threshold) = 5.46
             .sampFrac = 0.10200085,
             .readout = "EcalBarrelScFiHits",
@@ -95,6 +105,12 @@ extern "C" {
           )
         );
 
+        // Make sure digi and reco use the same value
+        decltype(CalorimeterHitDigiConfig::capADC)        EcalBarrelImaging_capADC = 8192; //8192,  13bit ADC
+        decltype(CalorimeterHitDigiConfig::dyRangeADC)    EcalBarrelImaging_dyRangeADC = 3 * dd4hep::MeV;
+        decltype(CalorimeterHitDigiConfig::pedMeanADC)    EcalBarrelImaging_pedMeanADC = 14; // Noise floor at 5 keV: 8192 / 3 * 0.005
+        decltype(CalorimeterHitDigiConfig::pedSigmaADC)   EcalBarrelImaging_pedSigmaADC = 5; // Upper limit for sigma for AstroPix
+        decltype(CalorimeterHitDigiConfig::resolutionTDC) EcalBarrelImaging_resolutionTDC = 3.25 * dd4hep::nanosecond;
         app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
            "EcalBarrelImagingRawHits",
           {"EcalBarrelImagingHits"},
@@ -102,11 +118,11 @@ extern "C" {
           {
              .eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV},
              .tRes = 0.0 * dd4hep::ns,
-             .capADC = 8192,
-             .dyRangeADC = 3 * dd4hep::MeV,
-             .pedMeanADC = 14, // Noise floor at 5 keV: 8192 / 3 * 0.005
-             .pedSigmaADC = 5, // Upper limit for sigma for AstroPix
-             .resolutionTDC = 3.25 * dd4hep::nanosecond,
+             .capADC        = EcalBarrelImaging_capADC,
+             .dyRangeADC    = EcalBarrelImaging_dyRangeADC,
+             .pedMeanADC    = EcalBarrelImaging_pedMeanADC,
+             .pedSigmaADC   = EcalBarrelImaging_pedSigmaADC,
+             .resolutionTDC = EcalBarrelImaging_resolutionTDC,
              .corrMeanScale = 1.0,
            },
            app   // TODO: Remove me once fixed
@@ -114,10 +130,12 @@ extern "C" {
         app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitReco_factoryT>(
           "EcalBarrelImagingRecHits", {"EcalBarrelImagingRawHits"}, {"EcalBarrelImagingRecHits"},
           {
-            .capADC = 8192,
-            .dyRangeADC = 3 * dd4hep::MeV,
-            .pedMeanADC = 14,
-            .resolutionTDC = 3.25 * dd4hep::nanosecond,
+            .capADC     = EcalBarrelImaging_capADC,
+            .dyRangeADC = EcalBarrelImaging_dyRangeADC,
+            .pedMeanADC    = EcalBarrelImaging_pedMeanADC,
+            .pedSigmaADC   = EcalBarrelImaging_pedSigmaADC, // not needed; use only thresholdValue
+            .resolutionTDC = EcalBarrelImaging_resolutionTDC,
+            .thresholdFactor = 0.0, // use only thresholdValue
             .thresholdValue = 41, // 8192 ADC counts/3 MeV * 0.015 MeV (desired threshold) = 41
             .sampFrac = 0.00619766,
             .readout = "EcalBarrelImagingHits",

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -27,13 +27,6 @@ extern "C" {
 
         InitJANAPlugin(app);
 
-
-        // Make sure digi and reco use the same value
-        decltype(CalorimeterHitDigiConfig::capADC)        EcalBarrelScFi_capADC = 16384; //16384,  14bit ADC
-        decltype(CalorimeterHitDigiConfig::dyRangeADC)    EcalBarrelScFi_dyRangeADC = 1500 * dd4hep::MeV;
-        decltype(CalorimeterHitDigiConfig::pedMeanADC)    EcalBarrelScFi_pedMeanADC = 100;
-        decltype(CalorimeterHitDigiConfig::pedSigmaADC)   EcalBarrelScFi_pedSigmaADC = 1;
-        decltype(CalorimeterHitDigiConfig::resolutionTDC) EcalBarrelScFi_resolutionTDC = 10 * dd4hep::picosecond;
         app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
            "EcalBarrelScFiRawHits",
            {"EcalBarrelScFiHits"},
@@ -41,12 +34,11 @@ extern "C" {
            {
              .eRes = {0.0 * sqrt(dd4hep::GeV), 0.0, 0.0 * dd4hep::GeV},
              .tRes = 0.0 * dd4hep::ns,
-             .threshold = 0.0*dd4hep::keV, // threshold is set in ADC in reco
-             .capADC        = EcalBarrelScFi_capADC,
-             .dyRangeADC    = EcalBarrelScFi_dyRangeADC,
-             .pedMeanADC    = EcalBarrelScFi_pedMeanADC,
-             .pedSigmaADC   = EcalBarrelScFi_pedSigmaADC,
-             .resolutionTDC = EcalBarrelScFi_resolutionTDC,
+             .capADC = 16384, // 14bit ADC
+             .dyRangeADC = 1500 * dd4hep::MeV,
+             .pedMeanADC = 100,
+             .pedSigmaADC = 1,
+             .resolutionTDC = 10 * dd4hep::picosecond,
              .corrMeanScale = 1.0,
              .readout = "EcalBarrelScFiHits",
              .fields = {"fiber", "z"},
@@ -56,12 +48,10 @@ extern "C" {
         app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitReco_factoryT>(
           "EcalBarrelScFiRecHits", {"EcalBarrelScFiRawHits"}, {"EcalBarrelScFiRecHits"},
           {
-            .capADC        = EcalBarrelScFi_capADC,
-            .dyRangeADC    = EcalBarrelScFi_dyRangeADC,
-            .pedMeanADC    = EcalBarrelScFi_pedMeanADC,
-            .pedSigmaADC   = EcalBarrelScFi_pedSigmaADC, // not needed; use only thresholdValue
-            .resolutionTDC = EcalBarrelScFi_resolutionTDC,
-            .thresholdFactor = 0.0, // use only thresholdValue
+            .capADC = 16384,
+            .dyRangeADC = 1500. * dd4hep::MeV,
+            .pedMeanADC = 100,
+            .resolutionTDC = 10 * dd4hep::picosecond,
             .thresholdValue = 5.0, // 16384 ADC counts/1500 MeV * 0.5 MeV (desired threshold) = 5.46
             .sampFrac = 0.10200085,
             .readout = "EcalBarrelScFiHits",
@@ -105,12 +95,6 @@ extern "C" {
           )
         );
 
-        // Make sure digi and reco use the same value
-        decltype(CalorimeterHitDigiConfig::capADC)        EcalBarrelImaging_capADC = 8192; //8192,  13bit ADC
-        decltype(CalorimeterHitDigiConfig::dyRangeADC)    EcalBarrelImaging_dyRangeADC = 3 * dd4hep::MeV;
-        decltype(CalorimeterHitDigiConfig::pedMeanADC)    EcalBarrelImaging_pedMeanADC = 14; // Noise floor at 5 keV: 8192 / 3 * 0.005
-        decltype(CalorimeterHitDigiConfig::pedSigmaADC)   EcalBarrelImaging_pedSigmaADC = 5; // Upper limit for sigma for AstroPix
-        decltype(CalorimeterHitDigiConfig::resolutionTDC) EcalBarrelImaging_resolutionTDC = 3.25 * dd4hep::nanosecond;
         app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
            "EcalBarrelImagingRawHits",
           {"EcalBarrelImagingHits"},
@@ -118,11 +102,11 @@ extern "C" {
           {
              .eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV},
              .tRes = 0.0 * dd4hep::ns,
-             .capADC        = EcalBarrelImaging_capADC,
-             .dyRangeADC    = EcalBarrelImaging_dyRangeADC,
-             .pedMeanADC    = EcalBarrelImaging_pedMeanADC,
-             .pedSigmaADC   = EcalBarrelImaging_pedSigmaADC,
-             .resolutionTDC = EcalBarrelImaging_resolutionTDC,
+             .capADC = 8192,
+             .dyRangeADC = 3 * dd4hep::MeV,
+             .pedMeanADC = 14, // Noise floor at 5 keV: 8192 / 3 * 0.005
+             .pedSigmaADC = 5, // Upper limit for sigma for AstroPix
+             .resolutionTDC = 3.25 * dd4hep::nanosecond,
              .corrMeanScale = 1.0,
            },
            app   // TODO: Remove me once fixed
@@ -130,12 +114,10 @@ extern "C" {
         app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitReco_factoryT>(
           "EcalBarrelImagingRecHits", {"EcalBarrelImagingRawHits"}, {"EcalBarrelImagingRecHits"},
           {
-            .capADC     = EcalBarrelImaging_capADC,
-            .dyRangeADC = EcalBarrelImaging_dyRangeADC,
-            .pedMeanADC    = EcalBarrelImaging_pedMeanADC,
-            .pedSigmaADC   = EcalBarrelImaging_pedSigmaADC, // not needed; use only thresholdValue
-            .resolutionTDC = EcalBarrelImaging_resolutionTDC,
-            .thresholdFactor = 0.0, // use only thresholdValue
+            .capADC = 8192,
+            .dyRangeADC = 3 * dd4hep::MeV,
+            .pedMeanADC = 14,
+            .resolutionTDC = 3.25 * dd4hep::nanosecond,
             .thresholdValue = 41, // 8192 ADC counts/3 MeV * 0.015 MeV (desired threshold) = 41
             .sampFrac = 0.00619766,
             .readout = "EcalBarrelImagingHits",

--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -34,7 +34,7 @@ extern "C" {
           {
             .eRes = {},
             .tRes = 0.0 * dd4hep::ns,
-            .threshold = 5.0 * dd4hep::MeV,
+            .threshold = 0.0, // Use ADC cut instead
             .capADC        = HcalBarrel_capADC,
             .capTime = 100, // given in ns, 4 samples in HGCROC
             .dyRangeADC    = HcalBarrel_dyRangeADC,
@@ -54,8 +54,8 @@ extern "C" {
             .pedMeanADC    = HcalBarrel_pedMeanADC,
             .pedSigmaADC   = HcalBarrel_pedSigmaADC, // not used; relying on energy cut
             .resolutionTDC = HcalBarrel_resolutionTDC,
-            .thresholdFactor = 0.0, // not used; relying on energy cut
-            .thresholdValue = 0.0, // not used; relying on energy cut
+            .thresholdFactor = 0.0, // not used; relying on flat ADC cut
+            .thresholdValue = 33, // pedSigmaADC + thresholdValue = half-MIP (333 ADC)
             .sampFrac = 0.033, // average, from sPHENIX simulations
             .readout = "HcalBarrelHits",
             .layerField = "tower",

--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -14,6 +14,7 @@
 #include "factories/calorimetry/CalorimeterHitReco_factoryT.h"
 #include "factories/calorimetry/CalorimeterIslandCluster_factoryT.h"
 #include "factories/calorimetry/CalorimeterTruthClustering_factoryT.h"
+#include "factories/calorimetry/CalorimeterTruthClustering_factoryT.h"
 
 extern "C" {
     void InitPlugin(JApplication *app) {
@@ -22,18 +23,25 @@ extern "C" {
 
         InitJANAPlugin(app);
 
+        // Make sure digi and reco use the same value
+        decltype(CalorimeterHitDigiConfig::capADC)        HcalBarrel_capADC = 65536; //65536,  16bit ADC
+        decltype(CalorimeterHitDigiConfig::dyRangeADC)    HcalBarrel_dyRangeADC = 1.0 * dd4hep::GeV;
+        decltype(CalorimeterHitDigiConfig::pedMeanADC)    HcalBarrel_pedMeanADC = 300;
+        decltype(CalorimeterHitDigiConfig::pedSigmaADC)   HcalBarrel_pedSigmaADC = 2;
+        decltype(CalorimeterHitDigiConfig::resolutionTDC) HcalBarrel_resolutionTDC = 1 * dd4hep::picosecond;
+
         app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
           "HcalBarrelRawHits", {"HcalBarrelHits"}, {"HcalBarrelRawHits"},
           {
             .eRes = {},
             .tRes = 0.0 * dd4hep::ns,
             .threshold = 5.0 * dd4hep::MeV,
-            .capADC = 65536,
+            .capADC        = HcalBarrel_capADC,
             .capTime = 100, // given in ns, 4 samples in HGCROC
-            .dyRangeADC = 1.0 * dd4hep::GeV,
-            .pedMeanADC = 10,
-            .pedSigmaADC = 2.0,
-            .resolutionTDC = 1.0 * dd4hep::picosecond,
+            .dyRangeADC    = HcalBarrel_dyRangeADC,
+            .pedMeanADC    = HcalBarrel_pedMeanADC,
+            .pedSigmaADC   = HcalBarrel_pedSigmaADC,
+            .resolutionTDC = HcalBarrel_resolutionTDC,
             .corrMeanScale = 1.0,
             .readout = "HcalBarrelHits",
           },
@@ -42,13 +50,13 @@ extern "C" {
         app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitReco_factoryT>(
           "HcalBarrelRecHits", {"HcalBarrelRawHits"}, {"HcalBarrelRecHits"},
           {
-            .capADC = 65536,
-            .dyRangeADC = 1.0 * dd4hep::GeV,
-            .pedMeanADC = 10,
-            .pedSigmaADC = 2.0,
-            .resolutionTDC = 1.0 * dd4hep::picosecond,
-            .thresholdFactor = 5.0,
-            .thresholdValue = 1.0,
+            .capADC        = HcalBarrel_capADC,
+            .dyRangeADC    = HcalBarrel_dyRangeADC,
+            .pedMeanADC    = HcalBarrel_pedMeanADC,
+            .pedSigmaADC   = HcalBarrel_pedSigmaADC, // not used; relying on energy cut
+            .resolutionTDC = HcalBarrel_resolutionTDC,
+            .thresholdFactor = 0.0, // not used; relying on energy cut
+            .thresholdValue = 0.0, // not used; relying on energy cut
             .sampFrac = 0.033, // average, from sPHENIX simulations
             .readout = "HcalBarrelHits",
             .layerField = "tower",

--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -7,13 +7,12 @@
 #include <JANA/JApplication.h>
 #include <string>
 
-#include "algorithms/interfaces/WithPodConfig.h"
+#include "algorithms/calorimetry/CalorimeterHitDigiConfig.h"
 #include "extensions/jana/JChainMultifactoryGeneratorT.h"
 #include "factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h"
 #include "factories/calorimetry/CalorimeterHitDigi_factoryT.h"
 #include "factories/calorimetry/CalorimeterHitReco_factoryT.h"
 #include "factories/calorimetry/CalorimeterIslandCluster_factoryT.h"
-#include "factories/calorimetry/CalorimeterTruthClustering_factoryT.h"
 #include "factories/calorimetry/CalorimeterTruthClustering_factoryT.h"
 
 extern "C" {


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Updated BHCAL thresholds and digitization parameters from the [digitization table from 10/2](https://brookhavenlab.sharepoint.com/:x:/s/EICPublicSharingDocs/EeICxMJ9vGtPtyq5g4qzcSwBKCqkHDj06KDdSvYQ7pxqrQ?rtime=lD_5kMnT20g).

### Notes:
- This uses a cut on accumulated energy. Instead, you could set the energy cut to 0 and use `.thresholdValue=328` instead (or `.thresholdFactor = 164`). The difference between the two is that in the latter case, an ADC fluctuation can bring the result below/above threshold.
- I believe the 5 MeV threshold corresponds to a 150 MeV real deposition, accounting for sampling fraction. Just double-checking that that's correct.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #895 )
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: Maintenance

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes.


