### PR TITLE
fix(ci): accept failing workflow runs as source of capybara reference

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -583,6 +583,7 @@ jobs:
         branch: ${{ github.event.pull_request.base.ref || github.ref_name }}
         path: ref/
         name: rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
+        workflow_conclusion: ""
         if_no_artifact_found: warn
     - name: Compare to previous artifacts
       uses: eic/run-cvmfs-osg-eic-shell@main
@@ -733,6 +734,7 @@ jobs:
         branch: ${{ github.event.pull_request.base.ref || github.ref_name }}
         path: ref/
         name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root
+        workflow_conclusion: ""
         if_no_artifact_found: warn
     - name: Compare to previous artifacts
       uses: eic/run-cvmfs-osg-eic-shell@main
@@ -890,6 +892,7 @@ jobs:
           pr: ${{ matrix.pr }}
           path: publishing_docs/pr/${{ matrix.pr }}/
           name: docs
+          workflow_conclusion: ""
           if_no_artifact_found: ignore
       - name: Download docs artifact (this PR)
         uses: actions/download-artifact@v4
@@ -905,6 +908,7 @@ jobs:
           pr: ${{ matrix.pr }}
           path: publishing_docs/pr/${{ matrix.pr }}/capybara/
           name: capybara
+          workflow_conclusion: ""
           if_no_artifact_found: ignore
       - name: Download capybara artifact (this PR)
         uses: actions/download-artifact@v4
@@ -935,6 +939,7 @@ jobs:
           branch: main
           path: publishing_docs/
           name: docs
+          workflow_conclusion: ""
           if_no_artifact_found: fail
       - name: Download docs artifact (on main)
         uses: actions/download-artifact@v4
@@ -950,6 +955,7 @@ jobs:
           pr: ${{ matrix.pr }}
           path: publishing_docs/capybara/
           name: capybara
+          workflow_conclusion: ""
           if_no_artifact_found: ignore
       - name: Download capybara artifact (on main)
         uses: actions/download-artifact@v4


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Each PR (and main) publishes the capybara artifacts for all open PRs:
- Within the PR's own workflow run itself, it pulls the capybara artifacts regardless of completion of the workflow (since the workflow is still running), and it posts this as a comment.
- Within another PR's (or main's) workflow run, it pulls the capybara artifacts with dawidd6/download-artifact-action, and it does this with the default of `workflow_conclusion: success`.

This strategy results in a comment being posted on the PR with working capybara artifacts links, but the workflow fails (e.g. clang-tidy-iwyu or later API requests exceeded), and the workflow is marked as failed (e.g. https://github.com/eic/EICrecon/pull/1285/commits has two failing workflows right now). Since it is failed, the capybara artifacts are never again pulled and deployed by other PRs, e.g. 1291 failed to get the 1285 artifacts in https://github.com/eic/EICrecon/actions/runs/8010313431/job/21882716350#step:4:29.

A similar issue may occur during comparisons themselves: instead of comparing to the most recent workflow run of `main` (or at least `base.ref`), it compares to the most recent *successful* run of that branch. The most recent run could have had API request exceeded issues too.

This PR relaxes the requirement to use the most recent workflow run, even if the conclusion was failed, as long as it had a matching artifact. It does this for two cases:
- when we pull the reference eicrecon rec.root artifact to compare to,
- when we pull the docs and capybara artifacts from another PR (or main) than the one we're on.

This should not increase API requests since workflow conclusion is not added to the request call but is handled as an early `continue` at https://github.com/dawidd6/action-download-artifact/blob/master/main.js#L131-L133.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://eicrecon.epic-eic.org/pr/1285/capybara/rec_dis_18x275_minQ2=1000_craterlake/index.html is a dead link right now)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.