### PR TITLE
Fix: Small change to phi difference calculation in seed charge determination

### DIFF
--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -270,8 +270,8 @@ int eicrecon::TrackSeeding::determineCharge(std::vector<std::pair<float,float>>&
   const auto firstphi = atan2(firstpos.second, firstpos.first);
   const auto secondphi = atan2(secondpos.second, secondpos.first);
   auto dphi = secondphi - firstphi;
-  if(dphi > M_PI) dphi = 2.*M_PI - dphi;
-  if(dphi < -M_PI) dphi = 2*M_PI + dphi;
+  if(dphi > M_PI) dphi -= 2.*M_PI;
+  if(dphi < -M_PI) dphi += 2*M_PI;
   if(dphi < 0) charge = -1;
 
   return charge;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Essentially changes this line

```if(dphi > M_PI) dphi = 2.*M_PI - dphi;```

to 
```if(dphi > M_PI) dphi = dphi - 2.*M_PI;```

This will affect a seed where, for example, the first hit is at ```phi = - 179.5 degrees``` and the second hit is at ```phi = + 179.5 degrees```. In the prior version, ```dphi = 360 - 359 = +1 degrees```, returning a positive charge. Now it will correctly return a negative charge.

This has a very small overall effect. For 10k single muons generated from ```(x,y,z) = (0,0,0)``` with eta [-4,4] and p = [0.5,20] GeV/c, we have ```0.86%``` seed charge misidentification now, compared to ```0.87%``` previously.

Thanks to @veprbl for pointing this out.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
Yes, change affects seed charge calculation for a small number of seeds
