### PR TITLE
Updated LFHCAL ADC parameters and threshold

### DIFF
--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -6,7 +6,7 @@
 #include <TString.h>
 #include <string>
 
-#include "algorithms/interfaces/WithPodConfig.h"
+#include "algorithms/calorimetry/CalorimeterHitDigiConfig.h"
 #include "extensions/jana/JChainMultifactoryGeneratorT.h"
 #include "factories/calorimetry/CalorimeterClusterRecoCoG_factoryT.h"
 #include "factories/calorimetry/CalorimeterHitDigi_factoryT.h"
@@ -117,17 +117,24 @@ extern "C" {
           )
         );
 
+        // Make sure digi and reco use the same value
+        decltype(CalorimeterHitDigiConfig::capADC)        LFHCAL_capADC = 65536;
+        decltype(CalorimeterHitDigiConfig::dyRangeADC)    LFHCAL_dyRangeADC = 1 * dd4hep::GeV;
+        decltype(CalorimeterHitDigiConfig::pedMeanADC)    LFHCAL_pedMeanADC = 50;
+        decltype(CalorimeterHitDigiConfig::pedSigmaADC)   LFHCAL_pedSigmaADC = 10;
+        decltype(CalorimeterHitDigiConfig::resolutionTDC) LFHCAL_resolutionTDC = 10 * dd4hep::picosecond;
+
         app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitDigi_factoryT>(
           "LFHCALRawHits", {"LFHCALHits"}, {"LFHCALRawHits"},
           {
             .eRes = {},
             .tRes = 0.0 * dd4hep::ns,
-            .capADC = 65536,
+            .capADC = LFHCAL_capADC,
             .capTime = 100,
-            .dyRangeADC = 1 * dd4hep::GeV,
-            .pedMeanADC = 20,
-            .pedSigmaADC = 0.8,
-            .resolutionTDC = 10 * dd4hep::picosecond,
+            .dyRangeADC = LFHCAL_dyRangeADC,
+            .pedMeanADC = LFHCAL_pedMeanADC,
+            .pedSigmaADC = LFHCAL_pedSigmaADC,
+            .resolutionTDC = LFHCAL_resolutionTDC,
             .corrMeanScale = 1.0,
             .readout = "LFHCALHits",
             .fields = {"layerz"},
@@ -137,13 +144,13 @@ extern "C" {
         app->Add(new JChainMultifactoryGeneratorT<CalorimeterHitReco_factoryT>(
           "LFHCALRecHits", {"LFHCALRawHits"}, {"LFHCALRecHits"},
           {
-            .capADC = 65536,
-            .dyRangeADC = 1 * dd4hep::GeV,
-            .pedMeanADC = 20,
-            .pedSigmaADC = 0.8,
-            .resolutionTDC = 10 * dd4hep::picosecond,
-            .thresholdFactor = 1.0,
-            .thresholdValue = 3.0,
+            .capADC = LFHCAL_capADC,
+            .dyRangeADC = LFHCAL_dyRangeADC,
+            .pedMeanADC = LFHCAL_pedMeanADC,
+            .pedSigmaADC = LFHCAL_pedSigmaADC,
+            .resolutionTDC = LFHCAL_resolutionTDC,
+            .thresholdFactor = 0.0,
+            .thresholdValue = 20, // 0.3 MeV deposition --> adc = 50 + 0.3 / 1000 * 65536 == 70
             .sampFrac = 0.033,
             .sampFracLayer = {
               0.019, //  0


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Updated LFHCAL ADC params from the [digitization table from 10/2](https://brookhavenlab.sharepoint.com/:x:/s/EICPublicSharingDocs/EeICxMJ9vGtPtyq5g4qzcSwBKCqkHDj06KDdSvYQ7pxqrQ?rtime=lD_5kMnT20g).

Threshold on the ADC level:
0.3 MeV deposition --> adc = 50 + 0.3 / 1000 * 65536 == 70 --> thresholdValue = 20


### What kind of change does this PR introduce?
- [x] Bug fix (issue #895 )
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: Maintenance

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes.
