### PR TITLE
Fix: Allow matching to only primary particles

### DIFF
--- a/src/algorithms/pid/ParticlesWithPID.cc
+++ b/src/algorithms/pid/ParticlesWithPID.cc
@@ -81,8 +81,8 @@ namespace eicrecon {
                 }
 
                 // Check if non-primary
-                if (mc_part.getGeneratorStatus() > 1) {
-                    m_log->trace("    Ignoring. GeneratorStatus > 1 => Non-primary particle");
+                if (mc_part.getGeneratorStatus() != 1) {
+                    m_log->trace("    Ignoring. GeneratorStatus != 1 => Non-primary particle");
                     continue;
                 }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
In current main branch, it is possible to match a reconstructed track to a secondary particle with generatorStatus==0. An example where this incorrectly happens can be seen below.

<img width="728" alt="image1" src="https://github.com/eic/EICrecon/assets/8701169/4bf5b90b-f1d3-4ae3-9a1a-164f455d4734">
<img width="806" alt="image2" src="https://github.com/eic/EICrecon/assets/8701169/72309144-8b5c-48d5-96fc-14d0386569cb">


### What kind of change does this PR introduce?
- [x ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
Yes, for matching of ReconstructedChargedParticles and ReconstructedSeededChargedParticles
