### PR TITLE
feat: write capybara diff dashboards for PRs to ghpages

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -552,6 +552,22 @@ jobs:
         path: ref/
         name: rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
         if_no_artifact_found: warn
+    - name: Compare to previous artifacts
+      uses: eic/run-cvmfs-osg-eic-shell@main
+      if: steps.download_previous_artifact.outputs.found_artifact == 'true'
+      with:
+        platform-release: "${{ env.platform-release }}"
+        setup: "/opt/detector/epic-${{ env.detector-version }}/setup.sh"
+        run: |
+          pip install 'pygithub>=2' 'bokeh>=3'
+          export PYTHONPATH=$HOME/.local/lib/python3.10/site-packages:$PYTHONPATH
+          mkdir capybara-reports
+          capybara bara ref/rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
+    - uses: actions/upload-artifact@v3
+      with:
+        name: rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.report
+        path: capybara-reports
+        if-no-files-found: error
     - name: Checkout epic-capybara
       uses: actions/checkout@v3
       if: steps.download_previous_artifact.outputs.found_artifact == 'true'
@@ -565,7 +581,7 @@ jobs:
         cd epic-capybara
         hatch build
         pip install dist/*.whl
-    - name: Compare to previous artifacts
+    - name: Compare to previous artifacts (local capybara)
       uses: eic/run-cvmfs-osg-eic-shell@main
       if: steps.download_previous_artifact.outputs.found_artifact == 'true'
       with:
@@ -575,8 +591,9 @@ jobs:
           echo "::group::pip install"
           python3 -m pip install -r ${{ github.workspace }}/.github/requirements.txt
           echo "::endgroup::"
+          echo "::group::diff ref -> new"
           python3 ${{ github.workspace }}/epic-capybara/bara.py ref/rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
-
+          echo "::endgroup::"
 
   eicrecon-gun-EcalLumiSpec:
     runs-on: ubuntu-latest
@@ -679,6 +696,22 @@ jobs:
         path: ref/
         name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root
         if_no_artifact_found: warn
+    - name: Compare to previous artifacts
+      uses: eic/run-cvmfs-osg-eic-shell@main
+      if: steps.download_previous_artifact.outputs.found_artifact == 'true'
+      with:
+        platform-release: "${{ env.platform-release }}"
+        setup: "/opt/detector/epic-${{ env.detector-version }}/setup.sh"
+        run: |
+          pip install 'pygithub>=2' 'bokeh>=3'
+          export PYTHONPATH=$HOME/.local/lib/python3.10/site-packages:$PYTHONPATH
+          mkdir capybara-reports
+          capybara bara ref/rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root
+    - uses: actions/upload-artifact@v3
+      with:
+        name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.report
+        path: capybara-reports
+        if-no-files-found: error
     - name: Checkout epic-capybara
       uses: actions/checkout@v3
       if: steps.download_previous_artifact.outputs.found_artifact == 'true'
@@ -692,7 +725,7 @@ jobs:
         cd epic-capybara
         hatch build
         pip install dist/*.whl
-    - name: Compare to previous artifacts
+    - name: Compare to previous artifacts (local capybara)
       uses: eic/run-cvmfs-osg-eic-shell@main
       if: steps.download_previous_artifact.outputs.found_artifact == 'true'
       with:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -566,6 +566,7 @@ jobs:
           mv capybara-reports rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}
           touch .rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}
     - uses: actions/upload-artifact@v3
+      if: steps.download_previous_artifact.outputs.found_artifact == 'true'
       with:
         name: capybara
         path: |
@@ -714,6 +715,7 @@ jobs:
           mv capybara-reports rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}
           touch .rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}
     - uses: actions/upload-artifact@v3
+      if: steps.download_previous_artifact.outputs.found_artifact == 'true'
       with:
         name: capybara
         path: |

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -557,7 +557,7 @@ jobs:
       if: steps.download_previous_artifact.outputs.found_artifact == 'true'
       with:
         platform-release: "${{ env.platform-release }}"
-        setup: "/opt/detector/epic-${{ env.detector-version }}/setup.sh"
+        setup: "/opt/detector/setup.sh"
         run: |
           pip install 'pygithub>=2' 'bokeh>=3'
           export PYTHONPATH=$HOME/.local/lib/python3.10/site-packages:$PYTHONPATH
@@ -705,7 +705,7 @@ jobs:
       if: steps.download_previous_artifact.outputs.found_artifact == 'true'
       with:
         platform-release: "${{ env.platform-release }}"
-        setup: "/opt/detector/epic-${{ env.detector-version }}/setup.sh"
+        setup: "/opt/detector/setup.sh"
         run: |
           pip install 'pygithub>=2' 'bokeh>=3'
           export PYTHONPATH=$HOME/.local/lib/python3.10/site-packages:$PYTHONPATH

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -567,7 +567,7 @@ jobs:
           touch .rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}
     - uses: actions/upload-artifact@v3
       with:
-        name: rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.capybara
+        name: capybara
         path: |
           .rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}
           rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}/
@@ -715,7 +715,7 @@ jobs:
           touch .rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}
     - uses: actions/upload-artifact@v3
       with:
-        name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.capybara
+        name: capybara
         path: |
           .rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}
           rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}/
@@ -822,9 +822,13 @@ jobs:
         with:
           pr: ${{ matrix.pr }}
           path: publishing_docs/pr/${{ matrix.pr }}/capybara/
-          name: .*\.capybara
-          name_is_regexp: true
+          name: capybara
           if_no_artifact_found: ignore
+      - uses: actions/download-artifact@v3
+        if: github.event.pull_request.number == matrix.pr
+        with:
+          name: capybara
+          path: publishing_docs/pr/${{ matrix.pr }}/capybara/
       - run: rm -rf publishing_docs/pr/*/doxygen
       - uses: actions/upload-artifact@v3
         with:
