### PR TITLE
Migrate remaining factories to JOmniFactory

### DIFF
--- a/src/factories/tracking/TrackerHitCollector_factory.h
+++ b/src/factories/tracking/TrackerHitCollector_factory.h
@@ -3,72 +3,38 @@
 
 #pragma once
 
-#include <spdlog/logger.h>
 #include <edm4eic/TrackerHit.h>
-#include "extensions/jana/JChainMultifactoryT.h"
-#include "extensions/spdlog/SpdlogMixin.h"
+#include "extensions/jana/JOmniFactory.h"
 #include "algorithms/tracking/TrackerHitCollector.h"
 
 namespace eicrecon {
 
 /// This factory just collects reconstructed hits edm4eic::TrackerHit from different sources
 /// And makes a single array out of them
-class TrackerHitCollector_factory :
-    public JChainMultifactoryT<NoConfig>,
-    public SpdlogMixin {
+class TrackerHitCollector_factory : public JOmniFactory<TrackerHitCollector_factory> {
+public:
+    using AlgoT = TrackerHitCollector;
 
-  public:
-    explicit TrackerHitCollector_factory(
-        std::string tag,
-        const std::vector<std::string>& input_tags,
-        const std::vector<std::string>& output_tags)
-    : JChainMultifactoryT<NoConfig>(std::move(tag), input_tags, output_tags) {
+private:
+    std::unique_ptr<AlgoT> m_algo;
 
-      bool owns_data = false; // this produces a subset collection
-      DeclarePodioOutput<edm4eic::TrackerHit>(GetOutputTags()[0], owns_data);
+    VariadicPodioInput<edm4eic::TrackerHit> m_inputs {this};
+    PodioOutput<edm4eic::TrackerHit> m_output {this};
 
+public:
+
+    void Configure() {
+        m_algo = std::make_unique<AlgoT>();
+        m_algo->init(logger());
     }
 
-    /** One time initialization **/
-    void Init() override {
-      auto app = GetApplication();
-
-      // SpdlogMixin logger initialization, sets m_log
-      InitLogger(app, GetPrefix(), "info");
-
-      m_algo.init(logger());
+    void ChangeRun(int64_t run_number) {
     }
 
-    /** Event by event processing **/
-    void Process(const std::shared_ptr<const JEvent> &event) override {
-
-      std::vector<const edm4eic::TrackerHitCollection*> hit_collections;
-      for (const auto& input_tag : GetInputTags()) {
-        // TODO: we could avoid exceptions here by using JEvent::GetAllCollectionNames,
-        // but until that returns a std::set and we can use c++20 contains, there is
-        // not that much benefit to that approach since it requires searching through
-        // a std::vector of names.
-        try {
-          hit_collections.emplace_back(static_cast<const edm4eic::TrackerHitCollection*>(event->GetCollectionBase(input_tag)));
-        }
-        catch(std::exception &e) {
-          // ignore missing collections, but notify them in debug mode
-          m_log->debug(e.what());
-        }
-      }
-
-      try {
-        auto hits = m_algo.process(hit_collections);
-        SetCollection<edm4eic::TrackerHit>(GetOutputTags()[0], std::move(hits));
-      }
-      catch(std::exception &e) {
-        throw JException(e.what());
-      }
+    void Process(int64_t run_number, uint64_t event_number) {
+        // TODO: NWB: optional variadic inputs? m_log->debug(e.what());
+        m_output() = m_algo->process(m_inputs());
     }
-
-  private:
-    TrackerHitCollector m_algo;
-
-  };
+};
 
 } // eicrecon

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -35,7 +35,7 @@ void InitPlugin(JApplication *app) {
             ));
 
     // Tracker hits collector
-    app->Add(new JChainMultifactoryGeneratorT<TrackerHitCollector_factory>(
+    app->Add(new JOmniFactoryGeneratorT<TrackerHitCollector_factory>(
         "CentralTrackingRecHits",
         {
             "SiBarrelTrackerRecHits",          // Si tracker hits


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR makes all JANA factories use JOmniFactory as a base class. This: 
1. Reduces the number of things a user has to learn in order to add a new algorithm
2. Simplifies and deduplicates existing code
3. Removes the older abstractions that are more complex and bug-prone 
4. Paves the way for external wiring of factories
5. Paves the way for Generic Algorithms

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: Refactoring (issue #1176)

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
- Stops suppressing missing collection exceptions in JTrackerHitCollector_factory