### PR TITLE
fix: use Log_service inside DD4hep_service

### DIFF
--- a/src/services/geometry/dd4hep/DD4hep_service.cc
+++ b/src/services/geometry/dd4hep/DD4hep_service.cc
@@ -17,7 +17,23 @@
 #include <utility>
 #include <vector>
 
+#include "extensions/spdlog/SpdlogExtensions.h"
+#include "services/log/Log_service.h"
+
 #include "DD4hep_service.h"
+
+//----------------------------------------------------------------
+// Services
+//----------------------------------------------------------------
+void DD4hep_service::acquire_services(JServiceLocator *srv_locator) {
+    // logging service
+    auto log_service = srv_locator->get<Log_service>();
+    m_log = log_service->logger("dd4hep");
+    std::string log_level_str = "info";
+    m_app->SetDefaultParameter("dd4hep:LogLevel", log_level_str, "Log level for DD4hep_service");
+    m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
+    m_log->debug("DD4hep log level is set to {} ({})", log_level_str, fmt::underlying(m_log->level()));
+}
 
 //----------------------------------------------------------------
 // destructor
@@ -64,7 +80,7 @@ DD4hep_service::converter() {
 void DD4hep_service::Initialize() {
 
     if (m_dd4hepGeo) {
-        LOG_WARN(default_cout_logger) << "DD4hep_service already initialized!" << LOG_END;
+        m_log->warn("DD4hep_service already initialized!");
     }
 
     // The current recommended way of getting the XML file is to use the environment variables
@@ -87,36 +103,36 @@ void DD4hep_service::Initialize() {
 
     // User may specify multiple geometry files via the config. parameter. Normally, this
     // will be a single file which itself has includes for other files.
-    app->SetDefaultParameter("dd4hep:xml_files", m_xml_files, "Comma separated list of XML files describing the DD4hep geometry. (Defaults to ${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml using envars.)");
+    m_app->SetDefaultParameter("dd4hep:xml_files", m_xml_files, "Comma separated list of XML files describing the DD4hep geometry. (Defaults to ${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml using envars.)");
 
     if( m_xml_files.empty() ){
-        LOG_ERROR(default_cerr_logger) << "No dd4hep XML file specified for the geometry!" << LOG_END;
-        LOG_ERROR(default_cerr_logger) << "Set your DETECTOR_PATH and DETECTOR_CONFIG environment variables" << LOG_END;
-        LOG_ERROR(default_cerr_logger) << "(the latter is typically done by sourcing the setup.sh" << LOG_END;
-        LOG_ERROR(default_cerr_logger) << "script the epic directory.)" << LOG_END;
+        m_log->error("No dd4hep XML file specified for the geometry!");
+        m_log->error("Set your DETECTOR_PATH and DETECTOR_CONFIG environment variables");
+        m_log->error("(the latter is typically done by sourcing the setup.sh");
+        m_log->error("script the epic directory.)");
         throw std::runtime_error("No dd4hep XML file specified.");
     }
 
     // Set the DD4hep print level to be quieter by default, but let user adjust it
     int print_level = dd4hep::WARNING;
-    app->SetDefaultParameter("dd4hep:print_level", print_level, "Set DD4hep print level (see DD4hep/Printout.h)");
+    m_app->SetDefaultParameter("dd4hep:print_level", print_level, "Set DD4hep print level (see DD4hep/Printout.h)");
 
     // Reading the geometry may take a long time and if the JANA ticker is enabled, it will keep printing
     // while no other output is coming which makes it look like something is wrong. Disable the ticker
     // while parsing and loading the geometry
-    auto tickerEnabled = app->IsTickerEnabled();
-    app->SetTicker( false );
+    auto tickerEnabled = m_app->IsTickerEnabled();
+    m_app->SetTicker( false );
 
     // load geometry
     auto detector = dd4hep::Detector::make_unique("");
     try {
         dd4hep::setPrintLevel(static_cast<dd4hep::PrintLevel>(print_level));
-        LOG << "Loading DD4hep geometry from " << m_xml_files.size() << " files" << LOG_END;
+        m_log->info("Loading DD4hep geometry from {} files", m_xml_files.size());
         for (auto &filename : m_xml_files) {
 
             auto resolved_filename = resolveFileName(filename, detector_path_env);
 
-            LOG << "  - loading geometry file:  '" << resolved_filename << "' (patience ....)" << LOG_END;
+            m_log->info("  - loading geometry file:  '{}' (patience ....)", resolved_filename);
             try {
                 detector->fromCompact(resolved_filename);
             } catch(std::runtime_error &e) {        // dd4hep throws std::runtime_error, no way to detail further
@@ -128,14 +144,14 @@ void DD4hep_service::Initialize() {
         m_cellid_converter = std::make_unique<const dd4hep::rec::CellIDPositionConverter>(*detector);
         m_dd4hepGeo = std::move(detector); // const
 
-        LOG << "Geometry successfully loaded." << LOG_END;
+        m_log->info("Geometry successfully loaded.");
     } catch(std::exception &e) {
-        LOG_ERROR(default_cerr_logger)<< "Problem loading geometry: " << e.what() << LOG_END;
+        m_log->error("Problem loading geometry: {}", e.what());
         throw std::runtime_error(fmt::format("Problem loading geometry: {}", e.what()));
     }
 
     // Restore the ticker setting
-    app->SetTicker( tickerEnabled );
+    m_app->SetTicker( tickerEnabled );
 }
 
 std::string DD4hep_service::resolveFileName(const std::string &filename, char *detector_path_env) {

--- a/src/services/geometry/dd4hep/DD4hep_service.h
+++ b/src/services/geometry/dd4hep/DD4hep_service.h
@@ -9,6 +9,7 @@
 #include <JANA/JApplication.h>
 #include <JANA/Services/JServiceLocator.h>
 #include <gsl/pointers>
+#include <spdlog/logger.h>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -17,7 +18,7 @@
 class DD4hep_service : public JService
 {
 public:
-    DD4hep_service( JApplication *app ) : app(app) {}
+    DD4hep_service( JApplication *app ) : m_app(app) {}
     virtual ~DD4hep_service();
 
     virtual gsl::not_null<const dd4hep::Detector*> detector();
@@ -27,14 +28,17 @@ protected:
     void Initialize();
 
 private:
-    DD4hep_service()=default;
+    DD4hep_service() = default;
+    void acquire_services(JServiceLocator *) override;
 
     std::once_flag init_flag;
-    JApplication *app = nullptr;
+    JApplication *m_app = nullptr;
     std::unique_ptr<const dd4hep::Detector> m_dd4hepGeo = nullptr;
     std::unique_ptr<const dd4hep::rec::CellIDPositionConverter> m_cellid_converter = nullptr;
     std::vector<std::string> m_xml_files;
 
     /// Ensures there is a geometry file that should be opened
     std::string resolveFileName(const std::string &filename, char *detector_path_env);
+
+    std::shared_ptr<spdlog::logger> m_log;
 };


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Instead of using the JANA logger macros, this switches DD4hep_service over to using Log_service for logging. It also has the TGeoManager use a verbose level defined by the dd4hep::PrintLevel.

Default output is now:
```
[dd4hep] [info] Loading DD4hep geometry from 1 files
[dd4hep] [info]   - loading geometry file:  '/opt/detector/epic-nightly/share/epic/epic_craterlake.xml' (patience ....)
[dd4hep] [info] Geometry successfully loaded.
```

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Not really. Less output from TGeoManager by default; recover previous output with `-Pdd4hep:print_level=INFO`.