### PR TITLE
release.yml: implement a catch-all category

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -30,3 +30,6 @@ changelog:
     - title: 🐛 Bugs fixed
       labels:
         - 'bug'
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -32,4 +32,4 @@ changelog:
         - 'bug'
     - title: Other Changes
       labels:
-        - "*"
+        - '*'

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -30,6 +30,6 @@ changelog:
     - title: 🐛 Bugs fixed
       labels:
         - 'bug'
-    - title: Other Changes
+    - title: 🔩 Other Changes
       labels:
         - '*'


### PR DESCRIPTION
Without this, the generated release notes ignore contributions that don't belong to any of the tags specified.