### PR TITLE
feat: install capybara only when not available

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -609,13 +609,6 @@ jobs:
       with:
         repository: 'eic/epic-capybara'
         path: epic-capybara
-    - name: Build and install epic-capybara
-      if: steps.download_previous_artifact.outputs.found_artifact == 'true'
-      run: |
-        pip install hatch
-        cd epic-capybara
-        hatch build
-        pip install dist/*.whl
     - name: Compare to previous artifacts (local capybara)
       uses: eic/run-cvmfs-osg-eic-shell@main
       if: steps.download_previous_artifact.outputs.found_artifact == 'true'
@@ -623,9 +616,6 @@ jobs:
         platform-release: "${{ env.platform-release }}"
         setup: "/opt/detector/epic-${{ env.detector-version }}/setup.sh"
         run: |
-          echo "::group::pip install"
-          python3 -m pip install -r ${{ github.workspace }}/.github/requirements.txt
-          echo "::endgroup::"
           echo "::group::diff ref -> new"
           python3 ${{ github.workspace }}/epic-capybara/bara.py ref/rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
           echo "::endgroup::"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Instead of installing epic-capybara for every pipeline, this only installs when `capybara` is not already in the path.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.