### PR TITLE
Fix to seed theta and phi covariance indices

### DIFF
--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -69,8 +69,8 @@ namespace eicrecon {
       static constexpr std::array<std::pair<Acts::BoundIndices, double>, 6> edm4eic_indexed_units{{
         {Acts::eBoundLoc0, Acts::UnitConstants::mm},
         {Acts::eBoundLoc1, Acts::UnitConstants::mm},
+	{Acts::eBoundPhi, 1.},
         {Acts::eBoundTheta, 1.},
-        {Acts::eBoundPhi, 1.},
         {Acts::eBoundQOverP, 1. / Acts::UnitConstants::GeV},
         {Acts::eBoundTime, Acts::UnitConstants::ns}
       }};
@@ -155,8 +155,8 @@ namespace eicrecon {
             Acts::BoundVector params;
             params(Acts::eBoundLoc0)   = track_parameter.getLoc().a * Acts::UnitConstants::mm;  // cylinder radius
             params(Acts::eBoundLoc1)   = track_parameter.getLoc().b * Acts::UnitConstants::mm;  // cylinder length
+	    params(Acts::eBoundPhi)    = track_parameter.getPhi();
             params(Acts::eBoundTheta)  = track_parameter.getTheta();
-            params(Acts::eBoundPhi)    = track_parameter.getPhi();
             params(Acts::eBoundQOverP) = track_parameter.getQOverP() / Acts::UnitConstants::GeV;
             params(Acts::eBoundTime)   = track_parameter.getTime() * Acts::UnitConstants::ns;
 

--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -69,7 +69,7 @@ namespace eicrecon {
       static constexpr std::array<std::pair<Acts::BoundIndices, double>, 6> edm4eic_indexed_units{{
         {Acts::eBoundLoc0, Acts::UnitConstants::mm},
         {Acts::eBoundLoc1, Acts::UnitConstants::mm},
-	{Acts::eBoundPhi, 1.},
+        {Acts::eBoundPhi, 1.},
         {Acts::eBoundTheta, 1.},
         {Acts::eBoundQOverP, 1. / Acts::UnitConstants::GeV},
         {Acts::eBoundTime, Acts::UnitConstants::ns}
@@ -155,7 +155,7 @@ namespace eicrecon {
             Acts::BoundVector params;
             params(Acts::eBoundLoc0)   = track_parameter.getLoc().a * Acts::UnitConstants::mm;  // cylinder radius
             params(Acts::eBoundLoc1)   = track_parameter.getLoc().b * Acts::UnitConstants::mm;  // cylinder length
-	    params(Acts::eBoundPhi)    = track_parameter.getPhi();
+            params(Acts::eBoundPhi)    = track_parameter.getPhi();
             params(Acts::eBoundTheta)  = track_parameter.getTheta();
             params(Acts::eBoundQOverP) = track_parameter.getQOverP() / Acts::UnitConstants::GeV;
             params(Acts::eBoundTime)   = track_parameter.getTime() * Acts::UnitConstants::ns;

--- a/src/algorithms/tracking/TrackParamTruthInit.cc
+++ b/src/algorithms/tracking/TrackParamTruthInit.cc
@@ -128,16 +128,16 @@ eicrecon::TrackParamTruthInit::produce(const edm4hep::MCParticleCollection* mcpa
         auto track_parameter = track_parameters->create();
         track_parameter.setType(-1); // type --> seed(-1)
         track_parameter.setLoc({static_cast<float>(localpos(0)), static_cast<float>(localpos(1))}); // 2d location on surface [mm]
-        track_parameter.setTheta(theta); // theta [rad]
         track_parameter.setPhi(phi); // phi [rad]
+        track_parameter.setTheta(theta); // theta [rad]
         track_parameter.setQOverP(charge / (pinit / dd4hep::GeV)); // Q/p [e/GeV]
         track_parameter.setTime(mcparticle.getTime()); // time [ns]
         #if EDM4EIC_VERSION_MAJOR >= 5
           edm4eic::Cov6f cov;
           cov(0,0) = 1.0; // loc0
           cov(1,1) = 1.0; // loc1
-          cov(2,2) = 0.01; // theta
-          cov(3,3) = 0.05; // phi
+          cov(2,2) = 0.05; // phi
+          cov(3,3) = 0.01; // theta
           cov(4,4) = 0.1; // qOverP
           cov(5,5) = 10e9; // time
           track_parameter.setCovariance(cov);

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -233,16 +233,16 @@ std::unique_ptr<edm4eic::TrackParametersCollection> eicrecon::TrackSeeding::make
       auto trackparam = trackparams->create();
       trackparam.setType(-1); // type --> seed(-1)
       trackparam.setLoc({static_cast<float>(localpos(0)), static_cast<float>(localpos(1))}); // 2d location on surface
-      trackparam.setTheta(theta); //theta [rad]
       trackparam.setPhi(static_cast<float>(phi)); // phi [rad]
+      trackparam.setTheta(theta); //theta [rad]
       trackparam.setQOverP(qOverP); // Q/p [e/GeV]
       trackparam.setTime(10); // time in ns
       #if EDM4EIC_VERSION_MAJOR >= 5
         edm4eic::Cov6f cov;
         cov(0,0) = 0.1; // loc0
         cov(1,1) = 0.1; // loc1
-        cov(2,2) = 0.05; // theta
-        cov(3,3) = 0.05; // phi
+        cov(2,2) = 0.05; // phi
+        cov(3,3) = 0.05; // theta
         cov(4,4) = 0.05; // qOverP
         cov(5,5) = 0.1; // time
         trackparam.setCovariance(cov);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Uses correct indices for phi and theta in the seed covariance matrix (for EDM4EIC version 5). 

Indices are now consistent with those given here:

[https://github.com/acts-project/acts/blob/3eb0b4febd16ad8cee5664302e3542044ab17d35/Core/include/Acts/Definitions/TrackParametrization.hpp#L37-L56](https://github.com/acts-project/acts/blob/3eb0b4febd16ad8cee5664302e3542044ab17d35/Core/include/Acts/Definitions/TrackParametrization.hpp#L37-L56)

No modification was made for EDM4EIC version 4. So, `track_parameter.getMomentumError().xx` still corresponds to the theta error.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
None
### Does this PR change default behavior?
