### PR TITLE
fix: pass TrackerHitCollection to TrackerMeasurement, not std::vector<T*>

### DIFF
--- a/src/algorithms/tracking/TrackerMeasurementFromHits.h
+++ b/src/algorithms/tracking/TrackerMeasurementFromHits.h
@@ -13,7 +13,6 @@
 #include <edm4eic/TrackerHitCollection.h>
 #include <spdlog/logger.h>
 #include <memory>
-#include <vector>
 
 #include "ActsGeometryProvider.h"
 

--- a/src/algorithms/tracking/TrackerMeasurementFromHits.h
+++ b/src/algorithms/tracking/TrackerMeasurementFromHits.h
@@ -26,7 +26,7 @@ namespace eicrecon {
                   std::shared_ptr<const ActsGeometryProvider> acts_context,
                   std::shared_ptr<spdlog::logger> logger);
 
-        std::unique_ptr<edm4eic::Measurement2DCollection> produce(std::vector<const edm4eic::TrackerHit*> trk_hits);
+        std::unique_ptr<edm4eic::Measurement2DCollection> produce(const edm4eic::TrackerHitCollection& trk_hits);
 
     private:
         std::shared_ptr<spdlog::logger> m_log;

--- a/src/global/tracking/TrackerMeasurementFromHits_factory.cc
+++ b/src/global/tracking/TrackerMeasurementFromHits_factory.cc
@@ -10,7 +10,6 @@
 #include <edm4eic/TrackerHitCollection.h>
 #include <exception>
 #include <gsl/pointers>
-#include <map>
 
 #include "algorithms/tracking/TrackerMeasurementFromHits.h"
 #include "extensions/spdlog/SpdlogExtensions.h"

--- a/src/global/tracking/TrackerMeasurementFromHits_factory.cc
+++ b/src/global/tracking/TrackerMeasurementFromHits_factory.cc
@@ -61,11 +61,12 @@ namespace eicrecon {
 
     void TrackerMeasurementFromHits_factory::Process(const std::shared_ptr<const JEvent> &event) {
         // Collect all hits
-        std::vector<const edm4eic::TrackerHit*> total_hits;
+        edm4eic::TrackerHitCollection total_hits;
+        total_hits.setSubsetCollection();
 
-        for(auto input_tag: m_input_tags) {
-            auto hits = event->Get<edm4eic::TrackerHit>(input_tag);
-            for (const auto *const hit : hits) {
+        for (const auto& input_tag: m_input_tags) {
+            auto hits = static_cast<const edm4eic::TrackerHitCollection*>(event->GetCollectionBase(input_tag));
+            for (const auto& hit : *hits) {
                 total_hits.push_back(hit);
             }
         }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Instead of passing a std::vector<T*> to the TrackerMeasurementFromHits algorithm, we should pass a TrackerHitCollection. This PR modifies the algorithm and factory. The factory accepts an array of input collections in a similar way as the TrackerHitCollector does, but that functionality is not currently used (since we use the TrackerHitCollector). Nevertheless, it means we also need to use a subset collection here.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #1145)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.