### PR TITLE
fix: convert TrackParamTruthInit to use DD4hep units

### DIFF
--- a/src/algorithms/tracking/TrackParamTruthInit.cc
+++ b/src/algorithms/tracking/TrackParamTruthInit.cc
@@ -4,7 +4,7 @@
 
 #include "TrackParamTruthInit.h"
 
-#include <Evaluate/DD4hepUnits.hpp>
+#include <Evaluator/DD4hepUnits.hpp>
 #include <TParticlePDG.h>
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>

--- a/src/algorithms/tracking/TrackParamTruthInit.cc
+++ b/src/algorithms/tracking/TrackParamTruthInit.cc
@@ -91,7 +91,7 @@ eicrecon::TrackParamTruthInit::produce(const edm4hep::MCParticleCollection* mcpa
         // Insert into edm4eic::TrackParameters, which uses numerical values in its specified units
         auto track_parameter = track_parameters->create();
         track_parameter.setType(-1); // type --> seed(-1)
-        track_parameter.setLoc({static_cast<float>(std::hypot(v.x, v.y) / dd4hep::mm), static_cast<float>(v.z / dd4hep::mm)}); // 2d location on surface [mm]
+        track_parameter.setLoc({static_cast<float>(std::hypot(v.x, v.y)), static_cast<float>(v.z)}); // 2d location on surface [mm]
         track_parameter.setLocError({1.0, 1.0}); // sqrt(variance) of location [mm]
         track_parameter.setTheta(theta); // theta [rad]
         track_parameter.setPhi(phi); // phi [rad]

--- a/src/algorithms/tracking/TrackParamTruthInit.cc
+++ b/src/algorithms/tracking/TrackParamTruthInit.cc
@@ -4,7 +4,7 @@
 
 #include "TrackParamTruthInit.h"
 
-#include <Acts/Definitions/Units.hpp>
+#include <Evaluate/DD4hepUnits.hpp>
 #include <TParticlePDG.h>
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
@@ -29,12 +29,7 @@ void eicrecon::TrackParamTruthInit::init(const std::shared_ptr<spdlog::logger> &
 std::unique_ptr<edm4eic::TrackParametersCollection>
 eicrecon::TrackParamTruthInit::produce(const edm4hep::MCParticleCollection* mcparticles) {
     // MCParticles uses numerical values in its specified units,
-    // while m_cfg is in the Acts unit system
-    using Acts::UnitConstants::GeV;
-    using Acts::UnitConstants::MeV;
-    using Acts::UnitConstants::mm;
-    using Acts::UnitConstants::um;
-    using Acts::UnitConstants::ns;
+    // while m_cfg is in the DD4hep unit system
 
     // Create output collection
     auto track_parameters = std::make_unique<edm4eic::TrackParametersCollection>();
@@ -50,9 +45,9 @@ eicrecon::TrackParamTruthInit::produce(const edm4hep::MCParticleCollection* mcpa
 
         // require close to interaction vertex
         auto v = mcparticle.getVertex();
-        if (abs(v.x) * mm > m_cfg.m_maxVertexX ||
-            abs(v.y) * mm > m_cfg.m_maxVertexY ||
-            abs(v.z) * mm > m_cfg.m_maxVertexZ) {
+        if (abs(v.x) * dd4hep::mm > m_cfg.m_maxVertexX ||
+            abs(v.y) * dd4hep::mm > m_cfg.m_maxVertexY ||
+            abs(v.z) * dd4hep::mm > m_cfg.m_maxVertexZ) {
             m_log->trace("ignoring particle with vs = {} [mm]", v);
             continue;
         }
@@ -60,7 +55,7 @@ eicrecon::TrackParamTruthInit::produce(const edm4hep::MCParticleCollection* mcpa
         // require minimum momentum
         const auto& p = mcparticle.getMomentum();
         const auto pmag = std::hypot(p.x, p.y, p.z);
-        if (pmag * GeV < m_cfg.m_minMomentum) {
+        if (pmag * dd4hep::GeV < m_cfg.m_minMomentum) {
             m_log->trace("ignoring particle with p = {} GeV ", pmag);
             continue;
         }
@@ -91,16 +86,16 @@ eicrecon::TrackParamTruthInit::produce(const edm4hep::MCParticleCollection* mcpa
         }
 
         // modify initial momentum to avoid bleeding truth to results when fit fails
-        const auto pinit = pmag*(1.0 + m_cfg.m_momentumSmear * m_normDist(generator));
+        const auto pinit = pmag * (1.0 + m_cfg.m_momentumSmear * m_normDist(generator));
 
         // Insert into edm4eic::TrackParameters, which uses numerical values in its specified units
         auto track_parameter = track_parameters->create();
         track_parameter.setType(-1); // type --> seed(-1)
-        track_parameter.setLoc({static_cast<float>(std::hypot(v.x, v.y)), static_cast<float>(v.z)}); // 2d location on surface [mm]
+        track_parameter.setLoc({static_cast<float>(std::hypot(v.x, v.y) / dd4hep::mm), static_cast<float>(v.z / dd4hep::mm)}); // 2d location on surface [mm]
         track_parameter.setLocError({1.0, 1.0}); // sqrt(variance) of location [mm]
-        track_parameter.setTheta(theta); //theta [rad]
+        track_parameter.setTheta(theta); // heta [rad]
         track_parameter.setPhi(phi); // phi [rad]
-        track_parameter.setQOverP(charge / pinit); // Q/p [e/GeV]
+        track_parameter.setQOverP(charge / (pinit / dd4hep::GeV)); // Q/p [e/GeV]
         track_parameter.setMomentumError({0.01, 0.05, 0.1}); // sqrt(variance) on theta, phi, q/p [rad, rad, e/GeV]
         track_parameter.setTime(mcparticle.getTime()); // time [ns]
         track_parameter.setTimeError(10e9); // error on time [ns]
@@ -109,9 +104,9 @@ eicrecon::TrackParamTruthInit::produce(const edm4hep::MCParticleCollection* mcpa
         // Debug output
         if (m_log->level() <= spdlog::level::debug) {
             m_log->debug("Invoke track finding seeded by truth particle with:");
-            m_log->debug("   p     = {} GeV (smeared to {} GeV)", pmag, pinit);
+            m_log->debug("   p     = {} GeV (smeared to {} GeV)", pmag / dd4hep::GeV, pinit / dd4hep::GeV);
             m_log->debug("   q     = {}", charge);
-            m_log->debug("   q/p   = {} e/GeV (smeared to {} e/GeV)", charge / pmag, charge / pinit);
+            m_log->debug("   q/p   = {} e/GeV (smeared to {} e/GeV)", charge / (pmag / dd4hep::GeV), charge / (pinit / dd4hep::GeV));
             m_log->debug("   theta = {}", theta);
             m_log->debug("   phi   = {}", phi);
         }

--- a/src/algorithms/tracking/TrackParamTruthInit.cc
+++ b/src/algorithms/tracking/TrackParamTruthInit.cc
@@ -93,7 +93,7 @@ eicrecon::TrackParamTruthInit::produce(const edm4hep::MCParticleCollection* mcpa
         track_parameter.setType(-1); // type --> seed(-1)
         track_parameter.setLoc({static_cast<float>(std::hypot(v.x, v.y) / dd4hep::mm), static_cast<float>(v.z / dd4hep::mm)}); // 2d location on surface [mm]
         track_parameter.setLocError({1.0, 1.0}); // sqrt(variance) of location [mm]
-        track_parameter.setTheta(theta); // heta [rad]
+        track_parameter.setTheta(theta); // theta [rad]
         track_parameter.setPhi(phi); // phi [rad]
         track_parameter.setQOverP(charge / (pinit / dd4hep::GeV)); // Q/p [e/GeV]
         track_parameter.setMomentumError({0.01, 0.05, 0.1}); // sqrt(variance) on theta, phi, q/p [rad, rad, e/GeV]

--- a/src/algorithms/tracking/TrackParamTruthInit.cc
+++ b/src/algorithms/tracking/TrackParamTruthInit.cc
@@ -4,7 +4,7 @@
 
 #include "TrackParamTruthInit.h"
 
-#include <Evaluator/DD4hepUnits.hpp>
+#include <Evaluator/DD4hepUnits.h>
 #include <TParticlePDG.h>
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>

--- a/src/algorithms/tracking/TrackParamTruthInitConfig.h
+++ b/src/algorithms/tracking/TrackParamTruthInitConfig.h
@@ -4,14 +4,14 @@
 
 #pragma once
 
-#include <Acts/Definitions/Units.hpp>
+#include <Evaluator/DD4hepUnits.h>
 
 struct TrackParamTruthInitConfig {
 
-    double m_maxVertexX       = 80  * Acts::UnitConstants::mm;
-    double m_maxVertexY       = 80  * Acts::UnitConstants::mm;
-    double m_maxVertexZ       = 200 * Acts::UnitConstants::mm;
-    double m_minMomentum      = 100 * Acts::UnitConstants::MeV;
+    double m_maxVertexX       = 80  * dd4hep::mm;
+    double m_maxVertexY       = 80  * dd4hep::mm;
+    double m_maxVertexZ       = 200 * dd4hep::mm;
+    double m_minMomentum      = 100 * dd4hep::MeV;
     double m_maxEtaForward    = 6.0;
     double m_maxEtaBackward   = 4.1;
     double m_momentumSmear    = 0.1;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Units are set (via command line or config files) assuming a certain unit system. We have chosen DD4hep for this in all other cases (in part because it comes with a parser). Having one algorithm use Acts units is potentially confusing since distances may be passed in the wrong units.

This PR converts TrackParamTruthInit to store the config variables in DD4hep units, and modifies the algorithm itself to interpret the config in DD4hep units. No changes are expected to the output.

No values are specified in the factory or in the plugin, so this is the only change that should be needed.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #1166)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.