### PR TITLE
fix: avoid narrowing warning with decltype in MergeParticleID

### DIFF
--- a/src/algorithms/pid/MergeParticleID.cc
+++ b/src/algorithms/pid/MergeParticleID.cc
@@ -78,7 +78,7 @@ std::unique_ptr<edm4eic::CherenkovParticleIDCollection> eicrecon::MergeParticleI
 
   // fill `particle_pids`
   // -------------------------------------------------------------------------------
-  std::unordered_map< unsigned int, std::vector<std::pair<size_t,size_t>> > particle_pids;
+  std::unordered_map< decltype(podio::ObjectID::index), std::vector<std::pair<size_t,size_t>> > particle_pids;
   m_log->trace("{:-<70}","Build `particle_pids` indexing data structure ");
 
   // loop over list of PID collections


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This minor fix addresses a warning, e.g. at https://github.com/eic/EICrecon/actions/runs/7024158171/job/19112268764#step:7:295. Instead of forcing unsigned int, this uses the decltype of podio::ObjectID::index.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: compiler warning)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.