### PR TITLE
fix: rework podio options to allow specifying list, includes, and excludes

### DIFF
--- a/.github/lsan.supp
+++ b/.github/lsan.supp
@@ -1,6 +1,7 @@
 leak:CherenkovPID::AddMassHypothesis
 leak:dd4hep::DetElement::DetElement
 leak:dd4hep::Header::Header
+leak:edm4eic::*::createBuffers
 leak:edm4hep::*::createBuffers
 leak:libActsCore.so
 leak:libCling.so

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -401,7 +401,7 @@ jobs:
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
           export LD_LIBRARY_PATH=$PWD/install/lib:$LD_LIBRARY_PATH
           export JANA_PLUGIN_PATH=$PWD/install/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
-          $PWD/install/bin/eicrecon -Ppodio:output_include_collections=EventHeader,MCParticles,EcalBarrelScFiRawHits,EcalBarrelImagingRawHits -Ppodio:output_file=two_stage_raw_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -Pplugins=dump_flags,janadot -Pdump_flags:json=${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json -Pjana:warmup_timeout=0 -Pjana:timeout=0
+          $PWD/install/bin/eicrecon -Ppodio:output_collections=EventHeader,MCParticles,EcalBarrelScFiRawHits,EcalBarrelImagingRawHits -Ppodio:output_file=two_stage_raw_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -Pplugins=dump_flags,janadot -Pdump_flags:json=${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json -Pjana:warmup_timeout=0 -Pjana:timeout=0
     - name: Upload digitization output
       uses: actions/upload-artifact@v4
       with:
@@ -417,7 +417,7 @@ jobs:
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
           export LD_LIBRARY_PATH=$PWD/install/lib:$LD_LIBRARY_PATH
           export JANA_PLUGIN_PATH=$PWD/install/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
-          $PWD/install/bin/eicrecon -Ppodio:output_include_collections=EcalBarrelClusters,EcalBarrelClusterAssociations -Ppodio:output_file=two_stage_rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root two_stage_raw_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root -Pplugins=dump_flags,janadot -Pdump_flags:json=${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json -Pjana:warmup_timeout=0 -Pjana:timeout=0
+          $PWD/install/bin/eicrecon -Ppodio:output_collections=EcalBarrelClusters,EcalBarrelClusterAssociations -Ppodio:output_file=two_stage_rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root two_stage_raw_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root -Pplugins=dump_flags,janadot -Pdump_flags:json=${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json -Pjana:warmup_timeout=0 -Pjana:timeout=0
     - name: Upload reconstruction output
       uses: actions/upload-artifact@v4
       with:

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -9,7 +9,9 @@
 #include <podio/CollectionBase.h>
 #include <podio/Frame.h>
 #include <spdlog/common.h>
+#include <algorithm>
 #include <exception>
+#include <iterator>
 
 #include "services/log/Log_service.h"
 

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -241,7 +241,7 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
     japp->SetDefaultParameter(
             "podio:output_collections",
             output_collections,
-            "Comma separated list of collection names to write out. If explicitly set to an empty list, all collections including input collections will be written."      
+            "Comma separated list of collection names to write out. If explicitly set to an empty list, all collections including input collections will be written."
     );
     std::vector<std::string> output_include_collections;  // need to get as vector, then convert to set
     japp->SetDefaultParameter(

--- a/src/services/io/podio/JEventProcessorPODIO.h
+++ b/src/services/io/podio/JEventProcessorPODIO.h
@@ -33,6 +33,7 @@ public:
 
     std::string m_output_file = "podio_output.root";
     std::string m_output_file_copy_dir = "";
+    std::set<std::string> m_output_collections;  // config. parameter
     std::set<std::string> m_output_include_collections;  // config. parameter
     std::set<std::string> m_output_exclude_collections;  // config. parameter
     std::vector<std::string> m_collections_to_write;  // derived from above config. parameters


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR somewhat redefines the behavior of the option `-Ppodio:output_include_collections` in order to fix #300. There are now three similar options:
- `-Ppodio:output_collections` specifies which output collections to write,
- `-Ppodio:output_include_collections` specifies which output collections to include in addition to the default set,
- `-Ppodio:output_exclude_collections` specifies which output collections to exclude from the default set.

The behavior is technically backwards compatible. Where previously `-Ppodio:output_include_collections` resulted in only those collections being added to the output, now those collections will be added to the default set.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #300)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No. More collections will be written when using `-Ppodio:output_include_collections`.