### PR TITLE
fix: rm unused GeoSvc from CalorimeterClusterRecoCoG

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -36,9 +36,8 @@ namespace eicrecon {
 
   using namespace dd4hep;
 
-  void CalorimeterClusterRecoCoG::init(const dd4hep::Detector* detector, std::shared_ptr<spdlog::logger>& logger) {
+  void CalorimeterClusterRecoCoG::init(std::shared_ptr<spdlog::logger>& logger) {
     m_log = logger;
-    m_detector = detector;
 
     // select weighting method
     std::string ew = m_cfg.energyWeight;

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
@@ -74,12 +74,11 @@ namespace eicrecon {
                             "association provided both optional arguments are provided."} {}
 
   public:
-    void init(const dd4hep::Detector* detector, std::shared_ptr<spdlog::logger>& logger);
+    void init(std::shared_ptr<spdlog::logger>& logger);
 
     void process(const Input&, const Output&) const final;
 
   private:
-    const dd4hep::Detector* m_detector;
     std::shared_ptr<spdlog::logger> m_log;
 
     std::function<double(double, double, double, int)> weightFunc;

--- a/src/factories/calorimetry/CalorimeterClusterRecoCoG_factory.h
+++ b/src/factories/calorimetry/CalorimeterClusterRecoCoG_factory.h
@@ -29,14 +29,11 @@ private:
     ParameterRef<double> m_logWeightBase {this, "logWeightBase", config().logWeightBase};
     ParameterRef<bool> m_enableEtaBounds {this, "enableEtaBounds", config().enableEtaBounds};
 
-    Service<DD4hep_service> m_geoSvc {this};
-    // Resource<DD4hep_service, const dd4hep::Detector*> m_detector {this, [](std::shared_ptr<DD4hep_service> s, int64_t run_nr){ return s->detector(); }}
-
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
         m_algo->applyConfig(config());
-        m_algo->init(m_geoSvc().detector(), logger());
+        m_algo->init(logger());
     }
 
     void ChangeRun(int64_t run_number) {


### PR DESCRIPTION
This removes the unused `GeoSvc` from `CalorimeterClusterRecoCoG`. 