### PR TITLE
Variadic OmniFactories

### DIFF
--- a/src/algorithms/reco/ElectronReconstruction.cc
+++ b/src/algorithms/reco/ElectronReconstruction.cc
@@ -56,7 +56,7 @@ namespace eicrecon {
               m_log->trace( "ReconstructedParticle: Energy={} GeV, p={} GeV, E/p = {} for PDG (from truth): {}", clu.getEnergy(), edm4hep::utils::magnitude(reco_part.getMomentum()), EoverP, sim.getPDG() );
 
               // Apply the E/p cut here to select electons
-              if ( EoverP >= min_energy_over_momentum && EoverP <= max_energy_over_momentum ) {
+              if ( EoverP >= m_cfg.min_energy_over_momentum && EoverP <= m_cfg.max_energy_over_momentum ) {
                 out_electrons->push_back(reco_part.clone());
               }
 

--- a/src/algorithms/reco/ElectronReconstruction.cc
+++ b/src/algorithms/reco/ElectronReconstruction.cc
@@ -5,6 +5,7 @@
 #include <edm4eic/ClusterCollection.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
+#include "algorithms/reco/ElectronReconstructionConfig.h"
 
 namespace eicrecon {
 

--- a/src/algorithms/reco/ElectronReconstruction.h
+++ b/src/algorithms/reco/ElectronReconstruction.h
@@ -11,10 +11,13 @@
 #include <memory>
 #include <vector>
 
+#include "ElectronReconstructionConfig.h"
+#include "algorithms/interfaces/WithPodConfig.h"
+
 
 namespace eicrecon {
 
-    class ElectronReconstruction {
+    class ElectronReconstruction : public WithPodConfig<ElectronReconstructionConfig>{
 
     public:
 
@@ -28,12 +31,9 @@ namespace eicrecon {
                 const std::vector<const edm4eic::MCRecoClusterParticleAssociationCollection*> &in_clu_assoc
         );
 
-        void setEnergyOverMomentumCut( double minEoP, double maxEoP ) { min_energy_over_momentum = minEoP; max_energy_over_momentum = maxEoP; }
-
     private:
         std::shared_ptr<spdlog::logger> m_log;
         double m_electron{0.000510998928};
-        double min_energy_over_momentum{0.9}, max_energy_over_momentum{1.2};
 
     };
 } // namespace eicrecon

--- a/src/algorithms/reco/ElectronReconstructionConfig.h
+++ b/src/algorithms/reco/ElectronReconstructionConfig.h
@@ -1,0 +1,14 @@
+// Subject to the terms in the LICENSE file found in the top-level directory.
+
+#pragma once
+
+namespace eicrecon {
+
+struct ElectronReconstructionConfig {
+
+    double min_energy_over_momentum = 0.9;
+    double max_energy_over_momentum = 1.2;
+
+};
+
+} // namespace eicrecon

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -111,6 +111,7 @@ public:
         friend class JOmniFactory;
 
         void GetCollection(const JEvent& event) {
+            m_data.clear();
             for (auto& coll_name : this->collection_names) {
                 m_data.push_back(event.GetCollection<PodioT>(coll_name));
             }
@@ -440,6 +441,7 @@ public:
         }
 
         for (size_t i = 0; auto* input : m_inputs) {
+            input->collection_names.clear();
             if (input->is_variadic) {
                 for (size_t j = 0; j<(vcc/vic); ++j) {
                     input->collection_names.push_back(default_input_collection_names[i++]);

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -129,7 +129,9 @@ public:
 
     struct OutputBase {
         std::string type_name;
-        std::string collection_name;
+        std::vector<std::string> collection_names;
+        bool is_variadic = false;
+
         virtual void CreateHelperFactory(JOmniFactory& fac) = 0;
         virtual void SetCollection(JOmniFactory& fac) = 0;
         virtual void Reset() = 0;
@@ -142,7 +144,7 @@ public:
     public:
         Output(JOmniFactory* owner, std::string default_tag_name="") {
             owner->RegisterOutput(this);
-            this->collection_name = default_tag_name;
+            this->collection_names.push_back(default_tag_name);
             this->type_name = JTypeInfo::demangle<T>();
         }
 
@@ -152,11 +154,11 @@ public:
         friend class JOmniFactory;
 
         void CreateHelperFactory(JOmniFactory& fac) override {
-            fac.DeclareOutput<T>(this->collection_name);
+            fac.DeclareOutput<T>(this->collection_names[0]);
         }
 
         void SetCollection(JOmniFactory& fac) override {
-            fac.SetData<T>(this->collection_name, this->m_data);
+            fac.SetData<T>(this->collection_names[0], this->m_data);
         }
 
         void Reset() override { }
@@ -172,7 +174,7 @@ public:
 
         PodioOutput(JOmniFactory* owner, std::string default_collection_name="") {
             owner->RegisterOutput(this);
-            this->collection_name = default_collection_name;
+            this->collection_names.push_back(default_collection_name);
             this->type_name = JTypeInfo::demangle<PodioT>();
         }
 
@@ -182,19 +184,58 @@ public:
         friend class JOmniFactory;
 
         void CreateHelperFactory(JOmniFactory& fac) override {
-            fac.DeclarePodioOutput<PodioT>(this->collection_name);
+            fac.DeclarePodioOutput<PodioT>(this->collection_names[0]);
         }
 
         void SetCollection(JOmniFactory& fac) override {
             if (m_data == nullptr) {
-                throw JException("JOmniFactory: SetCollection failed due to missing output collection '%s'", this->collection_name.c_str());
+                throw JException("JOmniFactory: SetCollection failed due to missing output collection '%s'", this->collection_names[0].c_str());
                 // Otherwise this leads to a PODIO segfault
             }
-            fac.SetCollection<PodioT>(this->collection_name, std::move(this->m_data));
+            fac.SetCollection<PodioT>(this->collection_names[0], std::move(this->m_data));
         }
 
         void Reset() override {
             m_data = std::move(std::make_unique<typename PodioTypeMap<PodioT>::collection_t>());
+        }
+    };
+
+
+    template <typename PodioT>
+    class VariadicPodioOutput : public OutputBase {
+
+        std::vector<std::unique_ptr<typename PodioTypeMap<PodioT>::collection_t>> m_data;
+
+    public:
+
+        VariadicPodioOutput(JOmniFactory* owner, std::vector<std::string> default_collection_names={}) {
+            owner->RegisterOutput(this);
+            this->collection_names = default_collection_names;
+            this->type_name = JTypeInfo::demangle<PodioT>();
+            this->is_variadic = true;
+        }
+
+        std::vector<std::unique_ptr<typename PodioTypeMap<PodioT>::collection_t>>& operator()() { return m_data; }
+
+    private:
+        friend class JOmniFactory;
+
+        void CreateHelperFactory(JOmniFactory& fac) override {
+            for (auto& coll_name : this->collection_names) {
+                fac.DeclarePodioOutput<PodioT>(coll_name);
+            }
+        }
+
+        void SetCollection(JOmniFactory& fac) override {
+            if (m_data.size() != this->collection_names.size()) {
+                throw JException("JOmniFactory: VariadicPodioOutput SetCollection failed: Declared %d collections, but provided %d.", this->collection_names.size(), m_data.size());
+                // Otherwise this leads to a PODIO segfault
+            }
+            fac.SetCollection<PodioT>(this->collection_names[0], std::move(this->m_data));
+        }
+
+        void Reset() override {
+            m_data.clear();
         }
     };
 
@@ -395,6 +436,34 @@ private:
     ConfigT m_config;
 
 public:
+
+    size_t FindVariadicCollectionCount(size_t total_input_count, size_t variadic_input_count, size_t total_collection_count, bool is_input) {
+
+        size_t variadic_collection_count = total_collection_count - (total_input_count - variadic_input_count);
+
+        if (variadic_input_count == 0) {
+            // No variadic inputs: check that collection_name count matches input count exactly
+            if (total_input_count != total_collection_count) {
+                throw JException("JOmniFactory '%s': Wrong number of %s collection names: %d expected, %d found.",
+                                m_prefix.c_str(), (is_input ? "input" : "output"), total_input_count, total_collection_count);
+            }
+        }
+        else {
+            // Variadic inputs: check that we have enough collection names for the non-variadic inputs
+            if (total_input_count-variadic_input_count > total_collection_count) {
+                throw JException("JOmniFactory '%s': Not enough %s collection names: %d needed, %d found.",
+                                m_prefix.c_str(), (is_input ? "input" : "output"), total_input_count-variadic_input_count, total_collection_count);
+            }
+
+            // Variadic inputs: check that the variadic collection names is evenly divided by the variadic input count
+            if (variadic_collection_count % variadic_input_count != 0) {
+                throw JException("JOmniFactory '%s': Wrong number of %s collection names: %d found total, but %d can't be distributed among %d variadic inputs evenly.",
+                                m_prefix.c_str(), (is_input ? "input" : "output"), total_collection_count, variadic_collection_count, variadic_input_count);
+            }
+        }
+        return variadic_collection_count;
+    }
+
     inline void PreInit(std::string tag,
                         std::vector<std::string> default_input_collection_names,
                         std::vector<std::string> default_output_collection_names ) {
@@ -407,43 +476,20 @@ public:
         m_app->SetDefaultParameter(m_prefix + ":InputTags", default_input_collection_names, "Input collection names");
         m_app->SetDefaultParameter(m_prefix + ":OutputTags", default_output_collection_names, "Output collection names");
 
-        // Set input collection names
-        size_t total_input_count = m_inputs.size();
+        // Figure out variadic inputs
         size_t variadic_input_count = 0;
-        size_t total_collection_count = default_input_collection_names.size();
-
         for (auto* input : m_inputs) {
             if (input->is_variadic) {
                variadic_input_count += 1;
             }
         }
-        size_t variadic_collection_count = total_collection_count - (total_input_count - variadic_input_count);
+        size_t variadic_input_collection_count = FindVariadicCollectionCount(m_inputs.size(), variadic_input_count, default_input_collection_names.size(), true);
 
-        if (variadic_input_count == 0) {
-            // No variadic inputs: check that collection_name count matches input count exactly
-            if (total_input_count != total_collection_count) {
-                throw JException("JOmniFactory '%s': Wrong number of input collection names: %d expected, %d found.",
-                                m_prefix.c_str(), total_input_count, total_collection_count);
-            }
-        }
-        else {
-            // Variadic inputs: check that we have enough collection names for the non-variadic inputs
-            if (total_input_count-variadic_input_count > total_collection_count) {
-                throw JException("JOmniFactory '%s': Not enough input collection names: %d needed, %d found.",
-                                m_prefix.c_str(), total_input_count-variadic_input_count, total_collection_count);
-            }
-
-            // Variadic inputs: check that the variadic collection names is evenly divided by the variadic input count
-            if (variadic_collection_count % variadic_input_count != 0) {
-                throw JException("JOmniFactory '%s': Wrong number of input collection names: %d found total, but %d can't be distributed among %d variadic inputs evenly.",
-                                m_prefix.c_str(), total_collection_count, variadic_collection_count, variadic_input_count);
-            }
-        }
-
+        // Set input collection names
         for (size_t i = 0; auto* input : m_inputs) {
             input->collection_names.clear();
             if (input->is_variadic) {
-                for (size_t j = 0; j<(variadic_collection_count/variadic_input_count); ++j) {
+                for (size_t j = 0; j<(variadic_input_collection_count/variadic_input_count); ++j) {
                     input->collection_names.push_back(default_input_collection_names[i++]);
                 }
             }
@@ -452,13 +498,26 @@ public:
             }
         }
 
-        // Set output collection names and create corresponding helper factories
-        if (m_outputs.size() != default_output_collection_names.size()) {
-            throw JException("JOmniFactory '%s': Wrong number of output collection names: %d expected, %d found.",
-                             m_prefix.c_str(), m_outputs.size(), default_output_collection_names.size());
+        // Figure out variadic outputs
+        size_t variadic_output_count = 0;
+        for (auto* output : m_outputs) {
+            if (output->is_variadic) {
+               variadic_output_count += 1;
+            }
         }
+        size_t variadic_output_collection_count = FindVariadicCollectionCount(m_outputs.size(), variadic_output_count, default_output_collection_names.size(), true);
+
+        // Set output collection names and create corresponding helper factories
         for (size_t i = 0; auto* output : m_outputs) {
-            output->collection_name = default_output_collection_names[i++];
+            output->collection_names.clear();
+            if (output->is_variadic) {
+                for (size_t j = 0; j<(variadic_output_collection_count/variadic_output_count); ++j) {
+                    output->collection_names.push_back(default_output_collection_names[i++]);
+                }
+            }
+            else {
+                output->collection_names.push_back(default_output_collection_names[i++]);
+            }
             output->CreateHelperFactory(*this);
         }
 

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -412,8 +412,8 @@ public:
         size_t tcc = default_input_collection_names.size();
 
         for (auto* input : m_inputs) {
-            if (input->is_variadic) { 
-               vic += 1; 
+            if (input->is_variadic) {
+               vic += 1;
             }
         }
         size_t vcc = tcc - (tic - vic);

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -408,42 +408,42 @@ public:
         m_app->SetDefaultParameter(m_prefix + ":OutputTags", default_output_collection_names, "Output collection names");
 
         // Set input collection names
-        size_t tic = m_inputs.size();
-        size_t vic = 0;
-        size_t tcc = default_input_collection_names.size();
+        size_t total_input_count = m_inputs.size();
+        size_t variadic_input_count = 0;
+        size_t total_collection_count = default_input_collection_names.size();
 
         for (auto* input : m_inputs) {
             if (input->is_variadic) {
-               vic += 1;
+               variadic_input_count += 1;
             }
         }
-        size_t vcc = tcc - (tic - vic);
+        size_t variadic_collection_count = total_collection_count - (total_input_count - variadic_input_count);
 
-        if (vic == 0) {
+        if (variadic_input_count == 0) {
             // No variadic inputs: check that collection_name count matches input count exactly
-            if (tic != tcc) {
+            if (total_input_count != total_collection_count) {
                 throw JException("JOmniFactory '%s': Wrong number of input collection names: %d expected, %d found.",
-                                m_prefix.c_str(), tic, tcc);
+                                m_prefix.c_str(), total_input_count, total_collection_count);
             }
         }
         else {
             // Variadic inputs: check that we have enough collection names for the non-variadic inputs
-            if (tic-vic > tcc) {
+            if (total_input_count-variadic_input_count > total_collection_count) {
                 throw JException("JOmniFactory '%s': Not enough input collection names: %d needed, %d found.",
-                                m_prefix.c_str(), tic-vic, tcc);
+                                m_prefix.c_str(), total_input_count-variadic_input_count, total_collection_count);
             }
 
             // Variadic inputs: check that the variadic collection names is evenly divided by the variadic input count
-            if (vcc % vic != 0) {
+            if (variadic_collection_count % variadic_input_count != 0) {
                 throw JException("JOmniFactory '%s': Wrong number of input collection names: %d found total, but %d can't be distributed among %d variadic inputs evenly.",
-                                m_prefix.c_str(), tcc, vcc, vic);
+                                m_prefix.c_str(), total_collection_count, variadic_collection_count, variadic_input_count);
             }
         }
 
         for (size_t i = 0; auto* input : m_inputs) {
             input->collection_names.clear();
             if (input->is_variadic) {
-                for (size_t j = 0; j<(vcc/vic); ++j) {
+                for (size_t j = 0; j<(variadic_collection_count/variadic_input_count); ++j) {
                     input->collection_names.push_back(default_input_collection_names[i++]);
                 }
             }

--- a/src/global/reco/ReconstructedElectrons_factory.h
+++ b/src/global/reco/ReconstructedElectrons_factory.h
@@ -23,19 +23,19 @@ private:
 
     VariadicPodioInput<edm4eic::MCRecoClusterParticleAssociation> m_in_clu_assoc {this};
 
-    // Declare outputs 
+    // Declare outputs
     PodioOutput<edm4eic::ReconstructedParticle> m_out_reco_particles {this};
 
     // Declare parameters here, e.g.
     // ParameterRef<double> m_samplingFraction {this, "samplingFraction", config().sampFrac};
     // ParameterRef<std::string> m_energyWeight {this, "energyWeight", config().energyWeight};
-    
+
     // Declare services here, e.g.
     // Service<DD4hep_service> m_geoSvc {this};
 
 public:
     void Configure() {
-        // This is called when the factory is instantiated. 
+        // This is called when the factory is instantiated.
         // Use this callback to make sure the algorithm is configured.
         // The logger, parameters, and services have all been fetched before this is called
         m_algo = std::make_unique<eicrecon::ElectronReconstruction>();
@@ -50,7 +50,7 @@ public:
     }
 
     void ChangeRun(int64_t run_number) {
-        // This is called whenever the run number is changed. 
+        // This is called whenever the run number is changed.
         // Use this callback to retrieve state that is keyed off of run number.
         // This state should usually be managed by a Service.
         // Note: You usually don't need this, because you can declare a Resource instead.

--- a/src/global/reco/ReconstructedElectrons_factory.h
+++ b/src/global/reco/ReconstructedElectrons_factory.h
@@ -3,85 +3,74 @@
 
 #pragma once
 
-// JANA
-#include "extensions/jana/JChainMultifactoryT.h"
-#include <JANA/JEvent.h>
+#include "extensions/jana/JOmniFactory.h"
 
-// algorithms
 #include "algorithms/reco/ElectronReconstruction.h"
 
-// services
-#include "extensions/spdlog/SpdlogExtensions.h"
-#include "extensions/spdlog/SpdlogMixin.h"
 
 namespace eicrecon {
 
-  class ReconstructedElectrons_factory :
-    public JChainMultifactoryT<NoConfig>,
-    public SpdlogMixin
-  {
+class ReconstructedElectrons_factory : public JOmniFactory<ReconstructedElectrons_factory> {
+private:
 
-    public:
+    // Underlying algorithm
+    std::unique_ptr<eicrecon::ElectronReconstruction> m_algo;
 
-      explicit ReconstructedElectrons_factory(
-          std::string tag,
-          const std::vector<std::string>& input_tags,
-          const std::vector<std::string>& output_tags)
-      : JChainMultifactoryT<NoConfig>(std::move(tag), input_tags, output_tags) {
-          DeclarePodioOutput<edm4eic::ReconstructedParticle>(GetOutputTags()[0]);
-      }
+    // Declare inputs
+    PodioInput<edm4hep::MCParticle> m_in_mc_particles {this, "MCParticles"};
+    PodioInput<edm4eic::ReconstructedParticle> m_in_rc_particles {this, "ReconstructedChargedParticles"};
+    PodioInput<edm4eic::MCRecoParticleAssociation> m_in_rc_particles_assoc {this, "ReconstructedChargedParticleAssociations"};
 
-      /** One time initialization **/
-      void Init() override {
-        // get plugin name and tag
-        auto app    = GetApplication();
-        auto plugin = GetPluginName();
-        auto prefix = plugin + ":" + GetTag();
+    VariadicPodioInput<edm4eic::MCRecoClusterParticleAssociation> m_in_clu_assoc {this};
 
-        // services
-        InitLogger(app, prefix, "info");
-        m_algo.init(m_log);
-      }
+    // Declare outputs 
+    PodioOutput<edm4eic::ReconstructedParticle> m_out_reco_particles {this};
 
-      /** Event by event processing **/
-      void Process(const std::shared_ptr<const JEvent> &event) override{
-        // Step 1. lets collect the Cluster associations from various detectors
-        std::vector<const edm4eic::MCRecoClusterParticleAssociationCollection*> in_clu_assoc;
-        for(auto& input_tag : GetInputTags()){
-          // only collect from the sources that provide ClusterAssociations
-          if ( input_tag.find( "ClusterAssociations" ) == std::string::npos ) {
-            continue;
-          }
-          m_log->trace( "Adding cluster associations from: {}", input_tag );
-          in_clu_assoc.push_back(
-            static_cast<const edm4eic::MCRecoClusterParticleAssociationCollection*>(event->GetCollectionBase(input_tag))
-          );
-        }
+    // Declare parameters here, e.g.
+    // ParameterRef<double> m_samplingFraction {this, "samplingFraction", config().sampFrac};
+    // ParameterRef<std::string> m_energyWeight {this, "energyWeight", config().energyWeight};
+    
+    // Declare services here, e.g.
+    // Service<DD4hep_service> m_geoSvc {this};
 
-        // Step 2. Get MC, RC, and MC-RC association info
-        // This is needed as a bridge to get RecoCluster - RC Particle associations
+public:
+    void Configure() {
+        // This is called when the factory is instantiated. 
+        // Use this callback to make sure the algorithm is configured.
+        // The logger, parameters, and services have all been fetched before this is called
+        m_algo = std::make_unique<eicrecon::ElectronReconstruction>();
 
-        auto mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase("MCParticles"));
-        auto rc_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase("ReconstructedChargedParticles"));
-        auto rc_particles_assoc = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase("ReconstructedChargedParticleAssociations"));
+        // If we had a config object, we'd apply it like so:
+        // m_algo->applyConfig(config());
 
-        // Step 3. Pass everything to "the algorithm"
-        // in the future, select appropriate algorithm (truth, fully reco, etc.)
-        auto output = m_algo.execute(
-          mc_particles,
-          rc_particles,
-          rc_particles_assoc,
-          in_clu_assoc
+        // If we needed geometry, we'd obtain it like so
+        // m_algo->init(m_geoSvc().detector(), m_geoSvc().converter(), logger());
+
+        m_algo->init(logger());
+    }
+
+    void ChangeRun(int64_t run_number) {
+        // This is called whenever the run number is changed. 
+        // Use this callback to retrieve state that is keyed off of run number.
+        // This state should usually be managed by a Service.
+        // Note: You usually don't need this, because you can declare a Resource instead.
+    }
+
+    void Process(int64_t run_number, uint64_t event_number) {
+        // This is called on every event.
+        // Use this callback to call your Algorithm using all inputs and outputs
+        // The inputs will have already been fetched for you at this point.
+        auto output = m_algo->execute(
+          m_in_mc_particles(),
+          m_in_rc_particles(),
+          m_in_rc_particles_assoc(),
+          m_in_clu_assoc()
         );
 
-        m_log->debug( "We have found {} reconstructed electron candidates this event", output->size() );
-        // Step 4. Output the collection
-        SetCollection<edm4eic::ReconstructedParticle>(GetOutputTags()[0], std::move(output));
-      }
+        logger()->debug( "Event {}: Found {} reconstructed electron candidates", event_number, output->size() );
 
-    private:
-
-      // underlying algorithm
-      eicrecon::ElectronReconstruction m_algo;
-  };
-}
+        m_out_reco_particles() = std::move(output);
+        // JANA will take care of publishing the outputs for you.
+    }
+};
+} // namespace eicrecon

--- a/src/global/reco/ReconstructedElectrons_factory.h
+++ b/src/global/reco/ReconstructedElectrons_factory.h
@@ -40,7 +40,7 @@ public:
         // The logger, parameters, and services have all been fetched before this is called
         m_algo = std::make_unique<eicrecon::ElectronReconstruction>();
 
-        // Pass config object to algorithmm
+        // Pass config object to algorithm
         m_algo->applyConfig(config());
 
         // If we needed geometry, we'd obtain it like so

--- a/src/global/reco/ReconstructedElectrons_factory.h
+++ b/src/global/reco/ReconstructedElectrons_factory.h
@@ -10,7 +10,7 @@
 
 namespace eicrecon {
 
-class ReconstructedElectrons_factory : public JOmniFactory<ReconstructedElectrons_factory> {
+class ReconstructedElectrons_factory : public JOmniFactory<ReconstructedElectrons_factory, ElectronReconstructionConfig> {
 private:
 
     // Underlying algorithm
@@ -26,9 +26,9 @@ private:
     // Declare outputs
     PodioOutput<edm4eic::ReconstructedParticle> m_out_reco_particles {this};
 
-    // Declare parameters here, e.g.
-    // ParameterRef<double> m_samplingFraction {this, "samplingFraction", config().sampFrac};
-    // ParameterRef<std::string> m_energyWeight {this, "energyWeight", config().energyWeight};
+    // Declare parameters
+    ParameterRef<double> m_min_energy_over_momentum {this, "minEnergyOverMomentum", config().min_energy_over_momentum};
+    ParameterRef<double> m_max_energy_over_momentum {this, "maxEnergyOverMomentum", config().max_energy_over_momentum};
 
     // Declare services here, e.g.
     // Service<DD4hep_service> m_geoSvc {this};
@@ -40,8 +40,8 @@ public:
         // The logger, parameters, and services have all been fetched before this is called
         m_algo = std::make_unique<eicrecon::ElectronReconstruction>();
 
-        // If we had a config object, we'd apply it like so:
-        // m_algo->applyConfig(config());
+        // Pass config object to algorithmm
+        m_algo->applyConfig(config());
 
         // If we needed geometry, we'd obtain it like so
         // m_algo->init(m_geoSvc().detector(), m_geoSvc().converter(), logger());

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -133,7 +133,7 @@ void InitPlugin(JApplication *app) {
         app
     ));
 
-    app->Add(new JChainMultifactoryGeneratorT<ReconstructedElectrons_factory>(
+    app->Add(new JOmniFactoryGeneratorT<ReconstructedElectrons_factory>(
         "ReconstructedElectrons",
         {"MCParticles", "ReconstructedChargedParticles", "ReconstructedChargedParticleAssociations",
         "EcalBarrelScFiClusterAssociations",

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -143,6 +143,7 @@ void InitPlugin(JApplication *app) {
         "EcalLumiSpecClusterAssociations",
         },
         {"ReconstructedElectrons"},
+        {},
         app
     ));
 

--- a/src/tests/omnifactory_test/JOmniFactoryTests.cc
+++ b/src/tests/omnifactory_test/JOmniFactoryTests.cc
@@ -419,7 +419,3 @@ TEST_CASE("VariadicPodioOutputTests") {
     REQUIRE(left_hits->size() == 2);
     REQUIRE(right_hits->size() == 1);
 }
-
-
-
-

--- a/src/tests/omnifactory_test/JOmniFactoryTests.cc
+++ b/src/tests/omnifactory_test/JOmniFactoryTests.cc
@@ -78,11 +78,11 @@ MultifactoryT* RetrieveMultifactory(JFactorySet* facset, std::string output_coll
 TEST_CASE("Registering Podio outputs works") {
     BasicTestAlg alg;
     REQUIRE(alg.GetOutputs().size() == 3);
-    REQUIRE(alg.GetOutputs()[0]->collection_name == "output_hits_left");
+    REQUIRE(alg.GetOutputs()[0]->collection_names[0] == "output_hits_left");
     REQUIRE(alg.GetOutputs()[0]->type_name == "edm4hep::SimCalorimeterHit");
-    REQUIRE(alg.GetOutputs()[1]->collection_name == "output_hits_right");
+    REQUIRE(alg.GetOutputs()[1]->collection_names[0] == "output_hits_right");
     REQUIRE(alg.GetOutputs()[1]->type_name == "edm4hep::SimCalorimeterHit");
-    REQUIRE(alg.GetOutputs()[2]->collection_name == "output_vechits");
+    REQUIRE(alg.GetOutputs()[2]->collection_names[0] == "output_vechits");
     REQUIRE(alg.GetOutputs()[2]->type_name == "edm4hep::SimCalorimeterHit");
 }
 

--- a/src/tests/omnifactory_test/JOmniFactoryTests.cc
+++ b/src/tests/omnifactory_test/JOmniFactoryTests.cc
@@ -252,7 +252,7 @@ struct VariadicTestAlg : public JOmniFactory<VariadicTestAlg, BasicTestAlgConfig
     void Process(int64_t run_number, uint64_t event_number) {
         m_process_call_count++;
         logger()->info("Calling VariadicTestAlg::Process with bucket_count={}, threshold={}", config().bucket_count, config().threshold);
-        
+
         REQUIRE(m_hits_in()->size() == 3);
         REQUIRE(m_variadic_hits_in().size() == 2);
         REQUIRE(m_variadic_hits_in()[0]->size() == 1);
@@ -293,7 +293,7 @@ TEST_CASE("VariadicOmniFactoryTests") {
     event->InsertCollection<edm4hep::SimCalorimeterHit>(std::move(mains), "main_hits");
     event->InsertCollection<edm4hep::SimCalorimeterHit>(std::move(funs), "fun_hits");
     event->InsertCollection<edm4hep::SimCalorimeterHit>(std::move(funners), "funner_hits");
-    
+
     auto processed = event->GetCollection<edm4hep::SimCalorimeterHit>("processed_hits");
     REQUIRE(processed->size() == 4);
 }

--- a/src/tests/omnifactory_test/JOmniFactoryTests.cc
+++ b/src/tests/omnifactory_test/JOmniFactoryTests.cc
@@ -314,7 +314,7 @@ struct SubsetTestAlg : public JOmniFactory<SubsetTestAlg, BasicTestAlgConfig> {
 
     // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     void Process(int64_t run_number, uint64_t event_number) {
-        
+
         // Variadic collection count constrained to be same size
         REQUIRE(m_left_hits_in().size() == 1);
         REQUIRE(m_right_hits_in().size() == 1);
@@ -365,9 +365,7 @@ TEST_CASE("SubsetOmniFactoryTests") {
     event->InsertCollection<edm4hep::SimCalorimeterHit>(std::move(left), "left");
     event->InsertCollection<edm4hep::SimCalorimeterHit>(std::move(center), "center");
     event->InsertCollection<edm4hep::SimCalorimeterHit>(std::move(right), "right");
-    
+
     auto processed = event->GetCollection<edm4hep::SimCalorimeterHit>("processed_hits");
     REQUIRE(processed->size() == 5);
 }
-
-


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Adds support for variadic PODIO inputs inside JOmniFactories. This lets us fetch an arbitrary number of collections specified simply via input tags. Includes a migrated ReconstructedElectrons factory. 

It also enables us to migrate MatchClusters, MergeTrack, and TrackerHitCollector in the near future.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #1176)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No