### PR TITLE
fix: install {asan,lsan,tsan,ubsan}.supp with CMake; other CMake cleanup

### DIFF
--- a/.github/tsan.supp
+++ b/.github/tsan.supp
@@ -1,0 +1,1 @@
+# https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,9 +166,6 @@ if (NOT "cxx_std_${CMAKE_CXX_STANDARD}" IN_LIST ROOT_COMPILE_FEATURES)
   message(WARNING "ROOT has not been built with the requested C++ standard ${CMAKE_CXX_STANDARD}.")
 endif()
 
-# Set it ON for additional CMake printout
-set(EICRECON_VERBOSE_CMAKE OFF)
-
 
 # Add CMake additional functionality:
 include(cmake/print_functions.cmake)                        # Helpers to print fancy headers, file names, etc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@
 
 cmake_minimum_required(VERSION 3.18)
 
-project(EICRecon)
+project(EICrecon)
 
 # CMake includes
 include(CheckCXXCompilerFlag)
@@ -71,6 +71,9 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 if( ${CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT} )
     set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR} CACHE PATH "Install in top directory by default" FORCE)
 endif()
+
+# Install to standard location
+include(GNUInstallDirs)
 
 # Default plugins installation directory is 'plugins'
 if(NOT DEFINED PLUGIN_OUTPUT_DIRECTORY)
@@ -179,6 +182,7 @@ option(USE_ASAN "Compile with address sanitizer" OFF)
 if (${USE_ASAN})
     add_compile_options(-fsanitize=address -fno-omit-frame-pointer -g -O1)
     add_link_options(-fsanitize=address)
+    install(FILES .github/asan.supp .github/lsan.supp DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME})
 endif()
 
 # Thread sanitizer
@@ -186,6 +190,7 @@ option(USE_TSAN "Compile with thread sanitizer" OFF)
 if (${USE_TSAN})
     add_compile_options(-fsanitize=thread -g -O1)
     add_link_options(-fsanitize=thread)
+    install(FILES .github/tsan.supp DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME})
 endif()
 
 # Undefined behavior sanitizer
@@ -199,6 +204,7 @@ if (${USE_UBSAN})
         endif()
     endforeach()
     add_compile_options(-g -O1)
+    install(FILES .github/ubsan.supp DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME})
 endif()
 
 # Compress debug symbols if supported

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ include(GNUInstallDirs)
 
 # Default plugins installation directory is 'plugins'
 if(NOT DEFINED PLUGIN_OUTPUT_DIRECTORY)
-    set(PLUGIN_OUTPUT_DIRECTORY "lib/EICrecon/plugins")
+    set(PLUGIN_OUTPUT_DIRECTORY "lib/${PROJECT_NAME}/plugins")
     message(STATUS "${CMAKE_PROJECT_NAME}: Set default PLUGIN_OUTPUT_DIRECTORY")
 endif()
 message(STATUS "${CMAKE_PROJECT_NAME}: PLUGIN_OUTPUT_DIRECTORY: ${PLUGIN_OUTPUT_DIRECTORY}")
@@ -223,7 +223,5 @@ add_subdirectory( src/utilities )
 
 # Install all cmake helpers
 include(CMakePackageConfigHelpers)
-configure_package_config_file(cmake/EICreconConfig.cmake.in cmake/EICreconConfig.cmake INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cmake/EICrecon)
-install(FILES ${CMAKE_BINARY_DIR}/cmake/EICreconConfig.cmake DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cmake/EICrecon)  # why is this needed?
-file(GLOB EICRECON_CMAKE_FILES cmake/*.cmake)
-install(FILES ${EICRECON_CMAKE_FILES} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cmake/EICrecon)
+configure_package_config_file(cmake/${PROJECT_NAME}Config.cmake.in cmake/${PROJECT_NAME}Config.cmake INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+install(DIRECTORY cmake/ DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME} FILES_MATCHING PATTERN *.cmake)

--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -156,23 +156,19 @@ macro(plugin_glob_all _name)
         # Remove plugin.cc file from libraries
         list(REMOVE_ITEM LIB_SRC_FILES ${PLUGIN_CC_FILE_ABS})
 
-        # >oO Debug output if needed
-        if(${EICRECON_VERBOSE_CMAKE})
-            message(STATUS "plugin_glob_all:${_name}: LIB_SRC_FILES    ${LIB_SRC_FILES}")
-        endif()
+        # Debug output if needed
+        message(VERBOSE "plugin_glob_all:${_name}: LIB_SRC_FILES    ${LIB_SRC_FILES}")
 
         # Finally add sources to library
         target_sources(${_name}_library PRIVATE ${LIB_SRC_FILES})
     endif()     # WITH_LIBRARY
 
-    # >oO Debug output if needed
-    if(${EICRECON_VERBOSE_CMAKE})
-        message(STATUS "plugin_glob_all:${_name}: PLUGIN_CC_FILE   ${PLUGIN_CC_FILE}")
-        message(STATUS "plugin_glob_all:${_name}: LIB_SRC_FILES    ${LIB_SRC_FILES}")
-        message(STATUS "plugin_glob_all:${_name}: PLUGIN_SRC_FILES ${PLUGIN_SRC_FILES}")
-        message(STATUS "plugin_glob_all:${_name}: HEADER_FILES     ${HEADER_FILES}")
-        message(STATUS "plugin_glob_all:${_name}: PLUGIN_RLTV_PATH ${PLUGIN_RELATIVE_PATH}")
-    endif()
+    # Debug output if needed
+    message(VERBOSE "plugin_glob_all:${_name}: PLUGIN_CC_FILE   ${PLUGIN_CC_FILE}")
+    message(VERBOSE "plugin_glob_all:${_name}: LIB_SRC_FILES    ${LIB_SRC_FILES}")
+    message(VERBOSE "plugin_glob_all:${_name}: PLUGIN_SRC_FILES ${PLUGIN_SRC_FILES}")
+    message(VERBOSE "plugin_glob_all:${_name}: HEADER_FILES     ${HEADER_FILES}")
+    message(VERBOSE "plugin_glob_all:${_name}: PLUGIN_RLTV_PATH ${PLUGIN_RELATIVE_PATH}")
 
 endmacro()
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This installs the {asan,lsan,tsan,ubsan}.supp files into `share/EICrecon` when the installation has support for the respective sanitizers. At this point I'm leaving the *.supp files in .github/ since we don't have an equivalent other directory, and with the current practice of in-tree installations we don't really want to use share/ itself.

It also applies a few minor CMake cleanups:
- use `message(VERBOSE)` instead of an EICRECON flag; one can use `cmake --log-level VERBOSE` to print this,
- include GNUInstallDirs for consistent directory support (not yet propagated to plugins)
- use install DIRECTORY with FILE_PATTERN for cmake/*.cmake files instead of a GLOB

### What kind of change does this PR introduce?
- [x] Bug fix (issue #1126)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.