### PR TITLE
fix: namespace needed on link target algorithms::algocore

### DIFF
--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -216,7 +216,7 @@ macro(plugin_add_algorithms _name)
     endif()
 
     plugin_link_libraries(${_name}
-        algocore
+        algorithms::algocore
     )
 
 endmacro()


### PR DESCRIPTION
### Briefly, what does this PR introduce?
In #1203 this was included as an 'also', but we do want this in main. I am not entirely sure why this works in eic-shell right now, since even there algorithms exports the namespaced target... but it doesn't work without this outside eic-shell and should use the namespace that upstream specifies.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No.