### PR TITLE
fix: use proper SPDX headers to clarify LGPL3 vs JSA licensing

### DIFF
--- a/LICENSE.JSA
+++ b/LICENSE.JSA
@@ -1,0 +1,33 @@
+
+Copyright (c) 2020, Jefferson Science Associates, LLC. All Rights Reserved. Redistribution
+and use in source and binary forms, with or without modification, are permitted as a
+licensed user provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this
+   list of conditions and the following disclaimer in the documentation and/or other
+   materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+This material resulted from work developed under a United States Government Contract.
+The Government retains a paid-up, nonexclusive, irrevocable worldwide license in such
+copyrighted data to reproduce, distribute copies to the public, prepare derivative works,
+perform publicly and display publicly and to permit others to do so.
+
+THIS SOFTWARE IS PROVIDED BY JEFFERSON SCIENCE ASSOCIATES LLC "AS IS" AND ANY EXPRESS
+OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL
+JEFFERSON SCIENCE ASSOCIATES, LLC OR THE U.S. GOVERNMENT BE LIABLE TO LICENSEE OR ANY
+THIRD PARTES FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+
+Authors: David Lawrence, Nathan Brei, Paul Mattione
+
+Origin repository: http://github.com/eic/EICrecon

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,10 +1,18 @@
+# Notices for EICrecon
 
-Software contained in the repository exists in the public domain
-except where an alternate LICENSE.md file exists. Any other
-LICENSE.md file occurring in this repository will apply to the
-directory it resides in and all subdirectories from there except
-where another LICENSE.md file exists.
+This content is produced and maintained by the ePIC collaboration.
 
-By contributing to this repository in any directory on any branch,
-you are consenting to that contribution being entered into the public
-domain.
+## Trademarks
+
+Jefferson Lab is a trademark of United States Department of Energy.
+
+## Copyright
+
+All content is the property of the respective authors or their employers. For more information regarding authorship of content, please consult the listed source code repository logs.
+
+## Declared Project Licenses
+
+Software contained in this repository exists in the public domain unless indicated otherwise by the file header. By contributing to this repository in any directory on any branch, you are consenting to that your contribution will be licensed under the GNU Lesser General Public License version 3, or any later version.
+
+Any other LICENSE.md file occurring in this repository will apply to the files in the directory it resides in and in all subdirectories from there unless indicated otherwise by the file header and except where another LICENSE.md file exists.
+

--- a/src/detectors/B0ECAL/B0ECAL.cc
+++ b/src/detectors/B0ECAL/B0ECAL.cc
@@ -1,7 +1,5 @@
-// Copyright 2022, David Lawrence
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
-//
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 David Lawrence
 
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -1,7 +1,5 @@
-// Copyright 2022, David Lawrence
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
-//
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 David Lawrence
 
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>

--- a/src/detectors/BTOF/BTOF.cc
+++ b/src/detectors/BTOF/BTOF.cc
@@ -1,7 +1,5 @@
-// Copyright 2022, Dmitry Romanov
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
-//
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022, Dmitry Romanov
 
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>

--- a/src/detectors/DIRC/DIRC.cc
+++ b/src/detectors/DIRC/DIRC.cc
@@ -1,7 +1,5 @@
-// Copyright 2022,2023 Christopher Dilks, Nilanga Wickramaarachchi
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
-//
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 - 2023, Christopher Dilks, Nilanga Wickramaarachchi
 
 #include <JANA/JApplication.h>
 #include <stddef.h>

--- a/src/detectors/DRICH/DRICH.cc
+++ b/src/detectors/DRICH/DRICH.cc
@@ -1,5 +1,5 @@
-// Copyright (C) 2022, 2023, Christopher Dilks, Luigi Dello Stritto
-// Subject to the terms in the LICENSE file found in the top-level directory.
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 - 2023, Christopher Dilks, Luigi Dello Stritto
 
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>

--- a/src/detectors/ECTRK/ECTRK.cc
+++ b/src/detectors/ECTRK/ECTRK.cc
@@ -1,7 +1,5 @@
-// Copyright 2022, Dmitry Romanov
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
-//
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022, Dmitry Romanov
 
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>

--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -1,7 +1,5 @@
-// Copyright 2022, David Lawrence
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
-//
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 David Lawrence
 
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>

--- a/src/detectors/EHCAL/EHCAL.cc
+++ b/src/detectors/EHCAL/EHCAL.cc
@@ -1,7 +1,5 @@
-// Copyright 2023, Friederike Bock
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
-//
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2023, Friederike Bock
 
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -1,7 +1,5 @@
-// Copyright 2022, David Lawrence
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
-//
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 David Lawrence
 
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>

--- a/src/detectors/FOFFMTRK/FOFFMTRK.cc
+++ b/src/detectors/FOFFMTRK/FOFFMTRK.cc
@@ -1,7 +1,5 @@
-// Copyright 2023, Alex Jentsch
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
-//
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2023, Alex Jentsch
 
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>

--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -1,7 +1,5 @@
-// Copyright 2022, David Lawrence
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
-//
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 David Lawrence
 
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>

