### PR TITLE
fix: ensure eicrecon-this.sh prepends even when already in PATH

### DIFF
--- a/src/scripts/eicrecon-this.sh.in
+++ b/src/scripts/eicrecon-this.sh.in
@@ -12,17 +12,17 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 export EICrecon_ROOT=$( readlink -f ${SCRIPT_DIR}/.. )
 
-# POSIX-rated helper function to prepend paths without duplication,
+# A helper function to prepend paths without duplication,
 # allowing for empty and undefined values (but not checking existence),
 # but not escaping colons in your paths.
 pathadd() {
-    varname="$1"
-    newpath="$2"
+    local varname="$1"
+    local newpath="$2"
 
     eval "oldvalue=\${${varname}:-}"
 
     # surround with colon so also first and last entry are individually surrounded
-    canonical=":${oldvalue}:"
+    local canonical=":${oldvalue}:"
     # check whether removing newpath changes old path
     if [ "${canonical#*:${newpath}:}" = "${canonical}" ];
     then

--- a/src/scripts/eicrecon-this.sh.in
+++ b/src/scripts/eicrecon-this.sh.in
@@ -12,6 +12,30 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 export EICrecon_ROOT=$( readlink -f ${SCRIPT_DIR}/.. )
 
+# POSIX-rated helper function to prepend paths without duplication,
+# allowing for empty and undefined values (but not checking existence),
+# but not escaping colons in your paths.
+pathadd() {
+    varname="$1"
+    newpath="$2"
+
+    eval "oldvalue=\${${varname}:-}"
+
+    canonical=":${oldvalue}:"
+    if [ "${canonical#*:${newpath}:}" = "${canonical}" ];
+    then
+        if [ -n "${oldvalue}" ]; then
+            eval "export $varname=${newpath}:${oldvalue}"
+        else
+            eval "export $varname=${newpath}"
+        fi
+    else
+        canonical=${canonical%%:${newpath}:*}:${canonical##*:${newpath}:}
+        canonical=$(expr substr ${canonical} 2 $(expr ${#canonical} - 2))
+        eval "export $varname=${newpath}:${canonical}"
+    fi
+}
+
 #----------------- JANA2
 if [[ -f @JANA_DIR@/../../../bin/jana-this.sh ]] ; then
     unset ROOTSYS  # prevent ROOT from removing /usr/local/bin from PATH
@@ -43,9 +67,7 @@ EDM4HEP=$( readlink -f @EDM4HEP_DIR@/../../.. )
 if [[ -d ${EDM4HEP} ]] ; then
     export EDM4HEP_ROOT=${EDM4HEP}
     EDM4HEP_LIBDIR=${EDM4HEP_ROOT}/lib64
-    if [[ ! ":$LD_LIBRARY_PATH:" == *":$EDM4HEP_LIBDIR:"* ]]; then
-        export LD_LIBRARY_PATH="${EDM4HEP_LIBDIR}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
-    fi
+    pathadd LD_LIBRARY_PATH ${EDM4HEP_LIBDIR}
 fi
 
 #----------------- EDM4EIC
@@ -53,9 +75,7 @@ EDM4EIC=$( readlink -f @EDM4EIC_DIR@/../.. )
 if [[ -d ${EDM4EIC} ]] ; then
     export EDM4EIC_ROOT=${EDM4EIC}
     EDM4EIC_LIBDIR=$( readlink -f @EDM4EIC_DIR@/.. )
-    if [[ ! ":$LD_LIBRARY_PATH:" == *":EDM4EIC_LIBDIR:"* ]]; then
-        export LD_LIBRARY_PATH="${EDM4EIC_LIBDIR}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
-    fi
+    pathadd LD_LIBRARY_PATH ${EDM4EIC_LIBDIR}
 fi
 
 #----------------- DD4hep
@@ -68,41 +88,26 @@ fi
 if [[ -d @fmt_DIR@/../../.. ]] ; then
     export fmt_ROOT=@fmt_DIR@/../../..
     fmt_LIBDIR=$( readlink -f @fmt_DIR@/../.. )
-    if [[ ! ":$LD_LIBRARY_PATH:" == *":$fmt_LIBDIR:"* ]]; then
-        export LD_LIBRARY_PATH="${fmt_LIBDIR}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
-    fi
+    pathadd LD_LIBRARY_PATH ${fmt_LIBDIR}
 fi
-
-#----------------- epic detector geometry (disabled since this overwrites use DETECTOR and DETECTOR_CONFIG settings)
-# if [[ -f @DETECTOR_PATH@/../../setup.sh ]]; then
-#     source @DETECTOR_PATH@/../../setup.sh
-# fi
 
 #----------------- IRT
 if [[ -d $( readlink -f @IRT_LIBRARY_DIR@ ) ]] ; then
-    export LD_LIBRARY_PATH="@IRT_LIBRARY_DIR@${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+    pathadd LD_LIBRARY_PATH @IRT_LIBRARY_DIR@
 fi
 
 #----------------- EICrecon
 # Add bin to PATH if not already there
-if [[ ! ":$PATH:" == *":$SCRIPT_DIR:"* ]]; then
-    export PATH=${SCRIPT_DIR}:${PATH}
-fi
+pathadd PATH ${SCRIPT_DIR}
 
 # Add lib to LD_LIBRARY_PATH if not already there
 LIB_DIR=$( readlink -f ${EICrecon_ROOT}/lib )
-if [[ ! ":$LD_LIBRARY_PATH:" == *":$LIB_DIR:"* ]]; then
-    export LD_LIBRARY_PATH="${LIB_DIR}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
-fi
+pathadd LD_LIBRARY_PATH ${LIB_DIR}
 
 # Add plugins to JANA_PLUGIN_PATH if not already there
 PLUGINS_DIR=$( readlink -f ${EICrecon_ROOT}/@PLUGIN_OUTPUT_DIRECTORY@ )
-if [[ ! ":$JANA_PLUGIN_PATH:" == *":$PLUGINS_DIR:"* ]]; then
-    export JANA_PLUGIN_PATH="${PLUGINS_DIR}${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}"
-fi
+pathadd JANA_PLUGIN_PATH ${PLUGINS_DIR}
 
 # Add plugin headers to ROOT_INCLUDE_PATH if not already there
 HEADERS_DIR=$( readlink -f ${EICrecon_ROOT}/include )
-if [[ ! ":ROOT_INCLUDE_PATH:" == *":$HEADERS_DIR:"* ]]; then
-    export ROOT_INCLUDE_PATH="${HEADERS_DIR}${ROOT_INCLUDE_PATH:+:${ROOT_INCLUDE_PATH}}"
-fi
+pathadd ROOT_INCLUDE_PATH ${HEADERS_DIR}

--- a/src/scripts/eicrecon-this.sh.in
+++ b/src/scripts/eicrecon-this.sh.in
@@ -21,17 +21,24 @@ pathadd() {
 
     eval "oldvalue=\${${varname}:-}"
 
+    # surround with colon so also first and last entry are individually surrounded
     canonical=":${oldvalue}:"
+    # check whether removing newpath changes old path
     if [ "${canonical#*:${newpath}:}" = "${canonical}" ];
     then
+        # newpath not in old path
         if [ -n "${oldvalue}" ]; then
             eval "export $varname=${newpath}:${oldvalue}"
         else
             eval "export $varname=${newpath}"
         fi
     else
+        # newpath not in old path
+        # redefine as what's before newpath plus what's after newpath
         canonical=${canonical%%:${newpath}:*}:${canonical##*:${newpath}:}
+        # substring without surrounding colons
         canonical=$(expr substr ${canonical} 2 $(expr ${#canonical} - 2))
+        # prepend newpath
         eval "export $varname=${newpath}:${canonical}"
     fi
 }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
`eicrecon-this.sh` had an issue where it would **not** add EICrecon installs to the PATH and LD_LIBRARY_PATH if they were already in there, **even if there was another EICrecon install earlier in those paths**. That results in confusion when juggling (no pun intended) multiple worktrees with various EICrecon installs.

This PR adds a small utility `pathadd` that takes care of three things:
- always adds the specified directory to the front of the environment variable list to make sure it is found first,
- checks if the environment variable you want to add to is already there or not to avoid trailing colons,
- removes the specified directory from the interiors of the path if it is already somewhere.

On top of that it's POSIX-safe and doesn't use bashisms (which is what took 50% of the effort; writing a regex match and replace is the easy way).

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No. (Default behavior is having just one install tree...)