### PR TITLE
fix: link tests with --no-as-needed due to JANA #255

### DIFF
--- a/src/tests/algorithms_test/CMakeLists.txt
+++ b/src/tests/algorithms_test/CMakeLists.txt
@@ -11,6 +11,8 @@ add_executable(${TEST_NAME}
 
 # Explicit linking to podio::podio is needed due to https://github.com/JeffersonLab/JANA2/issues/151
 target_link_libraries(${TEST_NAME} PRIVATE Catch2::Catch2WithMain algorithms_calorimetry_library algorithms_pid_library podio::podio podio::podioRootIO)
+# As-needed fails due to absent podio symbols in libJANA.so (https://github.com/JeffersonLab/JANA2/pull/255)
+target_link_options(${TEST_NAME} PRIVATE "-Wl,--no-as-needed")
 
 # Install executable
 install(TARGETS ${TEST_NAME} DESTINATION bin)

--- a/src/tests/algorithms_test/CMakeLists.txt
+++ b/src/tests/algorithms_test/CMakeLists.txt
@@ -12,7 +12,9 @@ add_executable(${TEST_NAME}
 # Explicit linking to podio::podio is needed due to https://github.com/JeffersonLab/JANA2/issues/151
 target_link_libraries(${TEST_NAME} PRIVATE Catch2::Catch2WithMain algorithms_calorimetry_library algorithms_pid_library podio::podio podio::podioRootIO)
 # As-needed fails due to absent podio symbols in libJANA.so (https://github.com/JeffersonLab/JANA2/pull/255)
-target_link_options(${TEST_NAME} PRIVATE "-Wl,--no-as-needed")
+if (CMAKE_CXX_COMPILER_LINKER_ID MATCHES "GNU(gold)?")
+  target_link_options(${TEST_NAME} PRIVATE "-Wl,--no-as-needed")
+endif()
 
 # Install executable
 install(TARGETS ${TEST_NAME} DESTINATION bin)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This fixes an issue in the linking of algorithms_test which popped up today (and likely was always there...). Until https://github.com/JeffersonLab/JANA2/pull/255 is included, we install a libJANA.so with undefined references to podio because it doesn't include it in the NEEDED section. By passing `--no-as-needed` we don't strip the podio calls from the algorithms_test executables where they are unused.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.