### PR TITLE
feat: replace draw_surfaces with Acts-based obj and ply export

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -740,7 +740,7 @@ jobs:
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
           export LD_LIBRARY_PATH=$PWD/install/lib:$LD_LIBRARY_PATH
           export JANA_PLUGIN_PATH=$PWD/install/lib/EICrecon/plugins:/usr/local/plugins
-          $PWD/install/bin/eicrecon -Ppodio:output_file=rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root -Pplugins=janadot,janatop -Pjana:warmup_timeout=0 -Pjana:timeout=0
+          $PWD/install/bin/eicrecon -Ppodio:output_file=rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root -Pacts:WriteObj=true -Pacts:WritePly=true -Pplugins=janadot,janatop -Pjana:warmup_timeout=0 -Pjana:timeout=0
           dot -Tsvg jana.dot > jana.svg
           mv jana.dot rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.dot
           mv jana.svg rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.svg
@@ -755,6 +755,19 @@ jobs:
         path: |
           *.dot
           *.svg
+        if-no-files-found: error
+    - uses: actions/upload-artifact@v4
+      with:
+        name: obj_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}
+        path: |
+          *.mtl
+          *.obj
+        if-no-files-found: error
+    - uses: actions/upload-artifact@v4
+      with:
+        name: ply_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}
+        path: |
+          *.ply
         if-no-files-found: error
     - name: Download previous artifact
       id: download_previous_artifact

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,12 @@ install/*
 *.slo
 *.lo
 *.o
+
+# Auto-generated meshes
 *.obj
+*.mtl
+*.ply
+*.stl
 
 # Precompiled Headers
 *.gch

--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -1,20 +1,17 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022 - 2024 Whitney Armstrong, Wouter Deconinck, Dmitry Romanov
 
-#include <Acts/Definitions/Algebra.hpp>
 #include <Acts/Geometry/DetectorElementBase.hpp>
 #include <Acts/Geometry/GeometryIdentifier.hpp>
 #include <Acts/Geometry/TrackingGeometry.hpp>
+#include <Acts/Geometry/TrackingVolume.hpp>
 #include <Acts/MagneticField/MagneticFieldContext.hpp>
 #include <Acts/Material/IMaterialDecorator.hpp>
 #include <Acts/Plugins/DD4hep/ConvertDD4hepDetector.hpp>
 #include <Acts/Plugins/DD4hep/DD4hepDetectorElement.hpp>
 #include <Acts/Plugins/Json/JsonMaterialDecorator.hpp>
 #include <Acts/Plugins/Json/MaterialMapJsonConverter.hpp>
-#include <Acts/Surfaces/PlanarBounds.hpp>
-#include <Acts/Surfaces/PlaneSurface.hpp>
 #include <Acts/Surfaces/Surface.hpp>
-#include <Acts/Surfaces/SurfaceBounds.hpp>
 #include <Acts/Utilities/BinningType.hpp>
 #include <Acts/Utilities/Result.hpp>
 #include <Acts/Visualization/GeometryView3D.hpp>
@@ -27,13 +24,9 @@
 #include <fmt/core.h>
 #include <fmt/ostream.h>
 #include <spdlog/common.h>
-#include <stddef.h>
 #include <exception>
 #include <initializer_list>
-#include <iomanip>
-#include <iostream>
 #include <type_traits>
-#include <vector>
 
 #include "ActsGeometryProvider.h"
 #include "extensions/spdlog/SpdlogToActs.h"

--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -1,5 +1,5 @@
-// Original header license: SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2022 Whitney Armstrong, Wouter Deconinck, Dmitry Romanov
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2022 - 2024 Whitney Armstrong, Wouter Deconinck, Dmitry Romanov
 
 #include <Acts/Definitions/Algebra.hpp>
 #include <Acts/Geometry/DetectorElementBase.hpp>

--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -17,6 +17,9 @@
 #include <Acts/Surfaces/SurfaceBounds.hpp>
 #include <Acts/Utilities/BinningType.hpp>
 #include <Acts/Utilities/Result.hpp>
+#include <Acts/Visualization/GeometryView3D.hpp>
+#include <Acts/Visualization/ObjVisualization3D.hpp>
+#include <Acts/Visualization/PlyVisualization3D.hpp>
 #include <DD4hep/DetElement.h>
 #include <DD4hep/VolumeManager.h>
 #include <JANA/JException.h>
@@ -49,46 +52,6 @@ struct fmt::formatter<
 > : fmt::ostream_formatter {};
 #endif // FMT_VERSION >= 90000
 
-void draw_surfaces(std::shared_ptr<const Acts::TrackingGeometry> trk_geo, const Acts::GeometryContext geo_ctx, std::shared_ptr<spdlog::logger> init_log,
-                   const std::string &fname) {
-    using namespace Acts;
-    std::vector<const Surface *> surfaces;
-
-    trk_geo->visitSurfaces([&](const Acts::Surface *surface) {
-        // for now we just require a valid surface
-        if (surface == nullptr) {
-            std::cout << " Not a surface \n";
-            return;
-        }
-        surfaces.push_back(surface);
-    });
-    std::ofstream os;
-    os.open(fname);
-    os << std::fixed << std::setprecision(6);
-    size_t nVtx = 0;
-    for (const auto &srfx: surfaces) {
-        const auto *srf = dynamic_cast<const PlaneSurface *>(srfx);
-        if (srf==nullptr){
-          init_log->error("Warning: Attempting cast a {} to Acts::PlaneSurface returns nullptr. This surface will not be added to the .obj output.", srfx->name());
-          continue;
-        }
-        const auto *bounds = dynamic_cast<const PlanarBounds *>(&srf->bounds());
-        for (const auto &vtxloc: bounds->vertices()) {
-            Vector3 vtx = srf->transform(geo_ctx) * Vector3(vtxloc.x(), vtxloc.y(), 0);
-            os << "v " << vtx.x() << " " << vtx.y() << " " << vtx.z() << "\n";
-        }
-        // connect them
-        os << "f";
-        for (size_t i = 1; i <= bounds->vertices().size(); ++i) {
-            os << " " << nVtx + i;
-        }
-        os << "\n";
-        nVtx += bounds->vertices().size();
-    }
-    os.close();
-}
-
-
 void ActsGeometryProvider::initialize(const dd4hep::Detector* dd4hep_geo,
                                       std::string material_file,
                                       std::shared_ptr<spdlog::logger> log,
@@ -109,25 +72,6 @@ void ActsGeometryProvider::initialize(const dd4hep::Detector* dd4hep_geo,
     auto acts_init_log_level = eicrecon::SpdlogToActsLevel(m_init_log->level());
 
     m_dd4hepDetector = dd4hep_geo;
-
-    // create a list of all surfaces in the detector:
-//  dd4hep::rec::SurfaceManager surfMan( *m_dd4hepDetector ) ;
-//
-//  m_log->debug(" surface manager ");
-//  const auto* const sM = surfMan.map("tracker") ;
-//  if (sM != nullptr) {
-//      m_log->debug(" surface map  size: {}", sM->size());
-//    // setup  dd4hep surface map
-//    //for( dd4hep::rec::SurfaceMap::const_iterator it = sM->begin() ; it != sM->end() ; ++it ){
-//    for( const auto& [id, s] :   *sM) {
-//      //dd4hep::rec::Surface* surf = s ;
-//      m_surfaceMap[ id ] = dynamic_cast<dd4hep::rec::Surface*>(s) ;
-//        //m_log->debug(" surface : {}", *s );
-////      m_detPlaneMap[id] = std::shared_ptr<genfit::DetPlane>(
-////          new genfit::DetPlane({s->origin().x(), s->origin().y(), s->origin().z()}, {s->u().x(), s->u().y(), s->u().z()},
-////                               {s->v().x(), s->v().y(), s->v().z()}));
-//    }
-//  }
 
     // Load ACTS materials maps
     std::shared_ptr<const Acts::IMaterialDecorator> materialDeco{nullptr};
@@ -191,7 +135,26 @@ void ActsGeometryProvider::initialize(const dd4hep::Detector* dd4hep_geo,
     // Visit surfaces
     m_init_log->info("Checking surfaces...");
     if (m_trackingGeo) {
-        draw_surfaces(m_trackingGeo, m_trackingGeoCtx, m_init_log, "tracking_geometry.obj");
+        // Write tracking geometry to collection of obj or ply files
+        const Acts::TrackingVolume* world = m_trackingGeo->highestTrackingVolume();
+        if (m_objWriteIt) {
+          m_init_log->info("Writing obj files to {}...", m_outputDir);
+          Acts::ObjVisualization3D objVis;
+          Acts::GeometryView3D::drawTrackingVolume(
+            objVis, *world, m_trackingGeoCtx,
+            m_containerView, m_volumeView, m_passiveView, m_sensitiveView, m_gridView,
+            m_objWriteIt, m_outputTag, m_outputDir
+          );
+        }
+        if (m_plyWriteIt) {
+          m_init_log->info("Writing ply files to {}...", m_outputDir);
+          Acts::PlyVisualization3D plyVis;
+          Acts::GeometryView3D::drawTrackingVolume(
+            plyVis, *world, m_trackingGeoCtx,
+            m_containerView, m_volumeView, m_passiveView, m_sensitiveView, m_gridView,
+            m_plyWriteIt, m_outputTag, m_outputDir
+          );
+        }
 
         m_init_log->debug("visiting all the surfaces  ");
         m_trackingGeo->visitSurfaces([this](const Acts::Surface *surface) {

--- a/src/algorithms/tracking/ActsGeometryProvider.h
+++ b/src/algorithms/tracking/ActsGeometryProvider.h
@@ -111,4 +111,37 @@ private:
     /// But it might be customized to solely printout geometry information
     std::shared_ptr<spdlog::logger> m_init_log;
 
+    /// Configuration for obj export
+    Acts::ViewConfig m_containerView{{220, 220, 220}};
+    Acts::ViewConfig m_volumeView{{220, 220, 0}};
+    Acts::ViewConfig m_sensitiveView{{0, 180, 240}};
+    Acts::ViewConfig m_passiveView{{240, 280, 0}};
+    Acts::ViewConfig m_gridView{{220, 0, 0}};
+    bool m_objWriteIt{false};
+    bool m_plyWriteIt{false};
+    std::string m_outputTag{""};
+    std::string m_outputDir{""};
+
+public:
+    void setObjWriteIt(bool writeit) { m_objWriteIt = writeit; }
+    bool getObjWriteIt() const { return m_objWriteIt; }
+    void setPlyWriteIt(bool writeit) { m_plyWriteIt = writeit; }
+    bool getPlyWriteIt() const { return m_plyWriteIt; }
+
+    void setOutputTag(std::string tag) { m_outputTag = tag; }
+    std::string getOutputTag() const { return m_outputTag; }
+    void setOutputDir(std::string dir) { m_outputDir = dir; }
+    std::string getOutputDir() const { return m_outputDir; }
+
+    void setContainerView(std::array<int,3> view) { m_containerView = Acts::ViewConfig{view}; }
+    const Acts::ViewConfig& getContainerView() const { return m_containerView; }
+    void setVolumeView(std::array<int,3> view) { m_volumeView = Acts::ViewConfig{view}; }
+    const Acts::ViewConfig& getVolumeView() const { return m_volumeView; }
+    void setSensitiveView(std::array<int,3> view) { m_sensitiveView = Acts::ViewConfig{view}; }
+    const Acts::ViewConfig& getSensitiveView() const { return m_sensitiveView; }
+    void setPassiveView(std::array<int,3> view) { m_passiveView = Acts::ViewConfig{view}; }
+    const Acts::ViewConfig& getPassiveView() const { return m_passiveView; }
+    void setGridView(std::array<int,3> view) { m_gridView = Acts::ViewConfig{view}; }
+    const Acts::ViewConfig& getGridView() const { return m_gridView; }
+
 };

--- a/src/algorithms/tracking/ActsGeometryProvider.h
+++ b/src/algorithms/tracking/ActsGeometryProvider.h
@@ -10,12 +10,14 @@
 #include <Acts/MagneticField/MagneticFieldProvider.hpp>
 #include <Acts/Surfaces/Surface.hpp>
 #include <Acts/Utilities/Logger.hpp>
+#include <Acts/Visualization/ViewConfig.hpp>
 #include <DD4hep/Detector.h>
 #include <DD4hep/Fields.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <Math/GenVector/Cartesian3D.h>
 #include <Math/GenVector/DisplacementVector3D.h>
 #include <spdlog/logger.h>
+#include <array>
 #include <cstdint>
 #include <map>
 #include <memory>

--- a/src/algorithms/tracking/ActsGeometryProvider.h
+++ b/src/algorithms/tracking/ActsGeometryProvider.h
@@ -1,12 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2022 Whitney Armstrong, Wouter Deconinck, Dmitry Romanov
-//
-//  ActsGeometryProvider.h
-//
-//
-//  Created by Julia Hrdinka on 30/03/15.
-//
-//
+// Copyright (C) 2015 - 2024 Julia Hrdinka, Whitney Armstrong, Wouter Deconinck, Dmitry Romanov
+
 #pragma once
 
 // ACTS

--- a/src/services/geometry/acts/ACTSGeo_service.cc
+++ b/src/services/geometry/acts/ACTSGeo_service.cc
@@ -53,8 +53,41 @@ std::shared_ptr<const ActsGeometryProvider> ACTSGeo_service::actsGeoProvider() {
             auto tickerEnabled = m_app->IsTickerEnabled();
             m_app->SetTicker(false);
 
-            // Initialize m_acts_provider
+            // Create default m_acts_provider
             m_acts_provider = std::make_shared<ActsGeometryProvider>();
+
+            // Set ActsGeometryProvider parameters
+            bool objWriteIt = m_acts_provider->getObjWriteIt();
+            bool plyWriteIt = m_acts_provider->getPlyWriteIt();
+            m_app->SetDefaultParameter("acts:WriteObj", objWriteIt, "Write tracking geometry as obj files");
+            m_app->SetDefaultParameter("acts:WritePly", plyWriteIt, "Write tracking geometry as ply files");
+            m_acts_provider->setObjWriteIt(objWriteIt);
+            m_acts_provider->setPlyWriteIt(plyWriteIt);
+
+            std::string outputTag = m_acts_provider->getOutputTag();
+            std::string outputDir = m_acts_provider->getOutputDir();
+            m_app->SetDefaultParameter("acts:OutputTag", outputTag, "Obj and ply output file tag");
+            m_app->SetDefaultParameter("acts:OutputDir", outputDir, "Obj and ply output file dir");
+            m_acts_provider->setOutputTag(outputTag);
+            m_acts_provider->setOutputDir(outputDir);
+
+            std::array<int,3> containerView = m_acts_provider->getContainerView().color;
+            std::array<int,3> volumeView = m_acts_provider->getVolumeView().color;
+            std::array<int,3> sensitiveView = m_acts_provider->getSensitiveView().color;
+            std::array<int,3> passiveView = m_acts_provider->getPassiveView().color;
+            std::array<int,3> gridView = m_acts_provider->getGridView().color;
+            m_app->SetDefaultParameter("acts:ContainerView", containerView, "RGB for container views");
+            m_app->SetDefaultParameter("acts:VolumeView", volumeView, "RGB for volume views");
+            m_app->SetDefaultParameter("acts:SensitiveView", sensitiveView, "RGB for sensitive views");
+            m_app->SetDefaultParameter("acts:PassiveView", passiveView, "RGB for passive views");
+            m_app->SetDefaultParameter("acts:GridView", gridView, "RGB for grid views");
+            m_acts_provider->setContainerView(containerView);
+            m_acts_provider->setVolumeView(volumeView);
+            m_acts_provider->setSensitiveView(sensitiveView);
+            m_acts_provider->setPassiveView(passiveView);
+            m_acts_provider->setGridView(gridView);
+
+            // Initialize m_acts_provider
             m_acts_provider->initialize(m_dd4hepGeo, material_map_file, m_log, m_init_log);
 
             // Enable ticker back

--- a/src/services/geometry/acts/ACTSGeo_service.cc
+++ b/src/services/geometry/acts/ACTSGeo_service.cc
@@ -5,9 +5,11 @@
 
 #include "ACTSGeo_service.h"
 
+#include <Acts/Visualization/ViewConfig.hpp>
 #include <JANA/JException.h>
 #include <fmt/core.h>
 #include <fmt/format.h>
+#include <array>
 #include <exception>
 #include <gsl/pointers>
 #include <stdexcept>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Instead of writing our own obj files in `draw_surfaces` (with only support for planar surfaces), this PR converts it to use the Acts support for export to obj and ply files, optionally and with parameter support for coloring etc. Syntax is:
```
eicrecon -Pacts:WriteObj=true -Pacts:WritePly=true -Pacts:OutputDir=$PWD/tracking_geometry
```
where `OutputDir` must exist and defaults to current working directory (because it exists; upstream choice).

To open the obj and ply models, you can use e.g. [meshlab](https://www.meshlab.net). Just import all files at once.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #1330)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, by default `tracking_geometry.obj` will not be written anymore.