### PR TITLE
improvement in charge calculation in trackseeding

### DIFF
--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -20,6 +20,7 @@
 #include <boost/container/vector.hpp>
 #include <edm4eic/EDM4eicVersion.h>
 #include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <cmath>
 #include <functional>
 #include <limits>

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -25,7 +25,6 @@
 #include <limits>
 #include <tuple>
 #include <type_traits>
-#include <Eigen/LU>
 
 #if EDM4EIC_VERSION_MAJOR >= 5
 #include <edm4eic/Cov6f.h>

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -188,7 +188,7 @@ std::unique_ptr<edm4eic::TrackParametersCollection> eicrecon::TrackSeeding::make
 
       auto slopeZ0 = lineFit(rzHitPositions);
       const auto xypos = findPCA(RX0Y0);
-      
+
       auto xpos = xypos.first;
       auto ypos = xypos.second;
 

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -273,7 +273,7 @@ std::pair<float, float> eicrecon::TrackSeeding::findPCA(std::tuple<float,float,f
 
 int eicrecon::TrackSeeding::determineCharge(std::vector<std::pair<float,float>>& positions, const std::pair<float,float>& PCA, std::tuple<float,float,float>& RX0Y0) const
 {
-  // determine the charge by the bend angle of the first two hits
+  
   int charge = 1;
 
   const auto& firstpos = positions.at(0);

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -273,7 +273,7 @@ std::pair<float, float> eicrecon::TrackSeeding::findPCA(std::tuple<float,float,f
 
 int eicrecon::TrackSeeding::determineCharge(std::vector<std::pair<float,float>>& positions, const std::pair<float,float>& PCA, std::tuple<float,float,float>& RX0Y0) const
 {
-  
+
   int charge = 1;
 
   const auto& firstpos = positions.at(0);

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -273,7 +273,7 @@ std::pair<float, float> eicrecon::TrackSeeding::findPCA(std::tuple<float,float,f
 
 int eicrecon::TrackSeeding::determineCharge(std::vector<std::pair<float,float>>& positions, const std::pair<float,float>& PCA, std::tuple<float,float,float>& RX0Y0) const
 {
-  // determine the charge by the bend angle of the first two hits                                                                                                                                           
+  // determine the charge by the bend angle of the first two hits
   int charge = 1;
 
   const auto& firstpos = positions.at(0);

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -194,7 +194,7 @@ std::unique_ptr<edm4eic::TrackParametersCollection> eicrecon::TrackSeeding::make
 
       //Determine charge
 
-      int charge = determineCharge(xyHitPositions, X0, Y0, xpos, ypos);
+      int charge = determineCharge(xyHitPositions, xypos, RX0Y0);
 
       float theta = atan(1./std::get<0>(slopeZ0));
       // normalize to 0<theta<pi

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -290,7 +290,7 @@ int eicrecon::TrackSeeding::determineCharge(std::vector<std::pair<float,float>>&
 
   auto cross = radial.cross(hit);
 
-  float dot = cross.dot(z);
+  float dot = cross.dot(B_z);
 
   return copysign(1., -dot);
 }

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -194,7 +194,7 @@ std::unique_ptr<edm4eic::TrackParametersCollection> eicrecon::TrackSeeding::make
 
       //Determine charge
 
-      int charge = determineCharge(xyHitPositions,X0,Y0,xpos,ypos);
+      int charge = determineCharge(xyHitPositions, X0, Y0, xpos, ypos);
 
       float theta = atan(1./std::get<0>(slopeZ0));
       // normalize to 0<theta<pi
@@ -282,7 +282,7 @@ int eicrecon::TrackSeeding::determineCharge(std::vector<std::pair<float,float>>&
 
   auto del_phi = first_hit_vector.DeltaPhi(radial_vector);
 
-  if (del_phi>0) charge = -1;
+  if (del_phi > 0) charge = -1;
 
   return charge;
 }

--- a/src/algorithms/tracking/TrackSeeding.h
+++ b/src/algorithms/tracking/TrackSeeding.h
@@ -44,7 +44,7 @@ namespace eicrecon {
         Acts::SeedFinderOptions m_seedFinderOptions;
         Acts::SeedFinderOrthogonalConfig<SpacePoint> m_seedFinderConfig;
 
-        int determineCharge(std::vector<std::pair<float,float>>& positions, float X0, float Y0, float xpos, float ypos) const;
+        int determineCharge(std::vector<std::pair<float,float>>& positions, const std::pair<float,float>& PCA, std::tuple<float,float,float>& RX0Y0) const;
         std::pair<float,float> findPCA(std::tuple<float,float,float>& circleParams) const;
         std::vector<const eicrecon::SpacePoint*> getSpacePoints(const edm4eic::TrackerHitCollection& trk_hits);
         std::unique_ptr<edm4eic::TrackParametersCollection> makeTrackParams(SeedContainer& seeds);

--- a/src/algorithms/tracking/TrackSeeding.h
+++ b/src/algorithms/tracking/TrackSeeding.h
@@ -44,7 +44,7 @@ namespace eicrecon {
         Acts::SeedFinderOptions m_seedFinderOptions;
         Acts::SeedFinderOrthogonalConfig<SpacePoint> m_seedFinderConfig;
 
-        int determineCharge(std::vector<std::pair<float,float>>& positions) const;
+        int determineCharge(std::vector<std::pair<float,float>>& positions,float X0, float Y0, float xpos, float ypos) const;
         std::pair<float,float> findPCA(std::tuple<float,float,float>& circleParams) const;
         std::vector<const eicrecon::SpacePoint*> getSpacePoints(const edm4eic::TrackerHitCollection& trk_hits);
         std::unique_ptr<edm4eic::TrackParametersCollection> makeTrackParams(SeedContainer& seeds);

--- a/src/algorithms/tracking/TrackSeeding.h
+++ b/src/algorithms/tracking/TrackSeeding.h
@@ -44,7 +44,7 @@ namespace eicrecon {
         Acts::SeedFinderOptions m_seedFinderOptions;
         Acts::SeedFinderOrthogonalConfig<SpacePoint> m_seedFinderConfig;
 
-        int determineCharge(std::vector<std::pair<float,float>>& positions,float X0, float Y0, float xpos, float ypos) const;
+        int determineCharge(std::vector<std::pair<float,float>>& positions, float X0, float Y0, float xpos, float ypos) const;
         std::pair<float,float> findPCA(std::tuple<float,float,float>& circleParams) const;
         std::vector<const eicrecon::SpacePoint*> getSpacePoints(const edm4eic::TrackerHitCollection& trk_hits);
         std::unique_ptr<edm4eic::TrackParametersCollection> makeTrackParams(SeedContainer& seeds);


### PR DESCRIPTION
Closes: #1271
Closes: #1272

### Briefly, what does this PR introduce?
It calculates the charge more correctly. 

Before the change
```
events->Scan("CentralTrackSeedingResults.phi:CentralTrackSeedingResults.phi-atan2(MCParticles.momentum.y[0],MCParticles.momentum.x[0]):CentralTrackSeedingResults.charge","abs(CentralTrackSeedingResults.phi-atan2(MCParticles.momentum.y[0],MCParticles.momentum.x[0]))>0.5")
***********************************************************
*    Row   * Instance * CentralTr * CentralTr * CentralTr *
***********************************************************
*      457 *        0 * 3.1368908 * 6.2784049 *        -1 *
*      457 *        2 * 3.1409514 * 6.2824654 *        -1 *
*     1051 *        0 * 3.1248598 *  6.197864 *        -1 *
*     1541 *        2 * -2.652385 * -3.144119 *        -1 *
*     1593 *        0 * 2.1453850 * 3.1149456 *         1 *
*     1719 *        0 * 3.1414830 * 6.2790422 *        -1 *
*     1719 *        1 * 3.1376869 * 6.2752461 *        -1 *
*     1759 *        0 * 3.1079447 * 6.2340577 *        -1 *
*     1759 *        3 * 3.1407167 * 6.2668297 *        -1 *
*     2268 *        0 * -2.926911 * -3.144877 *        -1 *
*     2360 *        2 * -0.291468 * -3.144404 *        -1 *
*     2748 *        0 * 1.2643282 * 3.1381311 *        -1 *
*     3101 *        2 * 1.1373429 *  3.139108 *        -1 *
*     3460 *        4 * -0.901838 * -3.160678 *        -1 *
*     3464 *        0 * 3.1107549 * 6.2227986 *         1 *
*     3533 *        1 * 3.1413474 * 6.2821147 *        -1 *
*     3533 *        2 * 3.1400566 * 6.2808239 *        -1 *
*     3533 *        3 * 3.1406669 * 6.2814343 *        -1 *
*     3602 *        0 * 2.7184147 * 3.1398609 *         1 *
*     4080 *        2 * 0.1672719 * 1.5374061 *        -1 *
*     5168 *        2 * 1.1847635 * 3.1383791 *        -1 *
*     6023 *        2 * 0.1832947 * 3.1397418 *         1 *
*     6634 *        2 * 0.1372623 * 3.1390230 *        -1 *
*     6654 *        1 * 3.1401174 * 6.2715614 *        -1 *
*     6979 *        2 * 1.2488478 * 3.1390423 *        -1 *
Type <CR> to continue or q to quit ==> 
*     7302 *        2 * 0.0834536 * 3.1398086 *         1 *
*     7641 *        2 * 1.4545679 * 3.1399058 *         1 *
*     7896 *        0 * 3.1225175 * 6.2049581 *         1 *
*     8508 *        2 * -2.191989 * -3.143604 *         1 *
*     9033 *        2 * 1.2532205 * 3.1398001 *         1 *
*     9094 *        4 * -3.139707 * -6.280495 *        -1 *
*     9779 *        0 * 1.0651279 * 3.1089109 *        -1 *
*     9786 *        2 * -1.552465 * -3.143571 *        -1 *
***********************************************************
==> 33 selected entries
```

after the change:
```
events->Scan("CentralTrackSeedingResults.phi:CentralTrackSeedingResults.phi-atan2(MCParticles.momentum.y[0],MCParticles.momentum.x[0]):CentralTrackSeedingResults.charge","abs(CentralTrackSeedingResults.phi-atan2(MCParticles.momentum.y[0],MCParticles.momentum.x[0]))>0.5")
***********************************************************
*    Row   * Instance * CentralTr * CentralTr * CentralTr *
***********************************************************
*      457 *        0 * 3.1368908 * 6.2784049 *        -1 *
*      457 *        2 * 3.1409514 * 6.2824654 *        -1 *
*     1051 *        0 * 3.1248598 *  6.197864 *        -1 *
*     1719 *        0 * 3.1414830 * 6.2790422 *        -1 *
*     1719 *        1 * 3.1376869 * 6.2752461 *        -1 *
*     1759 *        0 * 3.1079447 * 6.2340577 *        -1 *
*     1759 *        3 * 3.1407167 * 6.2668297 *        -1 *
*     3464 *        0 * 3.1107549 * 6.2227986 *         1 *
*     3533 *        1 * 3.1413474 * 6.2821147 *        -1 *
*     3533 *        2 * 3.1400566 * 6.2808239 *        -1 *
*     3533 *        3 * 3.1406669 * 6.2814343 *        -1 *
*     4080 *        2 * 0.1672719 * 1.5374061 *        -1 *
*     6654 *        1 * 3.1401174 * 6.2715614 *        -1 *
*     7896 *        0 * 3.1225175 * 6.2049581 *         1 *
*     9094 *        4 * -3.139707 * -6.280495 *        -1 *
***********************************************************
==> 15 selected entries
```



### What kind of change does this PR introduce?
- [x ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [x ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ x] Tests for the changes have been added
- [x ] Documentation has been added / updated
- [x ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
no
