### PR TITLE
made phi change, independent of charge

### DIFF
--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -211,10 +211,22 @@ std::unique_ptr<edm4eic::TrackParametersCollection> eicrecon::TrackSeeding::make
       auto xpos = xypos.first;
       auto ypos = xypos.second;
 
-      auto vxpos = -1.*charge*(ypos-Y0);
-      auto vypos = charge*(xpos-X0);
+      
+	const auto& firstpos = xyHitPositions.at(0);                                                                                                                          
 
-      auto phi = atan2(vypos,vxpos);
+	TVector2 tangent_vector_candidate_1( (Y0-ypos) , -(X0-xpos) );
+	TVector2 tangent_vector_candidate_2( -(Y0-ypos) , (X0-xpos) );
+
+	TVector2 first_hit_vector(firstpos.first-xpos,firstpos.second-ypos);
+
+	auto dot_1 = tangent_vector_candidate_1*first_hit_vector;
+	auto dot_2 = tangent_vector_candidate_2*first_hit_vector;
+
+	TVector2 tangent_vector = (dot_1>dot_2) ? tangent_vector_candidate_1 : tangent_vector_candidate_2;
+
+	auto phi = atan2(tangent_vector.Py(),tangent_vector.Px());
+
+	
 
       const float z0 = seed.z();
       auto perigee = Acts::Surface::makeShared<Acts::PerigeeSurface>(Acts::Vector3(0,0,0));

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -211,22 +211,22 @@ std::unique_ptr<edm4eic::TrackParametersCollection> eicrecon::TrackSeeding::make
       auto xpos = xypos.first;
       auto ypos = xypos.second;
 
-      
-	const auto& firstpos = xyHitPositions.at(0);                                                                                                                          
 
-	TVector2 tangent_vector_candidate_1( (Y0-ypos) , -(X0-xpos) );
-	TVector2 tangent_vector_candidate_2( -(Y0-ypos) , (X0-xpos) );
+        const auto& firstpos = xyHitPositions.at(0);                                                                                                                          
 
-	TVector2 first_hit_vector(firstpos.first-xpos,firstpos.second-ypos);
+        TVector2 tangent_vector_candidate_1( (Y0-ypos) , -(X0-xpos) );
+        TVector2 tangent_vector_candidate_2( -(Y0-ypos) , (X0-xpos) );
 
-	auto dot_1 = tangent_vector_candidate_1*first_hit_vector;
-	auto dot_2 = tangent_vector_candidate_2*first_hit_vector;
+        TVector2 first_hit_vector(firstpos.first-xpos,firstpos.second-ypos);
 
-	TVector2 tangent_vector = (dot_1>dot_2) ? tangent_vector_candidate_1 : tangent_vector_candidate_2;
+        auto dot_1 = tangent_vector_candidate_1*first_hit_vector;
+        auto dot_2 = tangent_vector_candidate_2*first_hit_vector;
 
-	auto phi = atan2(tangent_vector.Py(),tangent_vector.Px());
+        TVector2 tangent_vector = (dot_1>dot_2) ? tangent_vector_candidate_1 : tangent_vector_candidate_2;
 
-	
+        auto phi = atan2(tangent_vector.Py(),tangent_vector.Px());
+
+
 
       const float z0 = seed.z();
       auto perigee = Acts::Surface::makeShared<Acts::PerigeeSurface>(Acts::Vector3(0,0,0));


### PR DESCRIPTION
### Briefly, what does this PR introduce?
In the standard EICrecon, in track seeding, we measure phi using charge. However, it gives us a lot of error. We have changed the phi formula, which now only depends on the tangential vector.

Here is data that shows more than 50% improvement in phi calculation:

# of events = 10000
particle generated= negative muon
vertex = (0,0,0)
eta = -4 to 4
p = 0.5 to 20 GeV
We measure seeds whose  phi differs from generated phi by more than 0.5 rad.  We find 33 wrong phi-seeds in standard phi calculation (main branch). With new formula, we find only 15 wrong phi-seeds, an improvement of more than 50%.

Here, the first column is event number, second column is seed number, third column is seed phi, fourth column is phi difference, and fifth column is charge 

Main branch, standard phi calculation:

