### PR TITLE
feat: use logger service that comes with algorithms

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -21,8 +21,10 @@
 #include <podio/RelationRange.h>
 #include <Eigen/Core>
 #include <Eigen/Eigenvalues>
+#include <Eigen/Householder>
 #include <cctype>
 #include <complex>
+#include <cstddef>
 #include <gsl/pointers>
 #include <limits>
 #include <map>

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -36,8 +36,7 @@ namespace eicrecon {
 
   using namespace dd4hep;
 
-  void CalorimeterClusterRecoCoG::init(std::shared_ptr<spdlog::logger>& logger) {
-    m_log = logger;
+  void CalorimeterClusterRecoCoG::init() {
 
     // select weighting method
     std::string ew = m_cfg.energyWeight;
@@ -45,7 +44,7 @@ namespace eicrecon {
     std::transform(ew.begin(), ew.end(), ew.begin(), [](char s) { return std::tolower(s); });
     auto it = weightMethods.find(ew);
     if (it == weightMethods.end()) {
-      m_log->error("Cannot find energy weighting method {}, choose one from [{}]", m_cfg.energyWeight, boost::algorithm::join(weightMethods | boost::adaptors::map_keys, ", "));
+      error("Cannot find energy weighting method {}, choose one from [{}]", m_cfg.energyWeight, boost::algorithm::join(weightMethods | boost::adaptors::map_keys, ", "));
       return;
     }
     weightFunc = it->second;
@@ -71,7 +70,7 @@ namespace eicrecon {
       }
       auto cl = *std::move(cl_opt);
 
-      m_log->debug("{} hits: {} GeV, ({}, {}, {})", cl.getNhits(), cl.getEnergy() / dd4hep::GeV, cl.getPosition().x / dd4hep::mm, cl.getPosition().y / dd4hep::mm, cl.getPosition().z / dd4hep::mm);
+      debug("{} hits: {} GeV, ({}, {}, {})", cl.getNhits(), cl.getEnergy() / dd4hep::GeV, cl.getPosition().x / dd4hep::mm, cl.getPosition().y / dd4hep::mm, cl.getPosition().z / dd4hep::mm);
       clusters->push_back(cl);
 
       // If mcHits are available, associate cluster with MCParticle
@@ -116,14 +115,14 @@ namespace eicrecon {
         }
         if (!(mchit != mchits->end())) {
           // break if no matching hit found for this CellID
-          m_log->warn("Proto-cluster has highest energy in CellID {}, but no mc hit with that CellID was found.", pclhit->getCellID());
-          m_log->trace("Proto-cluster hits: ");
+          warning("Proto-cluster has highest energy in CellID {}, but no mc hit with that CellID was found.", pclhit->getCellID());
+          trace("Proto-cluster hits: ");
           for (const auto& pclhit1: pclhits) {
-            m_log->trace("{}: {}", pclhit1.getCellID(), pclhit1.getEnergy());
+            trace("{}: {}", pclhit1.getCellID(), pclhit1.getEnergy());
           }
-          m_log->trace("MC hits: ");
+          trace("MC hits: ");
           for (const auto& mchit1: *mchits) {
-            m_log->trace("{}: {}", mchit1.getCellID(), mchit1.getEnergy());
+            trace("{}: {}", mchit1.getCellID(), mchit1.getEnergy());
           }
           break;
         }
@@ -131,10 +130,10 @@ namespace eicrecon {
         // 3. find mchit's MCParticle
         const auto& mcp = mchit->getContributions(0).getParticle();
 
-        m_log->debug("cluster has largest energy in cellID: {}", pclhit->getCellID());
-        m_log->debug("pcl hit with highest energy {} at index {}", pclhit->getEnergy(), pclhit->getObjectID().index);
-        m_log->debug("corresponding mc hit energy {} at index {}", mchit->getEnergy(), mchit->getObjectID().index);
-        m_log->debug("from MCParticle index {}, PDG {}, {}", mcp.getObjectID().index, mcp.getPDG(), edm4hep::utils::magnitude(mcp.getMomentum()));
+        debug("cluster has largest energy in cellID: {}", pclhit->getCellID());
+        debug("pcl hit with highest energy {} at index {}", pclhit->getEnergy(), pclhit->getObjectID().index);
+        debug("corresponding mc hit energy {} at index {}", mchit->getEnergy(), mchit->getObjectID().index);
+        debug("from MCParticle index {}, PDG {}, {}", mcp.getObjectID().index, mcp.getPDG(), edm4hep::utils::magnitude(mcp.getMomentum()));
 
         // set association
         auto clusterassoc = associations->create();
@@ -144,7 +143,7 @@ namespace eicrecon {
         clusterassoc.setRec(cl);
         clusterassoc.setSim(mcp);
       } else {
-        m_log->debug("No mcHitCollection was provided, so no truth association will be performed.");
+        debug("No mcHitCollection was provided, so no truth association will be performed.");
       }
     }
 }
@@ -154,7 +153,7 @@ std::optional<edm4eic::Cluster> CalorimeterClusterRecoCoG::reconstruct(const edm
   edm4eic::MutableCluster cl;
   cl.setNhits(pcl.hits_size());
 
-  m_log->debug("hit size = {}", pcl.hits_size());
+  debug("hit size = {}", pcl.hits_size());
 
   // no hits
   if (pcl.hits_size() == 0) {
@@ -171,7 +170,7 @@ std::optional<edm4eic::Cluster> CalorimeterClusterRecoCoG::reconstruct(const edm
   for (unsigned i = 0; i < pcl.getHits().size(); ++i) {
     const auto& hit   = pcl.getHits()[i];
     const auto weight = pcl.getWeights()[i];
-    m_log->debug("hit energy = {} hit weight: {}", hit.getEnergy(), weight);
+    debug("hit energy = {} hit weight: {}", hit.getEnergy(), weight);
     auto energy = hit.getEnergy() * weight;
     totalE += energy;
     cl.addToHits(hit);
@@ -211,7 +210,7 @@ std::optional<edm4eic::Cluster> CalorimeterClusterRecoCoG::reconstruct(const edm
     v = v + (hit.getPosition() * w);
   }
   if (tw == 0.) {
-    m_log->warn("zero total weights encountered, you may want to adjust your weighting parameter.");
+    warning("zero total weights encountered, you may want to adjust your weighting parameter.");
     return {};
   }
   cl.setPosition(v / tw);
@@ -227,7 +226,7 @@ std::optional<edm4eic::Cluster> CalorimeterClusterRecoCoG::reconstruct(const edm
       const double newR     = edm4hep::utils::magnitude(cl.getPosition());
       const double newPhi   = edm4hep::utils::angleAzimuthal(cl.getPosition());
       cl.setPosition(edm4hep::utils::sphericalToVector(newR, newTheta, newPhi));
-      m_log->debug("Bound cluster position to contributing hits due to {}", (overflow ? "overflow" : "underflow"));
+      debug("Bound cluster position to contributing hits due to {}", (overflow ? "overflow" : "underflow"));
     }
   }
 

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -21,7 +21,7 @@
 #include <podio/RelationRange.h>
 #include <Eigen/Core>
 #include <Eigen/Eigenvalues>
-#include <Eigen/Householder>
+#include <Eigen/Householder> // IWYU pragma: keep
 #include <cctype>
 #include <complex>
 #include <cstddef>

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include <DD4hep/Detector.h>
 #include <algorithms/algorithm.h>
 #include <edm4eic/ClusterCollection.h>
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
@@ -16,7 +16,6 @@
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <edm4eic/ProtoClusterCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
-#include <spdlog/logger.h>
 #include <algorithm>
 #include <cmath>
 #include <functional>
@@ -74,19 +73,15 @@ namespace eicrecon {
                             "association provided both optional arguments are provided."} {}
 
   public:
-    void init(std::shared_ptr<spdlog::logger>& logger);
+    void init() final;
 
     void process(const Input&, const Output&) const final;
 
   private:
-    std::shared_ptr<spdlog::logger> m_log;
-
     std::function<double(double, double, double, int)> weightFunc;
 
   private:
-
     std::optional<edm4eic::Cluster> reconstruct(const edm4eic::ProtoCluster& pcl) const;
-
   };
 
 } // eicrecon

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -46,8 +46,7 @@ namespace eicrecon {
 //   values here. This needs to be confirmed.
 
 
-void CalorimeterHitDigi::init(std::shared_ptr<spdlog::logger>& logger) {
-    m_log = logger;
+void CalorimeterHitDigi::init() {
 
     // Gaudi implements a random number generator service. It is not clear to me how this
     // can work. There are multiple race conditions that occur in parallel event processing:
@@ -67,7 +66,7 @@ void CalorimeterHitDigi::init(std::shared_ptr<spdlog::logger>& logger) {
     if (m_cfg.eRes.empty()) {
       m_cfg.eRes.resize(3);
     } else if (m_cfg.eRes.size() != 3) {
-      m_log->error("Invalid m_cfg.eRes.size()");
+      error("Invalid m_cfg.eRes.size()");
       throw std::runtime_error("Invalid m_cfg.eRes.size()");
     }
 
@@ -80,11 +79,11 @@ void CalorimeterHitDigi::init(std::shared_ptr<spdlog::logger>& logger) {
     if (!m_cfg.fields.empty()) {
         // sanity checks
         if (!m_geo.detector()) {
-            m_log->error("Unable to locate geometry.");
+            error("Unable to locate geometry.");
             throw std::runtime_error("Unable to locate Geometry Service.");
         }
         if (m_cfg.readout.empty()) {
-            m_log->error("readoutClass is not provided, it is needed to know the fields in readout ids.");
+            error("readoutClass is not provided, it is needed to know the fields in readout ids.");
             throw std::runtime_error("readoutClass is not provided.");
         }
 
@@ -97,11 +96,11 @@ void CalorimeterHitDigi::init(std::shared_ptr<spdlog::logger>& logger) {
         } catch (...) {
             // a workaround to avoid breaking the whole analysis if a field is not in some configurations
             // TODO: it should be a fatal error to not cause unexpected analysis results
-            m_log->warn("Failed to load ID decoder for {}, hits will not be merged.", m_cfg.readout);
+            warning("Failed to load ID decoder for {}, hits will not be merged.", m_cfg.readout);
             // throw::runtime_error(fmt::format("Failed to load ID decoder for {}", m_cfg.readout));
             return;
         }
-        m_log->debug("ID mask in {:s}: {:#064b}", m_cfg.readout, id_mask);
+        debug("ID mask in {:s}: {:#064b}", m_cfg.readout, id_mask);
     }
     id_mask = ~id_inverse_mask;
 }
@@ -120,8 +119,8 @@ void CalorimeterHitDigi::process(
     for (const auto &ahit : *simhits) {
         uint64_t hid = ahit.getCellID() & id_mask;
 
-        m_log->trace("org cell ID in {:s}: {:#064b}", m_cfg.readout, ahit.getCellID());
-        m_log->trace("new cell ID in {:s}: {:#064b}", m_cfg.readout, hid);
+        trace("org cell ID in {:s}: {:#064b}", m_cfg.readout, ahit.getCellID());
+        trace("new cell ID in {:s}: {:#064b}", m_cfg.readout, hid);
 
         merge_map[hid].push_back(ix);
 
@@ -147,7 +146,7 @@ void CalorimeterHitDigi::process(
             }
             if (timeC > m_cfg.capTime) continue;
             edep += hit.getEnergy();
-            m_log->trace("adding {} \t total: {}", hit.getEnergy(), edep);
+            trace("adding {} \t total: {}", hit.getEnergy(), edep);
 
             // change maximum hit energy & time if necessary
             if (hit.getEnergy() > max_edep) {
@@ -172,7 +171,7 @@ void CalorimeterHitDigi::process(
         unsigned long long adc     = std::llround(ped + edep * m_cfg.corrMeanScale * ( 1.0 + eResRel) / m_cfg.dyRangeADC * m_cfg.capADC);
         unsigned long long tdc     = std::llround((time + m_rng.gaussian<double>(0., 1.) * tRes) * stepTDC);
 
-        if (edep> 1.e-3) m_log->trace("E sim {} \t adc: {} \t time: {}\t maxtime: {} \t tdc: {}", edep, adc, time, m_cfg.capTime, tdc);
+        if (edep> 1.e-3) trace("E sim {} \t adc: {} \t time: {}\t maxtime: {} \t tdc: {}", edep, adc, time, m_cfg.capTime, tdc);
         rawhits->create(
                 mid,
                 (adc > m_cfg.capADC ? m_cfg.capADC : adc),

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.h
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.h
@@ -50,7 +50,7 @@ namespace eicrecon {
                             "Smear energy deposit, digitize within ADC range, add pedestal, "
                             "convert time with smearing resolution, and sum signals."} {}
 
-    void init(std::shared_ptr<spdlog::logger>& logger);
+    void init() final;
     void process(const Input&, const Output&) const final;
 
   private:
@@ -62,9 +62,6 @@ namespace eicrecon {
 
   private:
     const algorithms::GeoSvc& m_geo = algorithms::GeoSvc::instance();
-    std::shared_ptr<spdlog::logger> m_log;
-
-  private:
     algorithms::Generator m_rng = algorithms::RandomSvc::instance().generator();
 
   };

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.h
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.h
@@ -18,9 +18,7 @@
 #include <algorithms/random.h>
 #include <edm4hep/RawCalorimeterHitCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
-#include <spdlog/logger.h>
 #include <stdint.h>
-#include <memory>
 #include <string>
 #include <string_view>
 

--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -27,6 +27,7 @@
 #include <functional>
 #include <gsl/pointers>
 #include <map>
+#include <memory>
 #include <ostream>
 #include <stdexcept>
 #include <string>

--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -27,7 +27,6 @@
 #include <functional>
 #include <gsl/pointers>
 #include <map>
-#include <memory>
 #include <ostream>
 #include <stdexcept>
 #include <string>

--- a/src/algorithms/calorimetry/CalorimeterHitReco.h
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.h
@@ -15,10 +15,8 @@
 #include <algorithms/algorithm.h>
 #include <edm4eic/CalorimeterHitCollection.h>
 #include <edm4hep/RawCalorimeterHitCollection.h>
-#include <spdlog/logger.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <memory>
 #include <string>
 #include <string_view>
 

--- a/src/algorithms/calorimetry/CalorimeterHitReco.h
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.h
@@ -47,7 +47,7 @@ namespace eicrecon {
                             {"outputRecHitCollection"},
                             "Reconstruct hit from digitized input."} {}
 
-    void init(const dd4hep::Detector* detector, const dd4hep::rec::CellIDPositionConverter* converter, std::shared_ptr<spdlog::logger>& logger);
+    void init(const dd4hep::Detector* detector, const dd4hep::rec::CellIDPositionConverter* converter);
     void process(const Input&, const Output&) const final;
 
   private:
@@ -71,7 +71,6 @@ namespace eicrecon {
   private:
     const dd4hep::Detector* m_detector;
     const dd4hep::rec::CellIDPositionConverter* m_converter;
-    std::shared_ptr<spdlog::logger> m_log;
 
   };
 

--- a/src/algorithms/calorimetry/CalorimeterHitsMerger.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitsMerger.cc
@@ -34,13 +34,12 @@
 
 namespace eicrecon {
 
-void CalorimeterHitsMerger::init(const dd4hep::Detector* detector, const dd4hep::rec::CellIDPositionConverter* converter, std::shared_ptr<spdlog::logger>& logger) {
+void CalorimeterHitsMerger::init(const dd4hep::Detector* detector, const dd4hep::rec::CellIDPositionConverter* converter) {
     m_detector = detector;
     m_converter = converter;
-    m_log = logger;
 
     if (m_cfg.readout.empty()) {
-        m_log->error("readoutClass is not provided, it is needed to know the fields in readout ids");
+        error("readoutClass is not provided, it is needed to know the fields in readout ids");
         return;
     }
 
@@ -57,11 +56,11 @@ void CalorimeterHitsMerger::init(const dd4hep::Detector* detector, const dd4hep:
         ref_mask = id_desc.encode(ref_fields);
     } catch (...) {
         auto mess = fmt::format("Failed to load ID decoder for {}", m_cfg.readout);
-        m_log->warn(mess);
+        warning(mess);
 //        throw std::runtime_error(mess);
     }
     id_mask = ~id_mask;
-    m_log->debug("ID mask in {:s}: {:#064b}", m_cfg.readout, id_mask);
+    debug("ID mask in {:s}: {:#064b}", m_cfg.readout, id_mask);
 }
 
 void CalorimeterHitsMerger::process(
@@ -100,7 +99,7 @@ void CalorimeterHitsMerger::process(
         // local positions
         auto alignment = volman.lookupDetElement(ref_id).nominal();
         const auto pos = alignment.worldToLocal(dd4hep::Position(gpos.x(), gpos.y(), gpos.z()));
-        m_log->debug("{}, {}", volman.lookupDetElement(ref_id).path(), volman.lookupDetector(ref_id).path());
+        debug("{}, {}", volman.lookupDetElement(ref_id).path(), volman.lookupDetector(ref_id).path());
         // sum energy
         float energy = 0.;
         float energyError = 0.;
@@ -140,7 +139,7 @@ void CalorimeterHitsMerger::process(
                         local); // Can do better here? Right now position is mapped on the central hit
     }
 
-    m_log->debug("Size before = {}, after = {}", in_hits->size(), out_hits->size());
+    debug("Size before = {}, after = {}", in_hits->size(), out_hits->size());
 }
 
 } // namespace eicrecon

--- a/src/algorithms/calorimetry/CalorimeterHitsMerger.h
+++ b/src/algorithms/calorimetry/CalorimeterHitsMerger.h
@@ -45,7 +45,7 @@ namespace eicrecon {
                             {"outputHitCollection"},
                             "Group readout hits from a calorimeter."} {}
 
-    void init(const dd4hep::Detector* detector, const dd4hep::rec::CellIDPositionConverter* converter, std::shared_ptr<spdlog::logger>& logger);
+    void init(const dd4hep::Detector* detector, const dd4hep::rec::CellIDPositionConverter* converter);
     void process(const Input&, const Output&) const final;
 
   private:
@@ -54,7 +54,6 @@ namespace eicrecon {
   private:
     const dd4hep::Detector* m_detector;
     const dd4hep::rec::CellIDPositionConverter* m_converter;
-    std::shared_ptr<spdlog::logger> m_log;
 
   };
 

--- a/src/algorithms/calorimetry/CalorimeterHitsMerger.h
+++ b/src/algorithms/calorimetry/CalorimeterHitsMerger.h
@@ -14,9 +14,7 @@
 #include <DDRec/CellIDPositionConverter.h>
 #include <algorithms/algorithm.h>
 #include <edm4eic/CalorimeterHitCollection.h>
-#include <spdlog/logger.h>
 #include <stdint.h>
-#include <memory>
 #include <string>
 #include <string_view>
 

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <gsl/pointers>
 #include <map>
+#include <memory>
 #include <set>
 #include <sstream>
 #include <stdexcept>

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -81,8 +81,7 @@ static edm4hep::Vector2f globalDistEtaPhi(const CaloHit &h1, const CaloHit &h2) 
 //------------------------
 // AlgorithmInit
 //------------------------
-void CalorimeterIslandCluster::init(const dd4hep::Detector* detector, std::shared_ptr<spdlog::logger>& logger) {
-    m_log = logger;
+void CalorimeterIslandCluster::init(const dd4hep::Detector* detector) {
     m_detector = detector;
 
     static std::map<std::string,
@@ -101,14 +100,14 @@ void CalorimeterIslandCluster::init(const dd4hep::Detector* detector, std::share
       }
       auto& [method, units] = distMethods[uprop.first];
       if (uprop.second.size() != units.size()) {
-        m_log->warn("Expect {} values from {}, received {}. ignored it.", units.size(), uprop.first,  uprop.second.size());
+        warning("Expect {} values from {}, received {}. ignored it.", units.size(), uprop.first,  uprop.second.size());
         return false;
       } else {
         for (size_t i = 0; i < units.size(); ++i) {
           neighbourDist[i] = uprop.second[i] / units[i];
         }
         hitsDist = method;
-        m_log->info("Clustering uses {} with distances <= [{}]", uprop.first, fmt::join(neighbourDist, ","));
+        info("Clustering uses {} with distances <= [{}]", uprop.first, fmt::join(neighbourDist, ","));
       }
       return true;
     };
@@ -129,7 +128,7 @@ void CalorimeterIslandCluster::init(const dd4hep::Detector* detector, std::share
     if (!m_cfg.adjacencyMatrix.empty()) {
       // sanity checks
       if (m_cfg.readout.empty()) {
-        m_log->error("readoutClass is not provided, it is needed to know the fields in readout ids");
+        error("readoutClass is not provided, it is needed to know the fields in readout ids");
       }
       m_idSpec = m_detector->readout(m_cfg.readout).idSpec();
 
@@ -145,7 +144,7 @@ void CalorimeterIslandCluster::init(const dd4hep::Detector* detector, std::share
       }
       sstr << "return " << m_cfg.adjacencyMatrix << ";";
       sstr << "}";
-      m_log->debug("Compiling {}", sstr.str());
+      debug("Compiling {}", sstr.str());
 
       TInterpreter *interp = TInterpreter::Instance();
       interp->ProcessLine(sstr.str().c_str());
@@ -162,8 +161,8 @@ void CalorimeterIslandCluster::init(const dd4hep::Detector* detector, std::share
           const dd4hep::IDDescriptor::Field* field = p.second;
           params.push_back(field->value(h1.getCellID()));
           params.push_back(field->value(h2.getCellID()));
-          m_log->trace("{}_1 = {}", name, field->value(h1.getCellID()));
-          m_log->trace("{}_2 = {}", name, field->value(h2.getCellID()));
+          trace("{}_1 = {}", name, field->value(h1.getCellID()));
+          trace("{}_2 = {}", name, field->value(h2.getCellID()));
         }
         return func(params.data());
       };
@@ -189,7 +188,7 @@ void CalorimeterIslandCluster::init(const dd4hep::Detector* detector, std::share
             }
           };
 
-          m_log->info("Using clustering method: {}", uprop.first);
+          info("Using clustering method: {}", uprop.first);
           break;
         }
       }
@@ -233,7 +232,7 @@ void CalorimeterIslandCluster::process(
 
       {
         const auto& hit = (*hits)[i];
-        m_log->debug("hit {:d}: energy = {:.4f} MeV, local = ({:.4f}, {:.4f}) mm, global=({:.4f}, {:.4f}, {:.4f}) mm", i, hit.getEnergy() * 1000., hit.getLocal().x, hit.getLocal().y, hit.getPosition().x,  hit.getPosition().y, hit.getPosition().z);
+        debug("hit {:d}: energy = {:.4f} MeV, local = ({:.4f}, {:.4f}) mm, global=({:.4f}, {:.4f}, {:.4f}) mm", i, hit.getEnergy() * 1000., hit.getLocal().x, hit.getLocal().y, hit.getPosition().x,  hit.getPosition().y, hit.getPosition().z);
       }
       // already in a group
       if (visits[i]) {
@@ -251,7 +250,7 @@ void CalorimeterIslandCluster::process(
       auto maxima = find_maxima(*hits, group, !m_cfg.splitCluster);
       split_group(*hits, group, maxima, proto_clusters);
 
-      m_log->debug("hits in a group: {}, local maxima: {}", group.size(), maxima.size());
+      debug("hits in a group: {}, local maxima: {}", group.size(), maxima.size());
     }
 }
 

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.h
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.h
@@ -49,12 +49,11 @@ namespace eicrecon {
                             {"outputClusterCollection"},
                             "Island clustering."} {}
 
-    void init(const dd4hep::Detector* detector, std::shared_ptr<spdlog::logger>& logger);
+    void init(const dd4hep::Detector* detector);
     void process(const Input&, const Output&) const final;
 
   private:
     const dd4hep::Detector* m_detector;
-    std::shared_ptr<spdlog::logger> m_log;
 
   public:
 
@@ -170,7 +169,7 @@ namespace eicrecon {
   void split_group(const edm4eic::CalorimeterHitCollection &hits, std::set<std::size_t>& group, const std::vector<std::size_t>& maxima, edm4eic::ProtoClusterCollection *protoClusters) const {
     // special cases
     if (maxima.empty()) {
-      m_log->debug("No maxima found, not building any clusters");
+      debug("No maxima found, not building any clusters");
       return;
     } else if (maxima.size() == 1) {
       edm4eic::MutableProtoCluster pcl = protoClusters->create();
@@ -179,7 +178,7 @@ namespace eicrecon {
         pcl.addToWeights(1.);
       }
 
-      m_log->debug("A single maximum found, added one ProtoCluster");
+      debug("A single maximum found, added one ProtoCluster");
 
       return;
     }
@@ -223,7 +222,7 @@ namespace eicrecon {
         pcls[k].addToWeights(weight);
       }
     }
-    m_log->debug("Multiple ({}) maxima found, added a ProtoClusters for each maximum", maxima.size());
+    debug("Multiple ({}) maxima found, added a ProtoClusters for each maximum", maxima.size());
   }
 };
 

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.h
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.h
@@ -11,12 +11,10 @@
 #include <edm4hep/Vector2f.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
-#include <spdlog/logger.h>
 #include <array>
 #include <cmath>
 #include <cstddef>
 #include <functional>
-#include <memory>
 #include <set>
 #include <string>
 #include <string_view>

--- a/src/algorithms/calorimetry/CalorimeterTruthClustering.cc
+++ b/src/algorithms/calorimetry/CalorimeterTruthClustering.cc
@@ -16,9 +16,7 @@ using namespace dd4hep;
 
 namespace eicrecon {
 
-  void CalorimeterTruthClustering::init(std::shared_ptr<spdlog::logger> &logger) {
-      m_log = logger;
-  }
+  void CalorimeterTruthClustering::init() { }
 
 
   void CalorimeterTruthClustering::process(

--- a/src/algorithms/calorimetry/CalorimeterTruthClustering.h
+++ b/src/algorithms/calorimetry/CalorimeterTruthClustering.h
@@ -8,8 +8,6 @@
 #include <edm4eic/CalorimeterHitCollection.h>
 #include <edm4eic/ProtoClusterCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
-#include <spdlog/logger.h>
-#include <memory>
 #include <string>
 #include <string_view>
 

--- a/src/algorithms/calorimetry/CalorimeterTruthClustering.h
+++ b/src/algorithms/calorimetry/CalorimeterTruthClustering.h
@@ -36,11 +36,8 @@ namespace eicrecon {
                             "Use truth information for clustering."} {}
 
   public:
-    void init(std::shared_ptr<spdlog::logger>& logger);
+    void init() final;
     void process(const Input&, const Output&) const final;
-
-  private:
-    std::shared_ptr<spdlog::logger> m_log;
 
   };
 

--- a/src/algorithms/calorimetry/EnergyPositionClusterMerger.h
+++ b/src/algorithms/calorimetry/EnergyPositionClusterMerger.h
@@ -54,24 +54,19 @@ namespace eicrecon {
                             {"outputClusterCollection", "outputClusterAssociations"},
                             "Merge energy and position clusters if matching."} {}
 
-  private:
-    std::shared_ptr<spdlog::logger> m_log;
-
   public:
 
-    void init(std::shared_ptr<spdlog::logger>& logger) {
-        m_log = logger;
-    }
+    void init() { }
 
     void process(const Input& input, const Output& output) const final {
 
         const auto [energy_clus, energy_assoc, pos_clus, pos_assoc] = input;
         auto [merged_clus, merged_assoc] = output;
 
-        m_log->debug( "Merging energy and position clusters for new event" );
+        debug( "Merging energy and position clusters for new event" );
 
         if (energy_clus->size() == 0 && pos_clus->size() == 0) {
-            m_log->debug( "Nothing to do for this event, returning..." );
+            debug( "Nothing to do for this event, returning..." );
             return;
         }
 
@@ -80,7 +75,7 @@ namespace eicrecon {
         // use position clusters as starting point
         for (const auto& pc : *pos_clus) {
 
-            m_log->trace(" --> Processing position cluster {}, energy: {}", pc.getObjectID().index, pc.getEnergy());
+            trace(" --> Processing position cluster {}, energy: {}", pc.getObjectID().index, pc.getEnergy());
 
             // check if we find a good match
             int best_match    = -1;
@@ -92,7 +87,7 @@ namespace eicrecon {
 
                 const auto& ec = (*energy_clus)[ie];
 
-                m_log->trace("  --> Evaluating energy cluster {}, energy: {}", ec.getObjectID().index, ec.getEnergy());
+                trace("  --> Evaluating energy cluster {}, energy: {}", ec.getObjectID().index, ec.getEnergy());
 
                 // 1. stop if not within tolerance
                 //    (make sure to handle rollover of phi properly)
@@ -135,8 +130,8 @@ namespace eicrecon {
                 new_clus.addToClusters(pc);
                 new_clus.addToClusters(ec);
 
-                m_log->trace("   --> Found matching energy cluster {}, energy: {}", ec.getObjectID().index, ec.getEnergy() );
-                m_log->trace("   --> Created a new combined cluster {}, energy: {}", new_clus.getObjectID().index, new_clus.getEnergy() );
+                trace("   --> Found matching energy cluster {}, energy: {}", ec.getObjectID().index, ec.getEnergy() );
+                trace("   --> Created a new combined cluster {}, energy: {}", new_clus.getObjectID().index, new_clus.getEnergy() );
 
                 // find association from energy cluster
                 auto ea = energy_assoc->begin();
@@ -166,7 +161,7 @@ namespace eicrecon {
                             clusterassoc.setSim(ea->getSim());
                         } else {
                             // both associations disagree on the MCParticles entry
-                            m_log->debug("   --> Two associations added to {} and {}", ea->getSimID(), pa->getSimID());
+                            debug("   --> Two associations added to {} and {}", ea->getSimID(), pa->getSimID());
                             auto clusterassoc1 = merged_assoc->create();
                             clusterassoc1.setRecID(new_clus.getObjectID().index);
                             clusterassoc1.setSimID(ea->getSimID());
@@ -182,7 +177,7 @@ namespace eicrecon {
                         }
                     } else if (ea != energy_assoc->end()) {
                         // no position association
-                        m_log->debug("   --> Only added energy cluster association to {}", ea->getSimID());
+                        debug("   --> Only added energy cluster association to {}", ea->getSimID());
                         auto clusterassoc = merged_assoc->create();
                         clusterassoc.setRecID(new_clus.getObjectID().index);
                         clusterassoc.setSimID(ea->getSimID());
@@ -191,7 +186,7 @@ namespace eicrecon {
                         clusterassoc.setSim(ea->getSim());
                     } else if (pa != pos_assoc->end()) {
                         // no energy association
-                        m_log->debug("   --> Only added position cluster association to {}", pa->getSimID());
+                        debug("   --> Only added position cluster association to {}", pa->getSimID());
                         auto clusterassoc = merged_assoc->create();
                         clusterassoc.setRecID(new_clus.getObjectID().index);
                         clusterassoc.setSimID(pa->getSimID());
@@ -204,18 +199,18 @@ namespace eicrecon {
                 // label our energy cluster as consumed
                 consumed[best_match] = true;
 
-                m_log->debug("  Matched position cluster {} with energy cluster {}", pc.getObjectID().index, ec.getObjectID().index);
-                m_log->debug("  - Position cluster: (E: {}, phi: {}, z: {})", pc.getEnergy(),
+                debug("  Matched position cluster {} with energy cluster {}", pc.getObjectID().index, ec.getObjectID().index);
+                debug("  - Position cluster: (E: {}, phi: {}, z: {})", pc.getEnergy(),
                              edm4hep::utils::angleAzimuthal(pc.getPosition()), pc.getPosition().z);
-                m_log->debug("  - Energy cluster: (E: {}, phi: {}, z: {})", ec.getEnergy(),
+                debug("  - Energy cluster: (E: {}, phi: {}, z: {})", ec.getEnergy(),
                              edm4hep::utils::angleAzimuthal(ec.getPosition()), ec.getPosition().z);
-                m_log->debug("  ---> Merged cluster: (E: {}, phi: {}, z: {})", new_clus.getEnergy(),
+                debug("  ---> Merged cluster: (E: {}, phi: {}, z: {})", new_clus.getEnergy(),
                              edm4hep::utils::angleAzimuthal(new_clus.getPosition()), new_clus.getPosition().z);
 
 
             } else {
 
-                m_log->debug("  Unmatched position cluster {}", pc.getObjectID().index);
+                debug("  Unmatched position cluster {}", pc.getObjectID().index);
 
             }
 

--- a/src/algorithms/calorimetry/HEXPLIT.cc
+++ b/src/algorithms/calorimetry/HEXPLIT.cc
@@ -72,8 +72,7 @@ const std::vector<double> HEXPLIT::subcell_offsets_y =[]() {
   return y;
 }();
 
-void HEXPLIT::init(const dd4hep::Detector* detector, std::shared_ptr<spdlog::logger>& logger) {
-    m_log = logger;
+void HEXPLIT::init(const dd4hep::Detector* detector) {
     m_detector = detector;
 
 }
@@ -157,7 +156,7 @@ void HEXPLIT::process(const HEXPLIT::Input& input,
       }
       catch (...){
         // do this to prevent errors when running the test on the mock detector
-        m_log->warn("Cannot find transformation from local to global coordinates.");
+        warning("Cannot find transformation from local to global coordinates.");
         global_position = local_position;
       }
 

--- a/src/algorithms/calorimetry/HEXPLIT.h
+++ b/src/algorithms/calorimetry/HEXPLIT.h
@@ -41,7 +41,7 @@ using HEXPLITAlgorithm = algorithms::Algorithm<
                                    {"outputSubcellHits"},
                                    "Split hits into subcell hits"} {}
 
-    void init(const dd4hep::Detector* detector, std::shared_ptr<spdlog::logger>& logger);
+    void init(const dd4hep::Detector* detector);
     void process(const Input&, const Output&) const final;
 
   private:
@@ -62,7 +62,6 @@ using HEXPLITAlgorithm = algorithms::Algorithm<
 
   private:
     const dd4hep::Detector* m_detector;
-    std::shared_ptr<spdlog::logger> m_log;
 
   };
 

--- a/src/algorithms/calorimetry/HEXPLIT.h
+++ b/src/algorithms/calorimetry/HEXPLIT.h
@@ -9,13 +9,13 @@
 
 #pragma once
 
-#include <algorithms/algorithm.h>
 #include <DD4hep/Detector.h>
+#include <algorithms/algorithm.h>
 #include <edm4eic/CalorimeterHitCollection.h>
-#include <spdlog/logger.h>
-#include <memory>
 #include <string>                                 // for basic_string
 #include <string_view>                            // for string_view
+#include <vector>
+
 #include "HEXPLITConfig.h"
 #include "algorithms/interfaces/WithPodConfig.h"
 

--- a/src/algorithms/calorimetry/ImagingClusterReco.h
+++ b/src/algorithms/calorimetry/ImagingClusterReco.h
@@ -63,14 +63,9 @@ namespace eicrecon {
                             {"outputClusterCollection", "outputClusterAssociations", "outputLayerCollection"},
                             "Reconstruct the cluster/layer info for imaging calorimeter."} {}
 
-  private:
-    std::shared_ptr<spdlog::logger> m_log;
-
   public:
 
-    void init(std::shared_ptr<spdlog::logger>& logger) {
-        m_log = logger;
-    }
+    void init()  { }
 
     void process(const Input& input, const Output& output) const final {
 
@@ -79,7 +74,7 @@ namespace eicrecon {
 
         for (const auto& pcl: *proto) {
             if (!pcl.getHits().empty() && !pcl.getHits(0).isAvailable()) {
-                m_log->warn("Protocluster hit relation is invalid, skipping protocluster");
+                warning("Protocluster hit relation is invalid, skipping protocluster");
                 continue;
             }
             // get cluster and associated layers
@@ -122,7 +117,7 @@ namespace eicrecon {
                 }
                 if( !mchit ){
                     // break if no matching hit found for this CellID
-                    m_log->warn("Proto-cluster has highest energy in CellID {}, but no mc hit with that CellID was found.", pclhit->getCellID());
+                    warning("Proto-cluster has highest energy in CellID {}, but no mc hit with that CellID was found.", pclhit->getCellID());
                     break;
                 }
 
@@ -142,7 +137,7 @@ namespace eicrecon {
 
         // debug output
         for (const auto& cl: *clusters) {
-            m_log->debug("Cluster {:d}: Edep = {:.3f} MeV, Dir = ({:.3f}, {:.3f}) deg", cl.getObjectID().index,
+            debug("Cluster {:d}: Edep = {:.3f} MeV, Dir = ({:.3f}, {:.3f}) deg", cl.getObjectID().index,
                          cl.getEnergy() * 1000., cl.getIntrinsicTheta() / M_PI * 180.,
                          cl.getIntrinsicPhi() / M_PI * 180.
             );

--- a/src/algorithms/calorimetry/ImagingTopoCluster.h
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.h
@@ -63,24 +63,20 @@ namespace eicrecon {
 
   private:
 
-    std::shared_ptr<spdlog::logger> m_log;
-
     // unitless counterparts of the input parameters
     double localDistXY[2]{0, 0}, layerDistEtaPhi[2]{0, 0}, sectorDist{0};
     double minClusterHitEdep{0}, minClusterCenterEdep{0}, minClusterEdep{0}, minClusterNhits{0};
 
   public:
-    void init(std::shared_ptr<spdlog::logger>& logger) {
-        m_log = logger;
-
+    void init() {
         // unitless conversion
         // sanity checks
         if (m_cfg.localDistXY.size() != 2) {
-            m_log->error( "Expected 2 values (x_dist, y_dist) for localDistXY");
+            error( "Expected 2 values (x_dist, y_dist) for localDistXY");
             return;
         }
         if (m_cfg.layerDistEtaPhi.size() != 2) {
-            m_log->error( "Expected 2 values (eta_dist, phi_dist) for layerDistEtaPhi" );
+            error( "Expected 2 values (eta_dist, phi_dist) for layerDistEtaPhi" );
             return;
         }
 
@@ -95,15 +91,15 @@ namespace eicrecon {
         minClusterEdep = m_cfg.minClusterEdep / dd4hep::GeV;
 
         // summarize the clustering parameters
-        m_log->info("Local clustering (same sector and same layer): "
+        info("Local clustering (same sector and same layer): "
                     "Local [x, y] distance between hits <= [{:.4f} mm, {:.4f} mm].",
                     localDistXY[0], localDistXY[1]
         );
-        m_log->info("Neighbour layers clustering (same sector and layer id within +- {:d}: "
+        info("Neighbour layers clustering (same sector and layer id within +- {:d}: "
                     "Global [eta, phi] distance between hits <= [{:.4f}, {:.4f} rad].",
                     m_cfg.neighbourLayersRange, layerDistEtaPhi[0], layerDistEtaPhi[1]
         );
-        m_log->info("Neighbour sectors clustering (different sector): "
+        info("Neighbour sectors clustering (different sector): "
                     "Global distance between hits <= {:.4f} mm.",
                     sectorDist
         );
@@ -118,7 +114,7 @@ namespace eicrecon {
         std::vector<bool> visits(hits->size(), false);
         std::vector<std::set<std::size_t>> groups;
         for (size_t i = 0; i < hits->size(); ++i) {
-            m_log->debug("hit {:d}: local position = ({}, {}, {}), global position = ({}, {}, {})", i + 1,
+            debug("hit {:d}: local position = ({}, {}, {}), global position = ({}, {}, {})", i + 1,
                          (*hits)[i].getLocal().x, (*hits)[i].getLocal().y, (*hits)[i].getPosition().z,
                          (*hits)[i].getPosition().x, (*hits)[i].getPosition().y, (*hits)[i].getPosition().z
             );
@@ -130,9 +126,9 @@ namespace eicrecon {
             groups.emplace_back();
             bfs_group(*hits, groups.back(), i, visits);
         }
-        m_log->debug("found {} potential clusters (groups of hits)", groups.size());
+        debug("found {} potential clusters (groups of hits)", groups.size());
         for (size_t i = 0; i < groups.size(); ++i) {
-            m_log->debug("group {}: {} hits", i, groups[i].size());
+            debug("group {}: {} hits", i, groups[i].size());
         }
 
         // form clusters

--- a/src/factories/calorimetry/CalorimeterClusterRecoCoG_factory.h
+++ b/src/factories/calorimetry/CalorimeterClusterRecoCoG_factory.h
@@ -35,7 +35,7 @@ public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
         m_algo->applyConfig(config());
-        m_algo->init(logger());
+        m_algo->init();
     }
 
     void ChangeRun(int64_t run_number) {

--- a/src/factories/calorimetry/CalorimeterClusterRecoCoG_factory.h
+++ b/src/factories/calorimetry/CalorimeterClusterRecoCoG_factory.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "algorithms/calorimetry/CalorimeterClusterRecoCoG.h"
-#include "services/geometry/dd4hep/DD4hep_service.h"
+#include "services/algorithms_init/AlgorithmsInit_service.h"
 #include "extensions/jana/JOmniFactory.h"
 
 
@@ -30,6 +30,8 @@ private:
     ParameterRef<std::vector<double>> m_logWeightBaseCoeffs {this, "logWeightBaseCoeffs", config().logWeightBaseCoeffs};
     ParameterRef<double> m_logWeightBase_Eref {this, "logWeightBase_Eref", config().logWeightBase_Eref};
     ParameterRef<bool> m_enableEtaBounds {this, "enableEtaBounds", config().enableEtaBounds};
+
+    Service<AlgorithmsInit_service> m_algorithmsInit {this};
 
 public:
     void Configure() {

--- a/src/factories/calorimetry/CalorimeterClusterRecoCoG_factory.h
+++ b/src/factories/calorimetry/CalorimeterClusterRecoCoG_factory.h
@@ -34,6 +34,7 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
+        m_algo->level((algorithms::LogLevel)logger()->level());
         m_algo->applyConfig(config());
         m_algo->init();
     }

--- a/src/factories/calorimetry/CalorimeterHitDigi_factory.h
+++ b/src/factories/calorimetry/CalorimeterHitDigi_factory.h
@@ -37,8 +37,9 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
+        m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
         m_algo->applyConfig(config());
-        m_algo->init(logger());
+        m_algo->init();
     }
 
     void ChangeRun(int64_t run_number) {

--- a/src/factories/calorimetry/CalorimeterHitReco_factory.h
+++ b/src/factories/calorimetry/CalorimeterHitReco_factory.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "algorithms/calorimetry/CalorimeterHitReco.h"
+#include "services/algorithms_init/AlgorithmsInit_service.h"
 #include "services/geometry/dd4hep/DD4hep_service.h"
 #include "extensions/jana/JOmniFactory.h"
 
@@ -35,8 +36,8 @@ private:
     ParameterRef<std::string> m_localDetElement {this, "localDetElement", config().localDetElement};
     ParameterRef<std::vector<std::string>> m_localDetFields {this, "localDetFields", config().localDetFields};
 
+    Service<AlgorithmsInit_service> m_algorithmsInit {this};
     Service<DD4hep_service> m_geoSvc {this};
-
 
 public:
     void Configure() {

--- a/src/factories/calorimetry/CalorimeterHitReco_factory.h
+++ b/src/factories/calorimetry/CalorimeterHitReco_factory.h
@@ -41,8 +41,9 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
+        m_algo->level((algorithms::LogLevel)logger()->level());
         m_algo->applyConfig(config());
-        m_algo->init(m_geoSvc().detector(), m_geoSvc().converter(), logger());
+        m_algo->init(m_geoSvc().detector(), m_geoSvc().converter());
     }
 
     void ChangeRun(int64_t run_number) {

--- a/src/factories/calorimetry/CalorimeterHitsMerger_factory.h
+++ b/src/factories/calorimetry/CalorimeterHitsMerger_factory.h
@@ -30,8 +30,9 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
+        m_algo->level((algorithms::LogLevel)logger()->level());
         m_algo->applyConfig(config());
-        m_algo->init(m_geoSvc().detector(), m_geoSvc().converter(), logger());
+        m_algo->init(m_geoSvc().detector(), m_geoSvc().converter());
     }
 
     void ChangeRun(int64_t run_number) {

--- a/src/factories/calorimetry/CalorimeterHitsMerger_factory.h
+++ b/src/factories/calorimetry/CalorimeterHitsMerger_factory.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "algorithms/calorimetry/CalorimeterHitsMerger.h"
+#include "services/algorithms_init/AlgorithmsInit_service.h"
 #include "services/geometry/dd4hep/DD4hep_service.h"
 #include "extensions/jana/JOmniFactory.h"
 #include "extensions/spdlog/SpdlogMixin.h"

--- a/src/factories/calorimetry/CalorimeterIslandCluster_factory.h
+++ b/src/factories/calorimetry/CalorimeterIslandCluster_factory.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "algorithms/calorimetry/CalorimeterIslandCluster.h"
+#include "services/algorithms_init/AlgorithmsInit_service.h"
 #include "services/geometry/dd4hep/DD4hep_service.h"
 #include "extensions/jana/JOmniFactory.h"
 

--- a/src/factories/calorimetry/CalorimeterIslandCluster_factory.h
+++ b/src/factories/calorimetry/CalorimeterIslandCluster_factory.h
@@ -40,11 +40,12 @@ public:
 
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
+        m_algo->level((algorithms::LogLevel)logger()->level());
         // Remove spaces from adjacency matrix
         // cfg.adjacencyMatrix.erase(
         //  std::remove_if(cfg.adjacencyMatrix.begin(), cfg.adjacencyMatrix.end(), ::isspace), cfg.adjacencyMatrix.end());
         m_algo->applyConfig(config());
-        m_algo->init(m_geoSvc().detector(), logger());
+        m_algo->init(m_geoSvc().detector());
     }
 
     void ChangeRun(int64_t run_number) {

--- a/src/factories/calorimetry/CalorimeterTruthClustering_factory.h
+++ b/src/factories/calorimetry/CalorimeterTruthClustering_factory.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "algorithms/calorimetry/CalorimeterTruthClustering.h"
+#include "services/algorithms_init/AlgorithmsInit_service.h"
 #include "extensions/jana/JOmniFactory.h"
 
 

--- a/src/factories/calorimetry/CalorimeterTruthClustering_factory.h
+++ b/src/factories/calorimetry/CalorimeterTruthClustering_factory.h
@@ -23,7 +23,8 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
-        m_algo->init(logger());
+        m_algo->level((algorithms::LogLevel)logger()->level());
+        m_algo->init();
     }
 
     void ChangeRun(int64_t run_number) {

--- a/src/factories/calorimetry/EnergyPositionClusterMerger_factory.h
+++ b/src/factories/calorimetry/EnergyPositionClusterMerger_factory.h
@@ -32,8 +32,9 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
+        m_algo->level((algorithms::LogLevel)logger()->level());
         m_algo->applyConfig(config());
-        m_algo->init(logger());
+        m_algo->init();
     }
 
     void ChangeRun(int64_t run_number) {

--- a/src/factories/calorimetry/EnergyPositionClusterMerger_factory.h
+++ b/src/factories/calorimetry/EnergyPositionClusterMerger_factory.h
@@ -5,6 +5,7 @@
 
 #include "algorithms/calorimetry/EnergyPositionClusterMerger.h"
 #include "extensions/jana/JOmniFactory.h"
+#include "services/algorithms_init/AlgorithmsInit_service.h"
 
 
 namespace eicrecon {
@@ -28,6 +29,8 @@ private:
     ParameterRef<double> m_energyRelTolerance {this, "energyRelTolerance", config().energyRelTolerance};
     ParameterRef<double> m_phiTolerance {this, "phiTolerance", config().phiTolerance};
     ParameterRef<double> m_etaTolerance {this, "etaTolerance", config().etaTolerance};
+
+    Service<AlgorithmsInit_service> m_algorithmsInit {this};
 
 public:
     void Configure() {

--- a/src/factories/calorimetry/HEXPLIT_factory.h
+++ b/src/factories/calorimetry/HEXPLIT_factory.h
@@ -27,8 +27,9 @@ class HEXPLIT_factory : public JOmniFactory<HEXPLIT_factory, HEXPLITConfig> {
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
+        m_algo->level((algorithms::LogLevel)logger()->level());
         m_algo->applyConfig(config());
-        m_algo->init(m_geoSvc().detector(), logger());
+        m_algo->init(m_geoSvc().detector());
     }
 
     void ChangeRun(int64_t run_number) {

--- a/src/factories/calorimetry/HEXPLIT_factory.h
+++ b/src/factories/calorimetry/HEXPLIT_factory.h
@@ -3,9 +3,10 @@
 
 #pragma once
 
-#include <algorithms/calorimetry/HEXPLIT.h>
-#include <services/geometry/dd4hep/DD4hep_service.h>
-#include <extensions/jana/JOmniFactory.h>
+#include "algorithms/calorimetry/HEXPLIT.h"
+#include "services/algorithms_init/AlgorithmsInit_service.h"
+#include "services/geometry/dd4hep/DD4hep_service.h"
+#include "extensions/jana/JOmniFactory.h"
 
 
 namespace eicrecon {
@@ -22,6 +23,7 @@ class HEXPLIT_factory : public JOmniFactory<HEXPLIT_factory, HEXPLITConfig> {
     ParameterRef<double> m_Emin_in_MIPs     {this, "Emin_in_MIPs",          config().Emin_in_MIPs};
     ParameterRef<double> m_tmax     {this, "tmax",          config().tmax};
 
+    Service<AlgorithmsInit_service> m_algorithmsInit {this};
     Service<DD4hep_service> m_geoSvc {this};
 
 public:

--- a/src/factories/calorimetry/ImagingClusterReco_factory.h
+++ b/src/factories/calorimetry/ImagingClusterReco_factory.h
@@ -5,7 +5,7 @@
 
 #include "algorithms/calorimetry/ImagingClusterReco.h"
 #include "extensions/jana/JOmniFactory.h"
-
+#include "services/algorithms_init/AlgorithmsInit_service.h"
 
 namespace eicrecon {
 
@@ -25,6 +25,8 @@ private:
     PodioOutput<edm4eic::Cluster> m_layers_output {this};
 
     ParameterRef<int> m_trackStopLayer {this, "trackStopLayer", config().trackStopLayer};
+
+    Service<AlgorithmsInit_service> m_algorithmsInit {this};
 
 public:
     void Configure() {

--- a/src/factories/calorimetry/ImagingClusterReco_factory.h
+++ b/src/factories/calorimetry/ImagingClusterReco_factory.h
@@ -29,8 +29,9 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
+        m_algo->level((algorithms::LogLevel)logger()->level());
         m_algo->applyConfig(config());
-        m_algo->init(logger());
+        m_algo->init();
     }
 
     void ChangeRun(int64_t run_number) {

--- a/src/factories/calorimetry/ImagingTopoCluster_factory.h
+++ b/src/factories/calorimetry/ImagingTopoCluster_factory.h
@@ -31,8 +31,9 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
+        m_algo->level((algorithms::LogLevel)logger()->level());
         m_algo->applyConfig(config());
-        m_algo->init(logger());
+        m_algo->init();
     }
 
     void ChangeRun(int64_t run_number) {

--- a/src/factories/calorimetry/ImagingTopoCluster_factory.h
+++ b/src/factories/calorimetry/ImagingTopoCluster_factory.h
@@ -5,7 +5,7 @@
 
 #include "algorithms/calorimetry/ImagingTopoCluster.h"
 #include "extensions/jana/JOmniFactory.h"
-
+#include "services/algorithms_init/AlgorithmsInit_service.h"
 
 namespace eicrecon {
 
@@ -27,6 +27,8 @@ private:
     ParameterRef<double> m_mcced {this, "minClusterCenterEdep", config().minClusterCenterEdep};
     ParameterRef<double> m_mced {this, "minClusterEdep", config().minClusterEdep};
     ParameterRef<int> m_mcnh {this, "minClusterNhits", config().minClusterNhits};
+
+    Service<AlgorithmsInit_service> m_algorithmsInit {this};
 
 public:
     void Configure() {

--- a/src/factories/calorimetry/TruthEnergyPositionClusterMerger_factory.h
+++ b/src/factories/calorimetry/TruthEnergyPositionClusterMerger_factory.h
@@ -27,7 +27,8 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
-        m_algo->init(logger());
+        m_algo->level((algorithms::LogLevel)logger()->level());
+        m_algo->init();
     }
 
     void ChangeRun(int64_t run_number) {

--- a/src/factories/calorimetry/TruthEnergyPositionClusterMerger_factory.h
+++ b/src/factories/calorimetry/TruthEnergyPositionClusterMerger_factory.h
@@ -5,7 +5,7 @@
 
 #include "algorithms/calorimetry/TruthEnergyPositionClusterMerger.h"
 #include "extensions/jana/JOmniFactory.h"
-
+#include "services/algorithms_init/AlgorithmsInit_service.h"
 
 namespace eicrecon {
 
@@ -23,6 +23,8 @@ private:
 
     PodioOutput<edm4eic::Cluster> m_clusters_output {this};
     PodioOutput<edm4eic::MCRecoClusterParticleAssociation> m_assocs_output {this};
+
+    Service<AlgorithmsInit_service> m_algorithmsInit {this};
 
 public:
     void Configure() {

--- a/src/services/algorithms_init/AlgorithmsInit_service.h
+++ b/src/services/algorithms_init/AlgorithmsInit_service.h
@@ -38,7 +38,7 @@ class AlgorithmsInit_service : public JService
         // Register DD4hep_service as algorithms::GeoSvc
         [[maybe_unused]] auto& geoSvc = algorithms::GeoSvc::instance();
         serviceSvc.setInit<algorithms::GeoSvc>([this](auto&& g) {
-            this->m_log->info("Initializing algorithms::GeoSvc");
+            this->m_log->debug("Initializing algorithms::GeoSvc");
             g.init(const_cast<dd4hep::Detector*>(this->m_dd4hep_service->detector().get()));
         });
 
@@ -46,13 +46,13 @@ class AlgorithmsInit_service : public JService
         const algorithms::LogLevel level{
             static_cast<algorithms::LogLevel>(m_log->level())};
         serviceSvc.setInit<algorithms::LogSvc>([this,level](auto&& logger) {
-            this->m_log->info("Initializing algorithms::LogSvc");
+            this->m_log->debug("Initializing algorithms::LogSvc");
             logger.init([this](const algorithms::LogLevel l, std::string_view caller, std::string_view msg){
                 static std::mutex m;
                 std::lock_guard<std::mutex> lock(m);
                 static std::map<std::string_view, std::shared_ptr<spdlog::logger>> loggers;
                 if (! loggers.contains(caller)) {
-                    this->m_log->info("Initializing algorithms::LogSvc logger {}", caller);
+                    this->m_log->debug("Initializing algorithms::LogSvc logger {}", caller);
                     loggers[caller] = this->m_log_service->logger(std::string(caller));
                 }
                 loggers[caller]->log(static_cast<spdlog::level::level_enum>(l), msg);
@@ -63,7 +63,7 @@ class AlgorithmsInit_service : public JService
         // Register a random service (JANA2 does not have one)
         [[maybe_unused]] auto& randomSvc = algorithms::RandomSvc::instance();
         serviceSvc.setInit<algorithms::RandomSvc>([this](auto&& r) {
-            this->m_log->info("Initializing algorithms::RandomSvc");
+            this->m_log->debug("Initializing algorithms::RandomSvc");
             r.setProperty("seed", static_cast<size_t>(1));
             r.init();
         });

--- a/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
@@ -62,8 +62,9 @@ TEST_CASE( "the clustering algorithm runs", "[CalorimeterHitDigi]" ) {
     cfg.dyRangeADC = 5.0 /* GeV */;
     cfg.pedMeanADC = 123;
     cfg.resolutionTDC = 1.0 * dd4hep::ns;
+    algo.level(algorithms::LogLevel(spdlog::level::trace));
     algo.applyConfig(cfg);
-    algo.init(logger);
+    algo.init();
 
     auto calohits = std::make_unique<edm4hep::CaloHitContributionCollection>();
     auto simhits = std::make_unique<edm4hep::SimCalorimeterHitCollection>();

--- a/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
@@ -4,6 +4,7 @@
 #include <DD4hep/Detector.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <algorithms/geo.h>
+#include <algorithms/logger.h>
 #include <algorithms/random.h>
 #include <algorithms/service.h>
 #include <catch2/catch_test_macros.hpp>

--- a/src/tests/algorithms_test/calorimetry_CalorimeterIslandCluster.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterIslandCluster.cc
@@ -55,7 +55,7 @@ TEST_CASE( "the clustering algorithm runs", "[CalorimeterIslandCluster]" ) {
       cfg.localDistXY = {1 * dd4hep::mm, 1 * dd4hep::mm};
     }
     algo.applyConfig(cfg);
-    algo.init(detector.get(), logger);
+    algo.init(detector.get());
 
     SECTION( "on a single cell" ) {
       edm4eic::CalorimeterHitCollection hits_coll;
@@ -166,7 +166,7 @@ TEST_CASE( "the clustering algorithm runs", "[CalorimeterIslandCluster]" ) {
     }
     cfg.localDistXY = {1 * dd4hep::mm, 1 * dd4hep::mm};
     algo.applyConfig(cfg);
-    algo.init(detector.get(), logger);
+    algo.init(detector.get());
 
     edm4eic::CalorimeterHitCollection hits_coll;
     hits_coll.create(

--- a/src/tests/algorithms_test/calorimetry_HEXPLIT.cc
+++ b/src/tests/algorithms_test/calorimetry_HEXPLIT.cc
@@ -46,7 +46,7 @@ TEST_CASE( "the subcell-splitting algorithm runs", "[HEXPLIT]" ) {
   auto dimension = edm4hep::Vector3f(2*side_length, sqrt(3)*side_length, thickness);
 
   algo.applyConfig(cfg);
-  algo.init(detector.get(), logger);
+  algo.init(detector.get());
 
   edm4eic::CalorimeterHitCollection hits_coll;
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Instead of giving each algorithm an spdlog logger (`m_log`), the algorithms interface provides a centralized logger service with both stream and call interfaces (`error() << msg << endmsg` and `error(msg)`). This directs the CalorimeterClusterRecoCoG and other calorimeter algorithm to use this interface.

TODO:
- [x] depends on https://github.com/eic/algorithms/pull/13
- [x] depends on https://github.com/eic/algorithms/pull/15
- [x] will conflict with https://github.com/eic/EICrecon/pull/1194

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.