### PR TITLE
Associate matched calo cluster with reco electrons

### DIFF
--- a/src/algorithms/reco/ElectronReconstruction.cc
+++ b/src/algorithms/reco/ElectronReconstruction.cc
@@ -57,7 +57,7 @@ namespace eicrecon {
               m_log->trace( "ReconstructedParticle: Energy={} GeV, p={} GeV, E/p = {} for PDG (from truth): {}", clu.getEnergy(), edm4hep::utils::magnitude(reco_part.getMomentum()), EoverP, sim.getPDG() );
               auto reco_electron = reco_part.clone();
               reco_electron.addToClusters( clu );
-              
+
               m_log->trace( "ReconstructedElectron: nClusters={}", reco_electron.clusters_size() );
               m_log->trace( "ReconstructedElectron: Energy={} GeV, p={} GeV, E/p = {} for PDG (from truth): {}", reco_electron.getClusters(0).getEnergy(), edm4hep::utils::magnitude(reco_part.getMomentum()), (reco_electron.getClusters(0).getEnergy() / edm4hep::utils::magnitude(reco_part.getMomentum())), sim.getPDG() );
               // Apply the E/p cut here to select electons

--- a/src/algorithms/reco/ElectronReconstruction.cc
+++ b/src/algorithms/reco/ElectronReconstruction.cc
@@ -55,10 +55,14 @@ namespace eicrecon {
               auto reco_part = reco_part_assoc->getRec();
               double EoverP = clu.getEnergy() / edm4hep::utils::magnitude(reco_part.getMomentum());
               m_log->trace( "ReconstructedParticle: Energy={} GeV, p={} GeV, E/p = {} for PDG (from truth): {}", clu.getEnergy(), edm4hep::utils::magnitude(reco_part.getMomentum()), EoverP, sim.getPDG() );
-
+              auto reco_electron = reco_part.clone();
+              reco_electron.addToClusters( clu );
+              
+              m_log->trace( "ReconstructedElectron: nClusters={}", reco_electron.clusters_size() );
+              m_log->trace( "ReconstructedElectron: Energy={} GeV, p={} GeV, E/p = {} for PDG (from truth): {}", reco_electron.getClusters(0).getEnergy(), edm4hep::utils::magnitude(reco_part.getMomentum()), (reco_electron.getClusters(0).getEnergy() / edm4hep::utils::magnitude(reco_part.getMomentum())), sim.getPDG() );
               // Apply the E/p cut here to select electons
               if ( EoverP >= m_cfg.min_energy_over_momentum && EoverP <= m_cfg.max_energy_over_momentum ) {
-                out_electrons->push_back(reco_part.clone());
+                out_electrons->push_back(reco_electron);
               }
 
             } else {


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The previously introduced ElectronReconstruction factory outputs a ReconstructedParticleCollection of electron candidates via the E/p ratio. However, the matched cluster (used for the E/p calculation) was not associated. This calls repo_electron.addToClusters(...) to keep the association for use in later electron finder factories that use the electron candidates.

Note:
I also considered adding the energy (from the cluster) to the reco Electron via:
```
reco_electron.setEnergy(cluster.getEnergy());
```
but I am not sure if this is a good idea...

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__) 
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: __ Something between a bug fix and feature update

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
NO

### Does this PR change default behavior?
NO