### PR TITLE
fix: replace GetCollectionBase with GetCollection<T> (2nd attempt)

### DIFF
--- a/src/benchmarks/detectors/EcalBarrelScFiCheck/EcalBarrelScFiCheckProcessor.cc
+++ b/src/benchmarks/detectors/EcalBarrelScFiCheck/EcalBarrelScFiCheckProcessor.cc
@@ -53,10 +53,10 @@ void EcalBarrelScFiCheckProcessor::InitWithGlobalRootLock(){
 // ProcessSequential
 //-------------------------------------------
 void EcalBarrelScFiCheckProcessor::ProcessSequential(const std::shared_ptr<const JEvent>& event) {
-    const auto &EcalBarrelScFiHits          = *static_cast<const edm4hep::SimCalorimeterHitCollection*>(event->GetCollectionBase("EcalBarrelScFiHits"));
-    const auto &EcalBarrelScFiRawHits       = *static_cast<const edm4hep::RawCalorimeterHitCollection*>(event->GetCollectionBase("EcalBarrelScFiRawHits"));
-    const auto &EcalBarrelScFiRecHits       = *static_cast<const edm4eic::CalorimeterHitCollection*>   (event->GetCollectionBase("EcalBarrelScFiRecHits"));
-    const auto &EcalBarrelScFiProtoClusters = *static_cast<const edm4eic::ProtoClusterCollection*>     (event->GetCollectionBase("EcalBarrelScFiProtoClusters"));
+    const auto &EcalBarrelScFiHits          = *(event->GetCollection<edm4hep::SimCalorimeterHit>("EcalBarrelScFiHits"));
+    const auto &EcalBarrelScFiRawHits       = *(event->GetCollection<edm4hep::RawCalorimeterHit>("EcalBarrelScFiRawHits"));
+    const auto &EcalBarrelScFiRecHits       = *(event->GetCollection<edm4eic::CalorimeterHit>("EcalBarrelScFiRecHits"));
+    const auto &EcalBarrelScFiProtoClusters = *(event->GetCollection<edm4eic::ProtoCluster>("EcalBarrelScFiProtoClusters"));
 
     // Fill histograms here
 

--- a/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.cc
@@ -233,7 +233,7 @@ void femc_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event) 
   // ===============================================================================================
   // process MC particles
   // ===============================================================================================
-  const auto &mcParticles = *static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase("MCParticles"));
+  const auto &mcParticles = *(event->GetCollection<edm4hep::MCParticle>("MCParticles"));
   double mceta    = 0;
   double mcphi    = 0;
   double mcp      = 0;
@@ -271,7 +271,7 @@ void femc_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event) 
   int nCaloHitsSim = 0;
   float sumActiveCaloEnergy = 0;
   float sumPassiveCaloEnergy = 0;
-  const auto &simHits = *static_cast<const edm4hep::SimCalorimeterHitCollection*>(event->GetCollectionBase(nameSimHits));
+  const auto &simHits = *(event->GetCollection<edm4hep::SimCalorimeterHit>(nameSimHits));
   for (const auto caloHit : simHits) {
     float x         = caloHit.getPosition().x / 10.;
     float y         = caloHit.getPosition().y / 10.;
@@ -334,7 +334,7 @@ void femc_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event) 
   // ===============================================================================================
   // read rec hits & fill structs
   // ===============================================================================================
-  const auto &recHits = *static_cast<const edm4eic::CalorimeterHitCollection*>(event->GetCollectionBase(nameRecHits));
+  const auto &recHits = *(event->GetCollection<edm4eic::CalorimeterHit>(nameRecHits));
   int nCaloHitsRec = 0;
   std::vector<towersStrct> input_tower_rec;
   std::vector<towersStrct> input_tower_recSav;
@@ -523,7 +523,7 @@ void femc_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event) 
   float highestEFr  = 0;
   int iClFHigh      = 0;
 
