### PR TITLE
add raw tracker hits to output collection

### DIFF
--- a/src/detectors/BVTX/BVTX.cc
+++ b/src/detectors/BVTX/BVTX.cc
@@ -20,9 +20,9 @@ void InitPlugin(JApplication *app) {
 
     // Digitization
     app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
-        "BarrelVertexRawHits",
+        "SiBarrelVertexRawHits",
         {"VertexBarrelHits"},
-        {"BarrelVertexRawHits"},
+        {"SiBarrelVertexRawHits"},
         {
             .threshold = 0.54 * dd4hep::keV,
         },
@@ -32,7 +32,7 @@ void InitPlugin(JApplication *app) {
     // Convert raw digitized hits into hits with geometry info (ready for tracking)
     app->Add(new JOmniFactoryGeneratorT<TrackerHitReconstruction_factory>(
         "SiBarrelVertexRecHits",
-        {"BarrelVertexRawHits"},
+        {"SiBarrelVertexRawHits"},
         {"SiBarrelVertexRecHits"},
         {}, // default config
         app

--- a/src/detectors/ECTRK/ECTRK.cc
+++ b/src/detectors/ECTRK/ECTRK.cc
@@ -20,9 +20,9 @@ void InitPlugin(JApplication *app) {
 
     // Digitization
     app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
-        "EndcapTrackerRawHit",
+        "SiEndcapTrackerRawHits",
         {"TrackerEndcapHits"},
-        {"EndcapTrackerRawHit"},
+        {"SiEndcapTrackerRawHits"},
         {
             .threshold = 0.54 * dd4hep::keV,
         },
@@ -32,7 +32,7 @@ void InitPlugin(JApplication *app) {
     // Convert raw digitized hits into hits with geometry info (ready for tracking)
     app->Add(new JOmniFactoryGeneratorT<TrackerHitReconstruction_factory>(
         "SiEndcapTrackerRecHits",
-        {"EndcapTrackerRawHit"},
+        {"SiEndcapTrackerRawHits"},
         {"SiEndcapTrackerRecHits"},
         {}, // default config
         app

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -57,16 +57,24 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "SiBarrelTrackerRecHits",
             "SiBarrelVertexRecHits",
             "SiEndcapTrackerRecHits",
+
             "SiBarrelRawHits",
             "SiBarrelVertexRawHits",
             "SiEndcapTrackerRawHits",
 
+            "SiBarrelHits",
+            "VertexBarrelHits",
+            "TrackerEndcapHits",
+
             // TOF
             "TOFBarrelRecHit",
             "TOFEndcapRecHits",
+
             "TOFBarrelRawHit",
             "TOFEndcapRawHits",
-
+            
+            "TOFBarrelHits",
+            "TOFEndcapHits",
             // DRICH
             "DRICHRawHits",
             "DRICHRawHitsAssociations",
@@ -81,18 +89,26 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "OuterMPGDBarrelRecHits",
             "BackwardMPGDEndcapRecHits",
             "ForwardMPGDEndcapRecHits",
+
             "MPGDBarrelRawHits",
             "MPGDDIRCRawHits",
             "OuterMPGDBarrelRawHits",
             "BackwardMPGDEndcapRawHits",
             "ForwardMPGDEndcapRawHits",
 
+            "MPGDBarrelHits",
+            "MPGDDIRCHits",
+            "OuterMPGDBarrelHits",
+            "BackwardMPGDEndcapHits",
+            "ForwardMPGDEndcapHits",
             // LOWQ2 hits
             "TaggerTrackerRawHits",
 
             // Forward & Far forward hits
             "B0TrackerRecHits",
             "B0TrackerRawHits",
+            "B0TrackerHits",
+
             //
             "ForwardRomanPotRecParticles",
             "ForwardOffMRecParticles",

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -72,7 +72,7 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
 
             "TOFBarrelRawHit",
             "TOFEndcapRawHits",
-            
+
             "TOFBarrelHits",
             "TOFEndcapHits",
             // DRICH

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -57,10 +57,15 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "SiBarrelTrackerRecHits",
             "SiBarrelVertexRecHits",
             "SiEndcapTrackerRecHits",
+            "SiBarrelRawHits",
+            "SiBarrelVertexRawHits",
+            "SiEndcapTrackerRawHits",
 
             // TOF
             "TOFBarrelRecHit",
             "TOFEndcapRecHits",
+            "TOFBarrelRawHit",
+            "TOFEndcapRawHits",
 
             // DRICH
             "DRICHRawHits",
@@ -76,13 +81,18 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "OuterMPGDBarrelRecHits",
             "BackwardMPGDEndcapRecHits",
             "ForwardMPGDEndcapRecHits",
+            "MPGDBarrelRawHits",
+            "MPGDDIRCRawHits",
+            "OuterMPGDBarrelRawHits",
+            "BackwardMPGDEndcapRawHits",
+            "ForwardMPGDEndcapRawHits",
 
             // LOWQ2 hits
             "TaggerTrackerRawHits",
 
             // Forward & Far forward hits
             "B0TrackerRecHits",
-
+            "B0TrackerRawHits",
             //
             "ForwardRomanPotRecParticles",
             "ForwardOffMRecParticles",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
I updated the Si raw hits name. Also added all tracker raw hits (Si, MPGD, TOF, B0) to the default podio output collection.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x ] Changes have been communicated to collaborators @mdiefent 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
N/A. Some raw hits name changed. but since it's never used anywhere other than the digitization it should not be an issue.
### Does this PR change default behavior?
N/A