### PR TITLE
linux-eic-shell.yml: run newer version of IWYU from Ubuntu instead of eic-shell

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -132,7 +132,59 @@ jobs:
         path: build.tar.zst
         if-no-files-found: error
 
-  clang-tidy-iwyu:
+  include-what-you-use:
+    name: include-what-you-use (IWYU)
+    runs-on: ubuntu-latest
+    needs: build
+    container:
+      # provides IWYU 8.21
+      image: ubuntu:24.04
+      volumes:
+      - /home/runner:/home/runner
+    steps:
+    - run: apt update && apt install -y clang-tidy git iwyu zstd
+    - run: echo "FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: ${{ env.FETCH_DEPTH }}
+    - name: Workaround file ownership guard
+      run: git config --global --add safe.directory "$PWD"
+    - name: Download build artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: build-${{ env.clang-tidy-iwyu-CC }}-eic-shell-${{ env.clang-tidy-iwyu-CMAKE_BUILD_TYPE }}
+        path: .
+    - name: Uncompress build artifact
+      run: tar -xaf build.tar.zst
+    - name: Run include-what-you-use (iwyu) on changed files
+      if: ${{ github.event_name == 'pull_request' }}
+      run: |
+        # reduce headers until diff is stable
+        while [[ ${sha:-} != $(git diff | sha256sum) ]] ; do
+          sha=$(git diff | sha256sum)
+          echo $sha
+          iwyu_tool -p build $(git diff --name-only ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }}) -- -Xiwyu --verbose=3 -Xiwyu --no_fwd_decls -Xiwyu --cxx17ns -Xiwyu --mapping_file=${{github.workspace}}/.github/iwyu.imp -Xiwyu --regex=ecmascript | tee iwyu_fixes.log
+          fix_include --blank_lines --nosafe_headers --reorder --separate_project_includes="<tld>" --keep_iwyu_namespace_format < iwyu_fixes.log
+          git diff | tee iwyu_fixes.patch
+        done
+    - name: Run include-what-you-use (iwyu) on all files
+      if: ${{ github.event_name == 'push' }}
+      run: |
+        # don't aim for stability for all files
+        iwyu_tool -p build -- -Xiwyu --verbose=3 -Xiwyu --no_fwd_decls -Xiwyu --cxx17ns -Xiwyu --mapping_file=${{github.workspace}}/.github/iwyu.imp -Xiwyu --regex=ecmascript | tee iwyu_fixes.log
+        fix_include --blank_lines --nosafe_headers --reorder --separate_project_includes="<tld>" --keep_iwyu_namespace_format < iwyu_fixes.log
+        git diff | tee iwyu_fixes.patch
+    - name: Upload iwyu patch as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: iwyu_fixes.patch
+        path: iwyu_fixes.patch
+        if-no-files-found: ignore # no file is good
+    - name: Fail when iwyu provided a patch for this pull request
+      if: ${{ github.event_name == 'pull_request' }}
+      run: git diff --exit-code
+
+  clang-tidy:
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -154,7 +206,7 @@ jobs:
       with:
         platform-release: "${{ env.platform-release }}"
         run: |
-          git diff ${{github.event.pull_request.base.sha}} ${{ github.event.pull_request.base.sha }} | clang-tidy-diff -p 1 -path build -quiet -export-fixes clang_tidy_fixes.yml -extra-arg='-std=c++20' -checks='-*,bugprone-*,-bugprone-narrowing-conversions' -clang-tidy-binary run-clang-tidy
+          git diff ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }} | clang-tidy-diff -p 1 -path build -quiet -export-fixes clang_tidy_fixes.yml -extra-arg='-std=c++20' -checks='-*,bugprone-*,-bugprone-narrowing-conversions' -clang-tidy-binary run-clang-tidy
     - name: Run clang-tidy on all files
       uses: eic/run-cvmfs-osg-eic-shell@main
       if: ${{ github.event_name == 'push' }}
@@ -176,34 +228,6 @@ jobs:
         clang_tidy_fixes: clang_tidy_fixes.yml
         request_changes: true
         suggestions_per_comment: 10
-    - run: sudo apt-get install -y iwyu
-    - name: Run include-what-you-use (iwyu) on changed files
-      if: ${{ github.event_name == 'pull_request' }}
-      run: |
-        # reduce headers until diff is stable
-        while [[ ${sha:-} != $(git diff | sha256sum) ]] ; do
-          sha=$(git diff | sha256sum)
-          echo $sha
-          iwyu_tool -p build $(git diff --name-only ${{github.event.pull_request.head.sha}} ${{ github.event.pull_request.base.sha }}) -- -Xiwyu --verbose=3 -Xiwyu --no_fwd_decls -Xiwyu --cxx17ns -Xiwyu --mapping_file=${{github.workspace}}/.github/iwyu.imp -Xiwyu --regex=ecmascript | tee iwyu_fixes.log
-          fix_include --blank_lines --nosafe_headers --reorder --separate_project_includes="<tld>" --keep_iwyu_namespace_format < iwyu_fixes.log
-          git diff | tee iwyu_fixes.patch
-        done
-    - name: Run include-what-you-use (iwyu) on all files
-      if: ${{ github.event_name == 'push' }}
-      run: |
-        # don't aim for stability for all files
-        iwyu_tool -p build -- -Xiwyu --verbose=3 -Xiwyu --no_fwd_decls -Xiwyu --cxx17ns -Xiwyu --mapping_file=${{github.workspace}}/.github/iwyu.imp -Xiwyu --regex=ecmascript | tee iwyu_fixes.log
-        fix_include --blank_lines --nosafe_headers --reorder --separate_project_includes="<tld>" --keep_iwyu_namespace_format < iwyu_fixes.log
-        git diff | tee iwyu_fixes.patch
-    - name: Upload iwyu patch as artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: iwyu_fixes.patch
-        path: iwyu_fixes.patch
-        if-no-files-found: ignore # no file is good
-    - name: Fail when iwyu provided a patch for this pull request
-      if: ${{ github.event_name == 'pull_request' }}
-      run: git diff --exit-code
 
   llvm-cov:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -176,30 +176,25 @@ jobs:
         clang_tidy_fixes: clang_tidy_fixes.yml
         request_changes: true
         suggestions_per_comment: 10
