### PR TITLE
[Backport v1.7] fix: mv id() to getObjectID().index because id() returns ObjectID, not uint_t, in podio v0.17.1

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterTruthClustering.cc
+++ b/src/algorithms/calorimetry/CalorimeterTruthClustering.cc
@@ -66,7 +66,7 @@ std::unique_ptr<edm4eic::ProtoClusterCollection> CalorimeterTruthClustering::pro
             }
         }
 
-        const auto &trackID = mc[mcIndex].getContributions(0).getParticle().id();
+        const auto &trackID = mc[mcIndex].getContributions(0).getParticle().getObjectID().index;
         // Create a new protocluster if we don't have one for this trackID
         if (protoIndex.count(trackID) == 0) {
             output->create();

--- a/src/algorithms/calorimetry/ImagingClusterReco.h
+++ b/src/algorithms/calorimetry/ImagingClusterReco.h
@@ -131,7 +131,7 @@ namespace eicrecon {
 
         // debug output
         for (const auto& cl: *clusters) {
-            m_log->debug("Cluster {:d}: Edep = {:.3f} MeV, Dir = ({:.3f}, {:.3f}) deg", cl.id(),
+            m_log->debug("Cluster {:d}: Edep = {:.3f} MeV, Dir = ({:.3f}, {:.3f}) deg", cl.getObjectID().index,
                          cl.getEnergy() * 1000., cl.getIntrinsicTheta() / M_PI * 180.,
                          cl.getIntrinsicPhi() / M_PI * 180.
             );

--- a/src/algorithms/digi/PhotoMultiplierHitDigi.cc
+++ b/src/algorithms/digi/PhotoMultiplierHitDigi.cc
@@ -19,6 +19,7 @@
 #include <edm4hep/Vector3d.h>
 #include <fmt/core.h>
 #include <math.h>
+#include <podio/ObjectID.h>
 #include <spdlog/common.h>
 #include <algorithm>
 #include <exception>

--- a/src/algorithms/digi/PhotoMultiplierHitDigi.cc
+++ b/src/algorithms/digi/PhotoMultiplierHitDigi.cc
@@ -109,7 +109,7 @@ eicrecon::PhotoMultiplierHitDigiResult eicrecon::PhotoMultiplierHitDigi::Algorit
 
             // cell time, signal amplitude, truth photon
             m_log->trace(" -> hit accepted");
-            m_log->trace(" -> MC hit id={}", sim_hit.id());
+            m_log->trace(" -> MC hit id={}", sim_hit.getObjectID().index);
             auto   time = sim_hit.getTime();
             double amp  = m_cfg.speMean + m_rngNorm() * m_cfg.speError;
 
@@ -130,7 +130,7 @@ eicrecon::PhotoMultiplierHitDigiResult eicrecon::PhotoMultiplierHitDigi::Algorit
             for(auto &hit : hitVec) {
               m_log->trace("hit_group: pixel id={:#018X} -> npe={} signal={} time={}", id, hit.npe, hit.signal, hit.time);
               for(auto i : hit.sim_hit_indices)
-                m_log->trace(" - MC hit: EDep={}, id={}", sim_hits->at(i).getEDep(), sim_hits->at(i).id());
+                m_log->trace(" - MC hit: EDep={}, id={}", sim_hits->at(i).getEDep(), sim_hits->at(i).getObjectID().index);
             }
         }
 

--- a/src/algorithms/pid/ConvertParticleID.h
+++ b/src/algorithms/pid/ConvertParticleID.h
@@ -64,7 +64,7 @@ namespace eicrecon {
           // create output `ParticleID` object
           auto out_index = out_pids.size();
           auto out_pid   = out_pids.create();
-          out_indices.insert({out_index, out_pid.id()});
+          out_indices.insert({out_index, out_pid.getObjectID().index});
 
           // fill scalars
           out_pid.setPDG(           static_cast<decltype(edm4hep::ParticleIDData::PDG)>           (in_hyp.PDG)    );

--- a/src/algorithms/pid/MergeParticleID.cc
+++ b/src/algorithms/pid/MergeParticleID.cc
@@ -6,6 +6,7 @@
 #include <edm4eic/CherenkovParticleIDHypothesis.h>
 #include <edm4eic/TrackSegmentCollection.h>
 #include <fmt/core.h>
+#include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
 #include <spdlog/common.h>
 #include <stddef.h>

--- a/src/algorithms/pid/MergeParticleID.cc
+++ b/src/algorithms/pid/MergeParticleID.cc
@@ -94,7 +94,7 @@ std::unique_ptr<edm4eic::CherenkovParticleIDCollection> eicrecon::MergeParticleI
         m_log->error("PID object found with no charged particle");
         continue;
       }
-      auto id_particle = charged_particle_track_segment.getObjectId().index;
+      auto id_particle = charged_particle_track_segment.getObjectID().index;
       auto idx_paired  = std::make_pair(idx_coll, idx_pid);
       m_log->trace("  idx_pid={}  id_particle={}", idx_pid, id_particle);
 

--- a/src/algorithms/pid/MergeParticleID.cc
+++ b/src/algorithms/pid/MergeParticleID.cc
@@ -94,7 +94,7 @@ std::unique_ptr<edm4eic::CherenkovParticleIDCollection> eicrecon::MergeParticleI
         m_log->error("PID object found with no charged particle");
         continue;
       }
-      auto id_particle = charged_particle_track_segment.id();
+      auto id_particle = charged_particle_track_segment.getObjectId().index;
       auto idx_paired  = std::make_pair(idx_coll, idx_pid);
       m_log->trace("  idx_pid={}  id_particle={}", idx_pid, id_particle);
 

--- a/src/algorithms/pid/ParticlesWithPID.cc
+++ b/src/algorithms/pid/ParticlesWithPID.cc
@@ -335,7 +335,7 @@ namespace eicrecon {
         // relate matched ParticleID objects to output particle
         for (const auto& [out_pids_index, out_pids_id] : out_pid_index_map) {
             const auto& out_pid = out_pids->at(out_pids_index);
-            if (out_pid.id() != out_pids_id) { // sanity check
+            if (out_pid.getObjectID().index != out_pids_id) { // sanity check
                 m_log->error("indexing error in `edm4eic::ParticleID` collection");
                 return false;
             }


### PR DESCRIPTION
# Description
Backport of #1106 to `v1.7`.