### PR TITLE
Updated EEMC energy threshold and ADC parameters

### DIFF
--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -34,12 +34,12 @@ extern "C" {
           {
             .eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV},
             .tRes = 0.0 * dd4hep::ns,
-            .threshold =  5.0 * dd4hep::MeV;
+            .threshold =  5.0 * dd4hep::MeV,
             .capADC = EcalEndcapN_capADC,
             .dyRangeADC = EcalEndcapN_dyRangeADC,
             .pedMeanADC = EcalEndcapN_pedMeanADC,
             .pedSigmaADC = EcalEndcapN_pedSigmaADC,
-            .resolutionTDC = EcalEndcapN_pedSigmaADC_resolutionTDC,
+            .resolutionTDC = EcalEndcapN_resolutionTDC,
             .corrMeanScale = 1.0,
           },
           app   // TODO: Remove me once fixed
@@ -47,12 +47,11 @@ extern "C" {
         app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitReco_factoryT>(
           "EcalEndcapNRecHits", {"EcalEndcapNRawHits"}, {"EcalEndcapNRecHits"},
           {
-            .capADC = 16384,
             .capADC = EcalEndcapN_capADC,
             .dyRangeADC = EcalEndcapN_dyRangeADC,
             .pedMeanADC = EcalEndcapN_pedMeanADC,
             .pedSigmaADC = EcalEndcapN_pedSigmaADC,
-            .resolutionTDC = EcalEndcapN_pedSigmaADC_resolutionTDC,
+            .resolutionTDC = EcalEndcapN_resolutionTDC,
             .thresholdFactor = 0.0,
             .thresholdValue = 0.0,
             .sampFrac = 0.998,

--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -34,7 +34,7 @@ extern "C" {
           {
             .eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV},
             .tRes = 0.0 * dd4hep::ns,
-            .threshold =  5.0 * dd4hep::MeV,
+            .threshold =  0.0 * dd4hep::MeV,  // Use ADC cut instead
             .capADC = EcalEndcapN_capADC,
             .dyRangeADC = EcalEndcapN_dyRangeADC,
             .pedMeanADC = EcalEndcapN_pedMeanADC,

--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -8,7 +8,7 @@
 #include <math.h>
 #include <string>
 
-#include "algorithms/interfaces/WithPodConfig.h"
+#include "algorithms/calorimetry/CalorimeterHitDigiConfig.h"
 #include "extensions/jana/JChainMultifactoryGeneratorT.h"
 #include "factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h"
 #include "factories/calorimetry/CalorimeterHitDigi_factoryT.h"
@@ -23,16 +23,23 @@ extern "C" {
 
         InitJANAPlugin(app);
 
+        // Make sure digi and reco use the same value
+        decltype(CalorimeterHitDigiConfig::capADC)        EcalEndcapN_capADC = 16384; //65536,  16bit ADC
+        decltype(CalorimeterHitDigiConfig::dyRangeADC)    EcalEndcapN_dyRangeADC = 20.0 * dd4hep::GeV;
+        decltype(CalorimeterHitDigiConfig::pedMeanADC)    EcalEndcapN_pedMeanADC = 20;
+        decltype(CalorimeterHitDigiConfig::pedSigmaADC)   EcalEndcapN_pedSigmaADC = 1;
+        decltype(CalorimeterHitDigiConfig::resolutionTDC) EcalEndcapN_resolutionTDC = 10 * dd4hep::picosecond;
         app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
           "EcalEndcapNRawHits", {"EcalEndcapNHits"}, {"EcalEndcapNRawHits"},
           {
             .eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV},
             .tRes = 0.0 * dd4hep::ns,
-            .capADC = 16384,
-            .dyRangeADC = 20 * dd4hep::GeV,
-            .pedMeanADC = 100,
-            .pedSigmaADC = 1,
-            .resolutionTDC = 10 * dd4hep::picosecond,
+            .threshold =  5.0 * dd4hep::MeV;
+            .capADC = EcalEndcapN_capADC,
+            .dyRangeADC = EcalEndcapN_dyRangeADC,
+            .pedMeanADC = EcalEndcapN_pedMeanADC,
+            .pedSigmaADC = EcalEndcapN_pedSigmaADC,
+            .resolutionTDC = EcalEndcapN_pedSigmaADC_resolutionTDC,
             .corrMeanScale = 1.0,
           },
           app   // TODO: Remove me once fixed
@@ -41,12 +48,13 @@ extern "C" {
           "EcalEndcapNRecHits", {"EcalEndcapNRawHits"}, {"EcalEndcapNRecHits"},
           {
             .capADC = 16384,
-            .dyRangeADC = 20. * dd4hep::GeV,
-            .pedMeanADC = 100,
-            .pedSigmaADC = 1,
-            .resolutionTDC = 10 * dd4hep::picosecond,
-            .thresholdFactor = 4.0,
-            .thresholdValue = 3.0,
+            .capADC = EcalEndcapN_capADC,
+            .dyRangeADC = EcalEndcapN_dyRangeADC,
+            .pedMeanADC = EcalEndcapN_pedMeanADC,
+            .pedSigmaADC = EcalEndcapN_pedSigmaADC,
+            .resolutionTDC = EcalEndcapN_pedSigmaADC_resolutionTDC,
+            .thresholdFactor = 0.0,
+            .thresholdValue = 0.0,
             .sampFrac = 0.998,
             .readout = "EcalEndcapNHits",
             .sectorField = "sector",

--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -53,7 +53,7 @@ extern "C" {
             .pedSigmaADC = EcalEndcapN_pedSigmaADC,
             .resolutionTDC = EcalEndcapN_resolutionTDC,
             .thresholdFactor = 0.0,
-            .thresholdValue = 0.0,
+            .thresholdValue = 4.0, // (20. GeV / 16384) * 4 ~= 5 MeV
             .sampFrac = 0.998,
             .readout = "EcalEndcapNHits",
             .sectorField = "sector",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Updated EEMC thresholds and digitization parameters from the [digitization table from 10/2](https://brookhavenlab.sharepoint.com/:x:/s/EICPublicSharingDocs/EeICxMJ9vGtPtyq5g4qzcSwBKCqkHDj06KDdSvYQ7pxqrQ?rtime=lD_5kMnT20g).

### Notes:
- This uses a cut on accumulated energy.
- Previous adc cut settings would correspond to a cut of 
ped = 20; thresholdADC = 4.0*1+3 
https://github.com/eic/EICrecon/blob/main/src/algorithms/calorimetry/CalorimeterHitReco.cc#L47
Note that at most one of `.thresholdFactor`  and `.thresholdValue` should be non-zero/

Converting back, I get the lowest energy as
27 gets reconstructed as
(27 - 20) / 16384 * 20000 MeV / 0.998 = 8.56 MeV > 5 MeV

I therefore turned off zero suppression for this campaign. We can make the ADC cut more consistent, or replace the energy cut with it, in the future.


### What kind of change does this PR introduce?
- [x] Bug fix (issue #895 )
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: Maintenance

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes.




### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
