### PR TITLE
fix: adopt algorithms:: interface in CalorimeterHitsMerger

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitsMerger.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitsMerger.cc
@@ -63,13 +63,17 @@ void CalorimeterHitsMerger::init(const dd4hep::Detector* detector, const dd4hep:
     m_log->debug("ID mask in {:s}: {:#064b}", m_cfg.readout, id_mask);
 }
 
-std::unique_ptr<edm4eic::CalorimeterHitCollection> CalorimeterHitsMerger::process(const edm4eic::CalorimeterHitCollection &input) {
-    auto output = std::make_unique<edm4eic::CalorimeterHitCollection>();
+void CalorimeterHitsMerger::process(
+      const CalorimeterHitsMerger::Input& input,
+      const CalorimeterHitsMerger::Output& output) const {
+
+    const auto [in_hits] = input;
+    auto [out_hits] = output;
 
     // find the hits that belong to the same group (for merging)
     std::unordered_map<uint64_t, std::vector<std::size_t>> merge_map;
     std::size_t ix = 0;
-    for (const auto &h : input) {
+    for (const auto &h : *in_hits) {
         uint64_t id = h.getCellID() & id_mask;
         merge_map[id].push_back(ix);
 
@@ -79,7 +83,7 @@ std::unique_ptr<edm4eic::CalorimeterHitCollection> CalorimeterHitsMerger::proces
     // sort hits by energy from large to small
     for (auto &it : merge_map) {
         std::sort(it.second.begin(), it.second.end(), [&](std::size_t ix1, std::size_t ix2) {
-            return input[ix1].getEnergy() > input[ix2].getEnergy();
+            return (*in_hits)[ix1].getEnergy() > (*in_hits)[ix2].getEnergy();
         });
     }
 
@@ -102,7 +106,7 @@ std::unique_ptr<edm4eic::CalorimeterHitCollection> CalorimeterHitsMerger::proces
         float time = 0;
         float timeError = 0;
         for (auto ix : ixs) {
-            auto hit = input[ix];
+            auto hit = (*in_hits)[ix];
             energy += hit.getEnergy();
             energyError += hit.getEnergyError() * hit.getEnergyError();
             time += hit.getTime();
@@ -112,7 +116,7 @@ std::unique_ptr<edm4eic::CalorimeterHitCollection> CalorimeterHitsMerger::proces
         time /= ixs.size();
         timeError = sqrt(timeError) / ixs.size();
 
-        const auto href = input[ixs.front()];
+        const auto href = (*in_hits)[ixs.front()];
 
         // create const vectors for passing to hit initializer list
         const decltype(edm4eic::CalorimeterHitData::position) position(
@@ -122,7 +126,7 @@ std::unique_ptr<edm4eic::CalorimeterHitCollection> CalorimeterHitsMerger::proces
                 pos.x(), pos.y(), pos.z()
         );
 
-        output->create(
+        out_hits->create(
                         href.getCellID(),
                         energy,
                         energyError,
@@ -135,9 +139,7 @@ std::unique_ptr<edm4eic::CalorimeterHitCollection> CalorimeterHitsMerger::proces
                         local); // Can do better here? Right now position is mapped on the central hit
     }
 
-    m_log->debug("Size before = {}, after = {}", input.size(), output->size());
-
-    return output;
+    m_log->debug("Size before = {}, after = {}", in_hits->size(), out_hits->size());
 }
 
 } // namespace eicrecon

--- a/src/algorithms/calorimetry/CalorimeterHitsMerger.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitsMerger.cc
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <gsl/pointers>
 #include <string>
 #include <unordered_map>
 #include <utility>

--- a/src/algorithms/calorimetry/CalorimeterHitsMerger.h
+++ b/src/algorithms/calorimetry/CalorimeterHitsMerger.h
@@ -12,6 +12,7 @@
 
 #include <DD4hep/Detector.h>
 #include <DDRec/CellIDPositionConverter.h>
+#include <algorithms/algorithm.h>
 #include <edm4eic/CalorimeterHitCollection.h>
 #include <spdlog/logger.h>
 #include <stdint.h>
@@ -22,11 +23,28 @@
 
 namespace eicrecon {
 
-  class CalorimeterHitsMerger : public WithPodConfig<CalorimeterHitsMergerConfig>  {
+  using CalorimeterHitsMergerAlgorithm = algorithms::Algorithm<
+    algorithms::Input<
+      edm4eic::CalorimeterHitCollection
+    >,
+    algorithms::Output<
+      edm4eic::CalorimeterHitCollection
+    >
+  >;
+
+  class CalorimeterHitsMerger
+  : public CalorimeterHitsMergerAlgorithm,
+    public WithPodConfig<CalorimeterHitsMergerConfig> {
 
   public:
+    CalorimeterHitsMerger(std::string_view name)
+      : CalorimeterHitsMergerAlgorithm{name,
+                            {"inputHitCollection"},
+                            {"outputHitCollection"},
+                            "Group readout hits from a calorimeter."} {}
+
     void init(const dd4hep::Detector* detector, const dd4hep::rec::CellIDPositionConverter* converter, std::shared_ptr<spdlog::logger>& logger);
-    std::unique_ptr<edm4eic::CalorimeterHitCollection> process(const edm4eic::CalorimeterHitCollection &input);
+    void process(const Input&, const Output&) const final;
 
   private:
     uint64_t id_mask{0}, ref_mask{0};

--- a/src/algorithms/calorimetry/CalorimeterHitsMerger.h
+++ b/src/algorithms/calorimetry/CalorimeterHitsMerger.h
@@ -17,6 +17,8 @@
 #include <spdlog/logger.h>
 #include <stdint.h>
 #include <memory>
+#include <string>
+#include <string_view>
 
 #include "CalorimeterHitsMergerConfig.h"
 #include "algorithms/interfaces/WithPodConfig.h"

--- a/src/factories/calorimetry/CalorimeterHitsMerger_factory.h
+++ b/src/factories/calorimetry/CalorimeterHitsMerger_factory.h
@@ -12,8 +12,11 @@
 namespace eicrecon {
 
 class CalorimeterHitsMerger_factory : public JOmniFactory<CalorimeterHitsMerger_factory, CalorimeterHitsMergerConfig> {
+
+public:
+    using AlgoT = eicrecon::CalorimeterHitsMerger;
 private:
-    CalorimeterHitsMerger m_algo;
+    std::unique_ptr<AlgoT> m_algo;
 
     PodioInput<edm4eic::CalorimeterHit> m_hits_input {this};
     PodioOutput<edm4eic::CalorimeterHit> m_hits_output {this};
@@ -26,15 +29,16 @@ private:
 
 public:
     void Configure() {
-        m_algo.applyConfig(config());
-        m_algo.init(m_geoSvc().detector(), m_geoSvc().converter(), logger());
+        m_algo = std::make_unique<AlgoT>(GetPrefix());
+        m_algo->applyConfig(config());
+        m_algo->init(m_geoSvc().detector(), m_geoSvc().converter(), logger());
     }
 
     void ChangeRun(int64_t run_number) {
     }
 
     void Process(int64_t run_number, uint64_t event_number) {
-        m_hits_output() = m_algo.process(*m_hits_input());
+        m_algo->process({m_hits_input()}, {m_hits_output().get()});
     }
 };
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This adopts the algorithms:: interface in CalorimeterHitsMerger. Note: `input[ix]` becomes `(*in_hits)[ix]` because `input` is now a tuple of size 1, and it contains a smart pointer to a collection instead of a collection by reference.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.