### PR TITLE
fix(ci): set vm.mmap_rnd_bits=28

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -57,6 +57,10 @@ jobs:
             CMAKE_BUILD_TYPE: Debug
             CXXFLAGS: -fprofile-instr-generate -fcoverage-mapping
     steps:
+    - name: mmap rnd_bits workaround
+      # https://github.com/actions/runner/issues/3207#issuecomment-2000066889
+      run: |
+        sudo sysctl -w vm.mmap_rnd_bits=28
     - uses: actions/checkout@v4
     - name: Prepare ccache timestamp
       id: ccache_cache_timestamp

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -380,6 +380,10 @@ jobs:
         particle: [e]
         detector_config: [craterlake]
     steps:
+    - name: mmap rnd_bits workaround
+      # https://github.com/actions/runner/issues/3207#issuecomment-2000066889
+      run: |
+        sudo sysctl -w vm.mmap_rnd_bits=28
     - name: Checkout .github
       uses: actions/checkout@v4
       with:
@@ -440,6 +444,10 @@ jobs:
         particle: [e]
         detector_config: [craterlake]
     steps:
+    - name: mmap rnd_bits workaround
+      # https://github.com/actions/runner/issues/3207#issuecomment-2000066889
+      run: |
+        sudo sysctl -w vm.mmap_rnd_bits=28
     - name: Checkout .github
       uses: actions/checkout@v4
       with:
@@ -487,6 +495,10 @@ jobs:
         - tracking_efficiency
         - tracking_occupancy
     steps:
+    - name: mmap rnd_bits workaround
+      # https://github.com/actions/runner/issues/3207#issuecomment-2000066889
+      run: |
+        sudo sysctl -w vm.mmap_rnd_bits=28
     - name: Checkout .github
       uses: actions/checkout@v4
       with:
@@ -528,6 +540,10 @@ jobs:
         particle: [pi, e]
         detector_config: [craterlake]
     steps:
+    - name: mmap rnd_bits workaround
+      # https://github.com/actions/runner/issues/3207#issuecomment-2000066889
+      run: |
+        sudo sysctl -w vm.mmap_rnd_bits=28
     - name: Checkout .github
       uses: actions/checkout@v4
       with:
@@ -638,6 +654,10 @@ jobs:
         particle: [e]
         detector_config: [ip6_extended]
     steps:
+    - name: mmap rnd_bits workaround
+      # https://github.com/actions/runner/issues/3207#issuecomment-2000066889
+      run: |
+        sudo sysctl -w vm.mmap_rnd_bits=28
     - name: Checkout .github
       uses: actions/checkout@v4
       with:
@@ -693,6 +713,10 @@ jobs:
         - beam: 5x41
           minq2: 1000
     steps:
+    - name: mmap rnd_bits workaround
+      # https://github.com/actions/runner/issues/3207#issuecomment-2000066889
+      run: |
+        sudo sysctl -w vm.mmap_rnd_bits=28
     - name: Checkout .github
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR sets vm.mmap_rnd_bits=28 to get around the issues in:
- https://github.com/actions/runner/issues/3207
- https://github.com/google/sanitizers/issues/1614

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.