### PR TITLE
feat: example of how to use ONNX Runtime (Ort) in algorithms

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -414,7 +414,6 @@ jobs:
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
           export LD_LIBRARY_PATH=$PWD/install/lib:$LD_LIBRARY_PATH
           export JANA_PLUGIN_PATH=$PWD/install/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
-          wget --directory-prefix=calibrations https://github.com/eic/epic-data/raw/812daafabbe7ed7e269f1b20f090de0517b06b9c/onnx/identity_gemm_w1x1_b1.onnx
           $PWD/install/bin/eicrecon -Ppodio:output_include_collections=EventHeader,MCParticles,EcalBarrelScFiRawHits,EcalBarrelImagingRawHits -Ppodio:output_file=two_stage_raw_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -Pplugins=dump_flags,janadot -Pdump_flags:json=${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json -Pjana:warmup_timeout=0 -Pjana:timeout=0
     - name: Upload digitization output
       uses: actions/upload-artifact@v4
@@ -431,7 +430,6 @@ jobs:
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
           export LD_LIBRARY_PATH=$PWD/install/lib:$LD_LIBRARY_PATH
           export JANA_PLUGIN_PATH=$PWD/install/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
-          wget --directory-prefix=calibrations https://github.com/eic/epic-data/raw/812daafabbe7ed7e269f1b20f090de0517b06b9c/onnx/identity_gemm_w1x1_b1.onnx
           $PWD/install/bin/eicrecon -Ppodio:output_include_collections=EcalBarrelClusters,EcalBarrelClusterAssociations -Ppodio:output_file=two_stage_rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root two_stage_raw_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root -Pplugins=dump_flags,janadot -Pdump_flags:json=${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json -Pjana:warmup_timeout=0 -Pjana:timeout=0
     - name: Upload reconstruction output
       uses: actions/upload-artifact@v4
@@ -478,7 +476,6 @@ jobs:
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
           export LD_LIBRARY_PATH=$PWD/install/lib:$LD_LIBRARY_PATH
           export JANA_PLUGIN_PATH=$PWD/install/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
-          wget --directory-prefix=calibrations https://github.com/eic/epic-data/raw/812daafabbe7ed7e269f1b20f090de0517b06b9c/onnx/identity_gemm_w1x1_b1.onnx
           $PWD/install/bin/eicmkplugin.py MyCustomPlugin
           cmake -S MyCustomPlugin -B MyCustomPlugin/build -DEICrecon_ROOT=$PWD/install -DUSER_PLUGIN_OUTPUT_DIRECTORY=$PWD/install/lib/EICrecon/plugins
           cmake --build MyCustomPlugin/build -j $(getconf _NPROCESSORS_ONLN) --target install
@@ -530,7 +527,6 @@ jobs:
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
           export LD_LIBRARY_PATH=$PWD/install/lib:$LD_LIBRARY_PATH
           export JANA_PLUGIN_PATH=$PWD/install/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
-          wget --directory-prefix=calibrations https://github.com/eic/epic-data/raw/812daafabbe7ed7e269f1b20f090de0517b06b9c/onnx/identity_gemm_w1x1_b1.onnx
           $PWD/install/bin/eicrecon -Pplugins=${{ matrix.benchmark_plugins }} -Phistsfile=rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}_${{ matrix.benchmark_plugins }}.hists.root -Ppodio:output_file=rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -Pplugins=dump_flags,janadot -Pdump_flags:json=${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json -Pjana:warmup_timeout=0 -Pjana:timeout=0
     - uses: actions/upload-artifact@v4
       with:
@@ -584,7 +580,6 @@ jobs:
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
           export LD_LIBRARY_PATH=$PWD/install/lib:$LD_LIBRARY_PATH
           export JANA_PLUGIN_PATH=$PWD/install/lib/EICrecon/plugins:/usr/local/plugins
-          wget --directory-prefix=calibrations https://github.com/eic/epic-data/raw/812daafabbe7ed7e269f1b20f090de0517b06b9c/onnx/identity_gemm_w1x1_b1.onnx
           $PWD/install/bin/eicrecon -Ppodio:output_file=rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -Pplugins=dump_flags,janadot,janatop -Pdump_flags:json=${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json -Pjana:warmup_timeout=0 -Pjana:timeout=0
           dot -Tsvg jana.dot > jana.svg
           mv jana.dot rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.dot
@@ -691,7 +686,6 @@ jobs:
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
           export LD_LIBRARY_PATH=$PWD/install/lib:$LD_LIBRARY_PATH
           export JANA_PLUGIN_PATH=$PWD/install/lib/EICrecon/plugins:/usr/local/plugins
-          wget --directory-prefix=calibrations https://github.com/eic/epic-data/raw/812daafabbe7ed7e269f1b20f090de0517b06b9c/onnx/identity_gemm_w1x1_b1.onnx
           $PWD/install/bin/eicrecon -Ppodio:output_file=rec_${{ matrix.particle }}_EcalLumiSpec_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_EcalLumiSpec_${{ matrix.detector_config }}.edm4hep.root -Ppodio:output_include_collections=EcalLumiSpecRawHits,EcalLumiSpecRecHits,EcalLumiSpecClusters,EcalLumiSpecClusterAssociations -PLUMISPECCAL:EcalLumiSpecIslandProtoClusters:splitCluster=1 -Pplugins=dump_flags,janadot,janatop -Pdump_flags:json=${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json -Pjana:warmup_timeout=0 -Pjana:timeout=0
     - uses: actions/upload-artifact@v4
       with:
@@ -751,7 +745,6 @@ jobs:
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
           export LD_LIBRARY_PATH=$PWD/install/lib:$LD_LIBRARY_PATH
           export JANA_PLUGIN_PATH=$PWD/install/lib/EICrecon/plugins:/usr/local/plugins
-          wget --directory-prefix=calibrations https://github.com/eic/epic-data/raw/812daafabbe7ed7e269f1b20f090de0517b06b9c/onnx/identity_gemm_w1x1_b1.onnx
           $PWD/install/bin/eicrecon -Ppodio:output_file=rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root -Pacts:WriteObj=true -Pacts:WritePly=true -Pplugins=janadot,janatop -Pjana:warmup_timeout=0 -Pjana:timeout=0
           dot -Tsvg jana.dot > jana.svg
           mv jana.dot rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.dot

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -414,6 +414,7 @@ jobs:
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
           export LD_LIBRARY_PATH=$PWD/install/lib:$LD_LIBRARY_PATH
           export JANA_PLUGIN_PATH=$PWD/install/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
+          wget --directory-prefix=calibrations https://github.com/eic/epic-data/raw/812daafabbe7ed7e269f1b20f090de0517b06b9c/onnx/identity_gemm_w1x1_b1.onnx
           $PWD/install/bin/eicrecon -Ppodio:output_include_collections=EventHeader,MCParticles,EcalBarrelScFiRawHits,EcalBarrelImagingRawHits -Ppodio:output_file=two_stage_raw_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -Pplugins=dump_flags,janadot -Pdump_flags:json=${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json -Pjana:warmup_timeout=0 -Pjana:timeout=0
     - name: Upload digitization output
       uses: actions/upload-artifact@v4
@@ -430,6 +431,7 @@ jobs:
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
           export LD_LIBRARY_PATH=$PWD/install/lib:$LD_LIBRARY_PATH
           export JANA_PLUGIN_PATH=$PWD/install/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
+          wget --directory-prefix=calibrations https://github.com/eic/epic-data/raw/812daafabbe7ed7e269f1b20f090de0517b06b9c/onnx/identity_gemm_w1x1_b1.onnx
           $PWD/install/bin/eicrecon -Ppodio:output_include_collections=EcalBarrelClusters,EcalBarrelClusterAssociations -Ppodio:output_file=two_stage_rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root two_stage_raw_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root -Pplugins=dump_flags,janadot -Pdump_flags:json=${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json -Pjana:warmup_timeout=0 -Pjana:timeout=0
     - name: Upload reconstruction output
       uses: actions/upload-artifact@v4
@@ -476,6 +478,7 @@ jobs:
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
           export LD_LIBRARY_PATH=$PWD/install/lib:$LD_LIBRARY_PATH
           export JANA_PLUGIN_PATH=$PWD/install/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
+          wget --directory-prefix=calibrations https://github.com/eic/epic-data/raw/812daafabbe7ed7e269f1b20f090de0517b06b9c/onnx/identity_gemm_w1x1_b1.onnx
           $PWD/install/bin/eicmkplugin.py MyCustomPlugin
           cmake -S MyCustomPlugin -B MyCustomPlugin/build -DEICrecon_ROOT=$PWD/install -DUSER_PLUGIN_OUTPUT_DIRECTORY=$PWD/install/lib/EICrecon/plugins
           cmake --build MyCustomPlugin/build -j $(getconf _NPROCESSORS_ONLN) --target install
@@ -527,6 +530,7 @@ jobs:
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
           export LD_LIBRARY_PATH=$PWD/install/lib:$LD_LIBRARY_PATH
           export JANA_PLUGIN_PATH=$PWD/install/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
+          wget --directory-prefix=calibrations https://github.com/eic/epic-data/raw/812daafabbe7ed7e269f1b20f090de0517b06b9c/onnx/identity_gemm_w1x1_b1.onnx
           $PWD/install/bin/eicrecon -Pplugins=${{ matrix.benchmark_plugins }} -Phistsfile=rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}_${{ matrix.benchmark_plugins }}.hists.root -Ppodio:output_file=rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -Pplugins=dump_flags,janadot -Pdump_flags:json=${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json -Pjana:warmup_timeout=0 -Pjana:timeout=0
     - uses: actions/upload-artifact@v4
       with:
@@ -580,6 +584,7 @@ jobs:
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
           export LD_LIBRARY_PATH=$PWD/install/lib:$LD_LIBRARY_PATH
           export JANA_PLUGIN_PATH=$PWD/install/lib/EICrecon/plugins:/usr/local/plugins
+          wget --directory-prefix=calibrations https://github.com/eic/epic-data/raw/812daafabbe7ed7e269f1b20f090de0517b06b9c/onnx/identity_gemm_w1x1_b1.onnx
           $PWD/install/bin/eicrecon -Ppodio:output_file=rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -Pplugins=dump_flags,janadot,janatop -Pdump_flags:json=${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json -Pjana:warmup_timeout=0 -Pjana:timeout=0
           dot -Tsvg jana.dot > jana.svg
           mv jana.dot rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.dot
@@ -686,6 +691,7 @@ jobs:
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
           export LD_LIBRARY_PATH=$PWD/install/lib:$LD_LIBRARY_PATH
           export JANA_PLUGIN_PATH=$PWD/install/lib/EICrecon/plugins:/usr/local/plugins
+          wget --directory-prefix=calibrations https://github.com/eic/epic-data/raw/812daafabbe7ed7e269f1b20f090de0517b06b9c/onnx/identity_gemm_w1x1_b1.onnx
           $PWD/install/bin/eicrecon -Ppodio:output_file=rec_${{ matrix.particle }}_EcalLumiSpec_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_EcalLumiSpec_${{ matrix.detector_config }}.edm4hep.root -Ppodio:output_include_collections=EcalLumiSpecRawHits,EcalLumiSpecRecHits,EcalLumiSpecClusters,EcalLumiSpecClusterAssociations -PLUMISPECCAL:EcalLumiSpecIslandProtoClusters:splitCluster=1 -Pplugins=dump_flags,janadot,janatop -Pdump_flags:json=${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json -Pjana:warmup_timeout=0 -Pjana:timeout=0
     - uses: actions/upload-artifact@v4
       with:
@@ -745,6 +751,7 @@ jobs:
           export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
           export LD_LIBRARY_PATH=$PWD/install/lib:$LD_LIBRARY_PATH
           export JANA_PLUGIN_PATH=$PWD/install/lib/EICrecon/plugins:/usr/local/plugins
+          wget --directory-prefix=calibrations https://github.com/eic/epic-data/raw/812daafabbe7ed7e269f1b20f090de0517b06b9c/onnx/identity_gemm_w1x1_b1.onnx
           $PWD/install/bin/eicrecon -Ppodio:output_file=rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root -Pacts:WriteObj=true -Pacts:WritePly=true -Pplugins=janadot,janatop -Pjana:warmup_timeout=0 -Pjana:timeout=0
           dot -Tsvg jana.dot > jana.svg
           mv jana.dot rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.dot

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,12 @@ if(NOT "cxx_std_${CMAKE_CXX_STANDARD}" IN_LIST ROOT_COMPILE_FEATURES)
   )
 endif()
 
+# ONNX Runtime
+option(USE_ONNX "Compile with ONNX support" ON)
+if (${USE_ONNX})
+    find_package(onnxruntime)
+endif()
+
 # Add CMake additional functionality:
 include(cmake/jana_plugin.cmake) # Add common settings for plugins
 list(APPEND CMAKE_MODULE_PATH ${EICRECON_SOURCE_DIR}/cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,8 +221,8 @@ endif()
 
 # ONNX Runtime
 option(USE_ONNX "Compile with ONNX support" ON)
-if (${USE_ONNX})
-    find_package(onnxruntime)
+if(${USE_ONNX})
+  find_package(onnxruntime)
 endif()
 
 # Add CMake additional functionality:

--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -381,7 +381,7 @@ endmacro()
 macro(plugin_add_onnxruntime _name)
 
     if(NOT onnxruntime_FOUND)
-        find_package(onnxruntime_FOUND)
+        find_package(onnxruntime)
     endif()
 
     # Add libraries

--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -376,3 +376,17 @@ macro(plugin_add_fastjet _name)
   plugin_link_libraries(${PLUGIN_NAME} ${FASTJET_LIBRARIES})
 
 endmacro()
+
+# Adds ONNX Runtime for a plugin
+macro(plugin_add_onnxruntime _name)
+
+    if(NOT onnxruntime_FOUND)
+        find_package(onnxruntime_FOUND)
+    endif()
+
+    # Add libraries
+    plugin_link_libraries(${PLUGIN_NAME}
+        onnxruntime::onnxruntime
+    )
+
+endmacro()

--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -380,13 +380,11 @@ endmacro()
 # Adds ONNX Runtime for a plugin
 macro(plugin_add_onnxruntime _name)
 
-    if(NOT onnxruntime_FOUND)
-        find_package(onnxruntime)
-    endif()
+  if(NOT onnxruntime_FOUND)
+    find_package(onnxruntime)
+  endif()
 
-    # Add libraries
-    plugin_link_libraries(${PLUGIN_NAME}
-        onnxruntime::onnxruntime
-    )
+  # Add libraries
+  plugin_link_libraries(${PLUGIN_NAME} onnxruntime::onnxruntime)
 
 endmacro()

--- a/src/algorithms/CMakeLists.txt
+++ b/src/algorithms/CMakeLists.txt
@@ -9,5 +9,5 @@ add_subdirectory(reco)
 add_subdirectory(fardetectors)
 
 if(USE_ONNX)
-    add_subdirectory(onnx)
+  add_subdirectory(onnx)
 endif()

--- a/src/algorithms/CMakeLists.txt
+++ b/src/algorithms/CMakeLists.txt
@@ -7,3 +7,7 @@ add_subdirectory(pid)
 add_subdirectory(digi)
 add_subdirectory(reco)
 add_subdirectory(fardetectors)
+
+if(USE_ONNX)
+    add_subdirectory(onnx)
+endif()

--- a/src/algorithms/onnx/CMakeLists.txt
+++ b/src/algorithms/onnx/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.16)
+
+set(PLUGIN_NAME "algorithms_onnx")
+
+# Function creates ${PLUGIN_NAME}_plugin and ${PLUGIN_NAME}_library targets
+# Setting default includes, libraries and installation paths
+plugin_add(${PLUGIN_NAME} WITH_SHARED_LIBRARY WITHOUT_PLUGIN)
+
+# The macro grabs sources as *.cc *.cpp *.c and headers as *.h *.hh *.hpp
+# Then correctly sets sources for ${_name}_plugin and ${_name}_library targets
+# Adds headers to the correct installation directory
+plugin_glob_all(${PLUGIN_NAME})
+
+# Find dependencies
+plugin_add_event_model(${PLUGIN_NAME})
+plugin_add_onnxruntime(${PLUGIN_NAME})
+
+# The macro grabs sources as *.cc *.cpp *.c and headers as *.h *.hh *.hpp
+# Then correctly sets sources for ${_name}_plugin and ${_name}_library targets
+# Adds headers to the correct installation directory
+plugin_glob_all(${PLUGIN_NAME})

--- a/src/algorithms/onnx/CMakeLists.txt
+++ b/src/algorithms/onnx/CMakeLists.txt
@@ -6,16 +6,16 @@ set(PLUGIN_NAME "algorithms_onnx")
 # Setting default includes, libraries and installation paths
 plugin_add(${PLUGIN_NAME} WITH_SHARED_LIBRARY WITHOUT_PLUGIN)
 
-# The macro grabs sources as *.cc *.cpp *.c and headers as *.h *.hh *.hpp
-# Then correctly sets sources for ${_name}_plugin and ${_name}_library targets
-# Adds headers to the correct installation directory
+# The macro grabs sources as *.cc *.cpp *.c and headers as *.h *.hh *.hpp Then
+# correctly sets sources for ${_name}_plugin and ${_name}_library targets Adds
+# headers to the correct installation directory
 plugin_glob_all(${PLUGIN_NAME})
 
 # Find dependencies
 plugin_add_event_model(${PLUGIN_NAME})
 plugin_add_onnxruntime(${PLUGIN_NAME})
 
-# The macro grabs sources as *.cc *.cpp *.c and headers as *.h *.hh *.hpp
-# Then correctly sets sources for ${_name}_plugin and ${_name}_library targets
-# Adds headers to the correct installation directory
+# The macro grabs sources as *.cc *.cpp *.c and headers as *.h *.hh *.hpp Then
+# correctly sets sources for ${_name}_plugin and ${_name}_library targets Adds
+# headers to the correct installation directory
 plugin_glob_all(${PLUGIN_NAME})

--- a/src/algorithms/onnx/InclusiveKinematicsML.cc
+++ b/src/algorithms/onnx/InclusiveKinematicsML.cc
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022, 2023 Wouter Deconinck, Tooba Ali
 
-#include <assert.h>
 #include <fmt/core.h>
 #include <onnxruntime_c_api.h>
 #include <onnxruntime_cxx_api.h>

--- a/src/algorithms/onnx/InclusiveKinematicsML.cc
+++ b/src/algorithms/onnx/InclusiveKinematicsML.cc
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2022, 2023 Wouter Deconinck, Tooba Ali
+
+#include <edm4eic/InclusiveKinematicsCollection.h>
+#include <fmt/core.h>
+#include <podio/ObjectID.h>
+#include <cmath>
+#include <gsl/pointers>
+#include <onnxruntime_cxx_api.h>
+#include <vector>
+
+#include "InclusiveKinematicsML.h"
+
+namespace eicrecon {
+
+  void InclusiveKinematicsML::init(std::shared_ptr<spdlog::logger>& logger) {
+  }
+
+  void InclusiveKinematicsML::process(
+      const InclusiveKinematicsML::Input& input,
+      const InclusiveKinematicsML::Output& output) const {
+
+    const auto [electron, da] = input;
+    auto [ml] = output;
+
+    const auto& api = Ort::GetApi();
+
+    Ort::Session session(nullptr);
+  }
+
+} // namespace eicrecon

--- a/src/algorithms/onnx/InclusiveKinematicsML.cc
+++ b/src/algorithms/onnx/InclusiveKinematicsML.cc
@@ -1,13 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022, 2023 Wouter Deconinck, Tooba Ali
 
-#include <edm4eic/InclusiveKinematicsCollection.h>
-#include <fmt/core.h>
-#include <podio/ObjectID.h>
-#include <cmath>
-#include <gsl/pointers>
 #include <onnxruntime_cxx_api.h>
-#include <vector>
 
 #include "InclusiveKinematicsML.h"
 

--- a/src/algorithms/onnx/InclusiveKinematicsML.cc
+++ b/src/algorithms/onnx/InclusiveKinematicsML.cc
@@ -7,7 +7,58 @@
 
 namespace eicrecon {
 
+  static std::string print_shape(const std::vector<std::int64_t>& v) {
+    std::stringstream ss("");
+    for (std::size_t i = 0; i < v.size() - 1; i++) ss << v[i] << "x";
+    ss << v[v.size() - 1];
+    return ss.str();
+  }
+
+  template <typename T>
+  Ort::Value vec_to_tensor(std::vector<T>& data, const std::vector<std::int64_t>& shape) {
+    Ort::MemoryInfo mem_info =
+        Ort::MemoryInfo::CreateCpu(OrtAllocatorType::OrtArenaAllocator, OrtMemType::OrtMemTypeDefault);
+    auto tensor = Ort::Value::CreateTensor<T>(mem_info, data.data(), data.size(), shape.data(), shape.size());
+    return tensor;
+  }
+
   void InclusiveKinematicsML::init(std::shared_ptr<spdlog::logger>& logger) {
+    m_log = logger;
+
+    // onnxruntime setup
+    Ort::Env env(ORT_LOGGING_LEVEL_VERBOSE, "inclusive-kinematics-ml");
+    Ort::SessionOptions session_options;
+    try {
+      m_session = Ort::Session(env, m_cfg.modelPath.c_str(), session_options);
+
+      // print name/shape of inputs
+      Ort::AllocatorWithDefaultOptions allocator;
+      m_log->debug("Input Node Name/Shape:");
+      for (std::size_t i = 0; i < m_session.GetInputCount(); i++) {
+        m_input_names.emplace_back(m_session.GetInputNameAllocated(i, allocator).get());
+        m_input_shapes.emplace_back(m_session.GetInputTypeInfo(i).GetTensorTypeAndShapeInfo().GetShape());
+        m_log->debug("\t{} : {}", m_input_names.at(i), print_shape(m_input_shapes.at(i)));
+      }
+
+      // print name/shape of outputs
+      m_log->debug("Output Node Name/Shape:");
+      for (std::size_t i = 0; i < m_session.GetOutputCount(); i++) {
+        m_output_names.emplace_back(m_session.GetOutputNameAllocated(i, allocator).get());
+        m_output_shapes.emplace_back(m_session.GetOutputTypeInfo(i).GetTensorTypeAndShapeInfo().GetShape());
+        m_log->debug("\t{} : {}", m_output_names.at(i), print_shape(m_output_shapes.at(i)));
+      }
+
+      // convert names to char*
+      m_input_names_char.resize(m_input_names.size(), nullptr);
+      std::transform(std::begin(m_input_names), std::end(m_input_names), std::begin(m_input_names_char),
+                     [&](const std::string& str) { return str.c_str(); });
+      m_output_names_char.resize(m_output_names.size(), nullptr);
+      std::transform(std::begin(m_output_names), std::end(m_output_names), std::begin(m_output_names_char),
+                     [&](const std::string& str) { return str.c_str(); });
+
+    } catch(std::exception& e) {
+      m_log->error(e.what());
+    }
   }
 
   void InclusiveKinematicsML::process(
@@ -17,9 +68,37 @@ namespace eicrecon {
     const auto [electron, da] = input;
     auto [ml] = output;
 
-    const auto& api = Ort::GetApi();
+    // Assume model has 1 input nodes and 1 output node.
+    assert(m_input_names.size() == 1 && m_output_names.size() == 1);
 
-    Ort::Session session(nullptr);
+    // Prepare input tensor
+    std::vector<float> input_tensor_values;
+    std::vector<Ort::Value> input_tensors;
+    for (std::size_t i = 0; i < electron->size(); i++) {
+      input_tensor_values.push_back(electron->at(i).getX());
+    }
+    input_tensors.emplace_back(vec_to_tensor<float>(input_tensor_values, m_input_shapes.front()));
+
+    // Double-check the dimensions of the input tensor
+    assert(input_tensors[0].IsTensor() && input_tensors[0].GetTensorTypeAndShapeInfo().GetShape() == m_input_shapes.front());
+
+    // Attempt inference
+    try {
+      auto output_tensors = m_session.Run(Ort::RunOptions{nullptr}, m_input_names_char.data(), input_tensors.data(),
+                                          m_input_names_char.size(), m_output_names_char.data(), m_output_names_char.size());
+
+      // Double-check the dimensions of the output tensors
+      assert(output_tensors.size() == m_output_names.size() && output_tensors[0].IsTensor());
+
+      // Convert output tensor
+      float* output_tensor_data = output_tensors[0].GetTensorMutableData<float>();
+      auto x  = output_tensor_data[0];
+      auto kin = ml->create();
+      kin.setX(x);
+
+    } catch (const Ort::Exception& exception) {
+      m_log->error("error running model inference: {}", exception.what());
+    }
   }
 
 } // namespace eicrecon

--- a/src/algorithms/onnx/InclusiveKinematicsML.cc
+++ b/src/algorithms/onnx/InclusiveKinematicsML.cc
@@ -1,7 +1,16 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022, 2023 Wouter Deconinck, Tooba Ali
 
+#include <assert.h>
+#include <fmt/core.h>
+#include <onnxruntime_c_api.h>
 #include <onnxruntime_cxx_api.h>
+#include <algorithm>
+#include <cstddef>
+#include <exception>
+#include <gsl/pointers>
+#include <iterator>
+#include <ostream>
 
 #include "InclusiveKinematicsML.h"
 

--- a/src/algorithms/onnx/InclusiveKinematicsML.cc
+++ b/src/algorithms/onnx/InclusiveKinematicsML.cc
@@ -35,7 +35,7 @@ namespace eicrecon {
     m_log = logger;
 
     // onnxruntime setup
-    Ort::Env env(ORT_LOGGING_LEVEL_VERBOSE, "inclusive-kinematics-ml");
+    Ort::Env env(ORT_LOGGING_LEVEL_WARNING, "inclusive-kinematics-ml");
     Ort::SessionOptions session_options;
     try {
       m_session = Ort::Session(env, m_cfg.modelPath.c_str(), session_options);

--- a/src/algorithms/onnx/InclusiveKinematicsML.cc
+++ b/src/algorithms/onnx/InclusiveKinematicsML.cc
@@ -68,6 +68,9 @@ namespace eicrecon {
     const auto [electron, da] = input;
     auto [ml] = output;
 
+    // Require valid inputs
+    if (electron->size() == 0 || da->size() == 0) return;
+
     // Assume model has 1 input nodes and 1 output node.
     assert(m_input_names.size() == 1 && m_output_names.size() == 1);
 

--- a/src/algorithms/onnx/InclusiveKinematicsML.h
+++ b/src/algorithms/onnx/InclusiveKinematicsML.h
@@ -32,7 +32,7 @@ namespace eicrecon {
                             {"inclusiveKinematicsML"},
                             "Determine inclusive kinematics using combined ML method."} {}
 
-    void init(std::shared_ptr<spdlog::logger>& logger); 
+    void init(std::shared_ptr<spdlog::logger>& logger);
     void process(const Input&, const Output&) const final;
 
   private:

--- a/src/algorithms/onnx/InclusiveKinematicsML.h
+++ b/src/algorithms/onnx/InclusiveKinematicsML.h
@@ -42,6 +42,17 @@ namespace eicrecon {
 
   private:
     std::shared_ptr<spdlog::logger> m_log;
+
+    mutable Ort::Session m_session{nullptr};
+
+    std::vector<std::string> m_input_names;
+    std::vector<const char*> m_input_names_char;
+    std::vector<std::vector<std::int64_t>> m_input_shapes;
+
+    std::vector<std::string> m_output_names;
+    std::vector<const char*> m_output_names_char;
+    std::vector<std::vector<std::int64_t>> m_output_shapes;
+
   };
 
 } // namespace eicrecon

--- a/src/algorithms/onnx/InclusiveKinematicsML.h
+++ b/src/algorithms/onnx/InclusiveKinematicsML.h
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2022, 2023 Sylvester Joosten, Dmitry Romanov, Wouter Deconinck
+
+#pragma once
+
+#include <algorithms/algorithm.h>
+#include <edm4eic/InclusiveKinematicsCollection.h>
+#include <spdlog/logger.h>
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace eicrecon {
+
+  using InclusiveKinematicsMLAlgorithm = algorithms::Algorithm<
+    algorithms::Input<
+      edm4eic::InclusiveKinematicsCollection,
+      edm4eic::InclusiveKinematicsCollection
+    >,
+    algorithms::Output<
+      edm4eic::InclusiveKinematicsCollection
+    >
+  >;
+
+  class InclusiveKinematicsML
+  : public InclusiveKinematicsMLAlgorithm {
+
+  public:
+    InclusiveKinematicsML(std::string_view name)
+      : InclusiveKinematicsMLAlgorithm{name,
+                            {"inclusiveKinematicsElectron", "inclusiveKinematicsDA"},
+                            {"inclusiveKinematicsML"},
+                            "Determine inclusive kinematics using combined ML method."} {}
+
+    void init(std::shared_ptr<spdlog::logger>& logger); 
+    void process(const Input&, const Output&) const final;
+
+  private:
+    std::shared_ptr<spdlog::logger> m_log;
+  };
+
+} // namespace eicrecon

--- a/src/algorithms/onnx/InclusiveKinematicsML.h
+++ b/src/algorithms/onnx/InclusiveKinematicsML.h
@@ -7,8 +7,12 @@
 #include <edm4eic/InclusiveKinematicsCollection.h>
 #include <spdlog/logger.h>
 #include <memory>
+#include <onnxruntime_cxx_api.h>
 #include <string>
 #include <string_view>
+
+#include "algorithms/interfaces/WithPodConfig.h"
+#include "algorithms/onnx/InclusiveKinematicsMLConfig.h"
 
 namespace eicrecon {
 
@@ -23,7 +27,8 @@ namespace eicrecon {
   >;
 
   class InclusiveKinematicsML
-  : public InclusiveKinematicsMLAlgorithm {
+  : public InclusiveKinematicsMLAlgorithm,
+    public WithPodConfig<InclusiveKinematicsMLConfig> {
 
   public:
     InclusiveKinematicsML(std::string_view name)

--- a/src/algorithms/onnx/InclusiveKinematicsML.h
+++ b/src/algorithms/onnx/InclusiveKinematicsML.h
@@ -5,11 +5,13 @@
 
 #include <algorithms/algorithm.h>
 #include <edm4eic/InclusiveKinematicsCollection.h>
-#include <spdlog/logger.h>
-#include <memory>
 #include <onnxruntime_cxx_api.h>
+#include <spdlog/logger.h>
+#include <cstdint>
+#include <memory>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "algorithms/interfaces/WithPodConfig.h"
 #include "algorithms/onnx/InclusiveKinematicsMLConfig.h"

--- a/src/algorithms/onnx/InclusiveKinematicsMLConfig.h
+++ b/src/algorithms/onnx/InclusiveKinematicsMLConfig.h
@@ -9,7 +9,7 @@ namespace eicrecon {
 
   struct InclusiveKinematicsMLConfig {
 
-    std::string modelPath{"calibrations/identity_gemm_w1x1_b1.onnx"};
+    std::string modelPath{"calibrations/onnx/identity_gemm_w1x1_b1.onnx"};
 
   };
 

--- a/src/algorithms/onnx/InclusiveKinematicsMLConfig.h
+++ b/src/algorithms/onnx/InclusiveKinematicsMLConfig.h
@@ -9,7 +9,7 @@ namespace eicrecon {
 
   struct InclusiveKinematicsMLConfig {
 
-    std::string modelPath{""};
+    std::string modelPath{"calibrations/identity_gemm_w1x1_b1.onnx"};
 
   };
 

--- a/src/algorithms/onnx/InclusiveKinematicsMLConfig.h
+++ b/src/algorithms/onnx/InclusiveKinematicsMLConfig.h
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2024 Wouter Deconinck
+
+#pragma once
+
+#include <string>
+
+namespace eicrecon {
+
+  struct InclusiveKinematicsMLConfig {
+
+    std::string modelPath{""};
+
+  };
+
+} // eicrecon

--- a/src/factories/reco/InclusiveKinematicsML_factory.h
+++ b/src/factories/reco/InclusiveKinematicsML_factory.h
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2022 Wouter Deconinck
+
+#pragma once
+
+#include <JANA/JEvent.h>
+#include <edm4eic/InclusiveKinematicsCollection.h>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "algorithms/onnx/InclusiveKinematicsML.h"
+#include "extensions/jana/JOmniFactory.h"
+
+namespace eicrecon {
+
+class InclusiveKinematicsML_factory :
+        public JOmniFactory<InclusiveKinematicsML_factory, InclusiveKinematicsMLConfig> {
+
+public:
+    using AlgoT = eicrecon::InclusiveKinematicsML;
+private:
+    std::unique_ptr<AlgoT> m_algo;
+
+    PodioInput<edm4eic::InclusiveKinematics> m_inclusive_kinematics_electron_input {this};
+    PodioInput<edm4eic::InclusiveKinematics> m_inclusive_kinematics_da_input {this};
+    PodioOutput<edm4eic::InclusiveKinematics> m_inclusive_kinematics_output {this};
+
+    ParameterRef<std::string> m_modelPath {this, "modelPath", config().modelPath};
+
+public:
+    void Configure() {
+        m_algo = std::make_unique<AlgoT>(GetPrefix());
+        m_algo->applyConfig(config());
+        m_algo->init(logger());
+    }
+
+    void ChangeRun(int64_t run_number) {
+    }
+
+    void Process(int64_t run_number, uint64_t event_number) {
+        m_algo->process({m_inclusive_kinematics_electron_input(), m_inclusive_kinematics_da_input()}, {m_inclusive_kinematics_output().get()});
+    }
+};
+
+} // eicrecon

--- a/src/global/reco/CMakeLists.txt
+++ b/src/global/reco/CMakeLists.txt
@@ -27,4 +27,4 @@ plugin_glob_all(${PLUGIN_NAME})
 # Add libraries (same as target_include_directories but for both plugin and
 # library)
 plugin_link_libraries(${PLUGIN_NAME} algorithms_digi_library
-                      algorithms_tracking_library algorithms_reco_library)
+                      algorithms_tracking_library algorithms_onnx_library algorithms_reco_library)

--- a/src/global/reco/CMakeLists.txt
+++ b/src/global/reco/CMakeLists.txt
@@ -26,5 +26,6 @@ plugin_glob_all(${PLUGIN_NAME})
 
 # Add libraries (same as target_include_directories but for both plugin and
 # library)
-plugin_link_libraries(${PLUGIN_NAME} algorithms_digi_library
-                      algorithms_tracking_library algorithms_onnx_library algorithms_reco_library)
+plugin_link_libraries(
+  ${PLUGIN_NAME} algorithms_digi_library algorithms_tracking_library
+  algorithms_onnx_library algorithms_reco_library)

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -11,7 +11,7 @@
 #include <map>
 #include <memory>
 
-#include "algorithms/onnx/InclusiveKinematicsML.h"
+#include "algorithms/interfaces/WithPodConfig.h"
 #include "algorithms/reco/InclusiveKinematicsDA.h"
 #include "algorithms/reco/InclusiveKinematicsElectron.h"
 #include "algorithms/reco/InclusiveKinematicsJB.h"

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -11,6 +11,7 @@
 #include <map>
 #include <memory>
 
+#include "algorithms/onnx/InclusiveKinematicsML.h"
 #include "algorithms/reco/InclusiveKinematicsDA.h"
 #include "algorithms/reco/InclusiveKinematicsElectron.h"
 #include "algorithms/reco/InclusiveKinematicsJB.h"
@@ -18,6 +19,7 @@
 #include "algorithms/reco/InclusiveKinematicseSigma.h"
 #include "extensions/jana/JOmniFactoryGeneratorT.h"
 #include "factories/meta/CollectionCollector_factory.h"
+#include "factories/reco/InclusiveKinematicsML_factory.h"
 #include "factories/reco/InclusiveKinematicsReconstructed_factory.h"
 #include "factories/reco/InclusiveKinematicsTruth_factory.h"
 #include "factories/reco/JetReconstruction_factory.h"
@@ -151,6 +153,18 @@ void InitPlugin(JApplication *app) {
         },
         {
           "InclusiveKinematicsSigma"
+        },
+        app
+    ));
+
+    app->Add(new JOmniFactoryGeneratorT<InclusiveKinematicsML_factory>(
+        "InclusiveKinematicsML",
+        {
+          "InclusiveKinematicsElectron",
+          "InclusiveKinematicsDA"
+        },
+        {
+          "InclusiveKinematicsML"
         },
         app
     ));

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -136,6 +136,7 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "CentralCKFSeededTrackParameters",
             "InclusiveKinematicsDA",
             "InclusiveKinematicsJB",
+            "InclusiveKinematicsML",
             "InclusiveKinematicsSigma",
             "InclusiveKinematicseSigma",
             "InclusiveKinematicsElectron",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds the hooks for ONNX Runtime (CPU only) for fast inference, and an example that doesn't actually do anything except... Enabled by default but not actually doing anything.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: use ONNX for ML)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @rahmans1 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.