### PR TITLE
fix: W² = M² + 2pq - Q² in inclusive kinematics (electron)

### DIFF
--- a/src/algorithms/reco/InclusiveKinematicsElectron.cc
+++ b/src/algorithms/reco/InclusiveKinematicsElectron.cc
@@ -162,7 +162,7 @@ namespace eicrecon {
     const auto y = q_dot_pi / ei.Dot(pi);
     const auto nu = q_dot_pi / m_proton;
     const auto x = Q2 / (2. * q_dot_pi);
-    const auto W = sqrt( + 2.*q_dot_pi - Q2);
+    const auto W = sqrt(m_proton*m_proton + 2.*q_dot_pi - Q2);
     auto kin = kinematics->create(x, Q2, W, y, nu);
     kin.setScat(ef_rc);
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
In the W² = M² + 2pq - Q² formula in inclusive kinematics (electron) the M² was missing. This PR assume it is always scattering off protons.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #1275)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.