### PR TITLE
fix(ci): don't trigger eic_container in merge queue

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -784,6 +784,7 @@ jobs:
 
   trigger-container:
     runs-on: ubuntu-latest
+    if: github.event_name != "merge_group"
     needs:
     - eicrecon-gun
     steps:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -784,7 +784,7 @@ jobs:
 
   trigger-container:
     runs-on: ubuntu-latest
-    if: github.event_name != "merge_group"
+    if: ${{ github.event_name != "merge_group" }}
     needs:
     - eicrecon-gun
     steps:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -784,7 +784,7 @@ jobs:
 
   trigger-container:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'merge_group' }}
+    if: ${{ github.event_name != 'merge_group' && github.actor != 'dependabot[bot]' }}
     needs:
     - eicrecon-gun
     steps:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -784,7 +784,7 @@ jobs:
 
   trigger-container:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != "merge_group" }}
+    if: ${{ github.event_name != 'merge_group' }}
     needs:
     - eicrecon-gun
     steps:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Merge queues use a temporary branch that is not available for checkout. This PR disables the trigger of the eic_container build for merge queues because they fail (e.g. https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/2329046).

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/2329046)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.