### PR TITLE
feat: use unique_ptr in MatchClusters; require all collections in reco.cc

### DIFF
--- a/src/algorithms/reco/MatchClusters.cc
+++ b/src/algorithms/reco/MatchClusters.cc
@@ -39,8 +39,8 @@ namespace eicrecon {
         m_log->debug("Processing cluster info for new event");
 
         // Resulting reconstructed particles and associations
-        auto* outparts = new edm4eic::ReconstructedParticleCollection();
-        auto* outpartsassoc = new edm4eic::MCRecoParticleAssociationCollection();
+        auto outparts = std::make_unique<edm4eic::ReconstructedParticleCollection>();
+        auto outpartsassoc = std::make_unique<edm4eic::MCRecoParticleAssociationCollection>();
 
         m_log->debug("Step 0/2: Getting indexed list of clusters...");
 
@@ -128,7 +128,7 @@ namespace eicrecon {
             assoc.setSim((*mcparticles)[mcID]);
         }
 
-        return {outparts, outpartsassoc};
+        return {std::move(outparts), std::move(outpartsassoc)};
     }
 
 

--- a/src/algorithms/reco/MatchClusters.h
+++ b/src/algorithms/reco/MatchClusters.h
@@ -27,7 +27,10 @@ namespace eicrecon {
 
     public:
 
-        using MatchingResults = std::tuple<edm4eic::ReconstructedParticleCollection*, edm4eic::MCRecoParticleAssociationCollection*>;
+        using MatchingResults = std::tuple<
+            std::unique_ptr<edm4eic::ReconstructedParticleCollection>,
+            std::unique_ptr<edm4eic::MCRecoParticleAssociationCollection>
+        >;
 
         void init(std::shared_ptr<spdlog::logger> logger);
 

--- a/src/global/reco/MatchClusters_factory.cc
+++ b/src/global/reco/MatchClusters_factory.cc
@@ -30,10 +30,10 @@ namespace eicrecon {
     }
 
     void MatchClusters_factory::Process(const std::shared_ptr<const JEvent> &event) {
-        size_t i = 0;
-        auto mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase(GetInputTags()[i++]));
-        auto charged_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase(GetInputTags()[i++]));
-        auto charged_particle_assocs = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase(GetInputTags()[i++]));
+        size_t tag_ix = 0;
+        auto mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase(GetInputTags()[tag_ix++]));
+        auto charged_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase(GetInputTags()[tag_ix++]));
+        auto charged_particle_assocs = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase(GetInputTags()[tag_ix++]));
 
         std::vector<const edm4eic::ClusterCollection*> cluster_collections;
         std::vector<const edm4eic::MCRecoClusterParticleAssociationCollection*> cluster_assoc_collections;
@@ -43,7 +43,7 @@ namespace eicrecon {
             return [s = -1, n](auto const&) mutable { s = (s + 1) % n; return s == 0; };
         };
 
-        for (auto& input_tag : GetInputTags() | std::views::drop(i) | std::views::filter(stride(2))) {
+        for (auto& input_tag : GetInputTags() | std::views::drop(tag_ix) | std::views::filter(stride(2))) {
             auto clusters = static_cast<const edm4eic::ClusterCollection*>(event->GetCollectionBase(input_tag));
             cluster_collections.push_back(clusters);
 
@@ -53,7 +53,7 @@ namespace eicrecon {
             }
         }
 
-        for (auto& input_tag : GetInputTags() | std::views::drop(i+1) | std::views::filter(stride(2))) {
+        for (auto& input_tag : GetInputTags() | std::views::drop(tag_ix + 1) | std::views::filter(stride(2))) {
             auto assocs = static_cast<const edm4eic::MCRecoClusterParticleAssociationCollection*>(event->GetCollectionBase(input_tag));
             cluster_assoc_collections.push_back(assocs);
 

--- a/src/global/reco/MatchClusters_factory.cc
+++ b/src/global/reco/MatchClusters_factory.cc
@@ -10,8 +10,8 @@
 #include <podio/ObjectID.h>
 #include <spdlog/logger.h>
 #include <memory>
-#include <stdexcept>
 #include <ranges>
+#include <stdexcept>
 
 #include "MatchClusters_factory.h"
 

--- a/src/global/reco/MatchClusters_factory.cc
+++ b/src/global/reco/MatchClusters_factory.cc
@@ -24,20 +24,6 @@ namespace eicrecon {
         InitLogger(GetApplication(), GetPrefix(), "info");
 
         m_match_algo.init(m_log);
-
-        // Set up association tags
-        for (const std::string& input_tag : GetInputTags()) {
-            // "EcalEndcapNClusters" => "EcalEndcapNClusterAssociations"
-            auto pos = input_tag.find("Clusters");
-
-            // Validate that our input collection names conform to this convention
-            if (pos == std::string::npos) {
-                throw std::runtime_error(fmt::format("input_tag=\"{}\" doesn't end with \"Clusters\"", input_tag));
-            }
-            std::string output_tag = input_tag;
-            output_tag.replace(pos, 8, "ClusterAssociations");
-            m_input_assoc_tags.push_back(output_tag);
-        }
     }
 
     void MatchClusters_factory::BeginRun(const std::shared_ptr<const JEvent> &event) {

--- a/src/global/reco/MatchClusters_factory.cc
+++ b/src/global/reco/MatchClusters_factory.cc
@@ -11,7 +11,6 @@
 #include <spdlog/logger.h>
 #include <memory>
 #include <ranges>
-#include <stdexcept>
 
 #include "MatchClusters_factory.h"
 

--- a/src/global/reco/MatchClusters_factory.h
+++ b/src/global/reco/MatchClusters_factory.h
@@ -45,7 +45,6 @@ namespace eicrecon {
         void Process(const std::shared_ptr<const JEvent> &event) override;
     protected:
 
-        std::vector<std::string> m_input_assoc_tags;
         MatchClusters m_match_algo;
 
     };

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -39,9 +39,16 @@ void InitPlugin(JApplication *app) {
 
     app->Add(new JChainMultifactoryGeneratorT<MatchClusters_factory>(
         "ReconstructedParticlesWithAssoc",
-        { "EcalEndcapNClusters",
+        { 
+          "MCParticles",
+          "ReconstructedChargedParticles",
+          "ReconstructedChargedParticleAssociations",
+          "EcalEndcapNClusters",
+          "EcalEndcapNClusterAssociations",
           "EcalBarrelScFiClusters",
+          "EcalBarrelScFiClusterAssociations",
           "EcalEndcapPClusters",
+          "EcalEndcapPClusterAssociations"
         },
         { "ReconstructedParticles",           // edm4eic::ReconstructedParticle
           "ReconstructedParticleAssociations" // edm4eic::MCRecoParticleAssociation

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -39,7 +39,7 @@ void InitPlugin(JApplication *app) {
 
     app->Add(new JChainMultifactoryGeneratorT<MatchClusters_factory>(
         "ReconstructedParticlesWithAssoc",
-        { 
+        {
           "MCParticles",
           "ReconstructedChargedParticles",
           "ReconstructedChargedParticleAssociations",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
MatchClusters is trying to be clever in the factory, while at the same time assuming hardcoded collection names. This changes the MatchClusters factory to require MCParticles, ReconstructedChargedParticles, and ReconstructedChargedParticleAssociations as first collections, then a sequence of XClusters, XClusterAssociations (instead of building the Associations listing itself). This makes the reco.cc more complete and less dependent on MatchCluster_factory magic.

This also modifies MatchClusters the algorithm to return tuple<unique_ptr<Collection> x 2>.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.