### PR TITLE
feat: convert MergeTracks to use algorithms:: interface (not yet omni)

### DIFF
--- a/src/algorithms/pid/MergeTracks.cc
+++ b/src/algorithms/pid/MergeTracks.cc
@@ -13,31 +13,22 @@
 #include <unordered_map>
 #include <utility>
 
-// AlgorithmInit
-//---------------------------------------------------------------------------
-void eicrecon::MergeTracks::AlgorithmInit(std::shared_ptr<spdlog::logger>& logger)
+namespace eicrecon {
+
+void MergeTracks::init(std::shared_ptr<spdlog::logger>& logger)
 {
   m_log = logger;
 }
 
+void MergeTracks::process(
+    const MergeTracks::Input& input,
+    const MergeTracks::Output& output) const {
 
-// AlgorithmChangeRun
-//---------------------------------------------------------------------------
-void eicrecon::MergeTracks::AlgorithmChangeRun() {
-}
+  const auto [in_track_collections] = input;
+  auto [out_tracks] = output;
 
-
-// AlgorithmProcess
-//---------------------------------------------------------------------------
-std::unique_ptr<edm4eic::TrackSegmentCollection> eicrecon::MergeTracks::AlgorithmProcess(
-    std::vector<const edm4eic::TrackSegmentCollection*> in_track_collections
-    )
-{
   // logging
   m_log->trace("{:=^70}"," call MergeTracks::AlgorithmProcess ");
-
-  // start output collection
-  auto out_tracks = std::make_unique<edm4eic::TrackSegmentCollection>();
 
   // check that all input collections have the same size
   std::unordered_map<std::size_t, std::size_t> in_track_collection_size_distribution;
@@ -50,7 +41,7 @@ std::unique_ptr<edm4eic::TrackSegmentCollection> eicrecon::MergeTracks::Algorith
       std::back_inserter(in_track_collection_sizes),
       [](const auto& in_track_collection) { return in_track_collection->size(); });
     m_log->error("cannot merge input track collections with different sizes {}", fmt::join(in_track_collection_sizes, ", "));
-    return out_tracks;
+    return;
   }
 
   // loop over track collection elements
@@ -84,6 +75,6 @@ std::unique_ptr<edm4eic::TrackSegmentCollection> eicrecon::MergeTracks::Algorith
      */
 
   } // end loop over tracks
-
-  return out_tracks;
 }
+
+} // namespace eicrecon

--- a/src/algorithms/pid/MergeTracks.h
+++ b/src/algorithms/pid/MergeTracks.h
@@ -10,6 +10,7 @@
 #pragma once
 
 // data model
+#include <algorithms/algorithm.h>
 #include <edm4eic/TrackSegmentCollection.h>
 #include <spdlog/logger.h>
 #include <memory>