--- a/src/services/geometry/acts/ACTSGeo_service.cc
+++ b/src/services/geometry/acts/ACTSGeo_service.cc
@@ -1,7 +1,5 @@
-// Copyright 2022, David Lawrence
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
-//
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 David Lawrence
 
 #include "ACTSGeo_service.h"
 

--- a/src/services/geometry/acts/acts.cc
+++ b/src/services/geometry/acts/acts.cc
@@ -1,7 +1,5 @@
-// Copyright 2022, David Lawrence
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
-//
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 David Lawrence
 
 #include <JANA/JApplication.h>
 #include <memory>

--- a/src/services/geometry/dd4hep/dd4hep.cc
+++ b/src/services/geometry/dd4hep/dd4hep.cc
@@ -1,7 +1,5 @@
-// Copyright 2022, David Lawrence
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
-//
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 David Lawrence
 
 #include <JANA/JApplication.h>
 #include <memory>

--- a/src/services/geometry/richgeo/ActsGeo.cc
+++ b/src/services/geometry/richgeo/ActsGeo.cc
@@ -1,5 +1,5 @@
-// Copyright (C) 2022, 2023, Christopher Dilks
-// Subject to the terms in the LICENSE file found in the top-level directory.
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 - 2023, Christopher Dilks
 
 #include "ActsGeo.h"
 

--- a/src/services/geometry/richgeo/ActsGeo.h
+++ b/src/services/geometry/richgeo/ActsGeo.h
@@ -1,5 +1,5 @@
-// Copyright (C) 2022, 2023, Christopher Dilks
-// Subject to the terms in the LICENSE file found in the top-level directory.
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 - 2023, Christopher Dilks
 
 // bind IRT and DD4hep geometries for the RICHes
 #pragma once

--- a/src/services/geometry/richgeo/IrtGeo.cc
+++ b/src/services/geometry/richgeo/IrtGeo.cc
@@ -1,5 +1,5 @@
-// Copyright (C) 2022, 2023, Christopher Dilks
-// Subject to the terms in the LICENSE file found in the top-level directory.
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 - 2023, Christopher Dilks
 
 #include "IrtGeo.h"
 

--- a/src/services/geometry/richgeo/IrtGeo.h
+++ b/src/services/geometry/richgeo/IrtGeo.h
@@ -1,5 +1,5 @@
-// Copyright (C) 2022, 2023, Christopher Dilks
-// Subject to the terms in the LICENSE file found in the top-level directory.
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 - 2023, Christopher Dilks
 
 // bind IRT and DD4hep geometries for the RICHes
 #pragma once

--- a/src/services/geometry/richgeo/IrtGeoDRICH.cc
+++ b/src/services/geometry/richgeo/IrtGeoDRICH.cc
@@ -1,5 +1,5 @@
-// Copyright (C) 2022, 2023, Christopher Dilks
-// Subject to the terms in the LICENSE file found in the top-level directory.
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 - 2023, Christopher Dilks
 
 #include "IrtGeoDRICH.h"
 

--- a/src/services/geometry/richgeo/IrtGeoDRICH.h
+++ b/src/services/geometry/richgeo/IrtGeoDRICH.h
@@ -1,5 +1,5 @@
-// Copyright (C) 2022, 2023, Christopher Dilks
-// Subject to the terms in the LICENSE file found in the top-level directory.
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 - 2023, Christopher Dilks
 
 // bind IRT and DD4hep geometries for the dRICH
 #pragma once

--- a/src/services/geometry/richgeo/IrtGeoPFRICH.cc
+++ b/src/services/geometry/richgeo/IrtGeoPFRICH.cc
@@ -1,5 +1,5 @@
-// Copyright (C) 2022, 2023, Christopher Dilks
-// Subject to the terms in the LICENSE file found in the top-level directory.
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 - 2023, Christopher Dilks
 
 #include "IrtGeoPFRICH.h"
 

--- a/src/services/geometry/richgeo/IrtGeoPFRICH.h
+++ b/src/services/geometry/richgeo/IrtGeoPFRICH.h
@@ -1,5 +1,5 @@
-// Copyright (C) 2022, 2023, Christopher Dilks
-// Subject to the terms in the LICENSE file found in the top-level directory.
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 - 2023, Christopher Dilks
 
 // bind IRT and DD4hep geometries for the pfRICH
 #pragma once

--- a/src/services/geometry/richgeo/ReadoutGeo.cc
+++ b/src/services/geometry/richgeo/ReadoutGeo.cc
@@ -1,7 +1,5 @@
+// SPDX-License-Identifier: JSA
 // Copyright (C) 2023, Christopher Dilks, Luigi Dello Stritto
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
-//
 
 #include "ReadoutGeo.h"
 

--- a/src/services/geometry/richgeo/ReadoutGeo.h
+++ b/src/services/geometry/richgeo/ReadoutGeo.h
@@ -1,6 +1,5 @@
+// SPDX-License-Identifier: JSA
 // Copyright (C) 2023, Christopher Dilks, Luigi Dello Stritto
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
 
 // helper functions for RICH readout
 

