### PR TITLE
fix(ci): set 32 bits for all EICrecon runs

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -380,6 +380,10 @@ jobs:
         particle: [e]
         detector_config: [craterlake]
     steps:
+    - name: mmap rnd_bits workaround
+      # https://github.com/actions/runner/issues/3207#issuecomment-2000066889
+      run: |
+        sudo sysctl -w vm.mmap_rnd_bits=28
     - name: Checkout .github
       uses: actions/checkout@v4
       with:
@@ -440,6 +444,10 @@ jobs:
         particle: [e]
         detector_config: [craterlake]
     steps:
+    - name: mmap rnd_bits workaround
+      # https://github.com/actions/runner/issues/3207#issuecomment-2000066889
+      run: |
+        sudo sysctl -w vm.mmap_rnd_bits=28
     - name: Checkout .github
       uses: actions/checkout@v4
       with:
@@ -487,6 +495,10 @@ jobs:
         - tracking_efficiency
         - tracking_occupancy
     steps:
+    - name: mmap rnd_bits workaround
+      # https://github.com/actions/runner/issues/3207#issuecomment-2000066889
+      run: |
+        sudo sysctl -w vm.mmap_rnd_bits=28
     - name: Checkout .github
       uses: actions/checkout@v4
       with:
@@ -528,6 +540,10 @@ jobs:
         particle: [pi, e]
         detector_config: [craterlake]
     steps:
+    - name: mmap rnd_bits workaround
+      # https://github.com/actions/runner/issues/3207#issuecomment-2000066889
+      run: |
+        sudo sysctl -w vm.mmap_rnd_bits=28
     - name: Checkout .github
       uses: actions/checkout@v4
       with:
@@ -638,6 +654,10 @@ jobs:
         particle: [e]
         detector_config: [ip6_extended]
     steps:
+    - name: mmap rnd_bits workaround
+      # https://github.com/actions/runner/issues/3207#issuecomment-2000066889
+      run: |
+        sudo sysctl -w vm.mmap_rnd_bits=28
     - name: Checkout .github
       uses: actions/checkout@v4
       with:
@@ -693,6 +713,10 @@ jobs:
         - beam: 5x41
           minq2: 1000
     steps:
+    - name: mmap rnd_bits workaround
+      # https://github.com/actions/runner/issues/3207#issuecomment-2000066889
+      run: |
+        sudo sysctl -w vm.mmap_rnd_bits=28
     - name: Checkout .github
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Because `vm.mmap_rnd_bits-28` matches our pattern for protected stable release branches (`v*.*`), I can't push to it directly anymore...