### PR TITLE
fix: update CMAKE_CXX_STANDARD default to 20, now required by Acts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,10 +35,14 @@ include(CheckCXXCompilerFlag)
 include(cmake/git_version.cmake)
 set_git_version(CMAKE_PROJECT_VERSION)
 
-# Make C++17 a default
-if(NOT "${CMAKE_CXX_STANDARD}")
-    set(CMAKE_CXX_STANDARD 17)
+# Set default standard to C++20
+set(CMAKE_CXX_STANDARD_MIN 20)
+set(CMAKE_CXX_STANDARD ${CMAKE_CXX_STANDARD_MIN} CACHE STRING "C++ standard to be used")
+if(CMAKE_CXX_STANDARD LESS CMAKE_CXX_STANDARD_MIN)
+  message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD} (at least ${CMAKE_CXX_STANDARD_MIN} required)")
 endif()
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Export compile commands as json for run-clang-tidy
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This updates the default C++ standard from 17 to 20, which is now required by Acts. As of now, there do not appear to be any Acts headers that are using C++20 concepts (pun intended) but that should be considered a coincidence. After this PR, C++20 constructs in EICrecon are officially allowed. 

I thought about restricting it to just C++20, not allowing anything higher, but that prevents us from implementing C++23 support through the regular development process.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: we're running with C++17 standard, not enforced, and Acts headers may have C++20 features)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.