### PR TITLE
treewide: use PODIO ObjectID instead SimID/RecID indices

### DIFF
--- a/src/algorithms/pid/ParticlesWithPID.cc
+++ b/src/algorithms/pid/ParticlesWithPID.cc
@@ -198,7 +198,7 @@ namespace eicrecon {
                                  mcpart.getPDG());
 
                     m_log->debug(" Assoc: id={} SimId={} RecId={}",
-                                 rec_assoc.getObjectID().index, rec_assoc.getSimID(), rec_assoc.getSimID());
+                                 rec_assoc.getObjectID().index, rec_assoc.getSim().getObjectID().index, rec_assoc.getSim().getObjectID().index);
 
                     m_log->trace(" Assoc PDGs: sim.PDG | rec.PDG | rec.particleIDUsed.PDG = {:^6} | {:^6} | {:^6}",
                                  rec_assoc.getSim().getPDG(),

--- a/src/algorithms/reco/ElectronReconstruction.cc
+++ b/src/algorithms/reco/ElectronReconstruction.cc
@@ -5,6 +5,8 @@
 #include <edm4eic/ClusterCollection.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
+#include <podio/ObjectID.h>
+
 #include "algorithms/reco/ElectronReconstructionConfig.h"
 
 namespace eicrecon {

--- a/src/algorithms/reco/ElectronReconstruction.cc
+++ b/src/algorithms/reco/ElectronReconstruction.cc
@@ -37,7 +37,7 @@ namespace eicrecon {
             auto sim = clu_assoc.getSim(); // McParticle
             auto clu = clu_assoc.getRec(); // RecoCluster
 
-            m_log->trace( "SimId={}, CluId={}", clu_assoc.getSimID(), clu_assoc.getRecID() );
+            m_log->trace( "SimId={}, CluId={}", clu_assoc.getSim().getObjectID().index, clu_assoc.getRec().getObjectID().index );
             m_log->trace( "MCParticle: Energy={} GeV, p={} GeV, E/p = {} for PDG: {}", clu.getEnergy(), edm4hep::utils::magnitude(sim.getMomentum()), clu.getEnergy() / edm4hep::utils::magnitude(sim.getMomentum()), sim.getPDG() );
 
 
@@ -45,7 +45,7 @@ namespace eicrecon {
             // i.e. take (MC Particle <-> RC Cluster) + ( MC Particle <-> RC Particle ) = ( RC Particle <-> RC Cluster )
             auto reco_part_assoc = rcassoc->begin();
             for (; reco_part_assoc != rcassoc->end(); ++reco_part_assoc) {
-              if (reco_part_assoc->getSimID() == (unsigned) clu_assoc.getSimID()) {
+              if (reco_part_assoc->getSim().getObjectID() == clu_assoc.getSim().getObjectID()) {
                 break;
               }
             }
@@ -66,7 +66,7 @@ namespace eicrecon {
               }
 
             } else {
-              m_log->debug( "Could not find reconstructed particle for SimId={}", clu_assoc.getSimID() );
+              m_log->debug( "Could not find reconstructed particle for SimId={}", clu_assoc.getSim().getObjectID().index );
             }
 
           } // loop on MC particle to cluster associations in collection

--- a/src/algorithms/reco/InclusiveKinematicsDA.cc
+++ b/src/algorithms/reco/InclusiveKinematicsDA.cc
@@ -76,10 +76,10 @@ namespace eicrecon {
     //const auto ef_assoc = std::find_if(
     //  rcassoc->begin(),
     //  rcassoc->end(),
-    //  [&ef_coll](const auto& a){ return a.getSimID() == ef_coll[0].getObjectID().index; });
+    //  [&ef_coll](const auto& a){ return a.getSim().getObjectID() == ef_coll[0].getObjectID(); });
     auto ef_assoc = rcassoc->begin();
     for (; ef_assoc != rcassoc->end(); ++ef_assoc) {
-      if (ef_assoc->getSimID() == (unsigned) ef_coll[0].getObjectID().index) {
+      if (ef_assoc->getSim().getObjectID() == ef_coll[0].getObjectID()) {
         break;
       }
     }

--- a/src/algorithms/reco/InclusiveKinematicsElectron.cc
+++ b/src/algorithms/reco/InclusiveKinematicsElectron.cc
@@ -124,10 +124,10 @@ namespace eicrecon {
     //const auto ef_assoc = std::find_if(
     //  rcassoc->begin(),
     //  rcassoc->end(),
-    //  [&ef_coll](const auto& a){ return a.getSimID() == ef_coll[0].getObjectID().index; });
+    //  [&ef_coll](const auto& a){ return a.getSim().getObjectID() == ef_coll[0].getObjectID(); });
     auto ef_assoc = rcassoc->begin();
     for (; ef_assoc != rcassoc->end(); ++ef_assoc) {
-      if (ef_assoc->getSimID() == (unsigned) ef_coll[0].getObjectID().index) {
+      if (ef_assoc->getSim().getObjectID() == ef_coll[0].getObjectID()) {
         break;
       }
     }

--- a/src/algorithms/reco/InclusiveKinematicsJB.cc
+++ b/src/algorithms/reco/InclusiveKinematicsJB.cc
@@ -76,10 +76,10 @@ namespace eicrecon {
     //const auto ef_assoc = std::find_if(
     //  rcassoc->begin(),
     //  rcassoc->end(),
-    //  [&ef_coll](const auto& a){ return a.getSimID() == ef_coll[0].getObjectID().index; });
+    //  [&ef_coll](const auto& a){ return a.getSim().getObjectID() == ef_coll[0].getObjectID(); });
     auto ef_assoc = rcassoc->begin();
     for (; ef_assoc != rcassoc->end(); ++ef_assoc) {
-      if (ef_assoc->getSimID() == (unsigned) ef_coll[0].getObjectID().index) {
+      if (ef_assoc->getSim().getObjectID() == ef_coll[0].getObjectID()) {
         break;
       }
     }

--- a/src/algorithms/reco/InclusiveKinematicsSigma.cc
+++ b/src/algorithms/reco/InclusiveKinematicsSigma.cc
@@ -76,10 +76,10 @@ namespace eicrecon {
     //const auto ef_assoc = std::find_if(
     //  rcassoc->begin(),
     //  rcassoc->end(),
-    //  [&ef_coll](const auto& a){ return a.getSimID() == ef_coll[0].getObjectID().index; });
+    //  [&ef_coll](const auto& a){ return a.getSim().getObjectID() == ef_coll[0].getObjectID(); });
     auto ef_assoc = rcassoc->begin();
     for (; ef_assoc != rcassoc->end(); ++ef_assoc) {
-      if (ef_assoc->getSimID() == (unsigned) ef_coll[0].getObjectID().index) {
+      if (ef_assoc->getSim().getObjectID() == ef_coll[0].getObjectID()) {
         break;
       }
     }

--- a/src/algorithms/reco/InclusiveKinematicseSigma.cc
+++ b/src/algorithms/reco/InclusiveKinematicseSigma.cc
@@ -76,10 +76,10 @@ namespace eicrecon {
     //const auto ef_assoc = std::find_if(
     //  rcassoc->begin(),
     //  rcassoc->end(),
-    //  [&ef_coll](const auto& a){ return a.getSimID() == ef_coll[0].getObjectID().index; });
+    //  [&ef_coll](const auto& a){ return a.getSim().getObjectID() == ef_coll[0].getObjectID(); });
     auto ef_assoc = rcassoc->begin();
     for (; ef_assoc != rcassoc->end(); ++ef_assoc) {
-      if (ef_assoc->getSimID() == (unsigned) ef_coll[0].getObjectID().index) {
+      if (ef_assoc->getSim().getObjectID() == ef_coll[0].getObjectID()) {
         break;
       }
     }

--- a/src/algorithms/reco/MatchClusters.cc
+++ b/src/algorithms/reco/MatchClusters.cc
@@ -52,8 +52,8 @@ void MatchClusters::process(
 
         // find associated particle
         for (const auto &assoc: *inpartsassoc) {
-            if (assoc.getRecID() == inpart.getObjectID().index) {
-                mcID = assoc.getSimID();
+            if (assoc.getRec().getObjectID() == inpart.getObjectID()) {
+                mcID = assoc.getSim().getObjectID().index;
                 break;
             }
         }
@@ -135,7 +135,7 @@ std::map<int, edm4eic::Cluster> MatchClusters::indexedClusters(
         // find associated particle
         for (const auto assoc: *associations) {
             if (assoc.getRec() == cluster) {
-                mcID = assoc.getSimID();
+                mcID = assoc.getSim().getObjectID().index;
                 break;
             }
         }

--- a/src/tests/tracking_test/TrackingTest_processor.cc
+++ b/src/tests/tracking_test/TrackingTest_processor.cc
@@ -136,7 +136,7 @@ void TrackingTest_processor::ProcessTrackingMatching(const std::shared_ptr<const
         auto sim = assoc.getSim();
         auto rec = assoc.getRec();
 
-        m_log->debug("  {:<6} {:<6} {:>8d} {:>8d}", assoc.getSimID(), assoc.getRecID(), sim.getPDG(), rec.getPDG());
+        m_log->debug("  {:<6} {:<6} {:>8d} {:>8d}", assoc.getSim().getObjectID().index, assoc.getRec().getObjectID().index, sim.getPDG(), rec.getPDG());
     }
 
 //    m_log->debug("Particles [objID] [PDG] [simE] [recE] [simPDG] [recPDG]");


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This is a subset of #970, that removes use of SimID and RecID fields (while switching to comparisons of full object id's instead of just the indices).
In principle, we could even drop `.getObjectID()` in comparisons and just use `Object::operator==` https://github.com/AIDASoft/podio/blob/400f4f06bef3e7666c71e31be579ec715c412b8a/python/templates/macros/implementations.jinja2#L160, which relies on pointer comparison instead.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No