### PR TITLE
eic-shell requires "cd where/root/is" before calling ". bin/thisroot.sh"

### DIFF
--- a/src/scripts/eicrecon-this.sh.in
+++ b/src/scripts/eicrecon-this.sh.in
@@ -22,7 +22,10 @@ fi
 #----------------- ROOT
 if [[ -f @ROOT_BINDIR@/thisroot.sh ]] ; then
     unset ROOTSYS  # prevent ROOT from removing /usr/local/bin from PATH
-    source @ROOT_BINDIR@/thisroot.sh
+    # zsh and latest eic-shell require "cd where/root/is" before calling ". bin/thisroot.sh"
+    pushd @ROOT_BINDIR@ >/dev/null
+    source thisroot.sh
+    popd >/dev/null
 fi
 
 #----------------- PODIO

--- a/src/scripts/eicrecon-this.sh.in
+++ b/src/scripts/eicrecon-this.sh.in
@@ -22,7 +22,8 @@ fi
 #----------------- ROOT
 if [[ -f @ROOT_BINDIR@/thisroot.sh ]] ; then
     unset ROOTSYS  # prevent ROOT from removing /usr/local/bin from PATH
-    # zsh and latest eic-shell require "cd where/root/is" before calling ". bin/thisroot.sh"
+    # workaround for https://github.com/root-project/root/issues/14085
+    # thisroot.sh does not recognize bash when running in qemu (like eic-shell on Silicon)
     pushd @ROOT_BINDIR@ >/dev/null
     source thisroot.sh
     popd >/dev/null


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Small fix to `pushd` and `popd` around `source thisroot.sh`

### What kind of change does this PR introduce?
- [x] Bug fix (issue #1115 )
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
It shouldn't. 