--- a/src/services/geometry/richgeo/RichGeo.h
+++ b/src/services/geometry/richgeo/RichGeo.h
@@ -1,5 +1,5 @@
-// Copyright (C) 2022, 2023, Christopher Dilks
-// Subject to the terms in the LICENSE file found in the top-level directory.
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 - 2023, Christopher Dilks
 
 #pragma once
 

--- a/src/services/geometry/richgeo/RichGeo_service.cc
+++ b/src/services/geometry/richgeo/RichGeo_service.cc
@@ -1,5 +1,5 @@
-// Copyright (C) 2022, 2023, Christopher Dilks
-// Subject to the terms in the LICENSE file found in the top-level directory.
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 - 2023, Christopher Dilks
 
 #include "RichGeo_service.h"
 

--- a/src/services/geometry/richgeo/RichGeo_service.h
+++ b/src/services/geometry/richgeo/RichGeo_service.h
@@ -1,5 +1,5 @@
-// Copyright (C) 2022, 2023, Christopher Dilks
-// Subject to the terms in the LICENSE file found in the top-level directory.
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 - 2023, Christopher Dilks
 
 #pragma once
 

--- a/src/services/geometry/richgeo/richgeo.cc
+++ b/src/services/geometry/richgeo/richgeo.cc
@@ -1,7 +1,5 @@
+// SPDX-License-Identifier: JSA
 // Copyright (C) 2022, Christopher Dilks
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
-//
 
 #include <JANA/JApplication.h>
 #include <memory>

--- a/src/services/io/podio/JEventSourcePODIO.cc
+++ b/src/services/io/podio/JEventSourcePODIO.cc
@@ -1,6 +1,5 @@
-// Copyright 2022, David Lawrence
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 David Lawrence
 //
 // This is a JANA event source that uses PODIO to read from a ROOT
 // file created using the EDM4hep Data Model.

--- a/src/services/io/podio/JEventSourcePODIO.h
+++ b/src/services/io/podio/JEventSourcePODIO.h
@@ -1,6 +1,5 @@
-// Copyright 2022, David Lawrence
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 David Lawrence
 
 #pragma once
 

--- a/src/services/io/podio/JEventSourcePODIOLegacy.cc
+++ b/src/services/io/podio/JEventSourcePODIOLegacy.cc
@@ -1,6 +1,5 @@
-// Copyright 2022, David Lawrence
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 David Lawrence
 //
 // This is a JANA event source that uses PODIO to read from a ROOT
 // file created using the EDM4hep Data Model.

--- a/src/services/io/podio/JEventSourcePODIOLegacy.h
+++ b/src/services/io/podio/JEventSourcePODIOLegacy.h
@@ -1,6 +1,5 @@
-// Copyright 2022, David Lawrence
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 David Lawrence
 
 #pragma once
 

--- a/src/services/io/podio/datamodel_LinkDef.h
+++ b/src/services/io/podio/datamodel_LinkDef.h
@@ -1,6 +1,5 @@
-// Copyright 2022, David Lawrence
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 David Lawrence
 //
 // This is used when generating the ROOT dictionary file needed to define
 // the vector types like "vector<edm4hep::EventHeader>".

--- a/src/services/io/podio/make_datamodel_glue.py
+++ b/src/services/io/podio/make_datamodel_glue.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
-# Copyright 2022, David Lawrence
-# Subject to the terms in the LICENSE file found in the top-level directory.
+# SPDX-License-Identifier: JSA
+# Copyright (C) 2022 David Lawrence
 #
 # This is a stop gap and not intended for long term.  2022-07-09  DL
 #

--- a/src/services/io/podio/podio.cc
+++ b/src/services/io/podio/podio.cc
@@ -1,7 +1,5 @@
-// Copyright 2022, David Lawrence
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
-//
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 David Lawrence
 
 #include <JANA/JApplication.h>
 #include <JANA/JEventSourceGeneratorT.h>

--- a/src/services/log/Log_service.cc
+++ b/src/services/log/Log_service.cc
@@ -1,7 +1,6 @@
-// Copyright 2022, Dmitry Romanov
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
-//
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 Dmitry Romanov
+
 #include "Log_service.h"
 
 #include <JANA/JException.h>

--- a/src/services/log/log.cc
+++ b/src/services/log/log.cc
@@ -1,7 +1,5 @@
-// Copyright 2022, David Lawrence
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
-//
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 David Lawrence
 
 #include <JANA/JApplication.h>
 #include <memory>

--- a/src/services/rootfile/rootfile.cc
+++ b/src/services/rootfile/rootfile.cc
@@ -1,6 +1,5 @@
-// Copyright 2022, David Lawrence
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
+// SPDX-License-Identifier: JSA
+// Copyright (C) 2022 David Lawrence
 //
 
 #include <JANA/JApplication.h>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This modifies the headers to be clear about which license applies. All unclear licensing is deferred to JSA especially when it was still referring to the "top-level LICENSE file" which at the time was JSA.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #2)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.