### PR TITLE
fix: set LFHCAL_system_id correctly

### DIFF
--- a/src/global/tracking/TrackPropagation_factory.cc
+++ b/src/global/tracking/TrackPropagation_factory.cc
@@ -150,7 +150,7 @@ void eicrecon::TrackPropagation_factory::SetPropagationSurfaces() {
     auto LFHCAL_Trf2         = transform * Acts::Translation3(Acts::Vector3(0, 0, LFHCAL_Z + HCAL_avgClusterDepth));
     auto LFHCAL_prop_surface1   = Acts::Surface::makeShared<Acts::DiscSurface>(LFHCAL_Trf1, LFHCAL_Bounds);
     auto LFHCAL_prop_surface2   = Acts::Surface::makeShared<Acts::DiscSurface>(LFHCAL_Trf2, LFHCAL_Bounds);
-    auto LFHCAL_system_id = m_geoSvc->detector()->constant<uint32_t>("HCalEndcapN_ID");
+    auto LFHCAL_system_id = m_geoSvc->detector()->constant<uint32_t>("LFHCAL_ID");
     LFHCAL_prop_surface1->assignGeometryId(Acts::GeometryIdentifier().setExtra(LFHCAL_system_id).setLayer(1));
     LFHCAL_prop_surface2->assignGeometryId(Acts::GeometryIdentifier().setExtra(LFHCAL_system_id).setLayer(2));
     m_target_surface_list.push_back(LFHCAL_prop_surface1);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The LFHCAL system ID in track propagations was mistakenly set to the HCalEndcapN system ID. This PR fixes that.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: incorrect LFHCAL system ID in track projections)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @jdbrice 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, fixes a bug.