### PR TITLE
fix: use proper EDM4hep getter in ParticlesWithPID.cc

### DIFF
--- a/src/algorithms/pid/ParticlesWithPID.cc
+++ b/src/algorithms/pid/ParticlesWithPID.cc
@@ -142,7 +142,7 @@ namespace eicrecon {
             auto rec_part = parts->create();
             rec_part.addToTracks(track);
             int32_t best_pid = 0;
-            auto referencePoint = rec_part.referencePoint();
+            auto referencePoint = rec_part.getReferencePoint();
             // float time          = 0;
             float mass = 0;
             if (best_match >= 0) {


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR changes the direct member access to a getter to avoid a compiler warning:
```
/home/wdconinc/git/EICrecon/.worktree/pfrich-digitization/src/algorithms/pid/ParticlesWithPID.cc:145:44: warning: 'referencePoint' is deprecated: use getReferencePoint instead [-Wdeprecated-declarations]
  145 |             auto referencePoint = rec_part.referencePoint();
      |                                            ^
/opt/local/include/edm4eic/MutableReconstructedParticle.h:142:5: note: 'referencePoint' has been explicitly marked deprecated here
  142 |   [[deprecated("use getReferencePoint instead")]]
      |     ^
```
This applies since https://github.com/AIDASoft/podio/pull/553.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: deprecated )
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.