### PR TITLE
Fix: update collections passed into factories downstream of CKF in tracking.cc

### DIFF
--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -84,14 +84,14 @@ void InitPlugin(JApplication *app) {
     ));
 
     app->Add(new JChainFactoryGeneratorT<TrackProjector_factory>(
-            {"CentralCKFActsTrajectories", "CentralCKFSeededActsTracks"}, "CentralTrackSegments"));
+            {"CentralCKFActsTrajectories", "CentralCKFActsTracks"}, "CentralTrackSegments"));
 
     app->Add(new JChainFactoryGeneratorT<IterativeVertexFinder_factory>(
-            {"CentralCKFActsTrajectories", "CentralCKFSeededActsTracks"}, "CentralTrackVertices"));
+            {"CentralCKFActsTrajectories", "CentralCKFActsTracks"}, "CentralTrackVertices"));
 
     app->Add(new JChainMultifactoryGeneratorT<TrackPropagation_factory>(
             "CalorimeterTrackPropagator",
-            {"CentralCKFActsTrajectories", "CentralCKFSeededActsTracks"},
+            {"CentralCKFActsTrajectories", "CentralCKFActsTracks"},
             {"CalorimeterTrackProjections"},
             app
             ));


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Updates track collections that are passed into algorithms downstream of CKF to make them consistent with the trajectory collections that are provided -- both are now the truth seeded CKF output.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No. None.

### Does this PR change default behavior?
No.