### PR TITLE
TrackPropagation_factory: resolve an indexing bug by using ACTS surface ID fields

### DIFF
--- a/src/global/tracking/TrackPropagation_factory.cc
+++ b/src/global/tracking/TrackPropagation_factory.cc
@@ -20,7 +20,7 @@
 #include <spdlog/logger.h>
 #include <Eigen/Geometry>
 #include <algorithm>
-#include <cstddef>
+#include <cstdint>
 #include <gsl/pointers>
 #include <map>
 

--- a/src/global/tracking/TrackPropagation_factory.cc
+++ b/src/global/tracking/TrackPropagation_factory.cc
@@ -60,10 +60,8 @@ void eicrecon::TrackPropagation_factory::Process(const std::shared_ptr<const JEv
         for(auto& surf : m_target_surface_list) {
             auto prop_point = m_track_propagation_algo.propagate(traj, surf);
             if(!prop_point) continue;
-#if EDM4EIC_VERSION_MAJOR >= 3
             prop_point->surface = surf->geometryId().layer();
             prop_point->system  = surf->geometryId().extra();
-#endif
             this_propagated_track.addToPoints(*prop_point);
         }
         propagated_tracks.push_back(this_propagated_track);

--- a/src/global/tracking/TrackPropagation_factory.cc
+++ b/src/global/tracking/TrackPropagation_factory.cc
@@ -58,13 +58,14 @@ void eicrecon::TrackPropagation_factory::Process(const std::shared_ptr<const JEv
 
     for(auto traj: trajectories) {
         edm4eic::MutableTrackSegment this_propagated_track;
-        for(size_t isurf = 0; isurf < m_target_surface_list.size(); isurf++) {
-            auto surf = m_target_surface_list[isurf];
+        for(auto& surf : m_target_surface_list) {
             auto prop_point = m_track_propagation_algo.propagate(traj, surf);
             if(!prop_point) continue;
+            uint64_t sId = surf->geometryId().layer();
+            uint32_t dId = surf->geometryId().extra();
 #if EDM4EIC_VERSION_MAJOR >= 3
-            prop_point->surface = m_target_surface_ID[isurf];
-            prop_point->system = m_target_detector_ID[isurf];
+            prop_point->surface = sId;
+            prop_point->system  = dId;
 #endif
             this_propagated_track.addToPoints(*prop_point);
         }
@@ -100,11 +101,7 @@ void eicrecon::TrackPropagation_factory::SetPropagationSurfaces() {
     BEMC_prop_surface1->assignGeometryId(Acts::GeometryIdentifier().setExtra(BEMC_system_id).setLayer(1));
     BEMC_prop_surface2->assignGeometryId(Acts::GeometryIdentifier().setExtra(BEMC_system_id).setLayer(2));
     m_target_surface_list.push_back(BEMC_prop_surface1);
-    m_target_detector_ID.push_back(m_geoSvc->detector()->constant<uint32_t>("ECalBarrel_ID"));
-    m_target_surface_ID.push_back(1);
     m_target_surface_list.push_back(BEMC_prop_surface2);
-    m_target_detector_ID.push_back(m_geoSvc->detector()->constant<uint32_t>("ECalBarrel_ID"));
-    m_target_surface_ID.push_back(2);
 
     // Create propagation surface for FEMC
     const double FEMC_Z    = (m_geoSvc->detector()->constant<double>("EcalEndcapP_zmin") / dd4hep::mm) * Acts::UnitConstants::mm;
@@ -119,11 +116,7 @@ void eicrecon::TrackPropagation_factory::SetPropagationSurfaces() {
     FEMC_prop_surface1->assignGeometryId(Acts::GeometryIdentifier().setExtra(FEMC_system_id).setLayer(1));
     FEMC_prop_surface2->assignGeometryId(Acts::GeometryIdentifier().setExtra(FEMC_system_id).setLayer(2));
     m_target_surface_list.push_back(FEMC_prop_surface1);
-    m_target_detector_ID.push_back(m_geoSvc->detector()->constant<uint32_t>("ECalEndcapP_ID"));
-    m_target_surface_ID.push_back(1);
     m_target_surface_list.push_back(FEMC_prop_surface2);
-    m_target_detector_ID.push_back(m_geoSvc->detector()->constant<uint32_t>("ECalEndcapP_ID"));
-    m_target_surface_ID.push_back(2);
 
     // Create propagation surface for EEMC
     const double EEMC_Z    = -(m_geoSvc->detector()->constant<double>("EcalEndcapN_zmin") / dd4hep::mm) * Acts::UnitConstants::mm;
@@ -138,11 +131,7 @@ void eicrecon::TrackPropagation_factory::SetPropagationSurfaces() {
     EEMC_prop_surface1->assignGeometryId(Acts::GeometryIdentifier().setExtra(EEMC_system_id).setLayer(1));
     EEMC_prop_surface2->assignGeometryId(Acts::GeometryIdentifier().setExtra(EEMC_system_id).setLayer(2));
     m_target_surface_list.push_back(EEMC_prop_surface1);
-    m_target_detector_ID.push_back(m_geoSvc->detector()->constant<uint32_t>("ECalEndcapN_ID"));
-    m_target_surface_ID.push_back(1);
     m_target_surface_list.push_back(EEMC_prop_surface2);
-    m_target_detector_ID.push_back(m_geoSvc->detector()->constant<uint32_t>("ECalEndcapN_ID"));
-    m_target_surface_ID.push_back(2);
 
     // Create propagation surface for OHCAL
     const double OHCAL_R     = (m_geoSvc->detector()->constant<double>("HcalBarrel_rmin") / dd4hep::mm) * Acts::UnitConstants::mm;
@@ -155,11 +144,7 @@ void eicrecon::TrackPropagation_factory::SetPropagationSurfaces() {
     OHCAL_prop_surface1->assignGeometryId(Acts::GeometryIdentifier().setExtra(OHCAL_system_id).setLayer(1));
     OHCAL_prop_surface2->assignGeometryId(Acts::GeometryIdentifier().setExtra(OHCAL_system_id).setLayer(2));
     m_target_surface_list.push_back(OHCAL_prop_surface1);
-    m_target_detector_ID.push_back(m_geoSvc->detector()->constant<uint32_t>("HCalBarrel_ID"));
-    m_target_surface_ID.push_back(1);
     m_target_surface_list.push_back(OHCAL_prop_surface2);
-    m_target_detector_ID.push_back(m_geoSvc->detector()->constant<uint32_t>("HCalBarrel_ID"));
-    m_target_surface_ID.push_back(2);
 
     // Create propagation surface for LFHCAL
     const double LFHCAL_Z    = (m_geoSvc->detector()->constant<double>("LFHCAL_zmin") / dd4hep::mm) * Acts::UnitConstants::mm;
@@ -174,11 +159,7 @@ void eicrecon::TrackPropagation_factory::SetPropagationSurfaces() {
     LFHCAL_prop_surface1->assignGeometryId(Acts::GeometryIdentifier().setExtra(LFHCAL_system_id).setLayer(1));
     LFHCAL_prop_surface2->assignGeometryId(Acts::GeometryIdentifier().setExtra(LFHCAL_system_id).setLayer(2));
     m_target_surface_list.push_back(LFHCAL_prop_surface1);
-    m_target_detector_ID.push_back(m_geoSvc->detector()->constant<uint32_t>("HCalEndcapP_ID"));
-    m_target_surface_ID.push_back(1);
     m_target_surface_list.push_back(LFHCAL_prop_surface2);
-    m_target_detector_ID.push_back(m_geoSvc->detector()->constant<uint32_t>("HCalEndcapP_ID"));
-    m_target_surface_ID.push_back(2);
 
     // Create propagation surface for EHCAL
     const double EHCAL_Z    = -(m_geoSvc->detector()->constant<double>("HcalEndcapN_zmin") / dd4hep::mm) * Acts::UnitConstants::mm;
@@ -193,11 +174,7 @@ void eicrecon::TrackPropagation_factory::SetPropagationSurfaces() {
     EHCAL_prop_surface1->assignGeometryId(Acts::GeometryIdentifier().setExtra(EHCAL_system_id).setLayer(1));
     EHCAL_prop_surface2->assignGeometryId(Acts::GeometryIdentifier().setExtra(EHCAL_system_id).setLayer(2));
     m_target_surface_list.push_back(EHCAL_prop_surface1);
-    m_target_detector_ID.push_back(m_geoSvc->detector()->constant<uint32_t>("HCalEndcapN_ID"));
-    m_target_surface_ID.push_back(1);
     m_target_surface_list.push_back(EHCAL_prop_surface2);
-    m_target_detector_ID.push_back(m_geoSvc->detector()->constant<uint32_t>("HCalEndcapN_ID"));
-    m_target_surface_ID.push_back(2);
 
 
     m_log->info("Setting track propagation surfaces to:");

--- a/src/global/tracking/TrackPropagation_factory.cc
+++ b/src/global/tracking/TrackPropagation_factory.cc
@@ -58,7 +58,8 @@ void eicrecon::TrackPropagation_factory::Process(const std::shared_ptr<const JEv
 
     for(auto traj: trajectories) {
         edm4eic::MutableTrackSegment this_propagated_track;
-        for(size_t isurf = 0; auto surf: m_target_surface_list) {
+        for(size_t isurf = 0; isurf < m_target_surface_list.size(); isurf++) {
+            auto surf = m_target_surface_list[isurf];
             auto prop_point = m_track_propagation_algo.propagate(traj, surf);
             if(!prop_point) continue;
 #if EDM4EIC_VERSION_MAJOR >= 3
@@ -66,7 +67,6 @@ void eicrecon::TrackPropagation_factory::Process(const std::shared_ptr<const JEv
             prop_point->system = m_target_detector_ID[isurf];
 #endif
             this_propagated_track.addToPoints(*prop_point);
-            isurf++;
         }
         propagated_tracks.push_back(this_propagated_track);
     }

--- a/src/global/tracking/TrackPropagation_factory.cc
+++ b/src/global/tracking/TrackPropagation_factory.cc
@@ -61,7 +61,7 @@ void eicrecon::TrackPropagation_factory::Process(const std::shared_ptr<const JEv
             auto prop_point = m_track_propagation_algo.propagate(traj, surf);
             if(!prop_point) continue;
 #if EDM4EIC_VERSION_MAJOR >= 3
-            prop_point->surface = surf->geometryId().layer();;
+            prop_point->surface = surf->geometryId().layer();
             prop_point->system  = surf->geometryId().extra();
 #endif
             this_propagated_track.addToPoints(*prop_point);

--- a/src/global/tracking/TrackPropagation_factory.h
+++ b/src/global/tracking/TrackPropagation_factory.h
@@ -5,18 +5,17 @@
 
 #include <Acts/Surfaces/Surface.hpp>
 #include <JANA/JEvent.h>
-#include "algorithms/tracking/TrackPropagation.h"
 #include <edm4eic/TrackSegmentCollection.h>
-#include "extensions/jana/JChainMultifactoryT.h"
-#include "extensions/spdlog/SpdlogMixin.h"
-#include "services/geometry/dd4hep/DD4hep_service.h"
-#include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
-
+ 
 #include "algorithms/interfaces/WithPodConfig.h"
+#include "algorithms/tracking/TrackPropagation.h"
+#include "extensions/jana/JChainMultifactoryT.h"
+#include "extensions/spdlog/SpdlogMixin.h"
+#include "services/geometry/dd4hep/DD4hep_service.h"
 
 namespace eicrecon {
 

--- a/src/global/tracking/TrackPropagation_factory.h
+++ b/src/global/tracking/TrackPropagation_factory.h
@@ -10,7 +10,7 @@
 #include <string>
 #include <utility>
 #include <vector>
- 
+
 #include "algorithms/interfaces/WithPodConfig.h"
 #include "algorithms/tracking/TrackPropagation.h"
 #include "extensions/jana/JChainMultifactoryT.h"

--- a/src/global/tracking/TrackPropagation_factory.h
+++ b/src/global/tracking/TrackPropagation_factory.h
@@ -46,8 +46,6 @@ namespace eicrecon {
         eicrecon::TrackPropagation m_track_propagation_algo;
 
         std::vector<std::shared_ptr<Acts::Surface>> m_target_surface_list;
-        std::vector<uint64_t> m_target_surface_ID;
-        std::vector<uint32_t> m_target_detector_ID;
 
         void SetPropagationSurfaces();
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Potentially fixes the track projection strange behavior and mismatch between detector/surface ID and eta range, etc.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #NA)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators: Issue discussed in several meetings (collaboration meeting in Jan 2024)

### Does this PR introduce breaking changes? What changes might users need to make to their code?
NO
### Does this PR change default behavior?
NO