### PR TITLE
feat: convert SiliconTrackerDigi to use algorithms:: interface

### DIFF
--- a/src/algorithms/digi/SiliconTrackerDigi.cc
+++ b/src/algorithms/digi/SiliconTrackerDigi.cc
@@ -25,20 +25,23 @@ void SiliconTrackerDigi::init(std::shared_ptr<spdlog::logger>& logger) {
     // Create random gauss function
     m_gauss = [&](){
         return m_random.Gaus(0, m_cfg.timeResolution);
+        //return m_rng.gaussian<double>(0., m_cfg.timeResolution);
     };
 }
 
 
-std::unique_ptr<edm4eic::RawTrackerHitCollection>
-SiliconTrackerDigi::process(const edm4hep::SimTrackerHitCollection& sim_hits) {
+void SiliconTrackerDigi::process(
+        const SiliconTrackerDigi::Input& input,
+        const SiliconTrackerDigi::Output& output) const {
 
-    auto raw_hits { std::make_unique<edm4eic::RawTrackerHitCollection>() };
+    const auto [sim_hits] = input;
+    auto [raw_hits] = output;
 
     // A map of unique cellIDs with temporary structure RawHit
     std::unordered_map<std::uint64_t, edm4eic::MutableRawTrackerHit> cell_hit_map;
 
 
-    for (const auto& sim_hit : sim_hits) {
+    for (const auto& sim_hit : *sim_hits) {
 
         // time smearing
         double time_smearing = m_gauss();
@@ -87,8 +90,6 @@ SiliconTrackerDigi::process(const edm4hep::SimTrackerHitCollection& sim_hits) {
     for (auto item : cell_hit_map) {
         raw_hits->push_back(item.second);
     }
-
-    return std::move(raw_hits);
 }
 
 } // namespace eicrecon

--- a/src/algorithms/digi/SiliconTrackerDigi.cc
+++ b/src/algorithms/digi/SiliconTrackerDigi.cc
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <gsl/pointers>
 #include <unordered_map>
 #include <utility>
 

--- a/src/algorithms/digi/SiliconTrackerDigi.h
+++ b/src/algorithms/digi/SiliconTrackerDigi.h
@@ -35,8 +35,8 @@ namespace eicrecon {
       : SiliconTrackerDigiAlgorithm{name,
                             {"inputHitCollection"},
                             {"outputRawHitCollection"},
-                            "Smear energy deposit, digitize within ADC range, add pedestal, "
-                            "convert time with smearing resolution, and sum signals."} {}
+                            "Apply threshold, digitize within ADC range, "
+                            "convert time with smearing resolution."} {}
 
     void init(std::shared_ptr<spdlog::logger>& logger);
     void process(const Input&, const Output&) const final;

--- a/src/algorithms/digi/SiliconTrackerDigi.h
+++ b/src/algorithms/digi/SiliconTrackerDigi.h
@@ -5,12 +5,13 @@
 
 #include <TRandomGen.h>
 #include <algorithms/algorithm.h>
-#include <algorithms/random.h>
 #include <edm4eic/RawTrackerHitCollection.h>
 #include <edm4hep/SimTrackerHitCollection.h>
 #include <spdlog/logger.h>
 #include <functional>
 #include <memory>
+#include <string>
+#include <string_view>
 
 #include "SiliconTrackerDigiConfig.h"
 #include "algorithms/interfaces/WithPodConfig.h"

--- a/src/algorithms/digi/SiliconTrackerDigi.h
+++ b/src/algorithms/digi/SiliconTrackerDigi.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #include <TRandomGen.h>
+#include <algorithms/algorithm.h>
+#include <algorithms/random.h>
 #include <edm4eic/RawTrackerHitCollection.h>
 #include <edm4hep/SimTrackerHitCollection.h>
 #include <spdlog/logger.h>
@@ -15,25 +17,44 @@
 
 namespace eicrecon {
 
-    /** digitization algorithm for a silicon trackers **/
-    class SiliconTrackerDigi : public WithPodConfig<SiliconTrackerDigiConfig>  {
+  using SiliconTrackerDigiAlgorithm = algorithms::Algorithm<
+    algorithms::Input<
+      edm4hep::SimTrackerHitCollection
+    >,
+    algorithms::Output<
+      edm4eic::RawTrackerHitCollection
+    >
+  >;
 
-    public:
-        void init(std::shared_ptr<spdlog::logger>& logger);
-        std::unique_ptr<edm4eic::RawTrackerHitCollection> process(const edm4hep::SimTrackerHitCollection& sim_hits);
+  class SiliconTrackerDigi
+  : public SiliconTrackerDigiAlgorithm,
+    public WithPodConfig<SiliconTrackerDigiConfig> {
 
-    private:
-        /** algorithm logger */
-        std::shared_ptr<spdlog::logger> m_log;
+  public:
+    SiliconTrackerDigi(std::string_view name)
+      : SiliconTrackerDigiAlgorithm{name,
+                            {"inputHitCollection"},
+                            {"outputRawHitCollection"},
+                            "Smear energy deposit, digitize within ADC range, add pedestal, "
+                            "convert time with smearing resolution, and sum signals."} {}
 
-        /** Random number generation*/
-        TRandomMixMax m_random;
-        std::function<double()> m_gauss;
+    void init(std::shared_ptr<spdlog::logger>& logger);
+    void process(const Input&, const Output&) const final;
 
-        // FIXME replace with standard random engine
-        //std::default_random_engine generator; // TODO: need something more appropriate here
-        //std::normal_distribution<double> m_normDist; // defaults to mean=0, sigma=1
+  private:
+    /** algorithm logger */
+    std::shared_ptr<spdlog::logger> m_log;
 
-    };
+    /** Random number generation*/
+    TRandomMixMax m_random;
+    std::function<double()> m_gauss;
+
+    // FIXME replace with standard random engine
+    //std::default_random_engine generator; // TODO: need something more appropriate here
+    //std::normal_distribution<double> m_normDist; // defaults to mean=0, sigma=1
+
+    //algorithms::Generator m_rng = algorithms::RandomSvc::instance().generator();
+
+  };
 
 } // eicrecon

--- a/src/factories/digi/SiliconTrackerDigi_factory.h
+++ b/src/factories/digi/SiliconTrackerDigi_factory.h
@@ -11,7 +11,10 @@ namespace eicrecon {
 
 class SiliconTrackerDigi_factory : public JOmniFactory<SiliconTrackerDigi_factory, SiliconTrackerDigiConfig> {
 
-    SiliconTrackerDigi m_algo;
+public:
+    using AlgoT = eicrecon::SiliconTrackerDigi;
+private:
+    std::unique_ptr<AlgoT> m_algo;
 
     PodioInput<edm4hep::SimTrackerHit> m_sim_hits_input {this};
     PodioOutput<edm4eic::RawTrackerHit> m_raw_hits_output {this};
@@ -21,15 +24,16 @@ class SiliconTrackerDigi_factory : public JOmniFactory<SiliconTrackerDigi_factor
 
 public:
     void Configure() {
-        m_algo.applyConfig(config());
-        m_algo.init(logger());
+        m_algo = std::make_unique<AlgoT>(GetPrefix());
+        m_algo->applyConfig(config());
+        m_algo->init(logger());
     }
 
     void ChangeRun(int64_t run_number) {
     }
 
     void Process(int64_t run_number, uint64_t event_number) {
-        m_raw_hits_output() = m_algo.process(*m_sim_hits_input());
+        m_algo->process({m_sim_hits_input()}, {m_raw_hits_output().get()});
     }
 };
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This converts SiliconTrackerDigi to use the algorithms:: interface.

TODO:
- [ ] ~~use the algorithms RandomSvc generator after it is shown that we maintain bit-for-bit identical results with the current TRandomGen~~ deferred to next PR

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.