### PR TITLE
Updated ADC parameters and threshold for HCal (and ECal) inserts

### DIFF
--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -117,16 +117,20 @@ extern "C" {
           )
         );
 
+	// Insert is identical to regular Ecal
         app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
           "EcalEndcapPInsertRawHits", {"EcalEndcapPInsertHits"}, {"EcalEndcapPInsertRawHits"},
           {
-            .eRes = {0.00340 * sqrt(dd4hep::GeV), 0.0009, 0.0 * dd4hep::GeV}, // (0.340% / sqrt(E)) \oplus 0.09%
-            .tRes = 0.0 * dd4hep::ns,
-            .capADC = 16384,
-            .dyRangeADC = 3 * dd4hep::GeV,
-            .pedMeanADC = 100,
-            .pedSigmaADC = 0.7,
-            .resolutionTDC = 10 * dd4hep::picosecond,
+            .eRes = {0.11333 * sqrt(dd4hep::GeV), 0.03, 0.0 * dd4hep::GeV}, // (11.333% / sqrt(E)) \oplus 3%
+            .tRes = 0.0,
+            .threshold = 0.0,
+             // .threshold = 15 * dd4hep::MeV for a single tower, applied on ADC level
+            .capADC = EcalEndcapP_capADC,
+            .capTime =  100, // given in ns, 4 samples in HGCROC
+            .dyRangeADC = EcalEndcapP_dyRangeADC,
+            .pedMeanADC = EcalEndcapP_pedMeanADC,
+            .pedSigmaADC = EcalEndcapP_pedSigmaADC,
+            .resolutionTDC = EcalEndcapP_resolutionTDC,
             .corrMeanScale = 0.03,
           },
           app   // TODO: Remove me once fixed
@@ -134,14 +138,14 @@ extern "C" {
         app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitReco_factoryT>(
           "EcalEndcapPInsertRecHits", {"EcalEndcapPInsertRawHits"}, {"EcalEndcapPInsertRecHits"},
           {
-            .capADC = 16384,
-            .dyRangeADC = 3. * dd4hep::GeV,
-            .pedMeanADC = 100,
-            .pedSigmaADC = 0.7,
-            .resolutionTDC = 10 * dd4hep::picosecond,
-            .thresholdFactor = 5.0,
-            .thresholdValue = 2.0,
-            .sampFrac = 0.03,
+            .capADC = EcalEndcapP_capADC,
+            .dyRangeADC = EcalEndcapP_dyRangeADC,
+            .pedMeanADC = EcalEndcapP_pedMeanADC,
+            .pedSigmaADC = EcalEndcapP_pedSigmaADC,
+            .resolutionTDC = EcalEndcapP_resolutionTDC,
+            .thresholdFactor = 0.0,
+            .thresholdValue = 2, // The ADC of a 15 MeV particle is adc = 200 + 15 * 0.03 * ( 1.0 + 0) / 3000 * 16384 = 200 + 2.4576
+            .sampFrac  =0.03,
             .readout = "EcalEndcapPInsertHits",
           },
           app   // TODO: Remove me once fixed

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -6,7 +6,7 @@
 #include <TString.h>
 #include <string>
 
-#include "algorithms/interfaces/WithPodConfig.h"
+#include "algorithms/calorimetry/CalorimeterHitDigiConfig.h"
 #include "extensions/jana/JChainMultifactoryGeneratorT.h"
 #include "factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h"
 #include "factories/calorimetry/CalorimeterHitDigi_factoryT.h"
@@ -22,16 +22,23 @@ extern "C" {
 
         InitJANAPlugin(app);
 
+        // Make sure digi and reco use the same value
+        decltype(CalorimeterHitDigiConfig::capADC)        HcalEndcapPInsert_capADC = 32768;
+        decltype(CalorimeterHitDigiConfig::dyRangeADC)    HcalEndcapPInsert_dyRangeADC = 200 * dd4hep::MeV;
+        decltype(CalorimeterHitDigiConfig::pedMeanADC)    HcalEndcapPInsert_pedMeanADC = 10;
+        decltype(CalorimeterHitDigiConfig::pedSigmaADC)   HcalEndcapPInsert_pedSigmaADC = 2;
+        decltype(CalorimeterHitDigiConfig::resolutionTDC) HcalEndcapPInsert_resolutionTDC = 10 * dd4hep::picosecond;
+
         app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
            "HcalEndcapPInsertRawHits", {"HcalEndcapPInsertHits"}, {"HcalEndcapPInsertRawHits"},
            {
              .eRes = {},
              .tRes = 0.0 * dd4hep::ns,
-             .capADC = 32768,
-             .dyRangeADC = 200 * dd4hep::MeV,
-             .pedMeanADC = 400,
-             .pedSigmaADC = 10,
-             .resolutionTDC = 10 * dd4hep::picosecond,
+             .capADC = HcalEndcapPInsert_capADC,
+             .dyRangeADC = HcalEndcapPInsert_dyRangeADC,
+             .pedMeanADC = HcalEndcapPInsert_pedMeanADC,
+             .pedSigmaADC = HcalEndcapPInsert_pedSigmaADC,
+             .resolutionTDC = HcalEndcapPInsert_resolutionTDC,
              .corrMeanScale = 1.0,
            },
           app   // TODO: Remove me once fixed
@@ -39,13 +46,14 @@ extern "C" {
         app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitReco_factoryT>(
           "HcalEndcapPInsertRecHits", {"HcalEndcapPInsertRawHits"}, {"HcalEndcapPInsertRecHits"},
           {
-            .capADC = 32768,
-            .dyRangeADC = 200. * dd4hep::MeV,
-            .pedMeanADC = 400,
-            .pedSigmaADC = 10.,
-            .resolutionTDC = 10 * dd4hep::picosecond,
+            .capADC = HcalEndcapPInsert_capADC,
+            .dyRangeADC = HcalEndcapPInsert_dyRangeADC,
+            .pedMeanADC = HcalEndcapPInsert_pedMeanADC,
+            .pedSigmaADC = HcalEndcapPInsert_pedSigmaADC,
+            .resolutionTDC = HcalEndcapPInsert_resolutionTDC,
             .thresholdFactor = 0.,
-            .thresholdValue = -100.,
+            .thresholdValue = 41.0, // 0.25 MeV --> adc = 50 + 0.25 / 200 * 32768 = 91
+
             .sampFrac = 0.0098,
             .readout = "HcalEndcapPInsertHits",
           },

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -52,7 +52,7 @@ extern "C" {
             .pedSigmaADC = HcalEndcapPInsert_pedSigmaADC,
             .resolutionTDC = HcalEndcapPInsert_resolutionTDC,
             .thresholdFactor = 0.,
-            .thresholdValue = 41.0, // 0.25 MeV --> adc = 50 + 0.25 / 200 * 32768 = 91
+            .thresholdValue = 41.0, // 0.25 MeV --> 0.25 / 200 * 32768 = 41
 
             .sampFrac = 0.0098,
             .readout = "HcalEndcapPInsertHits",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Updated backward Insert ADC parameters from the [digitization table from 10/2](https://brookhavenlab.sharepoint.com/:x:/s/EICPublicSharingDocs/EeICxMJ9vGtPtyq5g4qzcSwBKCqkHDj06KDdSvYQ7pxqrQ?rtime=lD_5kMnT20g).

### Notes:
- Threshold cut is applied on the ADC level.
0.25 MeV particle:
adc = 50 + 0.25 / 200 * 32768 = 91

### What kind of change does this PR introduce?
- [x] Bug fix (issue #895 )
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: Maintenance

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes.
