### PR TITLE
fix: avoid duplicate factory names in pid.cc

### DIFF
--- a/src/global/pid/pid.cc
+++ b/src/global/pid/pid.cc
@@ -48,7 +48,7 @@ extern "C" {
           ));
 
     app->Add(new JOmniFactoryGeneratorT<ParticlesWithPID_factory>(
-          "ChargedParticlesWithAssociations",
+          "SeededChargedParticlesWithAssociations",
           {
             "MCParticles",                      // edm4hep::MCParticle
             "CentralCKFSeededTrajectories",     // edm4eic::Trajectory


### PR DESCRIPTION
### Briefly, what does this PR introduce?
There were two factories with the same name in pid.cc: one for the truth-seeded reconstruction path, and one for the realistic-seeding-based reconstruction path. This PR makes sure they are named differently.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: duplicate factory name)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.