### PR TITLE
fix: adopt algorithms:: interface in CalorimeterHitReco

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <cctype>
 #include <functional>
+#include <gsl/pointers>
 #include <map>
 #include <ostream>
 #include <stdexcept>

--- a/src/algorithms/calorimetry/CalorimeterHitReco.h
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.h
@@ -19,6 +19,8 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <memory>
+#include <string>
+#include <string_view>
 
 #include "CalorimeterHitRecoConfig.h"
 #include "algorithms/interfaces/WithPodConfig.h"

--- a/src/algorithms/calorimetry/CalorimeterHitReco.h
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.h
@@ -12,6 +12,7 @@
 #include <DD4hep/Detector.h>
 #include <DDRec/CellIDPositionConverter.h>
 #include <Parsers/Primitives.h>
+#include <algorithms/algorithm.h>
 #include <edm4eic/CalorimeterHitCollection.h>
 #include <edm4hep/RawCalorimeterHitCollection.h>
 #include <spdlog/logger.h>
@@ -24,11 +25,28 @@
 
 namespace eicrecon {
 
-  class CalorimeterHitReco : public WithPodConfig<CalorimeterHitRecoConfig> {
+  using CalorimeterHitRecoAlgorithm = algorithms::Algorithm<
+    algorithms::Input<
+      edm4hep::RawCalorimeterHitCollection
+    >,
+    algorithms::Output<
+      edm4eic::CalorimeterHitCollection
+    >
+  >;
+
+  class CalorimeterHitReco
+    : public CalorimeterHitRecoAlgorithm,
+      public WithPodConfig<CalorimeterHitRecoConfig> {
 
   public:
+    CalorimeterHitReco(std::string_view name)
+      : CalorimeterHitRecoAlgorithm{name,
+                            {"inputRawHitCollection"},
+                            {"outputRecHitCollection"},
+                            "Reconstruct hit from digitized input."} {}
+
     void init(const dd4hep::Detector* detector, const dd4hep::rec::CellIDPositionConverter* converter, std::shared_ptr<spdlog::logger>& logger);
-    std::unique_ptr<edm4eic::CalorimeterHitCollection> process(const edm4hep::RawCalorimeterHitCollection &rawhits);
+    void process(const Input&, const Output&) const final;
 
   private:
 
@@ -37,14 +55,15 @@ namespace eicrecon {
     double stepTDC{0};
 
     dd4hep::BitFieldCoder* id_dec = nullptr;
-    uint32_t NcellIDerrors = 0;
+
+    mutable uint32_t NcellIDerrors = 0;
     uint32_t MaxCellIDerrors = 100;
 
     size_t sector_idx{0}, layer_idx{0};
 
-    bool warned_unsupported_segmentation = false;
+    mutable bool warned_unsupported_segmentation = false;
 
-    dd4hep::DetElement local;
+    dd4hep::DetElement m_local;
     size_t local_mask = ~static_cast<size_t>(0), gpos_mask = static_cast<size_t>(0);
 
   private:

--- a/src/factories/calorimetry/CalorimeterHitReco_factory.h
+++ b/src/factories/calorimetry/CalorimeterHitReco_factory.h
@@ -13,7 +13,10 @@ namespace eicrecon {
 class CalorimeterHitReco_factory : public JOmniFactory<CalorimeterHitReco_factory, CalorimeterHitRecoConfig> {
 
 private:
-    CalorimeterHitReco m_algo;
+public:
+    using AlgoT = eicrecon::CalorimeterHitReco;
+private:
+    std::unique_ptr<AlgoT> m_algo;
 
     PodioInput<edm4hep::RawCalorimeterHit> m_raw_hits_input {this};
     PodioOutput<edm4eic::CalorimeterHit> m_rec_hits_output {this};
@@ -37,15 +40,16 @@ private:
 
 public:
     void Configure() {
-        m_algo.applyConfig(config());
-        m_algo.init(m_geoSvc().detector(), m_geoSvc().converter(), logger());
+        m_algo = std::make_unique<AlgoT>(GetPrefix());
+        m_algo->applyConfig(config());
+        m_algo->init(m_geoSvc().detector(), m_geoSvc().converter(), logger());
     }
 
     void ChangeRun(int64_t run_number) {
     }
 
     void Process(int64_t run_number, uint64_t event_number) {
-        m_rec_hits_output() = m_algo.process(*m_raw_hits_input());
+        m_algo->process({m_raw_hits_input()}, {m_rec_hits_output().get()});
     }
 };
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This adopts the `algorithms::` interface in CalorimeterHitReco. Notable changes needed, since `process()` is now `const`:
- NcellIDerrors and warned_unsupported_segmentation are now mutable,
- the local DetElement copy is now handled slightly differently to allow for either a copy obtained during process, or one obtained during init.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.