### PR TITLE
fix: use track direction in localToGlobal in TrackProjector

### DIFF
--- a/src/algorithms/tracking/TrackProjector.cc
+++ b/src/algorithms/tracking/TrackProjector.cc
@@ -4,6 +4,7 @@
 #include <Acts/Definitions/TrackParametrization.hpp>
 #include <Acts/EventData/MultiTrajectoryHelpers.hpp>
 #include <Acts/Geometry/GeometryIdentifier.hpp>
+#include <Acts/Utilities/UnitVectors.hpp>
 #include <ActsExamples/EventData/Trajectories.hpp>
 #include <edm4eic/Cov2f.h>
 #include <edm4eic/Cov3f.h>

--- a/src/algorithms/tracking/TrackProjector.cc
+++ b/src/algorithms/tracking/TrackProjector.cc
@@ -89,7 +89,10 @@ namespace eicrecon {
                 auto global = trackstate.referenceSurface().localToGlobal(
                         m_geo_provider->getActsGeometryContext(),
                         {parameter[Acts::eBoundLoc0], parameter[Acts::eBoundLoc1]},
-                        {0, 0, 0}
+                        Acts::makeDirectionFromPhiTheta(
+                            parameter[Acts::eBoundPhi],
+                            parameter[Acts::eBoundTheta]
+                        )
                 );
                 // global position
                 const decltype(edm4eic::TrackPoint::position) position{


### PR DESCRIPTION
### Briefly, what does this PR introduce?
While going through this class for other reasons, I noticed the arbitrary direction `{0,0,0}` when we can provide the actual direction. I don't expect any difference due to this, but as we have seen there can be upstream changes that make it such that arbitrarily chosen directions suddenly start to matter. If the interface specifies a direction, then Acts is free to start expecting the direction to make sense and to start producing results that depend on it.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: TrackProjector uses zero-vector as direction in globalToLocal)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators: @ShujieL also occurs in TrackerMeasurementFromHits in globalToLocal

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.