@@ -866,14 +870,19 @@ jobs:
         - /home/runner/work/_temp:/home/runner/work/_temp
       # FIXME hard-coded: see https://github.com/actions/upload-pages-artifact/pull/14
     steps:
-      - uses: actions/download-artifact@v3
+      - name: Download GitHub Pages staging artifact
+        uses: actions/download-artifact@v3
         with:
           name: github-pages-staging
           path: publishing_docs/
+      - name: List content to publish
+        run:
+          find publishing_docs/
       - run:
           apk add tar bash
         # FIXME bash not really required: see https://github.com/actions/upload-pages-artifact/pull/14
-      - uses: actions/upload-pages-artifact@v1
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v1
         with:
           path: publishing_docs/
           retention-days: 7

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -563,10 +563,14 @@ jobs:
           export PYTHONPATH=$HOME/.local/lib/python3.10/site-packages:$PYTHONPATH
           mkdir capybara-reports
           capybara bara ref/rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
+          mv capybara-reports rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}
+          touch .rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}
     - uses: actions/upload-artifact@v3
       with:
-        name: rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.report
-        path: capybara-reports
+        name: rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.capybara
+        path: |
+          .rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}
+          rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}/
         if-no-files-found: error
     - name: Checkout epic-capybara
       uses: actions/checkout@v3
@@ -707,10 +711,14 @@ jobs:
           export PYTHONPATH=$HOME/.local/lib/python3.10/site-packages:$PYTHONPATH
           mkdir capybara-reports
           capybara bara ref/rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root
+          mv capybara-reports rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}
+          touch .rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}
     - uses: actions/upload-artifact@v3
       with:
-        name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.report
-        path: capybara-reports
+        name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.capybara
+        path: |
+          .rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}
+          rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}/
         if-no-files-found: error
     - name: Checkout epic-capybara
       uses: actions/checkout@v3
@@ -809,6 +817,14 @@ jobs:
         with:
           name: docs
           path: publishing_docs/pr/${{ matrix.pr }}/
+      - uses: dawidd6/action-download-artifact@v2
+        if: github.event.pull_request.number != matrix.pr
+        with:
+          pr: ${{ matrix.pr }}
+          path: publishing_docs/pr/${{ matrix.pr }}/capybara/
+          name: .*\.capybara
+          name_is_regexp: true
+          if_no_artifact_found: ignore
       - run: rm -rf publishing_docs/pr/*/doxygen
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This publishes the capybara diffs to the EICrecon ghpages, e.g. https://eicrecon.epic-eic.org/pr/1072/capybara/rec_dis_10x100_minQ2=1000_craterlake/#CalorimeterTrackProjections_0 (will be inactive as soon as a pipeline that doesn't support this overwrites the active ghpages deployment).

Cherry-picked from 1072.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.