@@ -17,21 +18,27 @@
 
 namespace eicrecon {
 
-  class MergeTracks {
+  using MergeTracksAlgorithm = algorithms::Algorithm<
+    algorithms::Input<
+      std::vector<const edm4eic::TrackSegmentCollection>
+    >,
+    algorithms::Output<
+      edm4eic::TrackSegmentCollection
+    >
+  >;
 
-    public:
-      MergeTracks() = default;
-      ~MergeTracks() {}
+  class MergeTracks
+  : public MergeTracksAlgorithm {
 
-      void AlgorithmInit(std::shared_ptr<spdlog::logger>& logger);
-      void AlgorithmChangeRun();
+  public:
+    MergeTracks(std::string_view name)
+      : MergeTracksAlgorithm{name,
+                            {"inputTrackSegments"},
+                            {"outputTrackSegments"},
+                            "Effecitvely 'zip' the input track segments."} {}
 
-      // AlgorithmProcess
-      // - input: a list of TrackSegment collections
-      // - output: the merged TrackSegment collections, effectively the "zip" of the input collections
-      std::unique_ptr<edm4eic::TrackSegmentCollection> AlgorithmProcess(
-          std::vector<const edm4eic::TrackSegmentCollection*> in_track_collections
-          );
+    void init(std::shared_ptr<spdlog::logger>& logger);
+    void process(const Input&, const Output&) const final;
 
     private:
       std::shared_ptr<spdlog::logger> m_log;

--- a/src/global/pid/MergeTrack_factory.cc
+++ b/src/global/pid/MergeTrack_factory.cc
@@ -18,7 +18,8 @@ void eicrecon::MergeTrack_factory::Init() {
 
   // services
   InitLogger(app, prefix, "info");
-  m_algo.AlgorithmInit(m_log);
+  m_algo = std::make_unique<AlgoT>(GetPrefix());
+  m_algo->init(m_log);
   m_log->debug("MergeTrack_factory: plugin='{}' prefix='{}'", plugin, prefix);
 
 }
@@ -27,15 +28,17 @@ void eicrecon::MergeTrack_factory::Init() {
 void eicrecon::MergeTrack_factory::Process(const std::shared_ptr<const JEvent> &event) {
 
   // get input collections
-  std::vector<const edm4eic::TrackSegmentCollection*> in_track_collections;
-  for(auto& input_tag : GetInputTags())
+  std::vector<gsl::not_null<const edm4eic::TrackSegmentCollection*>> in_track_collections;
+  for(auto& input_tag : GetInputTags()) {
     in_track_collections.push_back(
         static_cast<const edm4eic::TrackSegmentCollection*>(event->GetCollectionBase(input_tag))
-        );
+    );
+  }
 
   // call the MergeTracks algorithm
   try {
-    auto out_track_collection = m_algo.AlgorithmProcess(in_track_collections);
+    auto out_track_collection = std::make_unique<edm4eic::TrackSegmentCollection>();
+    m_algo->process({in_track_collections}, {out_track_collection.get()});
     SetCollection<edm4eic::TrackSegment>(GetOutputTags()[0], std::move(out_track_collection));
   }
   catch(std::exception &e) {

--- a/src/global/pid/MergeTrack_factory.h
+++ b/src/global/pid/MergeTrack_factory.h
@@ -26,6 +26,11 @@ namespace eicrecon {
   {
 
     public:
+        using AlgoT = eicrecon::MergeTracks;
+    private:
+        std::unique_ptr<AlgoT> m_algo;
+
+    public:
 
       explicit MergeTrack_factory(
           std::string tag,
@@ -41,9 +46,5 @@ namespace eicrecon {
       /** Event by event processing **/
       void Process(const std::shared_ptr<const JEvent> &event) override;
 
-    private:
-
-      // underlying algorithm
-      eicrecon::MergeTracks m_algo;
   };
 }

--- a/src/tests/algorithms_test/pid_MergeTracks.cc
+++ b/src/tests/algorithms_test/pid_MergeTracks.cc
@@ -17,13 +17,13 @@
 #include "algorithms/pid/MergeTracks.h"
 
 TEST_CASE("the PID MergeTracks algorithm runs", "[MergeTracks]") {
-  eicrecon::MergeTracks algo;
+  eicrecon::MergeTracks algo("test");
 
   // initialize algorithm
   //----------------------------------------------------------
   std::shared_ptr<spdlog::logger> logger = spdlog::default_logger()->clone("MergeTracks");
   logger->set_level(spdlog::level::debug);
-  algo.AlgorithmInit(logger);
+  algo.init(logger);
 
   // helper functions and objects
   //----------------------------------------------------------
@@ -131,8 +131,10 @@ TEST_CASE("the PID MergeTracks algorithm runs", "[MergeTracks]") {
 
   SECTION("merge tracks from 1 collection") {
     // run algorithm
-    std::vector<const edm4eic::TrackSegmentCollection*> colls = { collection0.get() };
-    auto trks = algo.AlgorithmProcess(colls);
+    std::vector<gsl::not_null<const edm4eic::TrackSegmentCollection*>> colls = { collection0.get() };
+    // create output collection
+    auto trks = std::make_unique<edm4eic::TrackSegmentCollection>();
+    algo.process({colls}, {trks.get()});
     // input collection(s) size == output collection size
     REQUIRE(trks->size() == colls.front()->size());
     // track length: from endpoints
@@ -147,8 +149,9 @@ TEST_CASE("the PID MergeTracks algorithm runs", "[MergeTracks]") {
 
   SECTION("merge tracks from 2 collections") {
     // run algorithm
-    std::vector<const edm4eic::TrackSegmentCollection*> colls = { collection0.get(), collection1.get() };
-    auto trks = algo.AlgorithmProcess(colls);
+    std::vector<gsl::not_null<const edm4eic::TrackSegmentCollection*>> colls = { collection0.get(), collection1.get() };
+    auto trks = std::make_unique<edm4eic::TrackSegmentCollection>();
+    algo.process({colls}, {trks.get()});
     // input collection(s) size == output collection size
     REQUIRE(trks->size() == colls.front()->size());
     // track length: from endpoints
@@ -163,8 +166,9 @@ TEST_CASE("the PID MergeTracks algorithm runs", "[MergeTracks]") {
 
   SECTION("merge tracks from 3 collections") {
     // run algorithm
-    std::vector<const edm4eic::TrackSegmentCollection*> colls = { collection0.get(), collection1.get(), collection2.get() };
-    auto trks = algo.AlgorithmProcess(colls);
+    std::vector<gsl::not_null<const edm4eic::TrackSegmentCollection*>> colls = { collection0.get(), collection1.get(), collection2.get() };
+    auto trks = std::make_unique<edm4eic::TrackSegmentCollection>();
+    algo.process({colls}, {trks.get()});
     // input collection(s) size == output collection size
     REQUIRE(trks->size() == colls.front()->size());
     // track length: from endpoints


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR converts the MergeTracks algorithm in PID to use the algorithms:: interface. I was pleasantly surprised that algorithms:: already supports vectors of input and output (<- FYI @nathanwbrei).

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.