-  const auto &fecalClustersF = *static_cast<const edm4eic::ClusterCollection*>(event->GetCollectionBase(nameClusters));
+  const auto &fecalClustersF = *(event->GetCollection<edm4eic::Cluster>(nameClusters));
   for (const auto cluster : fecalClustersF) {
     if (cluster.getEnergy() > highestEFr){
       iClFHigh    = iClF;

--- a/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.cc
@@ -28,6 +28,7 @@
 #include <gsl/pointers>
 #include <iostream>
 #include <limits>
+#include <map>
 #include <stdexcept>
 #include <vector>
 

--- a/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
@@ -28,6 +28,7 @@
 #include <gsl/pointers>
 #include <iostream>
 #include <limits>
+#include <map>
 #include <stdexcept>
 #include <vector>
 

--- a/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
@@ -273,7 +273,7 @@ void lfhcal_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event
   // ===============================================================================================
   // process MC particles
   // ===============================================================================================
-  const auto &mcParticles = *static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase("MCParticles"));
+  const auto &mcParticles = *(event->GetCollection<edm4hep::MCParticle>("MCParticles"));
   double mceta    = 0;
   double mcphi    = 0;
   double mcp      = 0;
@@ -311,7 +311,7 @@ void lfhcal_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event
   int nCaloHitsSim = 0;
   float sumActiveCaloEnergy = 0;
   float sumPassiveCaloEnergy = 0;
-  const auto &simHits = *static_cast<const edm4hep::SimCalorimeterHitCollection*>(event->GetCollectionBase(nameSimHits));
+  const auto &simHits = *(event->GetCollection<edm4hep::SimCalorimeterHit>(nameSimHits));
   for (const auto caloHit : simHits) {
     float x         = caloHit.getPosition().x / 10.;
     float y         = caloHit.getPosition().y / 10.;
@@ -390,7 +390,7 @@ void lfhcal_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event
   // ===============================================================================================
   // read rec hits & fill structs
   // ===============================================================================================
-  const auto &recHits = *static_cast<const edm4eic::CalorimeterHitCollection*>(event->GetCollectionBase(nameRecHits));
+  const auto &recHits = *(event->GetCollection<edm4eic::CalorimeterHit>(nameRecHits));
   int nCaloHitsRec = 0;
   std::vector<towersStrct> input_tower_rec;
   std::vector<towersStrct> input_tower_recSav;
@@ -599,7 +599,7 @@ void lfhcal_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event
   float highestEFr  = 0;
   int iClFHigh      = 0;
 
-  const auto &lfhcalClustersF = *static_cast<const edm4eic::ClusterCollection*>(event->GetCollectionBase(nameClusters));
+  const auto &lfhcalClustersF = *(event->GetCollection<edm4eic::Cluster>(nameClusters));
   for (const auto cluster : lfhcalClustersF) {
     if (cluster.getEnergy() > highestEFr){
       iClFHigh    = iClF;
@@ -630,7 +630,7 @@ void lfhcal_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event
 
   if (enableECalCluster){
     try {
-      const auto &fEMCClustersF = *static_cast<const edm4eic::ClusterCollection*>(event->GetCollectionBase("EcalEndcapPClusters"));
+      const auto &fEMCClustersF = *(event->GetCollection<edm4eic::Cluster>("EcalEndcapPClusters"));
       m_log->info("-----> found fEMCClustersF:" , fEMCClustersF.size());
       for (const auto cluster : fEMCClustersF) {
         if (iECl < maxNCluster && enableTreeCluster){

--- a/src/benchmarks/reconstruction/tof_efficiency/TofEfficiency_processor.cc
+++ b/src/benchmarks/reconstruction/tof_efficiency/TofEfficiency_processor.cc
@@ -58,10 +58,10 @@ void TofEfficiency_processor::InitWithGlobalRootLock(){
 // ProcessSequential
 //-------------------------------------------
 void TofEfficiency_processor::ProcessSequential(const std::shared_ptr<const JEvent>& event) {
-    const auto &mcParticles   = *static_cast<const edm4hep::MCParticleCollection*>  (event->GetCollectionBase("MCParticles"));
-    const auto &trackSegments = *static_cast<const edm4eic::TrackSegmentCollection*>(event->GetCollectionBase("CentralTrackSegments"));
-    const auto &barrelHits    = *static_cast<const edm4eic::TrackerHitCollection*>  (event->GetCollectionBase("TOFBarrelRecHit"));
-    const auto &endcapHits    = *static_cast<const edm4eic::TrackerHitCollection*>  (event->GetCollectionBase("TOFEndcapRecHits"));
+    const auto &mcParticles   = *(event->GetCollection<edm4hep::MCParticle>("MCParticles"));
+    const auto &trackSegments = *(event->GetCollection<edm4eic::TrackSegment>("CentralTrackSegments"));
+    const auto &barrelHits    = *(event->GetCollection<edm4eic::TrackerHit>("TOFBarrelRecHit"));
+    const auto &endcapHits    = *(event->GetCollection<edm4eic::TrackerHit>("TOFEndcapRecHits"));
 
     // List TOF Barrel hits from barrel
     logger()->trace("TOF barrel hits:");

--- a/src/global/pid/IrtCherenkovParticleID_factory.cc
+++ b/src/global/pid/IrtCherenkovParticleID_factory.cc
@@ -69,7 +69,7 @@ void eicrecon::IrtCherenkovParticleID_factory::Process(const std::shared_ptr<con
     if(radiator_id >= 0 && radiator_id < richgeo::nRadiators)
       charged_particles.insert({
           richgeo::RadiatorName(radiator_id),
-          static_cast<const edm4eic::TrackSegmentCollection*>(event->GetCollectionBase(input_tag))
+          (event->GetCollection<edm4eic::TrackSegment>(input_tag))
           });
     else m_log->error("Unknown input RICH track collection '{}'", input_tag);
   }
@@ -78,7 +78,7 @@ void eicrecon::IrtCherenkovParticleID_factory::Process(const std::shared_ptr<con
   if(GetInputTags()[tag_num].find("Merge") != std::string::npos)
     charged_particles.insert({
         "Merged",
-        static_cast<const edm4eic::TrackSegmentCollection*>(event->GetCollectionBase(GetInputTags()[tag_num++]))
+        (event->GetCollection<edm4eic::TrackSegment>(GetInputTags()[tag_num++]))
         });
   else {
     m_log->critical("input tag {} should be merged tracks", tag_num);
@@ -86,8 +86,8 @@ void eicrecon::IrtCherenkovParticleID_factory::Process(const std::shared_ptr<con
   }
 
   // get input hit collections
-  const auto *raw_hits   = static_cast<const edm4eic::RawTrackerHitCollection*>(event->GetCollectionBase(GetInputTags()[tag_num++]));
-  const auto *hit_assocs = static_cast<const edm4eic::MCRecoTrackerHitAssociationCollection*>(event->GetCollectionBase(GetInputTags()[tag_num++]));
+  const auto *raw_hits   = (event->GetCollection<edm4eic::RawTrackerHit>(GetInputTags()[tag_num++]));
+  const auto *hit_assocs = (event->GetCollection<edm4eic::MCRecoTrackerHitAssociation>(GetInputTags()[tag_num++]));
 
   try {
     // run the IrtCherenkovParticleID algorithm

--- a/src/global/pid/MergeCherenkovParticleID_factory.cc
+++ b/src/global/pid/MergeCherenkovParticleID_factory.cc
@@ -8,6 +8,8 @@
 #include <fmt/core.h>
 #include <spdlog/logger.h>
 #include <exception>
+#include <gsl/pointers>
+#include <map>
 
 //-----------------------------------------------------------------------------
 void eicrecon::MergeCherenkovParticleID_factory::Init() {

--- a/src/global/pid/MergeCherenkovParticleID_factory.cc
+++ b/src/global/pid/MergeCherenkovParticleID_factory.cc
@@ -42,7 +42,7 @@ void eicrecon::MergeCherenkovParticleID_factory::Process(const std::shared_ptr<c
   std::vector<gsl::not_null<const edm4eic::CherenkovParticleIDCollection*>> cherenkov_pids;
   for(auto& input_tag : GetInputTags()) {
     cherenkov_pids.push_back(
-        static_cast<const edm4eic::CherenkovParticleIDCollection*>(event->GetCollectionBase(input_tag))
+        (event->GetCollection<edm4eic::CherenkovParticleID>(input_tag))
     );
   }
 

--- a/src/global/pid/MergeTrack_factory.cc
+++ b/src/global/pid/MergeTrack_factory.cc
@@ -31,7 +31,7 @@ void eicrecon::MergeTrack_factory::Process(const std::shared_ptr<const JEvent> &
   std::vector<gsl::not_null<const edm4eic::TrackSegmentCollection*>> in_track_collections;
   for(auto& input_tag : GetInputTags()) {
     in_track_collections.push_back(
-        static_cast<const edm4eic::TrackSegmentCollection*>(event->GetCollectionBase(input_tag))
+        (event->GetCollection<edm4eic::TrackSegment>(input_tag))
     );
   }
 

--- a/src/global/pid/MergeTrack_factory.cc
+++ b/src/global/pid/MergeTrack_factory.cc
@@ -7,6 +7,8 @@
 #include <fmt/core.h>
 #include <spdlog/logger.h>
 #include <exception>
+#include <gsl/pointers>
+#include <map>
 
 //-----------------------------------------------------------------------------
 void eicrecon::MergeTrack_factory::Init() {

--- a/src/global/reco/MatchClusters_factory.cc
+++ b/src/global/reco/MatchClusters_factory.cc
@@ -31,9 +31,9 @@ namespace eicrecon {
 
     void MatchClusters_factory::Process(const std::shared_ptr<const JEvent> &event) {
         size_t tag_ix = 0;
-        auto mc_particles = static_cast<const edm4hep::MCParticleCollection*>(event->GetCollectionBase(GetInputTags()[tag_ix++]));
-        auto charged_particles = static_cast<const edm4eic::ReconstructedParticleCollection*>(event->GetCollectionBase(GetInputTags()[tag_ix++]));
-        auto charged_particle_assocs = static_cast<const edm4eic::MCRecoParticleAssociationCollection*>(event->GetCollectionBase(GetInputTags()[tag_ix++]));
+        auto mc_particles = (event->GetCollection<edm4hep::MCParticle>(GetInputTags()[tag_ix++]));
+        auto charged_particles = (event->GetCollection<edm4eic::ReconstructedParticle>(GetInputTags()[tag_ix++]));
+        auto charged_particle_assocs = (event->GetCollection<edm4eic::MCRecoParticleAssociation>(GetInputTags()[tag_ix++]));
 
         std::vector<const edm4eic::ClusterCollection*> cluster_collections;
         std::vector<const edm4eic::MCRecoClusterParticleAssociationCollection*> cluster_assoc_collections;
@@ -44,7 +44,7 @@ namespace eicrecon {
         };
 
         for (auto& input_tag : GetInputTags() | std::views::drop(tag_ix) | std::views::filter(stride(2))) {
-            auto clusters = static_cast<const edm4eic::ClusterCollection*>(event->GetCollectionBase(input_tag));
+            auto clusters = (event->GetCollection<edm4eic::Cluster>(input_tag));
             cluster_collections.push_back(clusters);
 
             m_log->debug("Clusters '{}' len: {}", input_tag,  clusters->size());
@@ -54,7 +54,7 @@ namespace eicrecon {
         }
 
         for (auto& input_tag : GetInputTags() | std::views::drop(tag_ix + 1) | std::views::filter(stride(2))) {
-            auto assocs = static_cast<const edm4eic::MCRecoClusterParticleAssociationCollection*>(event->GetCollectionBase(input_tag));
+            auto assocs = (event->GetCollection<edm4eic::MCRecoClusterParticleAssociation>(input_tag));
             cluster_assoc_collections.push_back(assocs);
 
             m_log->debug("Associations '{}' len: {}", input_tag, assocs->size());

--- a/src/global/reco/MatchClusters_factory.cc
+++ b/src/global/reco/MatchClusters_factory.cc
@@ -9,6 +9,8 @@
 #include <fmt/core.h>
 #include <podio/ObjectID.h>
 #include <spdlog/logger.h>
+#include <stddef.h>
+#include <map>
 #include <memory>
 #include <ranges>
 

--- a/src/scripts/eicmkplugin.py
+++ b/src/scripts/eicmkplugin.py
@@ -104,7 +104,7 @@ void {0}::InitWithGlobalRootLock(){{
 //-------------------------------------------
 void {0}::ProcessSequential(const std::shared_ptr<const JEvent>& event) {{
     // Data objects we will need from JANA e.g.
-    const auto &rawhits = *static_cast<const edm4hep::SimCalorimeterHitCollection*>(event->GetCollectionBase("EcalBarrelScFiHits"));
+    const auto &rawhits = *(event->GetCollection<edm4hep::SimCalorimeterHit>("EcalBarrelScFiHits"));
 
     // Fill histograms here. e.g.
     // for (auto hit : rawhits) hEraw->Fill(hit.getEnergy());


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Supersedes https://github.com/eic/EICrecon/pull/936.

Back in the early JMultifactory days, we were not able to use GetCollection<T>, so we ended up with many static_cast<const T::collection_t*>(GetCollectionBase()) workarounds. Nowadays, we can and already do use the GetCollection<T> syntax.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.