### PR TITLE
Updated backward HCAL ADC parameters, removed threshold

### DIFF
--- a/src/detectors/EHCAL/EHCAL.cc
+++ b/src/detectors/EHCAL/EHCAL.cc
@@ -23,8 +23,8 @@ extern "C" {
 
         InitJANAPlugin(app);
         // Make sure digi and reco use the same value
-        decltype(CalorimeterHitDigiConfig::capADC)        HcalEndcapN_capADC = 1024;
-        decltype(CalorimeterHitDigiConfig::dyRangeADC)    HcalEndcapN_dyRangeADC = 3.6 * dd4hep::MeV;
+        decltype(CalorimeterHitDigiConfig::capADC)        HcalEndcapN_capADC = 4096; // assuming 12 bit ADC
+        decltype(CalorimeterHitDigiConfig::dyRangeADC)    HcalEndcapN_dyRangeADC = 100 * dd4hep::MeV; // to be verified with simulations
         decltype(CalorimeterHitDigiConfig::pedMeanADC)    HcalEndcapN_pedMeanADC = 10;
         decltype(CalorimeterHitDigiConfig::pedSigmaADC)   HcalEndcapN_pedSigmaADC = 2;
         decltype(CalorimeterHitDigiConfig::resolutionTDC) HcalEndcapN_resolutionTDC = 10 * dd4hep::picosecond;
@@ -52,7 +52,7 @@ extern "C" {
             .resolutionTDC = HcalEndcapN_resolutionTDC,
             .thresholdFactor = 0.0,
             .thresholdValue = 0.0,
-            .sampFrac = 0.998,
+            .sampFrac = 0.0095, // from latest study - implement at level of reco hits rather than clusters
             .readout = "HcalEndcapNHits",
           },
           app   // TODO: Remove me once fixed

--- a/src/detectors/EHCAL/EHCAL.cc
+++ b/src/detectors/EHCAL/EHCAL.cc
@@ -23,7 +23,7 @@ extern "C" {
 
         InitJANAPlugin(app);
         // Make sure digi and reco use the same value
-        decltype(CalorimeterHitDigiConfig::capADC)        HcalEndcapN_capADC = 4096; // assuming 12 bit ADC
+        decltype(CalorimeterHitDigiConfig::capADC)        HcalEndcapN_capADC = 32768; // assuming 15 bit ADC like FHCal
         decltype(CalorimeterHitDigiConfig::dyRangeADC)    HcalEndcapN_dyRangeADC = 100 * dd4hep::MeV; // to be verified with simulations
         decltype(CalorimeterHitDigiConfig::pedMeanADC)    HcalEndcapN_pedMeanADC = 10;
         decltype(CalorimeterHitDigiConfig::pedSigmaADC)   HcalEndcapN_pedSigmaADC = 2;

--- a/src/detectors/EHCAL/EHCAL.cc
+++ b/src/detectors/EHCAL/EHCAL.cc
@@ -7,7 +7,7 @@
 #include <JANA/JApplication.h>
 #include <string>
 
-#include "algorithms/interfaces/WithPodConfig.h"
+#include "algorithms/calorimetry/CalorimeterHitDigiConfig.h"
 #include "extensions/jana/JChainMultifactoryGeneratorT.h"
 #include "factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h"
 #include "factories/calorimetry/CalorimeterHitDigi_factoryT.h"
@@ -22,16 +22,22 @@ extern "C" {
         using namespace eicrecon;
 
         InitJANAPlugin(app);
+        // Make sure digi and reco use the same value
+        decltype(CalorimeterHitDigiConfig::capADC)        HcalEndcapN_capADC = 1024;
+        decltype(CalorimeterHitDigiConfig::dyRangeADC)    HcalEndcapN_dyRangeADC = 3.6 * dd4hep::MeV;
+        decltype(CalorimeterHitDigiConfig::pedMeanADC)    HcalEndcapN_pedMeanADC = 10;
+        decltype(CalorimeterHitDigiConfig::pedSigmaADC)   HcalEndcapN_pedSigmaADC = 2;
+        decltype(CalorimeterHitDigiConfig::resolutionTDC) HcalEndcapN_resolutionTDC = 10 * dd4hep::picosecond;
 
         app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
           "HcalEndcapNRawHits", {"HcalEndcapNHits"}, {"HcalEndcapNRawHits"},
           {
             .tRes = 0.0 * dd4hep::ns,
-            .capADC = 1024,
-            .dyRangeADC = 3.6 * dd4hep::MeV,
-            .pedMeanADC = 20,
-            .pedSigmaADC = 0.3,
-            .resolutionTDC = 10 * dd4hep::picosecond,
+            .capADC = HcalEndcapN_capADC,
+            .dyRangeADC = HcalEndcapN_dyRangeADC,
+            .pedMeanADC = HcalEndcapN_pedMeanADC,
+            .pedSigmaADC = HcalEndcapN_pedSigmaADC,
+            .resolutionTDC = HcalEndcapN_resolutionTDC,
             .corrMeanScale = 1.0,
           },
           app   // TODO: Remove me once fixed
@@ -39,13 +45,13 @@ extern "C" {
         app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitReco_factoryT>(
           "HcalEndcapNRecHits", {"HcalEndcapNRawHits"}, {"HcalEndcapNRecHits"},
           {
-            .capADC = 1024,
-            .dyRangeADC = 3.6 * dd4hep::MeV,
-            .pedMeanADC = 20,
-            .pedSigmaADC = 0.3,
-            .resolutionTDC = 10 * dd4hep::picosecond,
-            .thresholdFactor = 4.0,
-            .thresholdValue = 1.0,
+            .capADC = HcalEndcapN_capADC,
+            .dyRangeADC = HcalEndcapN_dyRangeADC,
+            .pedMeanADC = HcalEndcapN_pedMeanADC,
+            .pedSigmaADC = HcalEndcapN_pedSigmaADC,
+            .resolutionTDC = HcalEndcapN_resolutionTDC,
+            .thresholdFactor = 0.0,
+            .thresholdValue = 0.0,
             .sampFrac = 0.998,
             .readout = "HcalEndcapNHits",
           },


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Updated backward HCal ADC params from the [digitization table from 10/2](https://brookhavenlab.sharepoint.com/:x:/s/EICPublicSharingDocs/EeICxMJ9vGtPtyq5g4qzcSwBKCqkHDj06KDdSvYQ7pxqrQ?rtime=lD_5kMnT20g).

### Notes:
- NO thresdhold is applied.
- Previous adc cut settings are inconsistent, at most one of `.thresholdFactor`  and `.thresholdValue` should be non-zero. I therefore turned off zero suppression for this campaign. 


### What kind of change does this PR introduce?
- [x] Bug fix (issue #895 )
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: Maintenance

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes.




### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
