### PR TITLE
fix: set C++std to 20, allow higher; agree with Acts and ROOT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,8 +35,8 @@ include(CheckCXXCompilerFlag)
 include(cmake/git_version.cmake)
 set_git_version(CMAKE_PROJECT_VERSION)
 
-# Set default standard to C++17
-set(CMAKE_CXX_STANDARD_MIN 17)
+# Set default standard to C++20
+set(CMAKE_CXX_STANDARD_MIN 20)
 set(CMAKE_CXX_STANDARD ${CMAKE_CXX_STANDARD_MIN} CACHE STRING "C++ standard to be used")
 if(CMAKE_CXX_STANDARD LESS CMAKE_CXX_STANDARD_MIN)
   message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD} (at least ${CMAKE_CXX_STANDARD_MIN} required)")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ endif()
 # ActsCore
 get_target_property(ACTS_COMPILE_FEATURES ActsCore INTERFACE_COMPILE_FEATURES)
 if (NOT "cxx_std_${CMAKE_CXX_STANDARD}" IN_LIST ACTS_COMPILE_FEATURES)
-  message(FATAL_ERROR "Acts has not been built with the requested C++ standard.")
+  message(WARNING "Acts has not been built with the requested C++ standard ${CMAKE_CXX_STANDARD}.")
 endif()
 
 # ROOT
@@ -160,7 +160,7 @@ find_package(ROOT REQUIRED)
 # Check that ROOT is compiled with a modern enough c++ standard
 get_target_property(ROOT_COMPILE_FEATURES ROOT::Core INTERFACE_COMPILE_FEATURES)
 if (NOT "cxx_std_${CMAKE_CXX_STANDARD}" IN_LIST ROOT_COMPILE_FEATURES)
-  message(FATAL_ERROR "ROOT has not been built with the requested C++ standard.")
+  message(WARNING "ROOT has not been built with the requested C++ standard ${CMAKE_CXX_STANDARD}.")
 endif()
 
 # Set it ON for additional CMake printout

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,8 +35,8 @@ include(CheckCXXCompilerFlag)
 include(cmake/git_version.cmake)
 set_git_version(CMAKE_PROJECT_VERSION)
 
-# Set default standard to C++20
-set(CMAKE_CXX_STANDARD_MIN 20)
+# Set default standard to C++17
+set(CMAKE_CXX_STANDARD_MIN 17)
 set(CMAKE_CXX_STANDARD ${CMAKE_CXX_STANDARD_MIN} CACHE STRING "C++ standard to be used")
 if(CMAKE_CXX_STANDARD LESS CMAKE_CXX_STANDARD_MIN)
   message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD} (at least ${CMAKE_CXX_STANDARD_MIN} required)")
@@ -149,9 +149,19 @@ if(${Acts_VERSION} VERSION_LESS ${Acts_VERSION_MIN}
         AND NOT "${Acts_VERSION}" STREQUAL "9.9.9")
     message(FATAL_ERROR "Acts version ${Acts_VERSION_MIN} or higher required, but ${Acts_VERSION} found")
 endif()
+# ActsCore
+get_target_property(ACTS_COMPILE_FEATURES ActsCore INTERFACE_COMPILE_FEATURES)
+if (NOT "cxx_std_${CMAKE_CXX_STANDARD}" IN_LIST ACTS_COMPILE_FEATURES)
+  message(FATAL_ERROR "Acts has not been built with the requested C++ standard.")
+endif()
 
-# CERN ROOT
+# ROOT
 find_package(ROOT REQUIRED)
+# Check that ROOT is compiled with a modern enough c++ standard
+get_target_property(ROOT_COMPILE_FEATURES ROOT::Core INTERFACE_COMPILE_FEATURES)
+if (NOT "cxx_std_${CMAKE_CXX_STANDARD}" IN_LIST ROOT_COMPILE_FEATURES)
+  message(FATAL_ERROR "ROOT has not been built with the requested C++ standard.")
+endif()
 
 # Set it ON for additional CMake printout
 set(EICRECON_VERBOSE_CMAKE OFF)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Maybe this is a better approach too: set by default to 17, allow user to set higher, check that C++std agrees with what ROOT and Acts are assuming.

Question: should we automatically upgrade default 17 to 20 if we find that Acts or ROOT requires it?

### What kind of change does this PR introduce?
- [x] Bug fix (issue: how to support C++17 and 20 at the same time)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.