### PR TITLE
feat: only run clang eicrecon-{dis,gun}, no more gcc

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -500,7 +500,7 @@ jobs:
     - npsim-gun
     strategy:
       matrix:
-        CC: [gcc, clang]
+        CC: [clang]
         particle: [pi, e]
         detector_config: [craterlake]
     steps:
@@ -658,7 +658,7 @@ jobs:
     - npsim-dis
     strategy:
       matrix:
-        CC: [gcc, clang]
+        CC: [clang]
         beam: [5x41, 10x100, 18x275]
         minq2: [1, 1000]
         detector_config: [craterlake]


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Instead of clobbering the summaries, we can just run clang only. There is not a lot of value in running both gcc and clang. Would reduce our CI pipelines too.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #1137)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.