### PR TITLE
linux-eic-shell.yml: fix cancel-in-progress

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -18,8 +18,8 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 env:
   platform-release: ${{ inputs.platform-release || 'jug_xl:nightly' }}


### PR DESCRIPTION
It looks like workflows on main continue to be cancelled: https://github.com/eic/EICrecon/actions/runs/6711622872/job/18239385242

This is yet another attempt at fixing this in the series of ... #968 #998.