### PR TITLE
feat: use algorithms:: interface CalorimeterHitDigi (incl RandomSvc)

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -111,13 +111,17 @@ void CalorimeterHitDigi::init(const dd4hep::Detector* detector, std::shared_ptr<
 }
 
 
-std::unique_ptr<edm4hep::RawCalorimeterHitCollection> CalorimeterHitDigi::process(const edm4hep::SimCalorimeterHitCollection &simhits)  {
-    auto rawhits = std::make_unique<edm4hep::RawCalorimeterHitCollection>();
+void CalorimeterHitDigi::process(
+      const CalorimeterHitDigi::Input& input,
+      const CalorimeterHitDigi::Output& output) const {
+
+    const auto [simhits] = input;
+    auto [rawhits] = output;
 
     // find the hits that belong to the same group (for merging)
     std::unordered_map<uint64_t, std::vector<std::size_t>> merge_map;
     std::size_t ix = 0;
-    for (const auto &ahit : simhits) {
+    for (const auto &ahit : *simhits) {
         uint64_t hid = ahit.getCellID() & id_mask;
 
         m_log->trace("org cell ID in {:s}: {:#064b}", m_cfg.readout, ahit.getCellID());
@@ -134,10 +138,10 @@ std::unique_ptr<edm4hep::RawCalorimeterHitCollection> CalorimeterHitDigi::proces
         double edep     = 0;
         double time     = std::numeric_limits<double>::max();
         double max_edep = 0;
-        auto   mid      = simhits[ixs[0]].getCellID();
+        auto   mid      = (*simhits)[ixs[0]].getCellID();
         // sum energy, take time from the most energetic hit
         for (size_t i = 0; i < ixs.size(); ++i) {
-            auto hit = simhits[ixs[i]];
+            auto hit = (*simhits)[ixs[i]];
 
             double timeC = std::numeric_limits<double>::max();
             for (const auto& c : hit.getContributions()) {
@@ -162,15 +166,15 @@ std::unique_ptr<edm4hep::RawCalorimeterHitCollection> CalorimeterHitDigi::proces
 
         // safety check
         const double eResRel = (edep > m_cfg.threshold)
-                ? m_normDist(generator) * std::sqrt(
+                ? m_rng.gaussian<double>(0., 1.) * std::sqrt(
                      std::pow(m_cfg.eRes[0] / std::sqrt(edep), 2) +
                      std::pow(m_cfg.eRes[1], 2) +
                      std::pow(m_cfg.eRes[2] / (edep), 2)
                   )
                 : 0;
-        double    ped     = m_cfg.pedMeanADC + m_normDist(generator) * m_cfg.pedSigmaADC;
+        double    ped     = m_cfg.pedMeanADC + m_rng.gaussian<double>(0., 1.) * m_cfg.pedSigmaADC;
         unsigned long long adc     = std::llround(ped + edep * m_cfg.corrMeanScale * ( 1.0 + eResRel) / m_cfg.dyRangeADC * m_cfg.capADC);
-        unsigned long long tdc     = std::llround((time + m_normDist(generator) * tRes) * stepTDC);
+        unsigned long long tdc     = std::llround((time + m_rng.gaussian<double>(0., 1.) * tRes) * stepTDC);
 
         if (edep> 1.e-3) m_log->trace("E sim {} \t adc: {} \t time: {}\t maxtime: {} \t tdc: {}", edep, adc, time, m_cfg.capTime, tdc);
         rawhits->create(
@@ -179,8 +183,6 @@ std::unique_ptr<edm4hep::RawCalorimeterHitCollection> CalorimeterHitDigi::proces
                 tdc
         );
     }
-
-    return std::move(rawhits);
 }
 
 } // namespace eicrecon

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -20,6 +20,7 @@
 #include <Evaluator/DD4hepUnits.h>
 #include <edm4hep/CaloHitContributionCollection.h>
 #include <fmt/core.h>
+#include <gsl/pointers>
 #include <podio/RelationRange.h>
 #include <algorithm>
 #include <cmath>
@@ -31,7 +32,6 @@
 #include <tuple>
 #include <type_traits>
 #include <unordered_map>
-#include <utility>
 #include <vector>
 
 #include "algorithms/calorimetry/CalorimeterHitDigiConfig.h"

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.h
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.h
@@ -14,6 +14,8 @@
 #pragma once
 
 #include <DD4hep/Detector.h>
+#include <algorithms/algorithm.h>
+#include <algorithms/random.h>
 #include <edm4hep/RawCalorimeterHitCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
 #include <spdlog/logger.h>
@@ -26,11 +28,29 @@
 
 namespace eicrecon {
 
-  class CalorimeterHitDigi : public WithPodConfig<CalorimeterHitDigiConfig> {
+  using CalorimeterHitDigiAlgorithm = algorithms::Algorithm<
+    algorithms::Input<
+      edm4hep::SimCalorimeterHitCollection
+    >,
+    algorithms::Output<
+      edm4hep::RawCalorimeterHitCollection
+    >
+  >;
+
+  class CalorimeterHitDigi
+  : public CalorimeterHitDigiAlgorithm,
+    public WithPodConfig<CalorimeterHitDigiConfig> {
 
   public:
+    CalorimeterHitDigi(std::string_view name)
+      : CalorimeterHitDigiAlgorithm{name,
+                            {"inputHitCollection"},
+                            {"outputRawHitCollection"},
+                            "Smear energy deposit, digitize within ADC range, add pedestal, "
+                            "convert time with smearing resolution, and sum signals."} {}
+
     void init(const dd4hep::Detector* detector, std::shared_ptr<spdlog::logger>& logger);
-    std::unique_ptr<edm4hep::RawCalorimeterHitCollection> process(const edm4hep::SimCalorimeterHitCollection &simhits) ;
+    void process(const Input&, const Output&) const final;
 
   private:
 
@@ -43,8 +63,8 @@ namespace eicrecon {
     const dd4hep::Detector* m_detector;
     std::shared_ptr<spdlog::logger> m_log;
 
-    std::default_random_engine generator; // TODO: need something more appropriate here
-    std::normal_distribution<double> m_normDist; // defaults to mean=0, sigma=1
+  private:
+    algorithms::Generator m_rng = algorithms::RandomSvc::instance().generator();
 
   };
 

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.h
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.h
@@ -21,7 +21,8 @@
 #include <spdlog/logger.h>
 #include <stdint.h>
 #include <memory>
-#include <random>
+#include <string>
+#include <string_view>
 
 #include "CalorimeterHitDigiConfig.h"
 #include "algorithms/interfaces/WithPodConfig.h"

--- a/src/factories/calorimetry/CalorimeterHitDigi_factoryT.h
+++ b/src/factories/calorimetry/CalorimeterHitDigi_factoryT.h
@@ -23,7 +23,7 @@ namespace eicrecon {
         const std::vector<std::string>& input_tags,
         const std::vector<std::string>& output_tags,
         CalorimeterHitDigiConfig cfg)
-    : JChainMultifactoryT<CalorimeterHitDigiConfig>(std::move(tag), input_tags, output_tags, cfg) {
+    : JChainMultifactoryT<CalorimeterHitDigiConfig>(tag, input_tags, output_tags, cfg), m_algo(tag) {
 
       DeclarePodioOutput<edm4hep::RawCalorimeterHit>(GetOutputTags()[0]);
 
@@ -65,7 +65,8 @@ namespace eicrecon {
         auto hits = static_cast<const edm4hep::SimCalorimeterHitCollection*>(event->GetCollectionBase(GetInputTags()[0]));
 
         try {
-            auto raw_hits = m_algo.process(*hits);
+            auto raw_hits = std::make_unique<edm4hep::RawCalorimeterHitCollection>();
+            m_algo.process({hits}, {raw_hits.get()});
             SetCollection<edm4hep::RawCalorimeterHit>(GetOutputTags()[0], std::move(raw_hits));
         }
         catch(std::exception &e) {

--- a/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
@@ -14,6 +14,7 @@
 #include <spdlog/spdlog.h>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "algorithms/calorimetry/CalorimeterHitDigi.h"

--- a/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
@@ -23,7 +23,7 @@ using eicrecon::CalorimeterHitDigi;
 using eicrecon::CalorimeterHitDigiConfig;
 
 TEST_CASE( "the clustering algorithm runs", "[CalorimeterHitDigi]" ) {
-  CalorimeterHitDigi algo;
+  CalorimeterHitDigi algo("test");
 
   std::shared_ptr<spdlog::logger> logger = spdlog::default_logger()->clone("CalorimeterHitDigi");
   logger->set_level(spdlog::level::trace);
@@ -47,9 +47,9 @@ TEST_CASE( "the clustering algorithm runs", "[CalorimeterHitDigi]" ) {
     algo.applyConfig(cfg);
     algo.init(detector.get(), logger);
 
-    edm4hep::CaloHitContributionCollection calohits;
-    edm4hep::SimCalorimeterHitCollection simhits;
-    auto mhit = simhits.create(
+    auto calohits = std::make_unique<edm4hep::CaloHitContributionCollection>();
+    auto simhits = std::make_unique<edm4hep::SimCalorimeterHitCollection>();
+    auto mhit = simhits->create(
       0xABABABAB, // std::uint64_t cellID
       1.0 /* GeV */, // float energy
       edm4hep::Vector3f({0. /* mm */, 0. /* mm */, 0. /* mm */}) // edm4hep::Vector3f position
@@ -67,7 +67,8 @@ TEST_CASE( "the clustering algorithm runs", "[CalorimeterHitDigi]" ) {
       edm4hep::Vector3f({0. /* mm */, 0. /* mm */, 0. /* mm */}) // edm4hep::Vector3f stepPosition
     ));
 
-    std::unique_ptr<edm4hep::RawCalorimeterHitCollection> rawhits = algo.process(simhits);
+    auto rawhits = std::make_unique<edm4hep::RawCalorimeterHitCollection>();
+    algo.process({simhits.get()}, {rawhits.get()});
 
     REQUIRE( (*rawhits).size() == 1 );
     REQUIRE( (*rawhits)[0].getCellID() == 0xABABABAB);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
In the ongoing attempts at making the algorithms self-descriptive and conformant to the algorithms:: specification, this converts another one: CalorimeterHitDigi. This wasn't as straightforward as CalorimeterClusterRecoCoG because of the RandomSvc. No attempt is made to connect a JANA2 random service (in part because I don't think JANA2 has one; @nathanwbrei is that still true?). Due to the change of random generator, this is not expected to agree bit-for-bit with what is in main.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added: algorithms_test/calorimetry_CalorimeterHitDigi.cc needed some modifications to deal with the unique pointer memory model.
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @sly2j 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.