### PR TITLE
Add digi and fix reco for roman pots

### DIFF
--- a/src/algorithms/fardetectors/MatrixTransferStatic.cc
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.cc
@@ -75,6 +75,8 @@ void eicrecon::MatrixTransferStatic::process(
   bool goodHit1 = false;
   bool goodHit2 = false;
 
+  std::cout << "num of raw hits: " << rawhits->size() << std::endl;
+
   for (const auto &h: *rawhits) {
 
     auto cellID = h.getCellID();
@@ -86,9 +88,15 @@ void eicrecon::MatrixTransferStatic::process(
 
     auto pos0 = local.nominal().worldToLocal(dd4hep::Position(gpos.x(), gpos.y(), gpos.z())); // hit position in local coordinates
 
+	//std::cout << "gpos = " << gpos.z() << " pos0 = " << pos0.z() << std::endl;
+
     // convert into mm
     gpos = gpos/dd4hep::mm;
     pos0 = pos0/dd4hep::mm;
+
+	std::cout << "gpos.z() = " << gpos.z() << " pos0.z() = " << pos0.z() << std::endl;
+
+	std::cout << "[gpos.x(), gpos.y()] = " << gpos.x() <<", "<< gpos.y() << "  and [pos0.x(), pos0.y()] = "<< pos0.x()<< ", " << pos0.y() << std::endl;
 
     if(!goodHit2 && gpos.z() > m_cfg.hit2minZ && gpos.z() < m_cfg.hit2maxZ){
 
@@ -115,6 +123,8 @@ void eicrecon::MatrixTransferStatic::process(
 
   if (goodHit1 && goodHit2) {
 
+	std::cout << "beginning roman pots reconstruction..." << std::endl;
+
     // extract hit, subtract orbit offset – this is to get the hits in the coordinate system of the orbit
     // trajectory
     double XL[2] = {goodHit[0].x - m_cfg.local_x_offset, goodHit[1].x - m_cfg.local_x_offset};
@@ -122,15 +132,18 @@ void eicrecon::MatrixTransferStatic::process(
 
     double base = goodHit[1].z - goodHit[0].z;
 
+	std::cout << "base = " << base << std::endl;
+	std::cout << "dd4hep::mm = " << dd4hep::mm << " dd4hep::mrad = " << dd4hep::mrad << std::endl;
+
     if (base == 0) {
       m_log->info("Detector separation = 0! Cannot calculate slope!");
     }
     else{
 
       double Xip[2] = {0.0, 0.0};
-      double Xrp[2] = {XL[1], ((XL[1] - XL[0]) / (base))/dd4hep::mrad - m_cfg.local_x_slope_offset}; //- _SX0RP_;
+      double Xrp[2] = {XL[1], 1000*((XL[1] - XL[0]) / (base)) - m_cfg.local_x_slope_offset}; //- _SX0RP_;
       double Yip[2] = {0.0, 0.0};
-      double Yrp[2] = {YL[1], ((YL[1] - YL[0]) / (base))/dd4hep::mrad - m_cfg.local_y_slope_offset}; //- _SY0RP_;
+      double Yrp[2] = {YL[1], 1000*((YL[1] - YL[0]) / (base)) - m_cfg.local_y_slope_offset}; //- _SY0RP_;
 
       // use the hit information and calculated slope at the RP + the transfer matrix inverse to calculate the
       // Polar Angle and deltaP at the IP

--- a/src/algorithms/fardetectors/MatrixTransferStatic.cc
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.cc
@@ -72,9 +72,7 @@ void eicrecon::MatrixTransferStatic::process(
   nomMomentum = runningMomentum/numBeamProtons;
    
   double nomMomentumError = 0.02;
-  
-  //std::cout << "average momentum is = " << nomMomentum << std::endl;
- 
+   
   //This is a temporary solution to get the beam energy information
   //needed to select the correct matrix
   
@@ -207,7 +205,6 @@ void eicrecon::MatrixTransferStatic::process(
     pos0 = pos0/dd4hep::mm;
 
 	//std::cout << "gpos.z() = " << gpos.z() << " pos0.z() = " << pos0.z() << std::endl;
-
 	//std::cout << "[gpos.x(), gpos.y()] = " << gpos.x() <<", "<< gpos.y() << "  and [pos0.x(), pos0.y()] = "<< pos0.x()<< ", " << pos0.y() << std::endl;
 
     if(!goodHit2 && gpos.z() > m_cfg.hit2minZ && gpos.z() < m_cfg.hit2maxZ){
@@ -235,8 +232,6 @@ void eicrecon::MatrixTransferStatic::process(
 
   if (goodHit1 && goodHit2) {
 
-	//std::cout << "beginning roman pots reconstruction..." << std::endl;
-
     // extract hit, subtract orbit offset – this is to get the hits in the coordinate system of the orbit
     // trajectory
     double XL[2] = {goodHit[0].x - local_x_offset, goodHit[1].x - local_x_offset};
@@ -244,18 +239,15 @@ void eicrecon::MatrixTransferStatic::process(
 
     double base = goodHit[1].z - goodHit[0].z;
 
-	std::cout << "base = " << base << std::endl;
-	std::cout << "dd4hep::mm = " << dd4hep::mm << " dd4hep::mrad = " << dd4hep::mrad << std::endl;
-
     if (base == 0) {
       m_log->info("Detector separation = 0! Cannot calculate slope!");
     }
     else{
 
       double Xip[2] = {0.0, 0.0};
-      double Xrp[2] = {XL[1], ((XL[1] - XL[0]) / (base))/dd4hep::mrad - local_x_slope_offset}; //- _SX0RP_;
+      double Xrp[2] = {XL[1], ((XL[1] - XL[0]) / (base))/dd4hep::mrad - local_x_slope_offset}; 
       double Yip[2] = {0.0, 0.0};
-      double Yrp[2] = {YL[1], ((YL[1] - YL[0]) / (base))/dd4hep::mrad - local_y_slope_offset}; //- _SY0RP_;
+      double Yrp[2] = {YL[1], ((YL[1] - YL[0]) / (base))/dd4hep::mrad - local_y_slope_offset}; 
 
       // use the hit information and calculated slope at the RP + the transfer matrix inverse to calculate the
       // Polar Angle and deltaP at the IP

--- a/src/algorithms/fardetectors/MatrixTransferStatic.cc
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.cc
@@ -28,7 +28,7 @@ void eicrecon::MatrixTransferStatic::init(const dd4hep::Detector* det,
   m_detector  = det;
   m_converter = id_conv;
   //Calculate inverse of static transfer matrix
-    
+
 }
 
 void eicrecon::MatrixTransferStatic::process(
@@ -37,45 +37,45 @@ void eicrecon::MatrixTransferStatic::process(
 
   const auto [mcparts, rechits] = input;
   auto [outputParticles] = output;
-  
+
   std::vector<std::vector<double>> aX(m_cfg.aX);
   std::vector<std::vector<double>> aY(m_cfg.aY);
-  
+
   //----- Define constants here ------
   double aXinv[2][2] = {{0.0, 0.0},
                         {0.0, 0.0}};
   double aYinv[2][2] = {{0.0, 0.0},
                         {0.0, 0.0}};
-  
+
   double nomMomentum     = m_cfg.nomMomentum; //extract the nominal value first -- will be overwritten by MCParticle
   double local_x_offset  = m_cfg.local_x_offset;
   double local_y_offset  = m_cfg.local_y_offset;
   double local_x_slope_offset  = m_cfg.local_x_slope_offset;
   double local_y_slope_offset  = m_cfg.local_y_slope_offset;
- 
+
   double numBeamProtons = 0;
   double runningMomentum = 0.0;
-  
+
   for (const auto& p: *mcparts) {
-	  if(mcparts->size() == 1 && p.getPDG() == 2212){
-	  	runningMomentum = p.getMomentum().z;
-		numBeamProtons++;
-	  }
-  	if (p.getGeneratorStatus() == 4 && p.getPDG() == 2212) { //look for "beam" proton
-		runningMomentum += p.getMomentum().z;
-		numBeamProtons++;
-	}
+          if(mcparts->size() == 1 && p.getPDG() == 2212){
+                runningMomentum = p.getMomentum().z;
+                numBeamProtons++;
+          }
+        if (p.getGeneratorStatus() == 4 && p.getPDG() == 2212) { //look for "beam" proton
+                runningMomentum += p.getMomentum().z;
+                numBeamProtons++;
+        }
   }
-  
+
   if(numBeamProtons == 0) {m_log->error("No beam protons to choose matrix!! Skipping!!"); return;}
-      
+
   nomMomentum = runningMomentum/numBeamProtons;
-   
+
   double nomMomentumError = 0.02;
-   
+
   //This is a temporary solution to get the beam energy information
   //needed to select the correct matrix
-  
+
   if(abs(275.0 - nomMomentum)/275.0 < nomMomentumError){
 
       aX[0][0] = 2.09948716; //a
@@ -131,12 +131,12 @@ void eicrecon::MatrixTransferStatic::process(
 
   }
   else if(abs(135.0 - nomMomentum)/135.0 < nomMomentumError){ //135 GeV deuterons
-  	
+
       aX[0][0] = 1.6248;
-	  aX[0][1] = 12.966293;
-      aX[1][0] = 0.1832; 
-	  aX[1][1] = -2.8636535;
-      
+          aX[0][1] = 12.966293;
+      aX[1][0] = 0.1832;
+          aX[1][1] = -2.8636535;
+
       aY[0][0] = 0.0001674; //a
       aY[0][1] = -28.6003; //b
       aY[1][0] = 0.0000837; //c
@@ -146,7 +146,7 @@ void eicrecon::MatrixTransferStatic::process(
       local_y_offset       = -0.0146;
       local_x_slope_offset = -14.75315;
       local_y_slope_offset = -0.0073;
-	  
+
   }
   else {
     m_log->error("MatrixTransferStatic:: No valid matrix found to match beam momentum!! Skipping!!");
@@ -204,8 +204,8 @@ void eicrecon::MatrixTransferStatic::process(
     gpos = gpos/dd4hep::mm;
     pos0 = pos0/dd4hep::mm;
 
-	//std::cout << "gpos.z() = " << gpos.z() << " pos0.z() = " << pos0.z() << std::endl;
-	//std::cout << "[gpos.x(), gpos.y()] = " << gpos.x() <<", "<< gpos.y() << "  and [pos0.x(), pos0.y()] = "<< pos0.x()<< ", " << pos0.y() << std::endl;
+        //std::cout << "gpos.z() = " << gpos.z() << " pos0.z() = " << pos0.z() << std::endl;
+        //std::cout << "[gpos.x(), gpos.y()] = " << gpos.x() <<", "<< gpos.y() << "  and [pos0.x(), pos0.y()] = "<< pos0.x()<< ", " << pos0.y() << std::endl;
 
     if(!goodHit2 && gpos.z() > m_cfg.hit2minZ && gpos.z() < m_cfg.hit2maxZ){
 
@@ -245,9 +245,9 @@ void eicrecon::MatrixTransferStatic::process(
     else{
 
       double Xip[2] = {0.0, 0.0};
-      double Xrp[2] = {XL[1], ((XL[1] - XL[0]) / (base))/dd4hep::mrad - local_x_slope_offset}; 
+      double Xrp[2] = {XL[1], ((XL[1] - XL[0]) / (base))/dd4hep::mrad - local_x_slope_offset};
       double Yip[2] = {0.0, 0.0};
-      double Yrp[2] = {YL[1], ((YL[1] - YL[0]) / (base))/dd4hep::mrad - local_y_slope_offset}; 
+      double Yrp[2] = {YL[1], ((YL[1] - YL[0]) / (base))/dd4hep::mrad - local_y_slope_offset};
 
       // use the hit information and calculated slope at the RP + the transfer matrix inverse to calculate the
       // Polar Angle and deltaP at the IP

--- a/src/algorithms/fardetectors/MatrixTransferStatic.cc
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.cc
@@ -70,9 +70,9 @@ void eicrecon::MatrixTransferStatic::process(
   if(numBeamProtons == 0) {m_log->error("No beam protons to choose matrix!! Skipping!!"); return;}
 
   nomMomentum = runningMomentum/numBeamProtons;
-
-  double nomMomentumError = 0.02;
-
+   
+  double nomMomentumError = 0.05;
+   
   //This is a temporary solution to get the beam energy information
   //needed to select the correct matrix
 

--- a/src/algorithms/fardetectors/MatrixTransferStatic.cc
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.cc
@@ -70,9 +70,9 @@ void eicrecon::MatrixTransferStatic::process(
   if(numBeamProtons == 0) {m_log->error("No beam protons to choose matrix!! Skipping!!"); return;}
 
   nomMomentum = runningMomentum/numBeamProtons;
-   
+
   double nomMomentumError = 0.05;
-   
+
   //This is a temporary solution to get the beam energy information
   //needed to select the correct matrix
 

--- a/src/algorithms/fardetectors/MatrixTransferStatic.cc
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.cc
@@ -204,8 +204,8 @@ void eicrecon::MatrixTransferStatic::process(
     gpos = gpos/dd4hep::mm;
     pos0 = pos0/dd4hep::mm;
 
-        //std::cout << "gpos.z() = " << gpos.z() << " pos0.z() = " << pos0.z() << std::endl;
-        //std::cout << "[gpos.x(), gpos.y()] = " << gpos.x() <<", "<< gpos.y() << "  and [pos0.x(), pos0.y()] = "<< pos0.x()<< ", " << pos0.y() << std::endl;
+    //std::cout << "gpos.z() = " << gpos.z() << " pos0.z() = " << pos0.z() << std::endl;
+    //std::cout << "[gpos.x(), gpos.y()] = " << gpos.x() <<", "<< gpos.y() << "  and [pos0.x(), pos0.y()] = "<< pos0.x()<< ", " << pos0.y() << std::endl;
 
     if(!goodHit2 && gpos.z() > m_cfg.hit2minZ && gpos.z() < m_cfg.hit2maxZ){
 

--- a/src/algorithms/fardetectors/MatrixTransferStatic.cc
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.cc
@@ -57,6 +57,10 @@ void eicrecon::MatrixTransferStatic::process(
   double runningMomentum = 0.0;
   
   for (const auto& p: *mcparts) {
+	  if(mcparts->size() == 1 && p.getPDG() == 2212){
+	  	runningMomentum = p.getMomentum().z;
+		numBeamProtons++;
+	  }
   	if (p.getGeneratorStatus() == 4 && p.getPDG() == 2212) { //look for "beam" proton
 		runningMomentum += p.getMomentum().z;
 		numBeamProtons++;
@@ -69,7 +73,7 @@ void eicrecon::MatrixTransferStatic::process(
    
   double nomMomentumError = 0.02;
   
-  std::cout << "average momentum is = " << nomMomentum << std::endl;
+  //std::cout << "average momentum is = " << nomMomentum << std::endl;
  
   //This is a temporary solution to get the beam energy information
   //needed to select the correct matrix
@@ -189,8 +193,6 @@ void eicrecon::MatrixTransferStatic::process(
 
   for (const auto &h: *rechits) {
 
-	m_log->debug( "Roman pots reconstruction starting...");
-
     auto cellID = h.getCellID();
     // The actual hit position in Global Coordinates
     auto gpos = m_converter->position(cellID);
@@ -204,9 +206,9 @@ void eicrecon::MatrixTransferStatic::process(
     gpos = gpos/dd4hep::mm;
     pos0 = pos0/dd4hep::mm;
 
-	std::cout << "gpos.z() = " << gpos.z() << " pos0.z() = " << pos0.z() << std::endl;
+	//std::cout << "gpos.z() = " << gpos.z() << " pos0.z() = " << pos0.z() << std::endl;
 
-	std::cout << "[gpos.x(), gpos.y()] = " << gpos.x() <<", "<< gpos.y() << "  and [pos0.x(), pos0.y()] = "<< pos0.x()<< ", " << pos0.y() << std::endl;
+	//std::cout << "[gpos.x(), gpos.y()] = " << gpos.x() <<", "<< gpos.y() << "  and [pos0.x(), pos0.y()] = "<< pos0.x()<< ", " << pos0.y() << std::endl;
 
     if(!goodHit2 && gpos.z() > m_cfg.hit2minZ && gpos.z() < m_cfg.hit2maxZ){
 
@@ -233,7 +235,7 @@ void eicrecon::MatrixTransferStatic::process(
 
   if (goodHit1 && goodHit2) {
 
-	std::cout << "beginning roman pots reconstruction..." << std::endl;
+	//std::cout << "beginning roman pots reconstruction..." << std::endl;
 
     // extract hit, subtract orbit offset – this is to get the hits in the coordinate system of the orbit
     // trajectory

--- a/src/algorithms/fardetectors/MatrixTransferStatic.h
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.h
@@ -22,7 +22,7 @@ namespace eicrecon {
 
   using MatrixTransferStaticAlgorithm = algorithms::Algorithm<
     algorithms::Input<
-          edm4hep::MCParticleCollection,
+      edm4hep::MCParticleCollection,
       edm4eic::TrackerHitCollection
     >,
     algorithms::Output<
@@ -50,8 +50,6 @@ namespace eicrecon {
     std::shared_ptr<spdlog::logger>   m_log;
     const dd4hep::Detector* m_detector{nullptr};
     const dd4hep::rec::CellIDPositionConverter* m_converter{nullptr};
-
-
 
   };
 }

--- a/src/algorithms/fardetectors/MatrixTransferStatic.h
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.h
@@ -7,6 +7,7 @@
 #include <DDRec/CellIDPositionConverter.h>
 #include <algorithms/algorithm.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
+#include <edm4eic/TrackerHitCollection.h>
 #include <edm4hep/SimTrackerHitCollection.h>
 #include <edm4hep/MCParticleCollection.h>
 #include <spdlog/logger.h>
@@ -21,7 +22,8 @@ namespace eicrecon {
 
   using MatrixTransferStaticAlgorithm = algorithms::Algorithm<
     algorithms::Input<
-      edm4hep::SimTrackerHitCollection
+	  edm4hep::MCParticleCollection,
+      edm4eic::TrackerHitCollection
     >,
     algorithms::Output<
       edm4eic::ReconstructedParticleCollection
@@ -35,7 +37,7 @@ namespace eicrecon {
   public:
     MatrixTransferStatic(std::string_view name)
       : MatrixTransferStaticAlgorithm{name,
-                            {"inputHitCollection"},
+                            {"mcParticles", "inputHitCollection"},
                             {"outputParticleCollection"},
                             "Apply matrix method reconstruction to hits."} {}
 
@@ -44,18 +46,12 @@ namespace eicrecon {
 
   private:
 
-    //----- Define constants here ------
-    double aXinv[2][2] = {{0.0, 0.0},
-                          {0.0, 0.0}};
-    double aYinv[2][2] = {{0.0, 0.0},
-                          {0.0, 0.0}};
-
-  private:
-
     /** algorithm logger */
     std::shared_ptr<spdlog::logger>   m_log;
     const dd4hep::Detector* m_detector{nullptr};
     const dd4hep::rec::CellIDPositionConverter* m_converter{nullptr};
+	
+	
 
   };
 }

--- a/src/algorithms/fardetectors/MatrixTransferStatic.h
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.h
@@ -8,7 +8,6 @@
 #include <algorithms/algorithm.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4eic/TrackerHitCollection.h>
-#include <edm4hep/SimTrackerHitCollection.h>
 #include <edm4hep/MCParticleCollection.h>
 #include <spdlog/logger.h>
 #include <memory>

--- a/src/algorithms/fardetectors/MatrixTransferStatic.h
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.h
@@ -22,7 +22,7 @@ namespace eicrecon {
 
   using MatrixTransferStaticAlgorithm = algorithms::Algorithm<
     algorithms::Input<
-	  edm4hep::MCParticleCollection,
+          edm4hep::MCParticleCollection,
       edm4eic::TrackerHitCollection
     >,
     algorithms::Output<
@@ -50,8 +50,8 @@ namespace eicrecon {
     std::shared_ptr<spdlog::logger>   m_log;
     const dd4hep::Detector* m_detector{nullptr};
     const dd4hep::rec::CellIDPositionConverter* m_converter{nullptr};
-	
-	
+
+
 
   };
 }

--- a/src/algorithms/fardetectors/MatrixTransferStatic.h
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.h
@@ -8,6 +8,7 @@
 #include <algorithms/algorithm.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/SimTrackerHitCollection.h>
+#include <edm4hep/MCParticleCollection.h>
 #include <spdlog/logger.h>
 #include <memory>
 #include <string>

--- a/src/algorithms/fardetectors/MatrixTransferStaticConfig.h
+++ b/src/algorithms/fardetectors/MatrixTransferStaticConfig.h
@@ -24,13 +24,13 @@ namespace eicrecon {
     //std::vector<std::vector<double>> aY = {{0.0000159900, 3.94082098},
     //                                       {0.0000079946, -0.1402995}};
 
-		
-	//x_offset       = 0.00979216;
-	//y_offset       = -0.00778646;
-	//x_slope_offset = 0.004526961;
-	//y_slope_offset = -0.003907849;	
 
-	std::vector<std::vector<double>> aX = {{2.03459216, 22.85780784},
+        //x_offset       = 0.00979216;
+        //y_offset       = -0.00778646;
+        //x_slope_offset = 0.004526961;
+        //y_slope_offset = -0.003907849;
+
+        std::vector<std::vector<double>> aX = {{2.03459216, 22.85780784},
                                            {0.179641961, -0.306626961}};
     std::vector<std::vector<double>> aY = {{0.38879, 3.71612646},
                                            {0.022685, -0.003907849}};

--- a/src/algorithms/fardetectors/MatrixTransferStaticConfig.h
+++ b/src/algorithms/fardetectors/MatrixTransferStaticConfig.h
@@ -17,12 +17,23 @@ namespace eicrecon {
     double local_x_slope_offset{-0.00622147};
     double local_y_slope_offset{-0.0451035};
     double crossingAngle       {0.025};
-    double nomMomentum         {275.0};
+    double nomMomentum         {100.0};
 
-    std::vector<std::vector<double>> aX = {{2.102403743, 29.11067626},
-                                           {0.186640381, 0.192604619}};
-    std::vector<std::vector<double>> aY = {{0.0000159900, 3.94082098},
-                                           {0.0000079946, -0.1402995}};
+    //std::vector<std::vector<double>> aX = {{2.102403743, 29.11067626},
+    //                                       {0.186640381, 0.192604619}};
+    //std::vector<std::vector<double>> aY = {{0.0000159900, 3.94082098},
+    //                                       {0.0000079946, -0.1402995}};
+
+		
+	//x_offset       = 0.00979216;
+	//y_offset       = -0.00778646;
+	//x_slope_offset = 0.004526961;
+	//y_slope_offset = -0.003907849;	
+
+	std::vector<std::vector<double>> aX = {{2.03459216, 22.85780784},
+                                           {0.179641961, -0.306626961}};
+    std::vector<std::vector<double>> aY = {{0.38879, 3.71612646},
+                                           {0.022685, -0.003907849}};
 
     double hit1minZ{0};
     double hit1maxZ{0};

--- a/src/algorithms/fardetectors/MatrixTransferStaticConfig.h
+++ b/src/algorithms/fardetectors/MatrixTransferStaticConfig.h
@@ -25,12 +25,12 @@ namespace eicrecon {
     //                                       {0.0000079946, -0.1402995}};
 
 
-        //x_offset       = 0.00979216;
-        //y_offset       = -0.00778646;
-        //x_slope_offset = 0.004526961;
-        //y_slope_offset = -0.003907849;
+    //x_offset       = 0.00979216;
+    //y_offset       = -0.00778646;
+    //x_slope_offset = 0.004526961;
+    //y_slope_offset = -0.003907849;
 
-        std::vector<std::vector<double>> aX = {{2.03459216, 22.85780784},
+    std::vector<std::vector<double>> aX = {{2.03459216, 22.85780784},
                                            {0.179641961, -0.306626961}};
     std::vector<std::vector<double>> aY = {{0.38879, 3.71612646},
                                            {0.022685, -0.003907849}};

--- a/src/detectors/FOFFMTRK/FOFFMTRK.cc
+++ b/src/detectors/FOFFMTRK/FOFFMTRK.cc
@@ -8,6 +8,8 @@
 
 #include "algorithms/fardetectors/MatrixTransferStaticConfig.h"
 #include "extensions/jana/JOmniFactoryGeneratorT.h"
+#include "factories/digi/SiliconTrackerDigi_factory.h"
+#include "factories/tracking/TrackerHitReconstruction_factory.h"
 #include "factories/fardetectors/MatrixTransferStatic_factory.h"
 
 
@@ -17,6 +19,28 @@ void InitPlugin(JApplication *app) {
     using namespace eicrecon;
 
     MatrixTransferStaticConfig recon_cfg;
+	
+	//Digitized hits, especially for thresholds
+	app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
+        "ForwardOffMTrackerRawHits",
+        {"ForwardOffMTrackerHits"},
+        {"ForwardOffMTrackerRawHits"},
+        {
+            .threshold = 10.0 * dd4hep::keV,
+            .timeResolution = 8,
+        },
+        app
+    ));
+
+	app->Add(new JOmniFactoryGeneratorT<TrackerHitReconstruction_factory>(
+        "ForwardOffMTrackerRecHits",
+        {"ForwardOffMTrackerRawHits"},
+        {"ForwardOffMTrackerRecHits"},
+        {
+            .timeResolution = 8,
+        },
+        app
+    ));
 
     //Static transport matrix for Off Momentum detectors
     recon_cfg.aX = {{1.6248, 12.966293},
@@ -35,9 +59,9 @@ void InitPlugin(JApplication *app) {
     recon_cfg.hit2minZ = 24499.0;
     recon_cfg.hit2maxZ = 24522.0;
 
-    recon_cfg.readout              = "ForwardOffMTrackerHits";
+    recon_cfg.readout              = "ForwardOffMTrackerRecHits";
 
-    app->Add(new JOmniFactoryGeneratorT<MatrixTransferStatic_factory>("ForwardOffMRecParticles",{"ForwardOffMTrackerHits"},{"ForwardOffMRecParticles"},recon_cfg,app));
+    app->Add(new JOmniFactoryGeneratorT<MatrixTransferStatic_factory>("ForwardOffMRecParticles",{"MCParticles","ForwardOffMTrackerRecHits"},{"ForwardOffMRecParticles"},recon_cfg,app));
 
 }
 }

--- a/src/detectors/FOFFMTRK/FOFFMTRK.cc
+++ b/src/detectors/FOFFMTRK/FOFFMTRK.cc
@@ -19,9 +19,9 @@ void InitPlugin(JApplication *app) {
     using namespace eicrecon;
 
     MatrixTransferStaticConfig recon_cfg;
-	
-	//Digitized hits, especially for thresholds
-	app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
+
+        //Digitized hits, especially for thresholds
+        app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
         "ForwardOffMTrackerRawHits",
         {"ForwardOffMTrackerHits"},
         {"ForwardOffMTrackerRawHits"},
@@ -32,7 +32,7 @@ void InitPlugin(JApplication *app) {
         app
     ));
 
-	app->Add(new JOmniFactoryGeneratorT<TrackerHitReconstruction_factory>(
+        app->Add(new JOmniFactoryGeneratorT<TrackerHitReconstruction_factory>(
         "ForwardOffMTrackerRecHits",
         {"ForwardOffMTrackerRawHits"},
         {"ForwardOffMTrackerRecHits"},

--- a/src/detectors/FOFFMTRK/FOFFMTRK.cc
+++ b/src/detectors/FOFFMTRK/FOFFMTRK.cc
@@ -3,14 +3,15 @@
 //
 //
 
+#include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
 #include <vector>
 
 #include "algorithms/fardetectors/MatrixTransferStaticConfig.h"
 #include "extensions/jana/JOmniFactoryGeneratorT.h"
 #include "factories/digi/SiliconTrackerDigi_factory.h"
-#include "factories/tracking/TrackerHitReconstruction_factory.h"
 #include "factories/fardetectors/MatrixTransferStatic_factory.h"
+#include "factories/tracking/TrackerHitReconstruction_factory.h"
 
 
 extern "C" {

--- a/src/detectors/RPOTS/RPOTS.cc
+++ b/src/detectors/RPOTS/RPOTS.cc
@@ -8,6 +8,8 @@
 
 #include "algorithms/fardetectors/MatrixTransferStaticConfig.h"
 #include "extensions/jana/JOmniFactoryGeneratorT.h"
+#include "factories/digi/SiliconTrackerDigi_factory.h"
+#include "factories/tracking/TrackerHitReconstruction_factory.h"
 #include "factories/fardetectors/MatrixTransferStatic_factory.h"
 
 
@@ -18,26 +20,62 @@ void InitPlugin(JApplication *app) {
 
     MatrixTransferStaticConfig recon_cfg;
 
-    //Static transport matrix for Roman Pots detectors
-    recon_cfg.aX = {{2.102403743, 29.11067626},
-                    {0.186640381, 0.192604619}};
-    recon_cfg.aY = {{0.0000159900, 3.94082098},
-                    {0.0000079946, -0.1402995}};
+	//Digitized hits, especially for thresholds
+	app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
+        "ForwardRomanPotRawHits",
+        {"ForwardRomanPotHits"},
+        {"ForwardRomanPotRawHits"},
+        {
+            .threshold = 10.0 * dd4hep::keV,
+            .timeResolution = 8,
+        },
+        app
+    ));
 
-    recon_cfg.local_x_offset       =  0.0;        // in mm --> this is from misalignment of the detector
-    recon_cfg.local_y_offset       =  0.0;        // in mm --> this is from misalignment of the detector
-    recon_cfg.local_x_slope_offset = -0.00622147; // in mrad
-    recon_cfg.local_y_slope_offset = -0.0451035;  // in mrad
-    recon_cfg.nomMomentum          =  275.0;      // in GEV --> exactly half of the top energy momentum (for proton spectators from deuteron breakup)
+	app->Add(new JOmniFactoryGeneratorT<TrackerHitReconstruction_factory>(
+        "ForwardRomanPotRecHits",
+        {"ForwardRomanPotRawHits"},
+        {"ForwardRomanPotRecHits"},
+        {
+            .timeResolution = 8,
+        },
+        app
+    ));
+
+
+    //Static transport matrix for Roman Pots detectors
+    //recon_cfg.aX = {{2.102403743, 29.11067626},
+    //                {0.186640381, 0.192604619}};
+    //recon_cfg.aY = {{0.0000159900, 3.94082098},
+    //                {0.0000079946, -0.1402995}};
+
+	//recon_cfg.local_x_offset       =  0.0;        // in mm --> this is from misalignment of the detector
+    //recon_cfg.local_y_offset       =  0.0;        // in mm --> this is from misalignment of the detector
+    //recon_cfg.local_x_slope_offset = -0.00622147; // in mrad
+    //recon_cfg.local_y_slope_offset = -0.0451035;  // in mrad
+	//recon_cfg.nomMomentum          =  275.0;      // in GEV --> exactly half of the top energy momentum (for proton spectators from deuteron breakup)
+
+	recon_cfg.aX = {{2.03459216, 22.85780784},
+                    {0.179641961, -0.306626961}};
+    recon_cfg.aY = {{0.38879, 3.71612646},
+                    {0.022685, -0.083092151}};
+	
+	recon_cfg.local_x_offset       =  0.00979216;        // in mm --> this is from misalignment of the detector
+    recon_cfg.local_y_offset       =  -0.00778646;        // in mm --> this is from misalignment of the detector
+    recon_cfg.local_x_slope_offset = 0.004526961; // in mrad
+    recon_cfg.local_y_slope_offset = -0.003907849;  // in mrad
+    recon_cfg.nomMomentum          =  100.0;      // in GEV --> exactly half of the top energy momentum (for proton spectators from deuteron breakup)
 
     recon_cfg.hit1minZ = 25099.0;
     recon_cfg.hit1maxZ = 26022.0;
     recon_cfg.hit2minZ = 27099.0;
     recon_cfg.hit2maxZ = 28022.0;
 
-    recon_cfg.readout              = "ForwardRomanPotHits";
+    //recon_cfg.readout              = "ForwardRomanPotHits";
+	recon_cfg.readout              = "ForwardRomanPotRecHits";
 
-    app->Add(new JOmniFactoryGeneratorT<MatrixTransferStatic_factory>("ForwardRomanPotRecParticles",{"ForwardRomanPotHits"},{"ForwardRomanPotRecParticles"},recon_cfg,app));
+    //app->Add(new JOmniFactoryGeneratorT<MatrixTransferStatic_factory>("ForwardRomanPotRecParticles",{"ForwardRomanPotHits"},{"ForwardRomanPotRecParticles"},recon_cfg,app));
+	app->Add(new JOmniFactoryGeneratorT<MatrixTransferStatic_factory>("ForwardRomanPotRecParticles",{"ForwardRomanPotRecHits"},{"ForwardRomanPotRecParticles"},recon_cfg,app));
 
 }
 }

--- a/src/detectors/RPOTS/RPOTS.cc
+++ b/src/detectors/RPOTS/RPOTS.cc
@@ -75,7 +75,7 @@ void InitPlugin(JApplication *app) {
 	recon_cfg.readout              = "ForwardRomanPotRecHits";
 
     //app->Add(new JOmniFactoryGeneratorT<MatrixTransferStatic_factory>("ForwardRomanPotRecParticles",{"ForwardRomanPotHits"},{"ForwardRomanPotRecParticles"},recon_cfg,app));
-	app->Add(new JOmniFactoryGeneratorT<MatrixTransferStatic_factory>("ForwardRomanPotRecParticles",{"ForwardRomanPotRecHits"},{"ForwardRomanPotRecParticles"},recon_cfg,app));
+	app->Add(new JOmniFactoryGeneratorT<MatrixTransferStatic_factory>("ForwardRomanPotRecParticles",{"MCParticles","ForwardRomanPotRecHits"},{"ForwardRomanPotRecParticles"},recon_cfg,app));
 
 }
 }

--- a/src/detectors/RPOTS/RPOTS.cc
+++ b/src/detectors/RPOTS/RPOTS.cc
@@ -26,7 +26,7 @@ void InitPlugin(JApplication *app) {
         {"ForwardRomanPotHits"},
         {"ForwardRomanPotRawHits"},
         {
-            .threshold = 0.0 * dd4hep::keV,
+            .threshold = 10.0 * dd4hep::keV,
             .timeResolution = 8,
         },
         app
@@ -55,27 +55,13 @@ void InitPlugin(JApplication *app) {
     recon_cfg.local_y_slope_offset = -0.0451035;  // in mrad
 	recon_cfg.nomMomentum          =  275.0;      // in GEV --> exactly half of the top energy momentum (for proton spectators from deuteron breakup)
 
-		/*
-	recon_cfg.aX = {{2.03459216, 22.85780784},
-                    {0.179641961, -0.306626961}};
-    recon_cfg.aY = {{0.38879, 3.71612646},
-                    {0.022685, -0.083092151}};
-	
-	recon_cfg.local_x_offset       =  0.00979216;        // in mm --> this is from misalignment of the detector
-    recon_cfg.local_y_offset       =  -0.00778646;        // in mm --> this is from misalignment of the detector
-    recon_cfg.local_x_slope_offset = 0.004526961; // in mrad
-    recon_cfg.local_y_slope_offset = -0.003907849;  // in mrad
-    recon_cfg.nomMomentum          =  100.0;      // in GEV --> exactly half of the top energy momentum (for proton spectators from deuteron breakup)
-		*/
     recon_cfg.hit1minZ = 25099.0;
     recon_cfg.hit1maxZ = 26022.0;
     recon_cfg.hit2minZ = 27099.0;
     recon_cfg.hit2maxZ = 28022.0;
 
-    //recon_cfg.readout              = "ForwardRomanPotHits";
 	recon_cfg.readout              = "ForwardRomanPotRecHits";
 
-    //app->Add(new JOmniFactoryGeneratorT<MatrixTransferStatic_factory>("ForwardRomanPotRecParticles",{"ForwardRomanPotHits"},{"ForwardRomanPotRecParticles"},recon_cfg,app));
 	app->Add(new JOmniFactoryGeneratorT<MatrixTransferStatic_factory>("ForwardRomanPotRecParticles",{"MCParticles","ForwardRomanPotRecHits"},{"ForwardRomanPotRecParticles"},recon_cfg,app));
 
 }

--- a/src/detectors/RPOTS/RPOTS.cc
+++ b/src/detectors/RPOTS/RPOTS.cc
@@ -20,8 +20,8 @@ void InitPlugin(JApplication *app) {
 
     MatrixTransferStaticConfig recon_cfg;
 
-	//Digitized hits, especially for thresholds
-	app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
+        //Digitized hits, especially for thresholds
+        app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
         "ForwardRomanPotRawHits",
         {"ForwardRomanPotHits"},
         {"ForwardRomanPotRawHits"},
@@ -32,7 +32,7 @@ void InitPlugin(JApplication *app) {
         app
     ));
 
-	app->Add(new JOmniFactoryGeneratorT<TrackerHitReconstruction_factory>(
+        app->Add(new JOmniFactoryGeneratorT<TrackerHitReconstruction_factory>(
         "ForwardRomanPotRecHits",
         {"ForwardRomanPotRawHits"},
         {"ForwardRomanPotRecHits"},
@@ -44,25 +44,25 @@ void InitPlugin(JApplication *app) {
 
 
     //Static transport matrix for Roman Pots detectors
-	recon_cfg.aX = {{2.102403743, 29.11067626},
-		            {0.186640381, 0.192604619}};
-	recon_cfg.aY = {{0.0000159900, 3.94082098},
-					{0.0000079946, -0.1402995}};
+        recon_cfg.aX = {{2.102403743, 29.11067626},
+                            {0.186640381, 0.192604619}};
+        recon_cfg.aY = {{0.0000159900, 3.94082098},
+                                        {0.0000079946, -0.1402995}};
 
-	recon_cfg.local_x_offset       =  0.0;        // in mm --> this is from misalignment of the detector
+        recon_cfg.local_x_offset       =  0.0;        // in mm --> this is from misalignment of the detector
     recon_cfg.local_y_offset       =  0.0;        // in mm --> this is from misalignment of the detector
     recon_cfg.local_x_slope_offset = -0.00622147; // in mrad
     recon_cfg.local_y_slope_offset = -0.0451035;  // in mrad
-	recon_cfg.nomMomentum          =  275.0;      // in GEV --> exactly half of the top energy momentum (for proton spectators from deuteron breakup)
+        recon_cfg.nomMomentum          =  275.0;      // in GEV --> exactly half of the top energy momentum (for proton spectators from deuteron breakup)
 
     recon_cfg.hit1minZ = 25099.0;
     recon_cfg.hit1maxZ = 26022.0;
     recon_cfg.hit2minZ = 27099.0;
     recon_cfg.hit2maxZ = 28022.0;
 
-	recon_cfg.readout              = "ForwardRomanPotRecHits";
+        recon_cfg.readout              = "ForwardRomanPotRecHits";
 
-	app->Add(new JOmniFactoryGeneratorT<MatrixTransferStatic_factory>("ForwardRomanPotRecParticles",{"MCParticles","ForwardRomanPotRecHits"},{"ForwardRomanPotRecParticles"},recon_cfg,app));
+        app->Add(new JOmniFactoryGeneratorT<MatrixTransferStatic_factory>("ForwardRomanPotRecParticles",{"MCParticles","ForwardRomanPotRecHits"},{"ForwardRomanPotRecParticles"},recon_cfg,app));
 
 }
 }

--- a/src/detectors/RPOTS/RPOTS.cc
+++ b/src/detectors/RPOTS/RPOTS.cc
@@ -3,14 +3,15 @@
 //
 //
 
+#include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
 #include <vector>
 
 #include "algorithms/fardetectors/MatrixTransferStaticConfig.h"
 #include "extensions/jana/JOmniFactoryGeneratorT.h"
 #include "factories/digi/SiliconTrackerDigi_factory.h"
-#include "factories/tracking/TrackerHitReconstruction_factory.h"
 #include "factories/fardetectors/MatrixTransferStatic_factory.h"
+#include "factories/tracking/TrackerHitReconstruction_factory.h"
 
 
 extern "C" {

--- a/src/detectors/RPOTS/RPOTS.cc
+++ b/src/detectors/RPOTS/RPOTS.cc
@@ -44,25 +44,25 @@ void InitPlugin(JApplication *app) {
 
 
     //Static transport matrix for Roman Pots detectors
-        recon_cfg.aX = {{2.102403743, 29.11067626},
-                            {0.186640381, 0.192604619}};
-        recon_cfg.aY = {{0.0000159900, 3.94082098},
-                                        {0.0000079946, -0.1402995}};
+    recon_cfg.aX = {{2.102403743, 29.11067626},
+                    {0.186640381, 0.192604619}};
+    recon_cfg.aY = {{0.0000159900, 3.94082098},
+                    {0.0000079946, -0.1402995}};
 
-        recon_cfg.local_x_offset       =  0.0;        // in mm --> this is from misalignment of the detector
+    recon_cfg.local_x_offset       =  0.0;        // in mm --> this is from misalignment of the detector
     recon_cfg.local_y_offset       =  0.0;        // in mm --> this is from misalignment of the detector
     recon_cfg.local_x_slope_offset = -0.00622147; // in mrad
     recon_cfg.local_y_slope_offset = -0.0451035;  // in mrad
-        recon_cfg.nomMomentum          =  275.0;      // in GEV --> exactly half of the top energy momentum (for proton spectators from deuteron breakup)
+    recon_cfg.nomMomentum          =  275.0;      // in GEV --> exactly half of the top energy momentum (for proton spectators from deuteron breakup)
 
     recon_cfg.hit1minZ = 25099.0;
     recon_cfg.hit1maxZ = 26022.0;
     recon_cfg.hit2minZ = 27099.0;
     recon_cfg.hit2maxZ = 28022.0;
 
-        recon_cfg.readout              = "ForwardRomanPotRecHits";
+    recon_cfg.readout              = "ForwardRomanPotRecHits";
 
-        app->Add(new JOmniFactoryGeneratorT<MatrixTransferStatic_factory>("ForwardRomanPotRecParticles",{"MCParticles","ForwardRomanPotRecHits"},{"ForwardRomanPotRecParticles"},recon_cfg,app));
+    app->Add(new JOmniFactoryGeneratorT<MatrixTransferStatic_factory>("ForwardRomanPotRecParticles",{"MCParticles","ForwardRomanPotRecHits"},{"ForwardRomanPotRecParticles"},recon_cfg,app));
 
 }
 }

--- a/src/detectors/RPOTS/RPOTS.cc
+++ b/src/detectors/RPOTS/RPOTS.cc
@@ -26,7 +26,7 @@ void InitPlugin(JApplication *app) {
         {"ForwardRomanPotHits"},
         {"ForwardRomanPotRawHits"},
         {
-            .threshold = 10.0 * dd4hep::keV,
+            .threshold = 0.0 * dd4hep::keV,
             .timeResolution = 8,
         },
         app
@@ -44,17 +44,18 @@ void InitPlugin(JApplication *app) {
 
 
     //Static transport matrix for Roman Pots detectors
-    //recon_cfg.aX = {{2.102403743, 29.11067626},
-    //                {0.186640381, 0.192604619}};
-    //recon_cfg.aY = {{0.0000159900, 3.94082098},
-    //                {0.0000079946, -0.1402995}};
+	recon_cfg.aX = {{2.102403743, 29.11067626},
+		            {0.186640381, 0.192604619}};
+	recon_cfg.aY = {{0.0000159900, 3.94082098},
+					{0.0000079946, -0.1402995}};
 
-	//recon_cfg.local_x_offset       =  0.0;        // in mm --> this is from misalignment of the detector
-    //recon_cfg.local_y_offset       =  0.0;        // in mm --> this is from misalignment of the detector
-    //recon_cfg.local_x_slope_offset = -0.00622147; // in mrad
-    //recon_cfg.local_y_slope_offset = -0.0451035;  // in mrad
-	//recon_cfg.nomMomentum          =  275.0;      // in GEV --> exactly half of the top energy momentum (for proton spectators from deuteron breakup)
+	recon_cfg.local_x_offset       =  0.0;        // in mm --> this is from misalignment of the detector
+    recon_cfg.local_y_offset       =  0.0;        // in mm --> this is from misalignment of the detector
+    recon_cfg.local_x_slope_offset = -0.00622147; // in mrad
+    recon_cfg.local_y_slope_offset = -0.0451035;  // in mrad
+	recon_cfg.nomMomentum          =  275.0;      // in GEV --> exactly half of the top energy momentum (for proton spectators from deuteron breakup)
 
+		/*
 	recon_cfg.aX = {{2.03459216, 22.85780784},
                     {0.179641961, -0.306626961}};
     recon_cfg.aY = {{0.38879, 3.71612646},
@@ -65,7 +66,7 @@ void InitPlugin(JApplication *app) {
     recon_cfg.local_x_slope_offset = 0.004526961; // in mrad
     recon_cfg.local_y_slope_offset = -0.003907849;  // in mrad
     recon_cfg.nomMomentum          =  100.0;      // in GEV --> exactly half of the top energy momentum (for proton spectators from deuteron breakup)
-
+		*/
     recon_cfg.hit1minZ = 25099.0;
     recon_cfg.hit1maxZ = 26022.0;
     recon_cfg.hit2minZ = 27099.0;

--- a/src/factories/fardetectors/MatrixTransferStatic_factory.h
+++ b/src/factories/fardetectors/MatrixTransferStatic_factory.h
@@ -9,7 +9,9 @@
 
 // Event Model related classes
 #include <edm4eic/ReconstructedParticleCollection.h>
+#include <edm4eic/TrackerHitCollection.h>
 #include <edm4hep/SimTrackerHitCollection.h>
+#include <edm4hep/MCParticleCollection.h>
 
 #include "extensions/jana/JOmniFactory.h"
 
@@ -23,7 +25,8 @@ public:
 private:
     std::unique_ptr<AlgoT> m_algo;
 
-    PodioInput<edm4hep::SimTrackerHit> m_hits_input {this};
+	PodioInput<edm4hep::MCParticle> m_mcparts_input {this};
+    PodioInput<edm4eic::TrackerHit> m_hits_input {this};
     PodioOutput<edm4eic::ReconstructedParticle> m_tracks_output {this};
 
     Service<DD4hep_service> m_geoSvc {this};
@@ -61,7 +64,7 @@ public:
     }
 
     void Process(int64_t run_number, uint64_t event_number) {
-        m_algo->process({m_hits_input()}, {m_tracks_output().get()});
+        m_algo->process({m_mcparts_input(), m_hits_input()}, {m_tracks_output().get()});
     }
 
 };

--- a/src/factories/fardetectors/MatrixTransferStatic_factory.h
+++ b/src/factories/fardetectors/MatrixTransferStatic_factory.h
@@ -25,7 +25,7 @@ public:
 private:
     std::unique_ptr<AlgoT> m_algo;
 
-        PodioInput<edm4hep::MCParticle> m_mcparts_input {this};
+    PodioInput<edm4hep::MCParticle> m_mcparts_input {this};
     PodioInput<edm4eic::TrackerHit> m_hits_input {this};
     PodioOutput<edm4eic::ReconstructedParticle> m_tracks_output {this};
 

--- a/src/factories/fardetectors/MatrixTransferStatic_factory.h
+++ b/src/factories/fardetectors/MatrixTransferStatic_factory.h
@@ -25,7 +25,7 @@ public:
 private:
     std::unique_ptr<AlgoT> m_algo;
 
-	PodioInput<edm4hep::MCParticle> m_mcparts_input {this};
+        PodioInput<edm4hep::MCParticle> m_mcparts_input {this};
     PodioInput<edm4eic::TrackerHit> m_hits_input {this};
     PodioOutput<edm4eic::ReconstructedParticle> m_tracks_output {this};
 

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -108,6 +108,8 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "B0TrackerRecHits",
             "B0TrackerRawHits",
             "B0TrackerHits",
+            "ForwardRomanPotRecHits",
+            "ForwardOffMTrackerRecHits",
 
             //
             "ForwardRomanPotRecParticles",

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -110,7 +110,6 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "B0TrackerHits",
             "ForwardRomanPotRecHits",
             "ForwardOffMTrackerRecHits",
-
             //
             "ForwardRomanPotRecParticles",
             "ForwardOffMRecParticles",


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Adds functionality to obtain beam energy information, at least for a few cases (protons, and one case, for now, for deuterons) to select correct matrix for RP reconstruction.

Also added correct collections to PODIO output in eicrecon to use digitized hits and store "rec" hits.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

Not breaking changes, adds proper functionality so the algorithm can actually handle different beam energies.

### Does this PR change default behavior?

Yes, see above.
