### PR TITLE
femc_studies,lfhcal_studies: remove broken code

### DIFF
--- a/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.cc
@@ -532,12 +532,6 @@ void femc_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event) 
     hRecFClusterEcalib_E_eta->Fill(mcenergy, cluster.getEnergy()/mcenergy, mceta);
     m_log->trace("Island cluster {}:\t {} \t {}", iClF, cluster.getEnergy(), cluster.getNhits());
 
-    for (const auto& hit: cluster.getHits()){
-      int pSav = 0;
-      while(hit.getCellID() !=  input_tower_recSav.at(pSav).cellID && pSav < (int)input_tower_recSav.size() ) pSav++;
-      if (hit.getCellID() == input_tower_recSav.at(pSav).cellID)
-        input_tower_recSav.at(pSav).tower_clusterIDB = iClF;
-    }
     iClF++;
   }
   hRecFNClusters_E_eta->Fill(mcenergy, iClF, mceta);

--- a/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
@@ -607,12 +607,6 @@ void lfhcal_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event
     }
     hRecFClusterEcalib_E_eta->Fill(mcenergy, cluster.getEnergy()/mcenergy, mceta);
     m_log->trace("Island cluster {}:\t {} \t {}", iClF, cluster.getEnergy(), cluster.getNhits());
-    for (const auto hit : cluster.getHits()){
-      int pSav = 0;
-      while(hit.getCellID() !=  input_tower_recSav.at(pSav).cellID && pSav < (int)input_tower_recSav.size() ) pSav++;
-      if (hit.getCellID() == input_tower_recSav.at(pSav).cellID)
-        input_tower_recSav.at(pSav).tower_clusterIDB = iClF;
-    }
     iClF++;
   }
   hRecFNClusters_E_eta->Fill(mcenergy, iClF, mceta);


### PR DESCRIPTION
Fixes regression introduced by https://github.com/eic/EICrecon/pull/1224

It would appear those loops were never utilized before. There are simular loops for the inlined "kMA" clustering code.