### PR TITLE
fix: backport into v1.9 of Acts v31 support 

### DIFF
--- a/.github/iwyu.imp
+++ b/.github/iwyu.imp
@@ -13,6 +13,7 @@
   # Acts
   { include: ['@<Acts/(.*)\.ipp>', private, '<Acts/$1.hpp>', public] },
   { include: ['@<Acts/(.*)/detail/(.*)\.ipp>', private, '<Acts/$1/$2.hpp>', public] },
+  { include: ['<Acts/Geometry/detail/DefaultDetectorElementBase.hpp>', private, '<Acts/Geometry/DetectorElementBase.hpp>', public] },
 
   # Eigen
   { include: ['@<Eigen/(src/)?(.*?)/.*>', private, '<Eigen/$2>', public] },

--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -248,6 +248,12 @@ macro(plugin_add_acts _name)
         ActsPluginDD4hep
         ${ActsCore_PATH}/${CMAKE_SHARED_LIBRARY_PREFIX}ActsExamplesFramework${CMAKE_SHARED_LIBRARY_SUFFIX}
     )
+    if(${_name}_WITH_LIBRARY)
+        target_compile_definitions(${PLUGIN_NAME}_library PRIVATE "Acts_VERSION_MAJOR=${Acts_VERSION_MAJOR}")
+    endif()
+    if(${_name}_WITH_PLUGIN)
+        target_compile_definitions(${PLUGIN_NAME}_plugin PRIVATE "Acts_VERSION_MAJOR=${Acts_VERSION_MAJOR}")
+    endif()
 
 endmacro()
 

--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -2,9 +2,9 @@
 // Copyright (C) 2022 Whitney Armstrong, Wouter Deconinck, Dmitry Romanov
 
 #include <Acts/Definitions/Algebra.hpp>
+#include <Acts/Geometry/DetectorElementBase.hpp>
 #include <Acts/Geometry/GeometryIdentifier.hpp>
 #include <Acts/Geometry/TrackingGeometry.hpp>
-#include <Acts/Geometry/detail/DefaultDetectorElementBase.hpp>
 #include <Acts/MagneticField/MagneticFieldContext.hpp>
 #include <Acts/Material/IMaterialDecorator.hpp>
 #include <Acts/Plugins/DD4hep/ConvertDD4hepDetector.hpp>

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -86,11 +86,15 @@ std::unique_ptr<edm4eic::VertexCollection> eicrecon::IterativeVertexFinder::prod
   VertexSeeder::Config seederCfg(ipEst);
   VertexSeeder seeder(seederCfg);
   // Set up the actual vertex finder
-  VertexFinder::Config finderCfg(vertexFitter, std::move(linearizer),
-                                 std::move(seeder), ipEst);
+  VertexFinder::Config finderCfg(std::move(vertexFitter), std::move(linearizer),
+                                 std::move(seeder), std::move(ipEst));
   finderCfg.maxVertices                 = m_cfg.m_maxVertices;
   finderCfg.reassignTracksAfterFirstFit = m_cfg.m_reassignTracksAfterFirstFit;
+  #if Acts_VERSION_MAJOR >= 31
+  VertexFinder finder(std::move(finderCfg));
+  #else
   VertexFinder finder(finderCfg);
+  #endif
   VertexFinder::State state(*m_BField, m_fieldctx);
   VertexFinderOptions finderOpts(m_geoctx, m_fieldctx);
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This backports 4023c3f139427766a304aeb43cb2ffc971571163 and 03b1049a4e7a6b7ff4d22998d815e73d78d329bc into v1.9 in prep for a v1.9.1 release. Acts v31 isn't expected to land officially until EICrecon v1.10 and container 24.02, but we need a stable version that compiles with the newer container for testing of the container builds.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.