### PR TITLE
Fix Jet Algorithm Initialization Bug (#1331)

### DIFF
--- a/src/algorithms/reco/JetReconstruction.h
+++ b/src/algorithms/reco/JetReconstruction.h
@@ -5,6 +5,7 @@
 
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <fastjet/AreaDefinition.hh>
+#include <fastjet/ClusterSequenceArea.hh>
 #include <fastjet/JetDefinition.hh>
 #include <spdlog/logger.h>
 #include <map>
@@ -30,6 +31,11 @@ namespace eicrecon {
     private:
 
       std::shared_ptr<spdlog::logger> m_log;
+
+      // fastjet components
+      std::unique_ptr<fastjet::JetDefinition> m_jet_def;
+      std::unique_ptr<fastjet::AreaDefinition> m_area_def;
+      std::unique_ptr<fastjet::ClusterSequenceArea> m_clus_seq;
 
       // maps of user input onto fastjet options
       std::map<std::string, fastjet::JetAlgorithm> m_mapJetAlgo = {

--- a/src/algorithms/reco/JetReconstructionConfig.h
+++ b/src/algorithms/reco/JetReconstructionConfig.h
@@ -11,6 +11,7 @@ namespace eicrecon {
   struct JetReconstructionConfig {
 
     float       rJet           = 1.0;                 // jet resolution  parameter
+    float       pJet           = -1.0;                // exponent for generalized kt algorithms
     double      minCstPt       = 0.2  * dd4hep::GeV;  // minimum pT of objects fed to cluster sequence
     double      maxCstPt       = 100. * dd4hep::GeV;  // maximum pT of objects fed to clsuter sequence
     double      minJetPt       = 1.0 * dd4hep::GeV;   // minimum jet pT

--- a/src/global/reco/JetReconstruction_factory.h
+++ b/src/global/reco/JetReconstruction_factory.h
@@ -26,6 +26,7 @@ namespace eicrecon {
 
       // parameter bindings
       ParameterRef<float>       m_rJet {this, "rJet", config().rJet};
+      ParameterRef<float>       m_pJet {this, "pJet", config().pJet};
       ParameterRef<double>      m_minCstPt {this, "minCstPt", config().minCstPt};
       ParameterRef<double>      m_maxCstPt {this, "maxCstPt", config().maxCstPt};
       ParameterRef<double>      m_minJetPt {this, "minJetPt", config().minJetPt};


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This PR resolves issue #1254. The `JetReconstruction` algorithm now determines the number of parameters needed for the selected fastjet algorithm and calls the relevant `JetDefinition` ctor.

In the process of resolving the issue, a new user-configurable parameter has been introduced into the algorithm's configuration: `pJet`, which sets the exponent on the energy weights of the distance measure in the case of the generalized kt algorithms.

### What kind of change does this PR introduce?
- [X] Bug fix (issue #1254 )
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [X] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No.

### Does this PR change default behavior?

No.

---------

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
