### PR TITLE
fix: explicitly set off-diagonal elements in the covariance matrices

### DIFF
--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -117,6 +117,7 @@ namespace eicrecon {
             cov(0, 0) = meas2D.getCovariance().xx;
             cov(1, 1) = meas2D.getCovariance().yy;
             cov(0, 1) = meas2D.getCovariance().xy;
+            cov(1, 0) = meas2D.getCovariance().xy;
 
             auto measurement = Acts::makeMeasurement(Acts::SourceLink{sourceLink}, loc, cov, Acts::eBoundLoc0, Acts::eBoundLoc1);
             measurements->emplace_back(std::move(measurement));

--- a/src/algorithms/tracking/TrackerMeasurementFromHits.cc
+++ b/src/algorithms/tracking/TrackerMeasurementFromHits.cc
@@ -57,7 +57,7 @@ namespace eicrecon {
             Acts::SquareMatrix2 cov = Acts::SquareMatrix2::Zero();
             cov(0, 0) = hit.getPositionError().xx * mm_acts * mm_acts; // note mm = 1 (Acts)
             cov(1, 1) = hit.getPositionError().yy * mm_acts * mm_acts;
-            cov(0, 1) = cov(1,0) = 0.0;
+            cov(0, 1) = cov(1, 0) = 0.0;
 
             const auto* vol_ctx = m_converter->findContext(hit.getCellID());
             auto vol_id = vol_ctx->identifier;

--- a/src/algorithms/tracking/TrackerMeasurementFromHits.cc
+++ b/src/algorithms/tracking/TrackerMeasurementFromHits.cc
@@ -57,8 +57,7 @@ namespace eicrecon {
             Acts::SquareMatrix2 cov = Acts::SquareMatrix2::Zero();
             cov(0, 0) = hit.getPositionError().xx * mm_acts * mm_acts; // note mm = 1 (Acts)
             cov(1, 1) = hit.getPositionError().yy * mm_acts * mm_acts;
-            cov(0, 1) = 0.0;
-
+            cov(0, 1) = cov(1,0) = 0.0;
 
             const auto* vol_ctx = m_converter->findContext(hit.getCellID());
             auto vol_id = vol_ctx->identifier;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Acts uses square matrices for covarianc matrices that are **not** required to be symmetric. This means that we should set **both** off-diagonal elements explicitly (but we can just read one of them). The EDM4eic data model does assume symmetry, so only upper diagonal is stored.

This PR ensures that we explicitly write off-diagonal covariance matrix elements everywhere, even if they are just written as zeros. This makes it clearer that we are not implicitly assuming symmetry.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: symmetry is assumed when not guaranteed)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.