### PR TITLE
fix(ci): run clang-tidy with extra-args -std=c++20

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -147,14 +147,14 @@ jobs:
       with:
         platform-release: "${{ env.platform-release }}"
         run: |
-          git diff ${{github.event.pull_request.base.sha}} ${{ github.event.pull_request.base.sha }} | clang-tidy-diff -p 1 -path build -quiet -export-fixes clang_tidy_fixes.yml -extra-arg='-std=c++17' -checks='-*,bugprone-*,-bugprone-narrowing-conversions' -clang-tidy-binary run-clang-tidy
+          git diff ${{github.event.pull_request.base.sha}} ${{ github.event.pull_request.base.sha }} | clang-tidy-diff -p 1 -path build -quiet -export-fixes clang_tidy_fixes.yml -extra-arg='-std=c++20' -checks='-*,bugprone-*,-bugprone-narrowing-conversions' -clang-tidy-binary run-clang-tidy
     - name: Run clang-tidy on all files
       uses: eic/run-cvmfs-osg-eic-shell@main
       if: ${{ github.event_name == 'push' }}
       with:
         platform-release: "${{ env.platform-release }}"
         run: |
-          run-clang-tidy -p build -export-fixes clang_tidy_fixes.yml -extra-arg='-std=c++17'
+          run-clang-tidy -p build -export-fixes clang_tidy_fixes.yml -extra-arg='-std=c++20'
     - name: Upload clang-tidy fixes as artifact
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This should address the clang-tidy issues on main (and likely soon in a PR). clang-tidy runs without errors in my local eic-shell test setup now.

I considered adding the logic to allow the builds to be against a variable that encodes the C++ standard, but that quickly ran out of hand (see discussion on doing this for compilers). With one standard every three years, I think it's reasonable to deal with this as we go. We only support C++20 now anyway.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #1149)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.