### PR TITLE
feat: set default CMAKE_BUILD_TYPE in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,9 +37,6 @@ set_git_version(CMAKE_PROJECT_VERSION)
 
 # Set a default build type if none was specified
 set(default_build_type "Release")
-if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
-  set(default_build_type "Debug")
-endif()
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
   set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,20 @@ include(CheckCXXCompilerFlag)
 include(cmake/git_version.cmake)
 set_git_version(CMAKE_PROJECT_VERSION)
 
+# Set a default build type if none was specified
+set(default_build_type "Release")
+if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+  set(default_build_type "Debug")
+endif()
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+      STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
 # Set default standard to C++20
 set(CMAKE_CXX_STANDARD_MIN 20)
 set(CMAKE_CXX_STANDARD ${CMAKE_CXX_STANDARD_MIN} CACHE STRING "C++ standard to be used")

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 [![DOI](https://zenodo.org/badge/512187504.svg)](https://zenodo.org/badge/latestdoi/512187504)
 
 # EICrecon
-JANA based reconstruction for the EPIC detector
+JANA based reconstruction for the ePIC detector
 
-The repository contains reconstruction source code for the EPIC detector. It's function
+The repository contains reconstruction source code for the ePIC detector. Its function
 is to take real or simulated data and reconstruct it into physical values
 for later analysis.
 
@@ -27,6 +27,8 @@ cmake -B build -S . -DCMAKE_INSTALL_PREFIX=install
 cmake --build build
 cmake --install build
 ```
+To change the default build type, add for example `-DCMAKE_BUILD_TYPE=Debug` to the first CMake configure step.
+
 To load, you can use the scripts in the `install` directory:
 ```bash
 source install/bin/eicrecon-this.sh


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Instead of leaving CMAKE_BUILD_TYPE unset, this sets the default to `Release`, unless `.git` exists and it sets `Debug`. This avoids ending up with `noconfig` on target exports (or unoptimized compiles).

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, developers with `.git` will likely switch from unspecified defaults to actual `Debug` configuration.