### PR TITLE
Adapt ElectronReconstruction to use MatchClusters

### DIFF
--- a/src/algorithms/reco/ElectronReconstruction.cc
+++ b/src/algorithms/reco/ElectronReconstruction.cc
@@ -3,6 +3,7 @@
 #include "ElectronReconstruction.h"
 
 #include <edm4eic/ClusterCollection.h>
+#include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
 #include <podio/ObjectID.h>
@@ -11,20 +12,13 @@
 
 namespace eicrecon {
 
-  void ElectronReconstruction::init(std::shared_ptr<spdlog::logger> logger) {
-    m_log = logger;
-  }
+    void ElectronReconstruction::init(std::shared_ptr<spdlog::logger> logger) {
+        m_log = logger;
+    }
 
-  std::unique_ptr<edm4eic::ReconstructedParticleCollection> ElectronReconstruction::execute(
-    const edm4hep::MCParticleCollection *mcparts,
-    const edm4eic::ReconstructedParticleCollection *rcparts,
-    const edm4eic::MCRecoParticleAssociationCollection *rcassoc,
-    const std::vector<const edm4eic::MCRecoClusterParticleAssociationCollection*> &in_clu_assoc
-    ) {
-
-        // Step 1. Loop through MCParticle - cluster associations
-        // Step 2. Get Reco particle for the Mc Particle matched to cluster
-        // Step 3. Apply E/p cut using Reco cluster Energy and Reco Particle momentum
+    std::unique_ptr<edm4eic::ReconstructedParticleCollection> ElectronReconstruction::execute(
+            const edm4eic::ReconstructedParticleCollection *rcparts
+            ) {
 
         // Some obvious improvements:
         // - E/p cut from real study optimized for electron finding and hadron rejection
@@ -33,49 +27,29 @@ namespace eicrecon {
 
         // output container
         auto out_electrons = std::make_unique<edm4eic::ReconstructedParticleCollection>();
+        out_electrons->setSubsetCollection(); // out_electrons is a subset of the ReconstructedParticles collection
 
-        for ( const auto *col : in_clu_assoc ){ // loop on cluster association collections
-          for ( auto clu_assoc : (*col) ){ // loop on MCRecoClusterParticleAssociation in this particular collection
-            auto sim = clu_assoc.getSim(); // McParticle
-            auto clu = clu_assoc.getRec(); // RecoCluster
-
-            m_log->trace( "SimId={}, CluId={}", clu_assoc.getSim().getObjectID().index, clu_assoc.getRec().getObjectID().index );
-            m_log->trace( "MCParticle: Energy={} GeV, p={} GeV, E/p = {} for PDG: {}", clu.getEnergy(), edm4hep::utils::magnitude(sim.getMomentum()), clu.getEnergy() / edm4hep::utils::magnitude(sim.getMomentum()), sim.getPDG() );
-
-
-            // Find the Reconstructed particle associated to the MC Particle that is matched with this reco cluster
-            // i.e. take (MC Particle <-> RC Cluster) + ( MC Particle <-> RC Particle ) = ( RC Particle <-> RC Cluster )
-            auto reco_part_assoc = rcassoc->begin();
-            for (; reco_part_assoc != rcassoc->end(); ++reco_part_assoc) {
-              if (reco_part_assoc->getSim().getObjectID() == clu_assoc.getSim().getObjectID()) {
-                break;
-              }
-            }
-
+        for (const auto particle : *rcparts) {
             // if we found a reco particle then test for electron compatibility
-            if ( reco_part_assoc != rcassoc->end() ){
-              auto reco_part = reco_part_assoc->getRec();
-              double EoverP = clu.getEnergy() / edm4hep::utils::magnitude(reco_part.getMomentum());
-              m_log->trace( "ReconstructedParticle: Energy={} GeV, p={} GeV, E/p = {} for PDG (from truth): {}", clu.getEnergy(), edm4hep::utils::magnitude(reco_part.getMomentum()), EoverP, sim.getPDG() );
-              auto reco_electron = reco_part.clone();
-              reco_electron.addToClusters( clu );
+            if (particle.getClusters().size() == 0) {
+                continue;
+            }
+            if (particle.getCharge() == 0) { // Skip over photons/other particles without a track
+                continue;
+            }
+            double E = particle.getClusters()[0].getEnergy();
+            double p = edm4hep::utils::magnitude(particle.getMomentum());
+            double EOverP = E / p;
 
-              m_log->trace( "ReconstructedElectron: nClusters={}", reco_electron.clusters_size() );
-              m_log->trace( "ReconstructedElectron: Energy={} GeV, p={} GeV, E/p = {} for PDG (from truth): {}", reco_electron.getClusters(0).getEnergy(), edm4hep::utils::magnitude(reco_part.getMomentum()), (reco_electron.getClusters(0).getEnergy() / edm4hep::utils::magnitude(reco_part.getMomentum())), sim.getPDG() );
-              // Apply the E/p cut here to select electons
-              if ( EoverP >= m_cfg.min_energy_over_momentum && EoverP <= m_cfg.max_energy_over_momentum ) {
-                out_electrons->push_back(reco_electron);
-              }
-
-            } else {
-              m_log->debug( "Could not find reconstructed particle for SimId={}", clu_assoc.getSim().getObjectID().index );
+            m_log->trace("ReconstructedElectron: Energy={} GeV, p={} GeV, E/p = {} for PDG (from truth): {}", E, p, EOverP, particle.getPDG());
+            // Apply the E/p cut here to select electons
+            if (EOverP >= m_cfg.min_energy_over_momentum && EOverP <= m_cfg.max_energy_over_momentum) {
+                out_electrons->push_back(particle);
             }
 
-          } // loop on MC particle to cluster associations in collection
-        } // loop on collections
-
-        m_log->debug( "Found {} electron candidates", out_electrons->size() );
-        return out_electrons;
+        }
+    m_log->debug("Found {} electron candidates", out_electrons->size());
+    return out_electrons;
     }
-
 }
+

--- a/src/algorithms/reco/ElectronReconstruction.cc
+++ b/src/algorithms/reco/ElectronReconstruction.cc
@@ -6,7 +6,7 @@
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
-#include <podio/ObjectID.h>
+#include <podio/RelationRange.h>
 
 #include "algorithms/reco/ElectronReconstructionConfig.h"
 

--- a/src/algorithms/reco/ElectronReconstruction.cc
+++ b/src/algorithms/reco/ElectronReconstruction.cc
@@ -52,4 +52,3 @@ namespace eicrecon {
     return out_electrons;
     }
 }
-

--- a/src/algorithms/reco/ElectronReconstruction.cc
+++ b/src/algorithms/reco/ElectronReconstruction.cc
@@ -27,7 +27,6 @@ namespace eicrecon {
 
         // output container
         auto out_electrons = std::make_unique<edm4eic::ReconstructedParticleCollection>();
-        out_electrons->setSubsetCollection(); // out_electrons is a subset of the ReconstructedParticles collection
 
         for (const auto particle : *rcparts) {
             // if we found a reco particle then test for electron compatibility
@@ -44,7 +43,7 @@ namespace eicrecon {
             m_log->trace("ReconstructedElectron: Energy={} GeV, p={} GeV, E/p = {} for PDG (from truth): {}", E, p, EOverP, particle.getPDG());
             // Apply the E/p cut here to select electons
             if (EOverP >= m_cfg.min_energy_over_momentum && EOverP <= m_cfg.max_energy_over_momentum) {
-                out_electrons->push_back(particle);
+                out_electrons->push_back(particle.clone());
             }
 
         }

--- a/src/algorithms/reco/ElectronReconstruction.cc
+++ b/src/algorithms/reco/ElectronReconstruction.cc
@@ -27,6 +27,7 @@ namespace eicrecon {
 
         // output container
         auto out_electrons = std::make_unique<edm4eic::ReconstructedParticleCollection>();
+        out_electrons->setSubsetCollection(); // out_electrons is a subset of the ReconstructedParticles collection
 
         for (const auto particle : *rcparts) {
             // if we found a reco particle then test for electron compatibility
@@ -43,7 +44,7 @@ namespace eicrecon {
             m_log->trace("ReconstructedElectron: Energy={} GeV, p={} GeV, E/p = {} for PDG (from truth): {}", E, p, EOverP, particle.getPDG());
             // Apply the E/p cut here to select electons
             if (EOverP >= m_cfg.min_energy_over_momentum && EOverP <= m_cfg.max_energy_over_momentum) {
-                out_electrons->push_back(particle.clone());
+                out_electrons->push_back(particle);
             }
 
         }

--- a/src/algorithms/reco/ElectronReconstruction.h
+++ b/src/algorithms/reco/ElectronReconstruction.h
@@ -25,10 +25,7 @@ namespace eicrecon {
 
         // idea will be to overload this with other version (e.g. reco mode)
         std::unique_ptr<edm4eic::ReconstructedParticleCollection> execute(
-                const edm4hep::MCParticleCollection *mcparts,
-                const edm4eic::ReconstructedParticleCollection *rcparts,
-                const edm4eic::MCRecoParticleAssociationCollection *rcassoc,
-                const std::vector<const edm4eic::MCRecoClusterParticleAssociationCollection*> &in_clu_assoc
+                const edm4eic::ReconstructedParticleCollection *rcparts
         );
 
     private:

--- a/src/algorithms/reco/ElectronReconstruction.h
+++ b/src/algorithms/reco/ElectronReconstruction.h
@@ -3,13 +3,9 @@
 
 #pragma once
 
-#include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
-#include <edm4eic/MCRecoParticleAssociationCollection.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
-#include <edm4hep/MCParticleCollection.h>
 #include <spdlog/logger.h>
 #include <memory>
-#include <vector>
 
 #include "ElectronReconstructionConfig.h"
 #include "algorithms/interfaces/WithPodConfig.h"

--- a/src/algorithms/reco/ScatteredElectronsEMinusPz.cc
+++ b/src/algorithms/reco/ScatteredElectronsEMinusPz.cc
@@ -83,15 +83,10 @@ namespace eicrecon {
       // Loop over reconstructed particles to
       // sum hadronic final state
       for (const auto& p: *rcparts) {
-        // this is a hack - getObjectID() only works within
-        // a collections, not unique across all collections.
         // What we want is to add all reconstructed particles
         // except the one we are currently considering as the
         // (scattered) electron candidate.
-        // This does work though and in general it has only
-        // one match as I would hope (tested on pythia events)
-        if (abs( edm4hep::utils::magnitude(p.getMomentum()) - edm4hep::utils::magnitude(e.getMomentum()) ) > 0.01 * dd4hep::GeV )
-                                {
+		if (p.getObjectID() != e.getObjectID()) {
           vHadron.SetCoordinates(
               p.getMomentum().x,
               p.getMomentum().y,

--- a/src/algorithms/reco/ScatteredElectronsEMinusPz.cc
+++ b/src/algorithms/reco/ScatteredElectronsEMinusPz.cc
@@ -51,7 +51,6 @@ namespace eicrecon {
     auto out_electrons =  std::make_unique<
         edm4eic::ReconstructedParticleCollection
       >();
-    out_electrons->setSubsetCollection();
 
     m_log->trace( "We have {} candidate electrons",
         rcele->size()
@@ -109,7 +108,7 @@ namespace eicrecon {
       m_log->trace( "\tScatteredElectron has Pxyz=( {}, {}, {} )", e.getMomentum().x, e.getMomentum().y, e.getMomentum().z );
 
       // Store the result of this calculation
-      scatteredElectronsMap[ EPz ] = e;
+      scatteredElectronsMap[ EPz ] = e.clone();
     } // electron loop
 
     m_log->trace( "Selecting candidates with {} < E-Pz < {}", m_cfg.minEMinusPz, m_cfg.maxEMinusPz );

--- a/src/algorithms/reco/ScatteredElectronsEMinusPz.cc
+++ b/src/algorithms/reco/ScatteredElectronsEMinusPz.cc
@@ -44,13 +44,14 @@ namespace eicrecon {
     // this map will store intermediate results
     // so that we can sort them before filling output
     // collection
-    std::map<double, edm4eic::MutableReconstructedParticle> scatteredElectronsMap;
+    std::map<double, edm4eic::ReconstructedParticle> scatteredElectronsMap;
 
     // our output collection of scattered electrons
     // ordered by E-Pz
     auto out_electrons =  std::make_unique<
         edm4eic::ReconstructedParticleCollection
       >();
+    out_electrons->setSubsetCollection();
 
     m_log->trace( "We have {} candidate electrons",
         rcele->size()
@@ -108,7 +109,7 @@ namespace eicrecon {
       m_log->trace( "\tScatteredElectron has Pxyz=( {}, {}, {} )", e.getMomentum().x, e.getMomentum().y, e.getMomentum().z );
 
       // Store the result of this calculation
-      scatteredElectronsMap[ EPz ] = e.clone();
+      scatteredElectronsMap[ EPz ] = e;
     } // electron loop
 
     m_log->trace( "Selecting candidates with {} < E-Pz < {}", m_cfg.minEMinusPz, m_cfg.maxEMinusPz );

--- a/src/algorithms/reco/ScatteredElectronsEMinusPz.cc
+++ b/src/algorithms/reco/ScatteredElectronsEMinusPz.cc
@@ -86,7 +86,7 @@ namespace eicrecon {
         // What we want is to add all reconstructed particles
         // except the one we are currently considering as the
         // (scattered) electron candidate.
-		if (p.getObjectID() != e.getObjectID()) {
+                if (p.getObjectID() != e.getObjectID()) {
           vHadron.SetCoordinates(
               p.getMomentum().x,
               p.getMomentum().y,

--- a/src/algorithms/reco/ScatteredElectronsEMinusPz.cc
+++ b/src/algorithms/reco/ScatteredElectronsEMinusPz.cc
@@ -84,7 +84,7 @@ namespace eicrecon {
         // What we want is to add all reconstructed particles
         // except the one we are currently considering as the
         // (scattered) electron candidate.
-                if (p.getObjectID() != e.getObjectID()) {
+        if (p.getObjectID() != e.getObjectID()) {
           vHadron.SetCoordinates(
               p.getMomentum().x,
               p.getMomentum().y,

--- a/src/algorithms/reco/ScatteredElectronsEMinusPz.cc
+++ b/src/algorithms/reco/ScatteredElectronsEMinusPz.cc
@@ -1,16 +1,13 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2024 Daniel Brandenburg
 
-#include <Evaluator/DD4hepUnits.h>
 #include <Math/GenVector/LorentzVector.h>
 #include <Math/GenVector/PxPyPzM4D.h>
 #include <Math/Vector4Dfwd.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/Vector3f.h>
-#include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
-#include <math.h>
-#include <stdlib.h>
+#include <podio/ObjectID.h>
 #include <iterator>
 #include <map>
 #include <utility>

--- a/src/algorithms/reco/ScatteredElectronsEMinusPz.cc
+++ b/src/algorithms/reco/ScatteredElectronsEMinusPz.cc
@@ -51,6 +51,7 @@ namespace eicrecon {
     auto out_electrons =  std::make_unique<
         edm4eic::ReconstructedParticleCollection
       >();
+    out_electrons->setSubsetCollection();
 
     m_log->trace( "We have {} candidate electrons",
         rcele->size()
@@ -108,7 +109,7 @@ namespace eicrecon {
       m_log->trace( "\tScatteredElectron has Pxyz=( {}, {}, {} )", e.getMomentum().x, e.getMomentum().y, e.getMomentum().z );
 
       // Store the result of this calculation
-      scatteredElectronsMap[ EPz ] = e.clone();
+      scatteredElectronsMap[ EPz ] = e;
     } // electron loop
 
     m_log->trace( "Selecting candidates with {} < E-Pz < {}", m_cfg.minEMinusPz, m_cfg.maxEMinusPz );

--- a/src/algorithms/reco/ScatteredElectronsTruth.cc
+++ b/src/algorithms/reco/ScatteredElectronsTruth.cc
@@ -45,7 +45,6 @@ namespace eicrecon {
     // get our input and outputs
     const auto [mcparts, rcparts, rcassoc] = input;
     auto [output_electrons] = output;
-    output_electrons->setSubsetCollection();
 
 
     // Get first scattered electron
@@ -90,7 +89,7 @@ namespace eicrecon {
     for (const auto& p: *rcparts) {
       if (p.getObjectID() == ef_rc_id) {
 
-        output_electrons->push_back( p );
+        output_electrons->push_back( p.clone() );
         vScatteredElectron.SetCoordinates( p.getMomentum().x, p.getMomentum().y, p.getMomentum().z, m_electron );
         electrons.emplace_back(p.getMomentum().x, p.getMomentum().y, p.getMomentum().z, p.getEnergy());
         // break; NOTE: if we are not computing E-Pz

--- a/src/algorithms/reco/ScatteredElectronsTruth.cc
+++ b/src/algorithms/reco/ScatteredElectronsTruth.cc
@@ -45,6 +45,8 @@ namespace eicrecon {
     // get our input and outputs
     const auto [mcparts, rcparts, rcassoc] = input;
     auto [output_electrons] = output;
+    output_electrons->setSubsetCollection();
+
 
     // Get first scattered electron
     const auto ef_coll = find_first_scattered_electron(mcparts);
@@ -88,7 +90,7 @@ namespace eicrecon {
     for (const auto& p: *rcparts) {
       if (p.getObjectID() == ef_rc_id) {
 
-        output_electrons->push_back( p.clone() );
+        output_electrons->push_back( p );
         vScatteredElectron.SetCoordinates( p.getMomentum().x, p.getMomentum().y, p.getMomentum().z, m_electron );
         electrons.emplace_back(p.getMomentum().x, p.getMomentum().y, p.getMomentum().z, p.getEnergy());
         // break; NOTE: if we are not computing E-Pz

--- a/src/algorithms/reco/ScatteredElectronsTruth.cc
+++ b/src/algorithms/reco/ScatteredElectronsTruth.cc
@@ -45,6 +45,7 @@ namespace eicrecon {
     // get our input and outputs
     const auto [mcparts, rcparts, rcassoc] = input;
     auto [output_electrons] = output;
+    output_electrons->setSubsetCollection();
 
 
     // Get first scattered electron
@@ -89,7 +90,7 @@ namespace eicrecon {
     for (const auto& p: *rcparts) {
       if (p.getObjectID() == ef_rc_id) {
 
-        output_electrons->push_back( p.clone() );
+        output_electrons->push_back( p );
         vScatteredElectron.SetCoordinates( p.getMomentum().x, p.getMomentum().y, p.getMomentum().z, m_electron );
         electrons.emplace_back(p.getMomentum().x, p.getMomentum().y, p.getMomentum().z, p.getEnergy());
         // break; NOTE: if we are not computing E-Pz

--- a/src/global/reco/ReconstructedElectrons_factory.h
+++ b/src/global/reco/ReconstructedElectrons_factory.h
@@ -17,11 +17,8 @@ private:
     std::unique_ptr<eicrecon::ElectronReconstruction> m_algo;
 
     // Declare inputs
-    PodioInput<edm4hep::MCParticle> m_in_mc_particles {this, "MCParticles"};
-    PodioInput<edm4eic::ReconstructedParticle> m_in_rc_particles {this, "ReconstructedChargedParticles"};
-    PodioInput<edm4eic::MCRecoParticleAssociation> m_in_rc_particles_assoc {this, "ReconstructedChargedParticleAssociations"};
+    PodioInput<edm4eic::ReconstructedParticle> m_in_rc_particles {this, "ReconstructedParticles"};
 
-    VariadicPodioInput<edm4eic::MCRecoClusterParticleAssociation> m_in_clu_assoc {this};
 
     // Declare outputs
     PodioOutput<edm4eic::ReconstructedParticle> m_out_reco_particles {this};
@@ -61,10 +58,7 @@ public:
         // Use this callback to call your Algorithm using all inputs and outputs
         // The inputs will have already been fetched for you at this point.
         auto output = m_algo->execute(
-          m_in_mc_particles(),
-          m_in_rc_particles(),
-          m_in_rc_particles_assoc(),
-          m_in_clu_assoc()
+          m_in_rc_particles()
         );
 
         logger()->debug( "Event {}: Found {} reconstructed electron candidates", event_number, output->size() );

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -168,9 +168,9 @@ void InitPlugin(JApplication *app) {
         {"ReconstructedParticles"},
         {"ReconstructedElectronsForDIS"},
         {
-			.min_energy_over_momentum = 0.7, // GeV
-			.max_energy_over_momentum = 1.3  // GeV
-		},
+                        .min_energy_over_momentum = 0.7, // GeV
+                        .max_energy_over_momentum = 1.3  // GeV
+                },
         app
     ));
 

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -168,9 +168,9 @@ void InitPlugin(JApplication *app) {
         {"ReconstructedParticles"},
         {"ReconstructedElectronsForDIS"},
         {
-                        .min_energy_over_momentum = 0.7, // GeV
-                        .max_energy_over_momentum = 1.3  // GeV
-                },
+          .min_energy_over_momentum = 0.7, // GeV
+          .max_energy_over_momentum = 1.3  // GeV
+        },
         app
     ));
 

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -154,13 +154,7 @@ void InitPlugin(JApplication *app) {
 
     app->Add(new JOmniFactoryGeneratorT<ReconstructedElectrons_factory>(
         "ReconstructedElectrons",
-        {"MCParticles", "ReconstructedChargedParticles", "ReconstructedChargedParticleAssociations",
-        "EcalBarrelScFiClusterAssociations",
-        "EcalEndcapNClusterAssociations",
-        "EcalEndcapPClusterAssociations",
-        "EcalEndcapPInsertClusterAssociations",
-        "EcalLumiSpecClusterAssociations",
-        },
+        {"ReconstructedParticles"},
         {"ReconstructedElectrons"},
         {},
         app

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -165,18 +165,12 @@ void InitPlugin(JApplication *app) {
 
     app->Add(new JOmniFactoryGeneratorT<ReconstructedElectrons_factory>(
         "ReconstructedElectronsForDIS",
-        {"MCParticles", "ReconstructedChargedParticles", "ReconstructedChargedParticleAssociations",
-        "EcalBarrelScFiClusterAssociations",
-        "EcalEndcapNClusterAssociations",
-        "EcalEndcapPClusterAssociations",
-        "EcalEndcapPInsertClusterAssociations",
-        "EcalLumiSpecClusterAssociations",
-        },
+        {"ReconstructedParticles"},
         {"ReconstructedElectronsForDIS"},
         {
-                                        .min_energy_over_momentum = 0.7, // GeV
-                                        .max_energy_over_momentum = 1.3  // GeV
-                                },
+			.min_energy_over_momentum = 0.7, // GeV
+			.max_energy_over_momentum = 1.3  // GeV
+		},
         app
     ));
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The ReconstructedElectron algorithm now uses the particle-cluster associations created by MatchClusters_factory rather than doing it itself.  It makes the collection ReconstructedElectrons a subset collection of ReconstructedParticles, so the association is kept between them.  

I will leave this as a draft until #1277 is merged, then update that code as well to take advantage of it.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #1320 )
- [ ] New feature (issue #__ )
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
ReconstructedElectrons is now a subset collection, but I don't believe that should break anything.

### Does this PR change default behavior?
No