root [1]  events->Scan("CentralTrackSeedingResults.phi:CentralTrackSeedingResults.phi-atan2(MCParticles.momentum.y[0],MCParticles.momentum.x[0]):CentralTrackSeedingResults.charge","abs(CentralTrackSeedingResults.phi-atan2(MCParticles.momentum.y[0],MCParticles.momentum.x[0]))>0.5")
***********************************************************
*    Row   * Instance * CentralTr * CentralTr * CentralTr *
***********************************************************
*      457 *        0 * 3.1368908 * 6.2784049 *        -1 *
*      457 *        2 * 3.1409514 * 6.2824654 *        -1 *
*     1051 *        0 * 3.1248598 *  6.197864 *        -1 *
*     1541 *        2 * -2.652385 * -3.144119 *        -1 *
*     1593 *        0 * 2.1453850 * 3.1149456 *         1 *
*     1719 *        0 * 3.1414830 * 6.2790422 *        -1 *
*     1719 *        1 * 3.1376869 * 6.2752461 *        -1 *
*     1759 *        0 * 3.1079447 * 6.2340577 *        -1 *
*     1759 *        3 * 3.1407167 * 6.2668297 *        -1 *
*     2268 *        0 * -2.926911 * -3.144877 *        -1 *
*     2360 *        2 * -0.291468 * -3.144404 *        -1 *
*     2748 *        0 * 1.2643282 * 3.1381311 *        -1 *
*     3101 *        2 * 1.1373429 *  3.139108 *        -1 *
*     3460 *        4 * -0.901838 * -3.160678 *        -1 *
*     3464 *        0 * 3.1107549 * 6.2227986 *         1 *
*     3533 *        1 * 3.1413474 * 6.2821147 *        -1 *
*     3533 *        2 * 3.1400566 * 6.2808239 *        -1 *
*     3533 *        3 * 3.1406669 * 6.2814343 *        -1 *
*     3602 *        0 * 2.7184147 * 3.1398609 *         1 *
*     4080 *        2 * 0.1672719 * 1.5374061 *        -1 *
*     5168 *        2 * 1.1847635 * 3.1383791 *        -1 *
*     6023 *        2 * 0.1832947 * 3.1397418 *         1 *
*     6634 *        2 * 0.1372623 * 3.1390230 *        -1 *
*     6654 *        1 * 3.1401174 * 6.2715614 *        -1 *
*     6979 *        2 * 1.2488478 * 3.1390423 *        -1 *
Type <CR> to continue or q to quit ==> 
*     7302 *        2 * 0.0834536 * 3.1398086 *         1 *
*     7641 *        2 * 1.4545679 * 3.1399058 *         1 *
*     7896 *        0 * 3.1225175 * 6.2049581 *         1 *
*     8508 *        2 * -2.191989 * -3.143604 *         1 *
*     9033 *        2 * 1.2532205 * 3.1398001 *         1 *
*     9094 *        4 * -3.139707 * -6.280495 *        -1 *
*     9779 *        0 * 1.0651279 * 3.1089109 *        -1 *
*     9786 *        2 * -1.552465 * -3.143571 *        -1 *
***********************************************************
==> 33 selected entries


new phi calculation:

root [1]  events->Scan("CentralTrackSeedingResults.phi:CentralTrackSeedingResults.phi-atan2(MCParticles.momentum.y[0],MCParticles.momentum.x[0]):CentralTrackSeedingResults.charge","abs(CentralTrackSeedingResults.phi-atan2(MCParticles.momentum.y[0],MCParticles.momentum.x[0]))>0.5")
***********************************************************
*    Row   * Instance * CentralTr * CentralTr * CentralTr *
***********************************************************
*      457 *        0 * 3.1368837 * 6.2783978 *        -1 *
*      457 *        2 * 3.1409020 * 6.2824161 *        -1 *
*     1051 *        0 * 3.1248586 * 6.1978628 *        -1 *
*     1719 *        0 * 3.1415927 * 6.2791518 *        -1 *
*     1719 *        1 * 3.1376864 * 6.2752456 *        -1 *
*     1759 *        0 * 3.1079473 * 6.2340603 *        -1 *
*     1759 *        3 * 3.1407468 * 6.2668598 *        -1 *
*     3464 *        0 * 3.1107542 * 6.2227979 *         1 *
*     3533 *        1 * 3.1415927 * 6.2823600 *        -1 *
*     3533 *        2 * 3.1400876 * 6.2808549 *        -1 *
*     3533 *        3 * 3.1406791 * 6.2814464 *        -1 *
*     4080 *        2 * 0.1672727 * 1.5374069 *        -1 *
*     6654 *        1 * 3.1401691 * 6.2716131 *        -1 *
*     7896 *        0 * 3.1225180 * 6.2049586 *         1 *
*     9094 *        4 * -3.139701 * -6.280489 *        -1 *
***********************************************************
==> 15 selected entries



### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x ] New feature (issue #__)
- [x ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x ] Tests for the changes have been added
- [x ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
