### PR TITLE
fix: disable bugprone-unchecked-optional-access in .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,6 +6,7 @@ Checks: '
   modernize-*,
   portability-*,
   readability-*,
+  -bugprone-unchecked-optional-access,
   -modernize-use-trailing-return-type,
   -modernize-avoid-c-arrays,
   -modernize-use-nodiscard,


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This may fix #1172 by disabling a problematic test. Without this change, I can reproduce the timeouts. With this change, I am not seeing the timeouts anymore.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #1172)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.