### PR TITLE
fix: Output uses collection_name; Input uses GetCollection in JOmniFactory.h

### DIFF
--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -121,11 +121,11 @@ public:
         friend class JOmniFactory;
 
         void CreateHelperFactory(JOmniFactory& fac) override {
-            fac.DeclareOutput<T>(this->tag_name);
+            fac.DeclareOutput<T>(this->collection_name);
         }
 
         void SetCollection(JOmniFactory& fac) override {
-            fac.SetData<T>(this->tag_name, this->data);
+            fac.SetData<T>(this->collection_name, this->m_data);
         }
 
         void Reset() override { }

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -55,7 +55,7 @@ public:
     private:
         friend class JOmniFactory;
 
-        void GetData(const JEvent& event) {
+        void GetCollection(const JEvent& event) {
             m_data = event.Get<T>(this->collection_name);
         }
     };

--- a/src/tests/omnifactory_test/JOmniFactoryTests.cc
+++ b/src/tests/omnifactory_test/JOmniFactoryTests.cc
@@ -28,6 +28,7 @@ struct BasicTestAlg : public JOmniFactory<BasicTestAlg, BasicTestAlgConfig> {
 
     PodioOutput<edm4hep::SimCalorimeterHit> output_hits_left {this, "output_hits_left"};
     PodioOutput<edm4hep::SimCalorimeterHit> output_hits_right {this, "output_hits_right"};
+    Output<std::string> day_of_the_week {this, "day_of_the_week"};
 
     ParameterRef<int> bucket_count {this, "bucket_count", config().bucket_count, "The total number of buckets [dimensionless]"};
     ParameterRef<double> threshold {this, "threshold", config().threshold, "The max cutoff threshold [V * A * kg^-1 * m^-2 * sec^-3]"};


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Small fix to be able to use `Output` in JOmniFactory.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/EICrecon/pull/1168#issuecomment-1839508786)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.