### PR TITLE
fix: convert DD4hepBfield position units without hardcoding

### DIFF
--- a/src/algorithms/tracking/DD4hepBField.cc
+++ b/src/algorithms/tracking/DD4hepBField.cc
@@ -16,10 +16,12 @@ namespace eicrecon::BField {
   Acts::Result<Acts::Vector3> DD4hepBField::getField(const Acts::Vector3& position,
                                                      Acts::MagneticFieldProvider::Cache& /*cache*/) const
   {
-    dd4hep::Position pos(position[0]/10.0,position[1]/10.0,position[2]/10.0); // FIXME
+    dd4hep::Position pos(
+      position[0] * (dd4hep::mm / Acts::UnitConstants::mm),
+      position[1] * (dd4hep::mm / Acts::UnitConstants::mm),
+      position[2] * (dd4hep::mm / Acts::UnitConstants::mm));
+
     auto fieldObj = m_det->field();
-
-
     auto field = fieldObj.magneticField(pos) * (Acts::UnitConstants::T / dd4hep::tesla);
     return Acts::Result<Acts::Vector3>::success({field.x(), field.y(),field.z()});
   }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Remove hard-coded unit conversion from DD4hepBfield. Cherry-picked from #1072.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.