### PR TITLE
fix: rm Acts detail header for stable interface

### DIFF
--- a/.github/iwyu.imp
+++ b/.github/iwyu.imp
@@ -13,6 +13,7 @@
   # Acts
   { include: ['@<Acts/(.*)\.ipp>', private, '<Acts/$1.hpp>', public] },
   { include: ['@<Acts/(.*)/detail/(.*)\.ipp>', private, '<Acts/$1/$2.hpp>', public] },
+  { include: ['<Acts/Geometry/detail/DefaultDetectorElementBase.hpp>', private, '<Acts/Geometry/DetectorElementBase.hpp>', public] },
 
   # Eigen
   { include: ['@<Eigen/(src/)?(.*?)/.*>', private, '<Eigen/$2>', public] },

--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -2,9 +2,9 @@
 // Copyright (C) 2022 Whitney Armstrong, Wouter Deconinck, Dmitry Romanov
 
 #include <Acts/Definitions/Algebra.hpp>
+#include <Acts/Geometry/DetectorElementBase.hpp>
 #include <Acts/Geometry/GeometryIdentifier.hpp>
 #include <Acts/Geometry/TrackingGeometry.hpp>
-#include <Acts/Geometry/detail/DefaultDetectorElementBase.hpp>
 #include <Acts/MagneticField/MagneticFieldContext.hpp>
 #include <Acts/Material/IMaterialDecorator.hpp>
 #include <Acts/Plugins/DD4hep/ConvertDD4hepDetector.hpp>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
In https://github.com/acts-project/acts/pull/2617 the detail header will be removed.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: Acts v31 compatibility)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.