### PR TITLE
fix: forward compatibility with Acts-v31

### DIFF
--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -248,6 +248,12 @@ macro(plugin_add_acts _name)
         ActsPluginDD4hep
         ${ActsCore_PATH}/${CMAKE_SHARED_LIBRARY_PREFIX}ActsExamplesFramework${CMAKE_SHARED_LIBRARY_SUFFIX}
     )
+    if(${_name}_WITH_LIBRARY)
+        target_compile_definitions(${PLUGIN_NAME}_library PRIVATE "Acts_VERSION_MAJOR=${Acts_VERSION_MAJOR}")
+    endif()
+    if(${_name}_WITH_PLUGIN)
+        target_compile_definitions(${PLUGIN_NAME}_plugin PRIVATE "Acts_VERSION_MAJOR=${Acts_VERSION_MAJOR}")
+    endif()
 
 endmacro()
 

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -87,21 +87,19 @@ std::unique_ptr<edm4eic::VertexCollection> eicrecon::IterativeVertexFinder::prod
   VertexSeeder::Config seederCfg(ipEst);
   VertexSeeder seeder(seederCfg);
   // Set up the actual vertex finder
-  VertexFinder finder = [&]<unsigned int ActsVersion = Acts::Version>(){
-    if constexpr (ActsVersion >= 310000u) {
-      VertexFinder::Config finderCfg(std::move(vertexFitter), std::move(linearizer),
-                                     std::move(seeder), std::move(ipEst));
-      finderCfg.maxVertices                 = m_cfg.m_maxVertices;
-      finderCfg.reassignTracksAfterFirstFit = m_cfg.m_reassignTracksAfterFirstFit;
-      return VertexFinder(std::move(finderCfg));
-    } else {
-      VertexFinder::Config finderCfg(vertexFitter, std::move(linearizer),
-                                     std::move(seeder), ipEst);
-      finderCfg.maxVertices                 = m_cfg.m_maxVertices;
-      finderCfg.reassignTracksAfterFirstFit = m_cfg.m_reassignTracksAfterFirstFit;
-      return VertexFinder(finderCfg);
-    }
-  }();
+  #if Acts_VERSION_MAJOR >= 31
+  VertexFinder::Config finderCfg(std::move(vertexFitter), std::move(linearizer),
+                                 std::move(seeder), std::move(ipEst));
+  finderCfg.maxVertices                 = m_cfg.m_maxVertices;
+  finderCfg.reassignTracksAfterFirstFit = m_cfg.m_reassignTracksAfterFirstFit;
+  VertexFinder finder(std::move(finderCfg));
+  #else
+  VertexFinder::Config finderCfg(vertexFitter, std::move(linearizer),
+                                 std::move(seeder), ipEst);
+  finderCfg.maxVertices                 = m_cfg.m_maxVertices;
+  finderCfg.reassignTracksAfterFirstFit = m_cfg.m_reassignTracksAfterFirstFit;
+  VertexFinder finder(finderCfg);
+  #endif
   VertexFinder::State state(*m_BField, m_fieldctx);
   VertexFinderOptions finderOpts(m_geoctx, m_fieldctx);
 

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -86,17 +86,13 @@ std::unique_ptr<edm4eic::VertexCollection> eicrecon::IterativeVertexFinder::prod
   VertexSeeder::Config seederCfg(ipEst);
   VertexSeeder seeder(seederCfg);
   // Set up the actual vertex finder
-  #if Acts_VERSION_MAJOR >= 31
   VertexFinder::Config finderCfg(std::move(vertexFitter), std::move(linearizer),
                                  std::move(seeder), std::move(ipEst));
   finderCfg.maxVertices                 = m_cfg.m_maxVertices;
   finderCfg.reassignTracksAfterFirstFit = m_cfg.m_reassignTracksAfterFirstFit;
+  #if Acts_VERSION_MAJOR >= 31
   VertexFinder finder(std::move(finderCfg));
   #else
-  VertexFinder::Config finderCfg(vertexFitter, std::move(linearizer),
-                                 std::move(seeder), ipEst);
-  finderCfg.maxVertices                 = m_cfg.m_maxVertices;
-  finderCfg.reassignTracksAfterFirstFit = m_cfg.m_reassignTracksAfterFirstFit;
   VertexFinder finder(finderCfg);
   #endif
   VertexFinder::State state(*m_BField, m_fieldctx);

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -4,7 +4,6 @@
 
 #include "IterativeVertexFinder.h"
 
-#include <Acts/ActsVersion.hpp>
 #include <Acts/Definitions/Common.hpp>
 #include <Acts/Definitions/Direction.hpp>
 #include <Acts/Definitions/TrackParametrization.hpp>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
~~Thanks to C++20 we can now do templated lambdas which don't require syntactic validity of all code paths. That makes forward/backward compatibility across Acts versions easier with constexpr lambdas.~~

Ifdefs on defined Acts major versions allow us to bypass code blocks that are not compilable or parsable under different versions of Acts.

Ref: https://github.com/acts-project/acts/pull/2649

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: Acts v31 compatibility)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.