### PR TITLE
fix(ci): store pull_request.head.sha for later use

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -874,6 +874,7 @@ jobs:
         uses: nickofthyme/object-remap@v2
         with:
           include.*.pr: ${{ toJSON(fromJSON(steps.query.outputs.data).*.number) }}
+          include.*.head_sha: ${{ toJSON(fromJSON(steps.query.outputs.data).*.head.sha) }}
 
   get-docs-from-open-prs:
     runs-on: ubuntu-latest
@@ -889,7 +890,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v3
         if: github.event.pull_request.number != matrix.pr
         with:
-          pr: ${{ matrix.pr }}
+          commit: ${{ matrix.head_sha }}
           path: publishing_docs/pr/${{ matrix.pr }}/
           name: docs
           workflow_conclusion: ""
@@ -905,7 +906,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v3
         if: github.event.pull_request.number != matrix.pr
         with:
-          pr: ${{ matrix.pr }}
+          commit: ${{ matrix.head_sha }}
           path: publishing_docs/pr/${{ matrix.pr }}/capybara/
           name: capybara
           workflow_conclusion: ""
@@ -952,7 +953,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v3
         if: github.ref_name != 'main'
         with:
-          pr: ${{ matrix.pr }}
+          commit: ${{ matrix.head_sha }}
           path: publishing_docs/capybara/
           name: capybara
           workflow_conclusion: ""

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -873,6 +873,7 @@ jobs:
         id: remap
         uses: nickofthyme/object-remap@v2
         with:
+          __case: snake
           include.*.pr: ${{ toJSON(fromJSON(steps.query.outputs.data).*.number) }}
           include.*.head_sha: ${{ toJSON(fromJSON(steps.query.outputs.data).*.head.sha) }}
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Specifying the commit hash with dawidd6/action-download-artifact avoids an API request by bypassing https://github.com/dawidd6/action-download-artifact/blob/master/main.js#L87. This PR modifies the list-open-prs job to pass the head.sha as commit to the get-docs-from-open-prs matrix.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: too many API requests)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.