### PR TITLE
fix(ci): don't compress build artifact (upload artifact does it anyway)

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -116,13 +116,13 @@ jobs:
           !.git/
           !.ccache/
         if-no-files-found: error
-    - name: Compress build directory
-      run: tar -czf build.tar.gz build/
+    - name: Archive build directory
+      run: tar -cf build.tar build/
     - name: Upload build directory
       uses: actions/upload-artifact@v3
       with:
         name: build-${{ matrix.CC }}-eic-shell-${{ matrix.CMAKE_BUILD_TYPE }}
-        path: build.tar.gz
+        path: build.tar
         if-no-files-found: error
 
   clang-tidy-iwyu:
@@ -139,8 +139,8 @@ jobs:
       with:
         name: build-clang-eic-shell-Debug
         path: .
-    - name: Uncompress build artifact
-      run: tar -zxf build.tar.gz
+    - name: Unarchive build artifact
+      run: tar -xf build.tar
     - name: Run clang-tidy on changed files
       uses: eic/run-cvmfs-osg-eic-shell@main
       if: ${{ github.event_name == 'pull_request' }}
@@ -216,7 +216,7 @@ jobs:
         name: build-clang-eic-shell-Debug
         path: .
     - name: Uncompress build artifact
-      run: tar -zxf build.tar.gz
+      run: tar -xf build.tar
     - run: sudo apt-get update
     - run: sudo apt-get install -y llvm-15 jq
     - name: llvm-cov


### PR DESCRIPTION
### Briefly, what does this PR introduce?
In #1112 we gzipped the tar, but the upload-artifact step does the compression anyway (and we can't turn it off), so we should gain some speed by just letting upload-artifact do the compression and letting the tar be faster.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.