### PR TITLE
fix: more generic iwyu command line interface

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -175,8 +175,8 @@ jobs:
           while [[ ${sha:-} != $(git diff | sha256sum) ]] ; do
             sha=$(git diff | sha256sum)
             echo $sha
-            iwyu_tool -p build $(git diff --name-only ${{github.event.pull_request.head.sha}} ${{ github.event.pull_request.base.sha }}) -- -Xiwyu --verbose=3 -Xiwyu --no_fwd_decls -Xiwyu --cxx17ns -Xiwyu --mapping_file=${{github.workspace}}/.github/iwyu.imp | tee iwyu_fixes.log
-            fix_include --blank_lines --nosafe_headers --reorder --separate_project_includes="<tld>" --keep_iwyu_namespace_format < iwyu_fixes.log
+            iwyu_tool.py -p build $(git diff --name-only ${{github.event.pull_request.head.sha}} ${{ github.event.pull_request.base.sha }}) -- -Xiwyu --verbose=3 -Xiwyu --no_fwd_decls -Xiwyu --cxx17ns -Xiwyu --mapping_file=${{github.workspace}}/.github/iwyu.imp | tee iwyu_fixes.log
+            fix_includes.py --blank_lines --nosafe_headers --reorder --separate_project_includes="<tld>" --keep_iwyu_namespace_format < iwyu_fixes.log
             git diff | tee iwyu_fixes.patch
           done
     - name: Run include-what-you-use (iwyu) on all files
@@ -186,8 +186,8 @@ jobs:
         platform-release: "${{ env.platform-release }}"
         run: |
           # don't aim for stability for all files
-          iwyu_tool -p build -- -Xiwyu --verbose=3 -Xiwyu --no_fwd_decls -Xiwyu --cxx17ns -Xiwyu --mapping_file=${{github.workspace}}/.github/iwyu.imp | tee iwyu_fixes.log
-          fix_include --blank_lines --nosafe_headers --reorder --separate_project_includes="<tld>" --keep_iwyu_namespace_format < iwyu_fixes.log
+          iwyu_tool.py -p build -- -Xiwyu --verbose=3 -Xiwyu --no_fwd_decls -Xiwyu --cxx17ns -Xiwyu --mapping_file=${{github.workspace}}/.github/iwyu.imp | tee iwyu_fixes.log
+          fix_includes.py --blank_lines --nosafe_headers --reorder --separate_project_includes="<tld>" --keep_iwyu_namespace_format < iwyu_fixes.log
           git diff | tee iwyu_fixes.patch
     - name: Upload iwyu patch as artifact
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
### Briefly, what does this PR introduce?
IWYU as previously installed was exposing non-standard commands as defined by the Debian package. Since we moved to the spack package, we have to revert back to the original command names.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.