### PR TITLE
B0 Ecal threshold

### DIFF
--- a/src/detectors/B0ECAL/B0ECAL.cc
+++ b/src/detectors/B0ECAL/B0ECAL.cc
@@ -22,13 +22,14 @@ extern "C" {
         using namespace eicrecon;
 
         InitJANAPlugin(app);
-
+	
         app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
           "B0ECalRawHits", {"B0ECalHits"}, {"B0ECalRawHits"},
           {
             .eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV},
             .tRes = 0.0 * dd4hep::ns,
             .capADC = 16384,
+            .threshold= 5.0 * dd4hep::MeV,
             .dyRangeADC = 20 * dd4hep::GeV,
             .pedMeanADC = 100,
             .pedSigmaADC = 1,
@@ -45,8 +46,8 @@ extern "C" {
             .pedMeanADC = 100,
             .pedSigmaADC = 1,
             .resolutionTDC = 1e-11,
-            .thresholdFactor = 4.0,
-            .thresholdValue = 3.0,
+            .thresholdFactor = 0.0,
+            .thresholdValue = 0.0,
             .sampFrac = 0.998,
             .readout = "B0ECalHits",
             .sectorField = "sector",

--- a/src/detectors/B0ECAL/B0ECAL.cc
+++ b/src/detectors/B0ECAL/B0ECAL.cc
@@ -22,7 +22,7 @@ extern "C" {
         using namespace eicrecon;
 
         InitJANAPlugin(app);
-	
+
         app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
           "B0ECalRawHits", {"B0ECalHits"}, {"B0ECalRawHits"},
           {

--- a/src/detectors/B0ECAL/B0ECAL.cc
+++ b/src/detectors/B0ECAL/B0ECAL.cc
@@ -8,7 +8,7 @@
 #include <math.h>
 #include <string>
 
-#include "algorithms/interfaces/WithPodConfig.h"
+#include "algorithms/calorimetry/CalorimeterHitDigiConfig.h"
 #include "extensions/jana/JChainMultifactoryGeneratorT.h"
 #include "factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h"
 #include "factories/calorimetry/CalorimeterHitDigi_factoryT.h"
@@ -28,8 +28,8 @@ extern "C" {
           {
             .eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV},
             .tRes = 0.0 * dd4hep::ns,
-            .capADC = 16384,
             .threshold= 5.0 * dd4hep::MeV,
+            .capADC = 16384,
             .dyRangeADC = 20 * dd4hep::GeV,
             .pedMeanADC = 100,
             .pedSigmaADC = 1,


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Updated B0ECAL threshold from the [digitization table from 10/2](https://brookhavenlab.sharepoint.com/:x:/s/EICPublicSharingDocs/EeICxMJ9vGtPtyq5g4qzcSwBKCqkHDj06KDdSvYQ7pxqrQ?rtime=lD_5kMnT20g).

### Notes:
- This uses a cut on accumulated energy.
- Previous adc cut settings are inconsistent, at most one of `.thresholdFactor`  and `.thresholdValue` should be non-zero. I therefore turned off zero suppression for this campaign. We can make the ADC cut more consistent, or replace the energy cut with it, in the future.


### What kind of change does this PR introduce?
- [x] Bug fix (issue #895 )
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: Maintenance

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes.




### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
