### PR TITLE
dbg: output rate limit info before/after download-artifact actions

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -576,6 +576,16 @@ jobs:
           *.dot
           *.svg
         if-no-files-found: error
+    - name: Check rate limit before
+      run: |
+        rate=$(gh api rate_limit | jq '.rate')
+        used=$(echo $rate | jq '.used')
+        remaining=$(echo $rate | jq '.remaining')
+        reset=$(echo $rate | jq '.reset')
+        resetdate=$(TZ="America/New_York" date --date @$reset)
+        echo "Rate limiting will reset on $resetdate; $used calls used; $remaining calls remaining."
+      env:
+        GH_TOKEN: ${{ github.token }}
     - name: Download previous artifact
       id: download_previous_artifact
       uses: dawidd6/action-download-artifact@v3
@@ -584,6 +594,16 @@ jobs:
         path: ref/
         name: rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
         if_no_artifact_found: warn
+    - name: Check rate limit after
+      run: |
+        rate=$(gh api rate_limit | jq '.rate')
+        used=$(echo $rate | jq '.used')
+        remaining=$(echo $rate | jq '.remaining')
+        reset=$(echo $rate | jq '.reset')
+        resetdate=$(TZ="America/New_York" date --date @$reset)
+        echo "Rate limiting will reset on $resetdate; $used calls used; $remaining calls remaining."
+      env:
+        GH_TOKEN: ${{ github.token }}
     - name: Compare to previous artifacts
       uses: eic/run-cvmfs-osg-eic-shell@main
       if: steps.download_previous_artifact.outputs.found_artifact == 'true'
@@ -726,6 +746,16 @@ jobs:
           *.dot
           *.svg
         if-no-files-found: error
+    - name: Check rate limit before
+      run: |
+        rate=$(gh api rate_limit | jq '.rate')
+        used=$(echo $rate | jq '.used')
+        remaining=$(echo $rate | jq '.remaining')
+        reset=$(echo $rate | jq '.reset')
+        resetdate=$(TZ="America/New_York" date --date @$reset)
+        echo "Rate limiting will reset on $resetdate; $used calls used; $remaining calls remaining."
+      env:
+        GH_TOKEN: ${{ github.token }}
     - name: Download previous artifact
       id: download_previous_artifact
       uses: dawidd6/action-download-artifact@v3
@@ -734,6 +764,16 @@ jobs:
         path: ref/
         name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root
         if_no_artifact_found: warn
+    - name: Check rate limit after
+      run: |
+        rate=$(gh api rate_limit | jq '.rate')
+        used=$(echo $rate | jq '.used')
+        remaining=$(echo $rate | jq '.remaining')
+        reset=$(echo $rate | jq '.reset')
+        resetdate=$(TZ="America/New_York" date --date @$reset)
+        echo "Rate limiting will reset on $resetdate; $used calls used; $remaining calls remaining."
+      env:
+        GH_TOKEN: ${{ github.token }}
     - name: Compare to previous artifacts
       uses: eic/run-cvmfs-osg-eic-shell@main
       if: steps.download_previous_artifact.outputs.found_artifact == 'true'
@@ -883,6 +923,16 @@ jobs:
       fail-fast: false
       max-parallel: 4
     steps:
+      - name: Check rate limit before
+        run: |
+          rate=$(gh api rate_limit | jq '.rate')
+          used=$(echo $rate | jq '.used')
+          remaining=$(echo $rate | jq '.remaining')
+          reset=$(echo $rate | jq '.reset')
+          resetdate=$(TZ="America/New_York" date --date @$reset)
+          echo "Rate limiting will reset on $resetdate; $used calls used; $remaining calls remaining."
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Download docs artifact (other PRs)
         uses: dawidd6/action-download-artifact@v3
         if: github.event.pull_request.number != matrix.pr
@@ -912,6 +962,16 @@ jobs:
         with:
           name: capybara
           path: publishing_docs/pr/${{ matrix.pr }}/capybara/
+      - name: Check rate limit after
+        run: |
+          rate=$(gh api rate_limit | jq '.rate')
+          used=$(echo $rate | jq '.used')
+          remaining=$(echo $rate | jq '.remaining')
+          reset=$(echo $rate | jq '.reset')
+          resetdate=$(TZ="America/New_York" date --date @$reset)
+          echo "Rate limiting will reset on $resetdate; $used calls used; $remaining calls remaining."
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Remove doxygen in PR
         run: rm -rf publishing_docs/pr/*/doxygen
       - uses: actions/upload-artifact@v4
@@ -928,6 +988,16 @@ jobs:
       # Note:
       # - If we run this on a non-main branch, we download from main with action-download-artifact.
       # - If we run this on the main branch, we have to download from this pipeline with download-artifact.
+      - name: Check rate limit before
+        run: |
+          rate=$(gh api rate_limit | jq '.rate')
+          used=$(echo $rate | jq '.used')
+          remaining=$(echo $rate | jq '.remaining')
+          reset=$(echo $rate | jq '.reset')
+          resetdate=$(TZ="America/New_York" date --date @$reset)
+          echo "Rate limiting will reset on $resetdate; $used calls used; $remaining calls remaining."
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Download docs artifact (in PR)
         uses: dawidd6/action-download-artifact@v3
         if: github.ref_name != 'main'
@@ -957,6 +1027,16 @@ jobs:
         with:
           name: capybara
           path: publishing_docs/capybara/
+      - name: Check rate limit after
+        run: |
+          rate=$(gh api rate_limit | jq '.rate')
+          used=$(echo $rate | jq '.used')
+          remaining=$(echo $rate | jq '.remaining')
+          reset=$(echo $rate | jq '.reset')
+          resetdate=$(TZ="America/New_York" date --date @$reset)
+          echo "Rate limiting will reset on $resetdate; $used calls used; $remaining calls remaining."
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Populate capybara summary (on main)
         if: github.ref_name == 'main' || steps.download_capybara.outputs.found_artifact == 'true'
         run: |


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds a debug output step in the jobs that use dawidd6/action-download-artifact to allow us to see which steps are having most detrimental impact on the rate limits.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