+    - run: sudo apt-get install -y iwyu
     - name: Run include-what-you-use (iwyu) on changed files
-      uses: eic/run-cvmfs-osg-eic-shell@main
       if: ${{ github.event_name == 'pull_request' }}
-      with:
-        platform-release: "${{ env.platform-release }}"
-        run: |
-          # reduce headers until diff is stable
-          while [[ ${sha:-} != $(git diff | sha256sum) ]] ; do
-            sha=$(git diff | sha256sum)
-            echo $sha
-            iwyu_tool.py -p build $(git diff --name-only ${{github.event.pull_request.head.sha}} ${{ github.event.pull_request.base.sha }}) -- -Xiwyu --verbose=3 -Xiwyu --no_fwd_decls -Xiwyu --cxx17ns -Xiwyu --mapping_file=${{github.workspace}}/.github/iwyu.imp -Xiwyu --regex=ecmascript | tee iwyu_fixes.log
-            fix_includes.py --blank_lines --nosafe_headers --reorder --separate_project_includes="<tld>" --keep_iwyu_namespace_format < iwyu_fixes.log
-            git diff | tee iwyu_fixes.patch
-          done
-    - name: Run include-what-you-use (iwyu) on all files
-      uses: eic/run-cvmfs-osg-eic-shell@main
-      if: ${{ github.event_name == 'push' }}
-      with:
-        platform-release: "${{ env.platform-release }}"
-        run: |
-          # don't aim for stability for all files
-          iwyu_tool.py -p build -- -Xiwyu --verbose=3 -Xiwyu --no_fwd_decls -Xiwyu --cxx17ns -Xiwyu --mapping_file=${{github.workspace}}/.github/iwyu.imp -Xiwyu --regex=ecmascript | tee iwyu_fixes.log
-          fix_includes.py --blank_lines --nosafe_headers --reorder --separate_project_includes="<tld>" --keep_iwyu_namespace_format < iwyu_fixes.log
+      run: |
+        # reduce headers until diff is stable
+        while [[ ${sha:-} != $(git diff | sha256sum) ]] ; do
+          sha=$(git diff | sha256sum)
+          echo $sha
+          iwyu_tool -p build $(git diff --name-only ${{github.event.pull_request.head.sha}} ${{ github.event.pull_request.base.sha }}) -- -Xiwyu --verbose=3 -Xiwyu --no_fwd_decls -Xiwyu --cxx17ns -Xiwyu --mapping_file=${{github.workspace}}/.github/iwyu.imp -Xiwyu --regex=ecmascript | tee iwyu_fixes.log
+          fix_include --blank_lines --nosafe_headers --reorder --separate_project_includes="<tld>" --keep_iwyu_namespace_format < iwyu_fixes.log
           git diff | tee iwyu_fixes.patch
+        done
+    - name: Run include-what-you-use (iwyu) on all files
+      if: ${{ github.event_name == 'push' }}
+      run: |
+        # don't aim for stability for all files
+        iwyu_tool -p build -- -Xiwyu --verbose=3 -Xiwyu --no_fwd_decls -Xiwyu --cxx17ns -Xiwyu --mapping_file=${{github.workspace}}/.github/iwyu.imp -Xiwyu --regex=ecmascript | tee iwyu_fixes.log
+        fix_include --blank_lines --nosafe_headers --reorder --separate_project_includes="<tld>" --keep_iwyu_namespace_format < iwyu_fixes.log
+        git diff | tee iwyu_fixes.patch
     - name: Upload iwyu patch as artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -221,7 +221,7 @@ jobs:
         path: clang_tidy_fixes.yml
         if-no-files-found: ignore
     - name: Suggest clang-tidy fixes as PR comments
-      uses: platisd/clang-tidy-pr-comments@v1.4.4
+      uses: platisd/clang-tidy-pr-comments@v1.4.0
       if: ${{ github.event_name == 'pull_request' }}
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -221,7 +221,7 @@ jobs:
         path: clang_tidy_fixes.yml
         if-no-files-found: ignore
     - name: Suggest clang-tidy fixes as PR comments
-      uses: platisd/clang-tidy-pr-comments@v1.5.0
+      uses: platisd/clang-tidy-pr-comments@v1.4.4
       if: ${{ github.event_name == 'pull_request' }}
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -41,7 +41,7 @@ extern "C" {
         // check if sector field is present
         bool useSectorIndex = false;
         try {
-          auto sector = descriptor.field("sector");
+          auto sector =  descriptor.field("sector");
           return true;
         } catch(const std::runtime_error &e) {
           return false;

--- a/src/utilities/eicrecon/eicrecon_cli.cpp
+++ b/src/utilities/eicrecon/eicrecon_cli.cpp
@@ -57,7 +57,6 @@ namespace jana {
     }
 
     void PrintUsageExample() {
-
         std::cout << "Example:" << std::endl;
         std::cout << "    eicrecon -Pplugins=plugin1,plugin2,plugin3 -Pnthreads=8 infile.root" << std::endl;
         std::cout << "    eicrecon -Ppodio:print_type_table=1 infile.root" << std::endl << std::endl;


### PR DESCRIPTION
We already have to do this for llvm-cov, and upgrading LLVM in eic-shell is undesirable.

Resolves: #1249