### PR TITLE
fix: don't trigger container build with VERSION

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -803,7 +803,6 @@ jobs:
           GITHUB_REPOSITORY=${{ github.repository }}
           GITHUB_SHA=${{ github.event.pull_request.head.sha || github.sha }}
           GITHUB_PR=${{ github.event.pull_request.number }}
-          VERSION="eicrecon-${{ github.event.pull_request.head.sha || github.sha }}"
           EICRECON_VERSION="${{ github.event.pull_request.head.ref || github.ref_name }}"
     - run: |
         gh api \


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes the VERSION variable from the trigger of the container build.

We specified the VERSION so the published container is identifiable. This also means that every trigger with a VERSION ends up getting published to docker hub, ghcr.io and the eicweb internal registry. This was fine for an occasional trigger, but it's overwhelming the registry storage (in particular eicweb) when we trigger a container for every commit on every branch, even with automatic cleanup rules.

So, with this PR we stop deploying the containers to tags with name eicrecon-$SHA.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: eicweb container registry instability)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.