### PR TITLE
Remove m_ member tags from tracking configuration structs

### DIFF
--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -91,8 +91,8 @@ namespace eicrecon {
         // eta bins, chi2 and #sourclinks per surface cutoffs
         m_sourcelinkSelectorCfg = {
                 {Acts::GeometryIdentifier(),
-                 {m_cfg.m_etaBins, m_cfg.m_chi2CutOff,
-                  {m_cfg.m_numMeasurementsCutOff.begin(), m_cfg.m_numMeasurementsCutOff.end()}
+                 {m_cfg.etaBins, m_cfg.chi2CutOff,
+                  {m_cfg.numMeasurementsCutOff.begin(), m_cfg.numMeasurementsCutOff.end()}
                  }
                 },
         };

--- a/src/algorithms/tracking/CKFTrackingConfig.h
+++ b/src/algorithms/tracking/CKFTrackingConfig.h
@@ -8,8 +8,8 @@
 
 namespace eicrecon {
     struct CKFTrackingConfig {
-        std::vector<double> m_etaBins = {};  // {this, "etaBins", {}};
-        std::vector<double> m_chi2CutOff = {15.}; //{this, "chi2CutOff", {15.}};
-        std::vector<size_t> m_numMeasurementsCutOff = {10}; //{this, "numMeasurementsCutOff", {10}};
+        std::vector<double> etaBins = {};  // {this, "etaBins", {}};
+        std::vector<double> chi2CutOff = {15.}; //{this, "chi2CutOff", {15.}};
+        std::vector<size_t> numMeasurementsCutOff = {10}; //{this, "numMeasurementsCutOff", {10}};
     };
 }

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -88,8 +88,8 @@ std::unique_ptr<edm4eic::VertexCollection> eicrecon::IterativeVertexFinder::prod
   // Set up the actual vertex finder
   VertexFinder::Config finderCfg(std::move(vertexFitter), std::move(linearizer),
                                  std::move(seeder), std::move(ipEst));
-  finderCfg.maxVertices                 = m_cfg.m_maxVertices;
-  finderCfg.reassignTracksAfterFirstFit = m_cfg.m_reassignTracksAfterFirstFit;
+  finderCfg.maxVertices                 = m_cfg.maxVertices;
+  finderCfg.reassignTracksAfterFirstFit = m_cfg.reassignTracksAfterFirstFit;
   #if Acts_VERSION_MAJOR >= 31
   VertexFinder finder(std::move(finderCfg));
   #else

--- a/src/algorithms/tracking/IterativeVertexFinderConfig.h
+++ b/src/algorithms/tracking/IterativeVertexFinderConfig.h
@@ -3,8 +3,8 @@
 namespace eicrecon {
 
 struct IterativeVertexFinderConfig {
-  int m_maxVertices                  = 10;
-  bool m_reassignTracksAfterFirstFit = true;
+  int  maxVertices                 = 10;
+  bool reassignTracksAfterFirstFit = true;
 };
 
 } // namespace eicrecon

--- a/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
+++ b/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
@@ -18,26 +18,26 @@ namespace eicrecon {
     float rMin = 33. * Acts::UnitConstants::mm; // min r to look for hits to compose seeds
     float zMax = 1700. * Acts::UnitConstants::mm; // max z to look for hits to compose seeds
     float zMin = -1500. * Acts::UnitConstants::mm; // min z to look for hits to compose seeds
-    float deltaRMinTopSP = 10. * Acts::UnitConstants::mm; // Min distance in r between middle and top SP in one seed
-    float deltaRMaxTopSP = 200. * Acts::UnitConstants::mm; // Max distance in r between middle and top SP in one seed
-    float deltaRMinBottomSP = 10. * Acts::UnitConstants::mm; // Min distance in r between middle and bottom SP in one seed
-    float deltaRMaxBottomSP = 200. * Acts::UnitConstants::mm; // Max distance in r between middle and bottom SP in one seed
+    float deltaRMinTopSP     = 10. * Acts::UnitConstants::mm; // Min distance in r between middle and top SP in one seed
+    float deltaRMaxTopSP     = 200. * Acts::UnitConstants::mm; // Max distance in r between middle and top SP in one seed
+    float deltaRMinBottomSP  = 10. * Acts::UnitConstants::mm; // Min distance in r between middle and bottom SP in one seed
+    float deltaRMaxBottomSP  = 200. * Acts::UnitConstants::mm; // Max distance in r between middle and bottom SP in one seed
     float collisionRegionMin = -250 * Acts::UnitConstants::mm; // Min z for primary vertex
     float collisionRegionMax = 250 * Acts::UnitConstants::mm; // Max z for primary vertex
 
     unsigned int maxSeedsPerSpM = 0; // max number of seeds a single middle sp can belong to - 1
     float cotThetaMax = 1.0 / tan(2. * atan(exp(-4.0))); // Cotangent of max theta angle (based on eta)
 
-    float sigmaScattering = 5; // How many standard devs of scattering angles to consider
+    float sigmaScattering  = 5; // How many standard devs of scattering angles to consider
     float radLengthPerSeed = 0.1; // Average radiation lengths of material on the length of a seed
-    float minPt = (100. * Acts::UnitConstants::MeV) / cotThetaMax; // MeV (in Acts units of GeV) - minimum transverse momentum
-    float bFieldInZ = 1.7 * Acts::UnitConstants::T; // T (in Acts units of GeV/[e*mm]) - Magnetic field strength
-    float beamPosX = 0; // x offset for beam position
-    float beamPosY = 0; // y offset for beam position
-    float impactMax = 3. * Acts::UnitConstants::mm; // Maximum transverse PCA allowed
-    float bFieldMin = 0.1 * Acts::UnitConstants::T; // T (in Acts units of GeV/[e*mm]) - Minimum Magnetic field strength
-    float rMinMiddle = 20. * Acts::UnitConstants::mm; // Middle spacepoint must fall between these two radii
-    float rMaxMiddle = 400. * Acts::UnitConstants::mm;
+    float minPt            = (100. * Acts::UnitConstants::MeV) / cotThetaMax; // MeV (in Acts units of GeV) - minimum transverse momentum
+    float bFieldInZ        = 1.7 * Acts::UnitConstants::T; // T (in Acts units of GeV/[e*mm]) - Magnetic field strength
+    float beamPosX         = 0; // x offset for beam position
+    float beamPosY         = 0; // y offset for beam position
+    float impactMax        = 3. * Acts::UnitConstants::mm; // Maximum transverse PCA allowed
+    float bFieldMin        = 0.1 * Acts::UnitConstants::T; // T (in Acts units of GeV/[e*mm]) - Minimum Magnetic field strength
+    float rMinMiddle       = 20. * Acts::UnitConstants::mm; // Middle spacepoint must fall between these two radii
+    float rMaxMiddle       = 400. * Acts::UnitConstants::mm;
 
     //////////////////////////////////////////////////////////////////////////
     /// SEED FILTER GENERAL PARAMETERS
@@ -46,46 +46,46 @@ namespace eicrecon {
     /// to global settings (more loose) followed by more strict cuts for the central
     /// and forward/backward regions separately.
 
-    float maxSeedsPerSpM_filter = 0; // max number of seeds a single middle sp can belong to - 1
-    float deltaRMin = 5* Acts::UnitConstants::mm;
-    bool seedConfirmation = false;
-    float deltaInvHelixDiameter = 0.00003 * 1. / Acts::UnitConstants::mm;
-    float impactWeightFactor = 1.;
-    float zOriginWeightFactor = 1.;
-    float compatSeedWeight = 200.;
-    size_t compatSeedLimit = 2;
-    float seedWeightIncrement = 0;
+    float  maxSeedsPerSpM_filter = 0; // max number of seeds a single middle sp can belong to - 1
+    float  deltaRMin             = 5* Acts::UnitConstants::mm;
+    bool   seedConfirmation      = false;
+    float  deltaInvHelixDiameter = 0.00003 * 1. / Acts::UnitConstants::mm;
+    float  impactWeightFactor    = 1.;
+    float  zOriginWeightFactor   = 1.;
+    float  compatSeedWeight      = 200.;
+    size_t compatSeedLimit       = 2;
+    float  seedWeightIncrement   = 0;
 
     ///////////////////////////////////////
     /// CENTRAL SEED FILTER PARAMETERS
-    float  zMinSeedConf_cent = -250 * Acts::UnitConstants::mm;
-    float  zMaxSeedConf_cent = 250 * Acts::UnitConstants::mm;
-    float  rMaxSeedConf_cent = 140 * Acts::UnitConstants::mm;
-    size_t nTopForLargeR_cent = 1;
-    size_t nTopForSmallR_cent = 2;
-    float  seedConfMinBottomRadius_cent = 60.0 * Acts::UnitConstants::mm;
-    float  seedConfMaxZOrigin_cent = 150.0 * Acts::UnitConstants::mm;
-    float  minImpactSeedConf_cent = 1.0 * Acts::UnitConstants::mm;
+    float  zMinSeedConfCentral  = -250 * Acts::UnitConstants::mm;
+    float  zMaxSeedConfCentral  = 250 * Acts::UnitConstants::mm;
+    float  rMaxSeedConfCentral  = 140 * Acts::UnitConstants::mm;
+    size_t nTopForLargeRCentral = 1;
+    size_t nTopForSmallRCentral = 2;
+    float  seedConfMinBottomRadiusCentral = 60.0 * Acts::UnitConstants::mm;
+    float  seedConfMaxZOriginCentral      = 150.0 * Acts::UnitConstants::mm;
+    float  minImpactSeedConfCentral       = 1.0 * Acts::UnitConstants::mm;
 
     ///////////////////////////////////////
     /// FORWARD / BACKWARD SEED FILTER PARAMETERS
-    float  zMinSeedConf_forw = -3000 * Acts::UnitConstants::mm;
-    float  zMaxSeedConf_forw = 3000 * Acts::UnitConstants::mm;
-    float  rMaxSeedConf_forw = 140 * Acts::UnitConstants::mm;
-    size_t nTopForLargeR_forw = 1;
-    size_t nTopForSmallR_forw = 2;
-    float  seedConfMinBottomRadius_forw = 60.0 * Acts::UnitConstants::mm;
-    float  seedConfMaxZOrigin_forw = 150.0 * Acts::UnitConstants::mm;
-    float  minImpactSeedConf_forw = 1.0 * Acts::UnitConstants::mm;
+    float  zMinSeedConfForward  = -3000 * Acts::UnitConstants::mm;
+    float  zMaxSeedConfForward  = 3000 * Acts::UnitConstants::mm;
+    float  rMaxSeedConfForward  = 140 * Acts::UnitConstants::mm;
+    size_t nTopForLargeRForward = 1;
+    size_t nTopForSmallRForward = 2;
+    float  seedConfMinBottomRadiusForward = 60.0 * Acts::UnitConstants::mm;
+    float  seedConfMaxZOriginForward      = 150.0 * Acts::UnitConstants::mm;
+    float  minImpactSeedConfForward       = 1.0 * Acts::UnitConstants::mm;
 
     //////////////////////////////////////
     ///Seed Covariance Error Matrix
-    float loc_a_Error = 1.5 * Acts::UnitConstants::mm;     //Error on Loc a
-    float loc_b_Error = 1.5 * Acts::UnitConstants::mm;     //Error on Loc b
-    float phi_Error = 0.02 * Acts::UnitConstants::rad;     //Error on phi
-    float theta_Error = 0.002 * Acts::UnitConstants::rad;  //Error on theta
-    float qOverP_Error = 0.025 / Acts::UnitConstants::GeV; //Error on q over p
-    float time_Error = 0.1 * Acts::UnitConstants::mm;      //Error on time
+    float locaError   = 1.5 * Acts::UnitConstants::mm;     //Error on Loc a
+    float locbError   = 1.5 * Acts::UnitConstants::mm;     //Error on Loc b
+    float phiError    = 0.02 * Acts::UnitConstants::rad;     //Error on phi
+    float thetaError  = 0.002 * Acts::UnitConstants::rad;  //Error on theta
+    float qOverPError = 0.025 / Acts::UnitConstants::GeV; //Error on q over p
+    float timeError   = 0.1 * Acts::UnitConstants::mm;      //Error on time
     // Note: Acts native time units are mm: https://acts.readthedocs.io/en/latest/core/definitions/units.html
   };
 }

--- a/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
+++ b/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
@@ -14,30 +14,30 @@ namespace eicrecon {
 
     //////////////////////////////////////////////////////////////////////////
     /// SEED FINDER GENERAL PARAMETERS
-    float m_rMax = 440. * Acts::UnitConstants::mm; // max r to look for hits to compose seeds
-    float m_rMin = 33. * Acts::UnitConstants::mm; // min r to look for hits to compose seeds
-    float m_zMax = 1700. * Acts::UnitConstants::mm; // max z to look for hits to compose seeds
-    float m_zMin = -1500. * Acts::UnitConstants::mm; // min z to look for hits to compose seeds
-    float m_deltaRMinTopSP = 10. * Acts::UnitConstants::mm; // Min distance in r between middle and top SP in one seed
-    float m_deltaRMaxTopSP = 200. * Acts::UnitConstants::mm; // Max distance in r between middle and top SP in one seed
-    float m_deltaRMinBottomSP = 10. * Acts::UnitConstants::mm; // Min distance in r between middle and bottom SP in one seed
-    float m_deltaRMaxBottomSP = 200. * Acts::UnitConstants::mm; // Max distance in r between middle and bottom SP in one seed
-    float m_collisionRegionMin = -250 * Acts::UnitConstants::mm; // Min z for primary vertex
-    float m_collisionRegionMax = 250 * Acts::UnitConstants::mm; // Max z for primary vertex
+    float rMax = 440. * Acts::UnitConstants::mm; // max r to look for hits to compose seeds
+    float rMin = 33. * Acts::UnitConstants::mm; // min r to look for hits to compose seeds
+    float zMax = 1700. * Acts::UnitConstants::mm; // max z to look for hits to compose seeds
+    float zMin = -1500. * Acts::UnitConstants::mm; // min z to look for hits to compose seeds
+    float deltaRMinTopSP = 10. * Acts::UnitConstants::mm; // Min distance in r between middle and top SP in one seed
+    float deltaRMaxTopSP = 200. * Acts::UnitConstants::mm; // Max distance in r between middle and top SP in one seed
+    float deltaRMinBottomSP = 10. * Acts::UnitConstants::mm; // Min distance in r between middle and bottom SP in one seed
+    float deltaRMaxBottomSP = 200. * Acts::UnitConstants::mm; // Max distance in r between middle and bottom SP in one seed
+    float collisionRegionMin = -250 * Acts::UnitConstants::mm; // Min z for primary vertex
+    float collisionRegionMax = 250 * Acts::UnitConstants::mm; // Max z for primary vertex
 
-    unsigned int m_maxSeedsPerSpM = 0; // max number of seeds a single middle sp can belong to - 1
-    float m_cotThetaMax = 1.0 / tan(2. * atan(exp(-4.0))); // Cotangent of max theta angle (based on eta)
+    unsigned int maxSeedsPerSpM = 0; // max number of seeds a single middle sp can belong to - 1
+    float cotThetaMax = 1.0 / tan(2. * atan(exp(-4.0))); // Cotangent of max theta angle (based on eta)
 
-    float m_sigmaScattering = 5; // How many standard devs of scattering angles to consider
-    float m_radLengthPerSeed = 0.1; // Average radiation lengths of material on the length of a seed
-    float m_minPt = (100. * Acts::UnitConstants::MeV) / m_cotThetaMax; // MeV (in Acts units of GeV) - minimum transverse momentum
-    float m_bFieldInZ = 1.7 * Acts::UnitConstants::T; // T (in Acts units of GeV/[e*mm]) - Magnetic field strength
-    float m_beamPosX = 0; // x offset for beam position
-    float m_beamPosY = 0; // y offset for beam position
-    float m_impactMax = 3. * Acts::UnitConstants::mm; // Maximum transverse PCA allowed
-    float m_bFieldMin = 0.1 * Acts::UnitConstants::T; // T (in Acts units of GeV/[e*mm]) - Minimum Magnetic field strength
-    float m_rMinMiddle = 20. * Acts::UnitConstants::mm; // Middle spacepoint must fall between these two radii
-    float m_rMaxMiddle = 400. * Acts::UnitConstants::mm;
+    float sigmaScattering = 5; // How many standard devs of scattering angles to consider
+    float radLengthPerSeed = 0.1; // Average radiation lengths of material on the length of a seed
+    float minPt = (100. * Acts::UnitConstants::MeV) / cotThetaMax; // MeV (in Acts units of GeV) - minimum transverse momentum
+    float bFieldInZ = 1.7 * Acts::UnitConstants::T; // T (in Acts units of GeV/[e*mm]) - Magnetic field strength
+    float beamPosX = 0; // x offset for beam position
+    float beamPosY = 0; // y offset for beam position
+    float impactMax = 3. * Acts::UnitConstants::mm; // Maximum transverse PCA allowed
+    float bFieldMin = 0.1 * Acts::UnitConstants::T; // T (in Acts units of GeV/[e*mm]) - Minimum Magnetic field strength
+    float rMinMiddle = 20. * Acts::UnitConstants::mm; // Middle spacepoint must fall between these two radii
+    float rMaxMiddle = 400. * Acts::UnitConstants::mm;
 
     //////////////////////////////////////////////////////////////////////////
     /// SEED FILTER GENERAL PARAMETERS
@@ -46,46 +46,46 @@ namespace eicrecon {
     /// to global settings (more loose) followed by more strict cuts for the central
     /// and forward/backward regions separately.
 
-    float m_maxSeedsPerSpM_filter = 0; // max number of seeds a single middle sp can belong to - 1
-    float m_deltaRMin = 5* Acts::UnitConstants::mm;
-    bool m_seedConfirmation = false;
-    float m_deltaInvHelixDiameter = 0.00003 * 1. / Acts::UnitConstants::mm;
-    float m_impactWeightFactor = 1.;
-    float m_zOriginWeightFactor = 1.;
-    float m_compatSeedWeight = 200.;
-    size_t m_compatSeedLimit = 2;
-    float m_seedWeightIncrement = 0;
+    float maxSeedsPerSpM_filter = 0; // max number of seeds a single middle sp can belong to - 1
+    float deltaRMin = 5* Acts::UnitConstants::mm;
+    bool seedConfirmation = false;
+    float deltaInvHelixDiameter = 0.00003 * 1. / Acts::UnitConstants::mm;
+    float impactWeightFactor = 1.;
+    float zOriginWeightFactor = 1.;
+    float compatSeedWeight = 200.;
+    size_t compatSeedLimit = 2;
+    float seedWeightIncrement = 0;
 
     ///////////////////////////////////////
     /// CENTRAL SEED FILTER PARAMETERS
-    float  m_zMinSeedConf_cent = -250 * Acts::UnitConstants::mm;
-    float  m_zMaxSeedConf_cent = 250 * Acts::UnitConstants::mm;
-    float  m_rMaxSeedConf_cent = 140 * Acts::UnitConstants::mm;
-    size_t m_nTopForLargeR_cent = 1;
-    size_t m_nTopForSmallR_cent = 2;
-    float  m_seedConfMinBottomRadius_cent = 60.0 * Acts::UnitConstants::mm;
-    float  m_seedConfMaxZOrigin_cent = 150.0 * Acts::UnitConstants::mm;
-    float  m_minImpactSeedConf_cent = 1.0 * Acts::UnitConstants::mm;
+    float  zMinSeedConf_cent = -250 * Acts::UnitConstants::mm;
+    float  zMaxSeedConf_cent = 250 * Acts::UnitConstants::mm;
+    float  rMaxSeedConf_cent = 140 * Acts::UnitConstants::mm;
+    size_t nTopForLargeR_cent = 1;
+    size_t nTopForSmallR_cent = 2;
+    float  seedConfMinBottomRadius_cent = 60.0 * Acts::UnitConstants::mm;
+    float  seedConfMaxZOrigin_cent = 150.0 * Acts::UnitConstants::mm;
+    float  minImpactSeedConf_cent = 1.0 * Acts::UnitConstants::mm;
 
     ///////////////////////////////////////
     /// FORWARD / BACKWARD SEED FILTER PARAMETERS
-    float  m_zMinSeedConf_forw = -3000 * Acts::UnitConstants::mm;
-    float  m_zMaxSeedConf_forw = 3000 * Acts::UnitConstants::mm;
-    float  m_rMaxSeedConf_forw = 140 * Acts::UnitConstants::mm;
-    size_t m_nTopForLargeR_forw = 1;
-    size_t m_nTopForSmallR_forw = 2;
-    float  m_seedConfMinBottomRadius_forw = 60.0 * Acts::UnitConstants::mm;
-    float  m_seedConfMaxZOrigin_forw = 150.0 * Acts::UnitConstants::mm;
-    float  m_minImpactSeedConf_forw = 1.0 * Acts::UnitConstants::mm;
+    float  zMinSeedConf_forw = -3000 * Acts::UnitConstants::mm;
+    float  zMaxSeedConf_forw = 3000 * Acts::UnitConstants::mm;
+    float  rMaxSeedConf_forw = 140 * Acts::UnitConstants::mm;
+    size_t nTopForLargeR_forw = 1;
+    size_t nTopForSmallR_forw = 2;
+    float  seedConfMinBottomRadius_forw = 60.0 * Acts::UnitConstants::mm;
+    float  seedConfMaxZOrigin_forw = 150.0 * Acts::UnitConstants::mm;
+    float  minImpactSeedConf_forw = 1.0 * Acts::UnitConstants::mm;
 
     //////////////////////////////////////
     ///Seed Covariance Error Matrix
-    float m_loc_a_Error = 1.5 * Acts::UnitConstants::mm;     //Error on Loc a
-    float m_loc_b_Error = 1.5 * Acts::UnitConstants::mm;     //Error on Loc b
-    float m_phi_Error = 0.02 * Acts::UnitConstants::rad;     //Error on phi
-    float m_theta_Error = 0.002 * Acts::UnitConstants::rad;  //Error on theta
-    float m_qOverP_Error = 0.025 / Acts::UnitConstants::GeV; //Error on q over p
-    float m_time_Error = 0.1 * Acts::UnitConstants::mm;      //Error on time
+    float loc_a_Error = 1.5 * Acts::UnitConstants::mm;     //Error on Loc a
+    float loc_b_Error = 1.5 * Acts::UnitConstants::mm;     //Error on Loc b
+    float phi_Error = 0.02 * Acts::UnitConstants::rad;     //Error on phi
+    float theta_Error = 0.002 * Acts::UnitConstants::rad;  //Error on theta
+    float qOverP_Error = 0.025 / Acts::UnitConstants::GeV; //Error on q over p
+    float time_Error = 0.1 * Acts::UnitConstants::mm;      //Error on time
     // Note: Acts native time units are mm: https://acts.readthedocs.io/en/latest/core/definitions/units.html
   };
 }

--- a/src/algorithms/tracking/TrackParamTruthInit.cc
+++ b/src/algorithms/tracking/TrackParamTruthInit.cc
@@ -56,9 +56,9 @@ eicrecon::TrackParamTruthInit::produce(const edm4hep::MCParticleCollection* mcpa
 
         // require close to interaction vertex
         auto v = mcparticle.getVertex();
-        if (abs(v.x) * dd4hep::mm > m_cfg.m_maxVertexX ||
-            abs(v.y) * dd4hep::mm > m_cfg.m_maxVertexY ||
-            abs(v.z) * dd4hep::mm > m_cfg.m_maxVertexZ) {
+        if (abs(v.x) * dd4hep::mm > m_cfg.maxVertexX ||
+            abs(v.y) * dd4hep::mm > m_cfg.maxVertexY ||
+            abs(v.z) * dd4hep::mm > m_cfg.maxVertexZ) {
             m_log->trace("ignoring particle with vs = {} [mm]", v);
             continue;
         }
@@ -66,7 +66,7 @@ eicrecon::TrackParamTruthInit::produce(const edm4hep::MCParticleCollection* mcpa
         // require minimum momentum
         const auto& p = mcparticle.getMomentum();
         const auto pmag = std::hypot(p.x, p.y, p.z);
-        if (pmag * dd4hep::GeV < m_cfg.m_minMomentum) {
+        if (pmag * dd4hep::GeV < m_cfg.minMomentum) {
             m_log->trace("ignoring particle with p = {} GeV ", pmag);
             continue;
         }
@@ -75,7 +75,7 @@ eicrecon::TrackParamTruthInit::produce(const edm4hep::MCParticleCollection* mcpa
         const auto phi   = std::atan2(p.y, p.x);
         const auto theta = std::atan2(std::hypot(p.x, p.y), p.z);
         const auto eta   = -std::log(std::tan(theta/2));
-        if (eta > m_cfg.m_maxEtaForward || eta < -std::abs(m_cfg.m_maxEtaBackward)) {
+        if (eta > m_cfg.maxEtaForward || eta < -std::abs(m_cfg.maxEtaBackward)) {
             m_log->trace("ignoring particle with Eta = {}", eta);
             continue;
         }
@@ -97,7 +97,7 @@ eicrecon::TrackParamTruthInit::produce(const edm4hep::MCParticleCollection* mcpa
         }
 
         // modify initial momentum to avoid bleeding truth to results when fit fails
-        const auto pinit = pmag * (1.0 + m_cfg.m_momentumSmear * m_normDist(generator));
+        const auto pinit = pmag * (1.0 + m_cfg.momentumSmear * m_normDist(generator));
 
         // define line surface for local position values
         auto perigee = Acts::Surface::makeShared<Acts::PerigeeSurface>(Acts::Vector3(0,0,0));

--- a/src/algorithms/tracking/TrackParamTruthInitConfig.h
+++ b/src/algorithms/tracking/TrackParamTruthInitConfig.h
@@ -8,12 +8,12 @@
 
 struct TrackParamTruthInitConfig {
 
-    double m_maxVertexX       = 80  * dd4hep::mm;
-    double m_maxVertexY       = 80  * dd4hep::mm;
-    double m_maxVertexZ       = 200 * dd4hep::mm;
-    double m_minMomentum      = 100 * dd4hep::MeV;
-    double m_maxEtaForward    = 6.0;
-    double m_maxEtaBackward   = 4.1;
-    double m_momentumSmear    = 0.1;
+    double maxVertexX       = 80  * dd4hep::mm;
+    double maxVertexY       = 80  * dd4hep::mm;
+    double maxVertexZ       = 200 * dd4hep::mm;
+    double minMomentum      = 100 * dd4hep::MeV;
+    double maxEtaForward    = 6.0;
+    double maxEtaBackward   = 4.1;
+    double momentumSmear    = 0.1;
 
 };

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -54,68 +54,68 @@ void eicrecon::TrackSeeding::init(std::shared_ptr<const ActsGeometryProvider> ge
 void eicrecon::TrackSeeding::configure() {
 
     // Filter parameters
-    m_seedFilterConfig.maxSeedsPerSpM = m_cfg.maxSeedsPerSpM_filter;
-    m_seedFilterConfig.deltaRMin = m_cfg.deltaRMin;
-    m_seedFilterConfig.seedConfirmation = m_cfg.seedConfirmation;
+    m_seedFilterConfig.maxSeedsPerSpM        = m_cfg.maxSeedsPerSpM_filter;
+    m_seedFilterConfig.deltaRMin             = m_cfg.deltaRMin;
+    m_seedFilterConfig.seedConfirmation      = m_cfg.seedConfirmation;
     m_seedFilterConfig.deltaInvHelixDiameter = m_cfg.deltaInvHelixDiameter;
-    m_seedFilterConfig.impactWeightFactor = m_cfg.impactWeightFactor;
-    m_seedFilterConfig.zOriginWeightFactor = m_cfg.zOriginWeightFactor;
-    m_seedFilterConfig.compatSeedWeight = m_cfg.compatSeedWeight;
-    m_seedFilterConfig.compatSeedLimit = m_cfg.compatSeedLimit;
-    m_seedFilterConfig.seedWeightIncrement = m_cfg.seedWeightIncrement;
+    m_seedFilterConfig.impactWeightFactor    = m_cfg.impactWeightFactor;
+    m_seedFilterConfig.zOriginWeightFactor   = m_cfg.zOriginWeightFactor;
+    m_seedFilterConfig.compatSeedWeight      = m_cfg.compatSeedWeight;
+    m_seedFilterConfig.compatSeedLimit       = m_cfg.compatSeedLimit;
+    m_seedFilterConfig.seedWeightIncrement   = m_cfg.seedWeightIncrement;
 
     m_seedFilterConfig.centralSeedConfirmationRange = Acts::SeedConfirmationRangeConfig{
-      m_cfg.zMinSeedConf_cent,
-      m_cfg.zMaxSeedConf_cent,
-      m_cfg.rMaxSeedConf_cent,
-      m_cfg.nTopForLargeR_cent,
-      m_cfg.nTopForSmallR_cent,
-      m_cfg.seedConfMinBottomRadius_cent,
-      m_cfg.seedConfMaxZOrigin_cent,
-      m_cfg.minImpactSeedConf_cent
+      m_cfg.zMinSeedConfCentral,
+      m_cfg.zMaxSeedConfCentral,
+      m_cfg.rMaxSeedConfCentral,
+      m_cfg.nTopForLargeRCentral,
+      m_cfg.nTopForSmallRCentral,
+      m_cfg.seedConfMinBottomRadiusCentral,
+      m_cfg.seedConfMaxZOriginCentral,
+      m_cfg.minImpactSeedConfCentral
     };
 
     m_seedFilterConfig.forwardSeedConfirmationRange = Acts::SeedConfirmationRangeConfig{
-      m_cfg.zMinSeedConf_forw,
-      m_cfg.zMaxSeedConf_forw,
-      m_cfg.rMaxSeedConf_forw,
-      m_cfg.nTopForLargeR_forw,
-      m_cfg.nTopForSmallR_forw,
-      m_cfg.seedConfMinBottomRadius_forw,
-      m_cfg.seedConfMaxZOrigin_forw,
-      m_cfg.minImpactSeedConf_forw
+      m_cfg.zMinSeedConfForward,
+      m_cfg.zMaxSeedConfForward,
+      m_cfg.rMaxSeedConfForward,
+      m_cfg.nTopForLargeRForward,
+      m_cfg.nTopForSmallRForward,
+      m_cfg.seedConfMinBottomRadiusForward,
+      m_cfg.seedConfMaxZOriginForward,
+      m_cfg.minImpactSeedConfForward
     };
 
     m_seedFilterConfig = m_seedFilterConfig.toInternalUnits();
 
     // Finder parameters
     m_seedFinderConfig.seedFilter = std::make_unique<Acts::SeedFilter<eicrecon::SpacePoint>>(Acts::SeedFilter<eicrecon::SpacePoint>(m_seedFilterConfig));
-    m_seedFinderConfig.rMax = m_cfg.rMax;
-    m_seedFinderConfig.deltaRMinTopSP = m_cfg.deltaRMinTopSP;
-    m_seedFinderConfig.deltaRMaxTopSP = m_cfg.deltaRMaxTopSP;
-    m_seedFinderConfig.deltaRMinBottomSP = m_cfg.deltaRMinBottomSP;
-    m_seedFinderConfig.deltaRMaxBottomSP = m_cfg.deltaRMaxBottomSP;
+    m_seedFinderConfig.rMax               = m_cfg.rMax;
+    m_seedFinderConfig.deltaRMinTopSP     = m_cfg.deltaRMinTopSP;
+    m_seedFinderConfig.deltaRMaxTopSP     = m_cfg.deltaRMaxTopSP;
+    m_seedFinderConfig.deltaRMinBottomSP  = m_cfg.deltaRMinBottomSP;
+    m_seedFinderConfig.deltaRMaxBottomSP  = m_cfg.deltaRMaxBottomSP;
     m_seedFinderConfig.collisionRegionMin = m_cfg.collisionRegionMin;
     m_seedFinderConfig.collisionRegionMax = m_cfg.collisionRegionMax;
-    m_seedFinderConfig.zMin = m_cfg.zMin;
-    m_seedFinderConfig.zMax = m_cfg.zMax;
-    m_seedFinderConfig.maxSeedsPerSpM = m_cfg.maxSeedsPerSpM;
-    m_seedFinderConfig.cotThetaMax = m_cfg.cotThetaMax;
-    m_seedFinderConfig.sigmaScattering = m_cfg.sigmaScattering;
-    m_seedFinderConfig.radLengthPerSeed = m_cfg.radLengthPerSeed;
-    m_seedFinderConfig.minPt = m_cfg.minPt;
-    m_seedFinderConfig.impactMax = m_cfg.impactMax;
-    m_seedFinderConfig.rMinMiddle = m_cfg.rMinMiddle;
-    m_seedFinderConfig.rMaxMiddle = m_cfg.rMaxMiddle;
+    m_seedFinderConfig.zMin               = m_cfg.zMin;
+    m_seedFinderConfig.zMax               = m_cfg.zMax;
+    m_seedFinderConfig.maxSeedsPerSpM     = m_cfg.maxSeedsPerSpM;
+    m_seedFinderConfig.cotThetaMax        = m_cfg.cotThetaMax;
+    m_seedFinderConfig.sigmaScattering    = m_cfg.sigmaScattering;
+    m_seedFinderConfig.radLengthPerSeed   = m_cfg.radLengthPerSeed;
+    m_seedFinderConfig.minPt              = m_cfg.minPt;
+    m_seedFinderConfig.impactMax          = m_cfg.impactMax;
+    m_seedFinderConfig.rMinMiddle         = m_cfg.rMinMiddle;
+    m_seedFinderConfig.rMaxMiddle         = m_cfg.rMaxMiddle;
 
-    m_seedFinderOptions.beamPos = Acts::Vector2(m_cfg.beamPosX, m_cfg.beamPosY);
+    m_seedFinderOptions.beamPos   = Acts::Vector2(m_cfg.beamPosX, m_cfg.beamPosY);
     m_seedFinderOptions.bFieldInZ = m_cfg.bFieldInZ;
 
     m_seedFinderConfig =
       m_seedFinderConfig.toInternalUnits().calculateDerivedQuantities();
     m_seedFinderOptions =
-      m_seedFinderOptions.toInternalUnits().calculateDerivedQuantities(
-          m_seedFinderConfig);
+      m_seedFinderOptions.toInternalUnits().calculateDerivedQuantities(m_seedFinderConfig);
+
 }
 
 std::unique_ptr<edm4eic::TrackParametersCollection> eicrecon::TrackSeeding::produce(const edm4eic::TrackerHitCollection& trk_hits) {
@@ -240,18 +240,18 @@ std::unique_ptr<edm4eic::TrackParametersCollection> eicrecon::TrackSeeding::make
       trackparam.setTime(10); // time in ns
       #if EDM4EIC_VERSION_MAJOR >= 5
         edm4eic::Cov6f cov;
-        cov(0,0) = m_cfg.loc_a_Error / Acts::UnitConstants::mm; // loc0
-        cov(1,1) = m_cfg.loc_b_Error / Acts::UnitConstants::mm; // loc1
-        cov(2,2) = m_cfg.phi_Error / Acts::UnitConstants::rad; // phi
-        cov(3,3) = m_cfg.theta_Error / Acts::UnitConstants::rad; // theta
-        cov(4,4) = m_cfg.qOverP_Error * Acts::UnitConstants::GeV; // qOverP
-        cov(5,5) = m_cfg.time_Error / Acts::UnitConstants::ns; // time
+        cov(0,0) = m_cfg.locaError / Acts::UnitConstants::mm; // loc0
+        cov(1,1) = m_cfg.locbError / Acts::UnitConstants::mm; // loc1
+        cov(2,2) = m_cfg.phiError / Acts::UnitConstants::rad; // phi
+        cov(3,3) = m_cfg.thetaError / Acts::UnitConstants::rad; // theta
+        cov(4,4) = m_cfg.qOverPError * Acts::UnitConstants::GeV; // qOverP
+        cov(5,5) = m_cfg.timeError / Acts::UnitConstants::ns; // time
         trackparam.setCovariance(cov);
       #else
         trackparam.setCharge(static_cast<float>(charge)); // charge
-        trackparam.setLocError({m_cfg.loc_a_Error, m_cfg.loc_b_Error}); //covariance of location
-        trackparam.setMomentumError({m_cfg.theta_Error, m_cfg.phi_Error, m_cfg.qOverP_Error}); // covariance on theta/phi/q/p
-        trackparam.setTimeError(m_cfg.time_Error); // error on time
+        trackparam.setLocError({m_cfg.locaError, m_cfg.locbError}); //covariance of location
+        trackparam.setMomentumError({m_cfg.thetaError, m_cfg.phiError, m_cfg.qOverPError}); // covariance on theta/phi/q/p
+        trackparam.setTimeError(m_cfg.timeError); // error on time
       #endif
     }
 

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -54,62 +54,62 @@ void eicrecon::TrackSeeding::init(std::shared_ptr<const ActsGeometryProvider> ge
 void eicrecon::TrackSeeding::configure() {
 
     // Filter parameters
-    m_seedFilterConfig.maxSeedsPerSpM = m_cfg.m_maxSeedsPerSpM_filter;
-    m_seedFilterConfig.deltaRMin = m_cfg.m_deltaRMin;
-    m_seedFilterConfig.seedConfirmation = m_cfg.m_seedConfirmation;
-    m_seedFilterConfig.deltaInvHelixDiameter = m_cfg.m_deltaInvHelixDiameter;
-    m_seedFilterConfig.impactWeightFactor = m_cfg.m_impactWeightFactor;
-    m_seedFilterConfig.zOriginWeightFactor = m_cfg.m_zOriginWeightFactor;
-    m_seedFilterConfig.compatSeedWeight = m_cfg.m_compatSeedWeight;
-    m_seedFilterConfig.compatSeedLimit = m_cfg.m_compatSeedLimit;
-    m_seedFilterConfig.seedWeightIncrement = m_cfg.m_seedWeightIncrement;
+    m_seedFilterConfig.maxSeedsPerSpM = m_cfg.maxSeedsPerSpM_filter;
+    m_seedFilterConfig.deltaRMin = m_cfg.deltaRMin;
+    m_seedFilterConfig.seedConfirmation = m_cfg.seedConfirmation;
+    m_seedFilterConfig.deltaInvHelixDiameter = m_cfg.deltaInvHelixDiameter;
+    m_seedFilterConfig.impactWeightFactor = m_cfg.impactWeightFactor;
+    m_seedFilterConfig.zOriginWeightFactor = m_cfg.zOriginWeightFactor;
+    m_seedFilterConfig.compatSeedWeight = m_cfg.compatSeedWeight;
+    m_seedFilterConfig.compatSeedLimit = m_cfg.compatSeedLimit;
+    m_seedFilterConfig.seedWeightIncrement = m_cfg.seedWeightIncrement;
 
     m_seedFilterConfig.centralSeedConfirmationRange = Acts::SeedConfirmationRangeConfig{
-      m_cfg.m_zMinSeedConf_cent,
-      m_cfg.m_zMaxSeedConf_cent,
-      m_cfg.m_rMaxSeedConf_cent,
-      m_cfg.m_nTopForLargeR_cent,
-      m_cfg.m_nTopForSmallR_cent,
-      m_cfg.m_seedConfMinBottomRadius_cent,
-      m_cfg.m_seedConfMaxZOrigin_cent,
-      m_cfg.m_minImpactSeedConf_cent
+      m_cfg.zMinSeedConf_cent,
+      m_cfg.zMaxSeedConf_cent,
+      m_cfg.rMaxSeedConf_cent,
+      m_cfg.nTopForLargeR_cent,
+      m_cfg.nTopForSmallR_cent,
+      m_cfg.seedConfMinBottomRadius_cent,
+      m_cfg.seedConfMaxZOrigin_cent,
+      m_cfg.minImpactSeedConf_cent
     };
 
     m_seedFilterConfig.forwardSeedConfirmationRange = Acts::SeedConfirmationRangeConfig{
-      m_cfg.m_zMinSeedConf_forw,
-      m_cfg.m_zMaxSeedConf_forw,
-      m_cfg.m_rMaxSeedConf_forw,
-      m_cfg.m_nTopForLargeR_forw,
-      m_cfg.m_nTopForSmallR_forw,
-      m_cfg.m_seedConfMinBottomRadius_forw,
-      m_cfg.m_seedConfMaxZOrigin_forw,
-      m_cfg.m_minImpactSeedConf_forw
+      m_cfg.zMinSeedConf_forw,
+      m_cfg.zMaxSeedConf_forw,
+      m_cfg.rMaxSeedConf_forw,
+      m_cfg.nTopForLargeR_forw,
+      m_cfg.nTopForSmallR_forw,
+      m_cfg.seedConfMinBottomRadius_forw,
+      m_cfg.seedConfMaxZOrigin_forw,
+      m_cfg.minImpactSeedConf_forw
     };
 
     m_seedFilterConfig = m_seedFilterConfig.toInternalUnits();
 
     // Finder parameters
     m_seedFinderConfig.seedFilter = std::make_unique<Acts::SeedFilter<eicrecon::SpacePoint>>(Acts::SeedFilter<eicrecon::SpacePoint>(m_seedFilterConfig));
-    m_seedFinderConfig.rMax = m_cfg.m_rMax;
-    m_seedFinderConfig.deltaRMinTopSP = m_cfg.m_deltaRMinTopSP;
-    m_seedFinderConfig.deltaRMaxTopSP = m_cfg.m_deltaRMaxTopSP;
-    m_seedFinderConfig.deltaRMinBottomSP = m_cfg.m_deltaRMinBottomSP;
-    m_seedFinderConfig.deltaRMaxBottomSP = m_cfg.m_deltaRMaxBottomSP;
-    m_seedFinderConfig.collisionRegionMin = m_cfg.m_collisionRegionMin;
-    m_seedFinderConfig.collisionRegionMax = m_cfg.m_collisionRegionMax;
-    m_seedFinderConfig.zMin = m_cfg.m_zMin;
-    m_seedFinderConfig.zMax = m_cfg.m_zMax;
-    m_seedFinderConfig.maxSeedsPerSpM = m_cfg.m_maxSeedsPerSpM;
-    m_seedFinderConfig.cotThetaMax = m_cfg.m_cotThetaMax;
-    m_seedFinderConfig.sigmaScattering = m_cfg.m_sigmaScattering;
-    m_seedFinderConfig.radLengthPerSeed = m_cfg.m_radLengthPerSeed;
-    m_seedFinderConfig.minPt = m_cfg.m_minPt;
-    m_seedFinderConfig.impactMax = m_cfg.m_impactMax;
-    m_seedFinderConfig.rMinMiddle = m_cfg.m_rMinMiddle;
-    m_seedFinderConfig.rMaxMiddle = m_cfg.m_rMaxMiddle;
+    m_seedFinderConfig.rMax = m_cfg.rMax;
+    m_seedFinderConfig.deltaRMinTopSP = m_cfg.deltaRMinTopSP;
+    m_seedFinderConfig.deltaRMaxTopSP = m_cfg.deltaRMaxTopSP;
+    m_seedFinderConfig.deltaRMinBottomSP = m_cfg.deltaRMinBottomSP;
+    m_seedFinderConfig.deltaRMaxBottomSP = m_cfg.deltaRMaxBottomSP;
+    m_seedFinderConfig.collisionRegionMin = m_cfg.collisionRegionMin;
+    m_seedFinderConfig.collisionRegionMax = m_cfg.collisionRegionMax;
+    m_seedFinderConfig.zMin = m_cfg.zMin;
+    m_seedFinderConfig.zMax = m_cfg.zMax;
+    m_seedFinderConfig.maxSeedsPerSpM = m_cfg.maxSeedsPerSpM;
+    m_seedFinderConfig.cotThetaMax = m_cfg.cotThetaMax;
+    m_seedFinderConfig.sigmaScattering = m_cfg.sigmaScattering;
+    m_seedFinderConfig.radLengthPerSeed = m_cfg.radLengthPerSeed;
+    m_seedFinderConfig.minPt = m_cfg.minPt;
+    m_seedFinderConfig.impactMax = m_cfg.impactMax;
+    m_seedFinderConfig.rMinMiddle = m_cfg.rMinMiddle;
+    m_seedFinderConfig.rMaxMiddle = m_cfg.rMaxMiddle;
 
-    m_seedFinderOptions.beamPos = Acts::Vector2(m_cfg.m_beamPosX, m_cfg.m_beamPosY);
-    m_seedFinderOptions.bFieldInZ = m_cfg.m_bFieldInZ;
+    m_seedFinderOptions.beamPos = Acts::Vector2(m_cfg.beamPosX, m_cfg.beamPosY);
+    m_seedFinderOptions.bFieldInZ = m_cfg.bFieldInZ;
 
     m_seedFinderConfig =
       m_seedFinderConfig.toInternalUnits().calculateDerivedQuantities();
@@ -199,7 +199,7 @@ std::unique_ptr<edm4eic::TrackParametersCollection> eicrecon::TrackSeeding::make
       if(theta < 0)
         { theta += M_PI; }
       float eta = -log(tan(theta/2.));
-      float pt = R * m_cfg.m_bFieldInZ; // pt[GeV] = R[mm] * B[GeV/mm]
+      float pt = R * m_cfg.bFieldInZ; // pt[GeV] = R[mm] * B[GeV/mm]
       float p = pt * cosh(eta);
       float qOverP = charge / p;
 
@@ -240,18 +240,18 @@ std::unique_ptr<edm4eic::TrackParametersCollection> eicrecon::TrackSeeding::make
       trackparam.setTime(10); // time in ns
       #if EDM4EIC_VERSION_MAJOR >= 5
         edm4eic::Cov6f cov;
-        cov(0,0) = m_cfg.m_loc_a_Error / Acts::UnitConstants::mm; // loc0
-        cov(1,1) = m_cfg.m_loc_b_Error / Acts::UnitConstants::mm; // loc1
-        cov(2,2) = m_cfg.m_phi_Error / Acts::UnitConstants::rad; // phi
-        cov(3,3) = m_cfg.m_theta_Error / Acts::UnitConstants::rad; // theta
-        cov(4,4) = m_cfg.m_qOverP_Error * Acts::UnitConstants::GeV; // qOverP
-        cov(5,5) = m_cfg.m_time_Error / Acts::UnitConstants::ns; // time
+        cov(0,0) = m_cfg.loc_a_Error / Acts::UnitConstants::mm; // loc0
+        cov(1,1) = m_cfg.loc_b_Error / Acts::UnitConstants::mm; // loc1
+        cov(2,2) = m_cfg.phi_Error / Acts::UnitConstants::rad; // phi
+        cov(3,3) = m_cfg.theta_Error / Acts::UnitConstants::rad; // theta
+        cov(4,4) = m_cfg.qOverP_Error * Acts::UnitConstants::GeV; // qOverP
+        cov(5,5) = m_cfg.time_Error / Acts::UnitConstants::ns; // time
         trackparam.setCovariance(cov);
       #else
         trackparam.setCharge(static_cast<float>(charge)); // charge
-        trackparam.setLocError({m_cfg.m_loc_a_Error, m_cfg.m_loc_b_Error}); //covariance of location
-        trackparam.setMomentumError({m_cfg.m_theta_Error, m_cfg.m_phi_Error, m_cfg.m_qOverP_Error}); // covariance on theta/phi/q/p
-        trackparam.setTimeError(m_cfg.m_time_Error); // error on time
+        trackparam.setLocError({m_cfg.loc_a_Error, m_cfg.loc_b_Error}); //covariance of location
+        trackparam.setMomentumError({m_cfg.theta_Error, m_cfg.phi_Error, m_cfg.qOverP_Error}); // covariance on theta/phi/q/p
+        trackparam.setTimeError(m_cfg.time_Error); // error on time
       #endif
     }
 

--- a/src/global/tracking/CKFTracking_factory.h
+++ b/src/global/tracking/CKFTracking_factory.h
@@ -37,9 +37,9 @@ private:
     Output<ActsExamples::Trajectories> m_acts_trajectories_output {this};
     Output<ActsExamples::ConstTrackContainer> m_acts_tracks_output {this};
 
-    ParameterRef<std::vector<double>> m_etaBins {this, "EtaBins", config().m_etaBins, "Eta Bins for ACTS CKF tracking reco"};
-    ParameterRef<std::vector<double>> m_chi2CutOff {this, "Chi2CutOff", config().m_chi2CutOff, "Chi2 Cut Off for ACTS CKF tracking"};
-    ParameterRef<std::vector<size_t>> m_numMeasurementsCutOff {this, "NumMeasurementsCutOff", config().m_numMeasurementsCutOff, "Number of measurements Cut Off for ACTS CKF tracking"};
+    ParameterRef<std::vector<double>> m_etaBins {this, "EtaBins", config().etaBins, "Eta Bins for ACTS CKF tracking reco"};
+    ParameterRef<std::vector<double>> m_chi2CutOff {this, "Chi2CutOff", config().chi2CutOff, "Chi2 Cut Off for ACTS CKF tracking"};
+    ParameterRef<std::vector<size_t>> m_numMeasurementsCutOff {this, "NumMeasurementsCutOff", config().numMeasurementsCutOff, "Number of measurements Cut Off for ACTS CKF tracking"};
 
     Service<ACTSGeo_service> m_ACTSGeoSvc {this};
 

--- a/src/global/tracking/IterativeVertexFinder_factory.h
+++ b/src/global/tracking/IterativeVertexFinder_factory.h
@@ -28,10 +28,10 @@ private:
     Input<ActsExamples::Trajectories> m_acts_trajectories_input {this};
     PodioOutput<edm4eic::Vertex> m_vertices_output {this};
 
-    ParameterRef<int> m_maxVertices {this, "maxVertices", config().m_maxVertices,
+    ParameterRef<int> m_maxVertices {this, "maxVertices", config().maxVertices,
                            "Maximum num vertices that can be found"};
     ParameterRef<bool> m_reassignTracksAfterFirstFit {this, "reassignTracksAfterFirstFit",
-                           config().m_reassignTracksAfterFirstFit,
+                           config().reassignTracksAfterFirstFit,
                            "Whether or not to reassign tracks after first fit"};
 
     Service<ACTSGeo_service> m_ACTSGeoSvc {this};

--- a/src/global/tracking/TrackParamTruthInit_factory.h
+++ b/src/global/tracking/TrackParamTruthInit_factory.h
@@ -29,13 +29,13 @@ private:
     PodioInput<edm4hep::MCParticle> m_particles_input {this};
     PodioOutput<edm4eic::TrackParameters> m_parameters_output {this};
 
-    ParameterRef<double> m_maxVertexX {this, "MaxVertexX", config().m_maxVertexX , "Maximum abs(vertex x) for truth tracks turned into seed"};
-    ParameterRef<double> m_maxVertexY {this, "MaxVertexY", config().m_maxVertexY , "Maximum abs(vertex y) for truth tracks turned into seed"};
-    ParameterRef<double> m_maxVertexZ {this, "MaxVertexZ", config().m_maxVertexZ , "Maximum abs(vertex z) for truth tracks turned into seed"};
-    ParameterRef<double> m_minMomentum {this, "MinMomentum", config().m_minMomentum , "Minimum momentum for truth tracks turned into seed"};
-    ParameterRef<double> m_maxEtaForward {this, "MaxEtaForward", config().m_maxEtaForward , "Maximum forward abs(eta) for truth tracks turned into seed"};
-    ParameterRef<double> m_maxEtaBackward {this, "MaxEtaBackward", config().m_maxEtaBackward , "Maximum backward abs(eta) for truth tracks turned into seed"};
-    ParameterRef<double> m_momentumSmear {this, "MomentumSmear", config().m_momentumSmear, "Momentum magnitude fraction to use as width of gaussian smearing"};
+    ParameterRef<double> m_maxVertexX {this, "MaxVertexX", config().maxVertexX , "Maximum abs(vertex x) for truth tracks turned into seed"};
+    ParameterRef<double> m_maxVertexY {this, "MaxVertexY", config().maxVertexY , "Maximum abs(vertex y) for truth tracks turned into seed"};
+    ParameterRef<double> m_maxVertexZ {this, "MaxVertexZ", config().maxVertexZ , "Maximum abs(vertex z) for truth tracks turned into seed"};
+    ParameterRef<double> m_minMomentum {this, "MinMomentum", config().minMomentum , "Minimum momentum for truth tracks turned into seed"};
+    ParameterRef<double> m_maxEtaForward {this, "MaxEtaForward", config().maxEtaForward , "Maximum forward abs(eta) for truth tracks turned into seed"};
+    ParameterRef<double> m_maxEtaBackward {this, "MaxEtaBackward", config().maxEtaBackward , "Maximum backward abs(eta) for truth tracks turned into seed"};
+    ParameterRef<double> m_momentumSmear {this, "MomentumSmear", config().momentumSmear, "Momentum magnitude fraction to use as width of gaussian smearing"};
 
     Service<ACTSGeo_service> m_ACTSGeoSvc {this};
 

--- a/src/global/tracking/TrackSeeding_factory.h
+++ b/src/global/tracking/TrackSeeding_factory.h
@@ -50,12 +50,12 @@ private:
     ParameterRef<float> m_impactMax {this, "impactMax", config().impactMax, "maximum impact parameter allowed for seeds for Acts::OrthogonalSeedFinder. rMin should be larger than impactMax."};
     ParameterRef<float> m_rMinMiddle {this, "rMinMiddle", config().rMinMiddle, "min radius for middle space point for Acts::OrthogonalSeedFinder"};
     ParameterRef<float> m_rMaxMiddle {this, "rMaxMiddle", config().rMaxMiddle, "max radius for middle space point for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_loc_a_Error {this, "loc_a_Error", config().loc_a_Error, "Error on Loc a for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_loc_b_Error {this, "loc_b_Error", config().loc_b_Error, "Error on Loc b for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_phi_Error {this, "phi_Error", config().phi_Error, "Error on phi for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_theta_Error {this, "theta_Error", config().theta_Error, "Error on theta for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_qOverP_Error {this, "qOverP_Error", config().qOverP_Error, "Error on q/p for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_time_Error {this, "time_Error", config().time_Error, "Error on time for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_locaError {this, "loc_a_Error", config().locaError, "Error on Loc a for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_locbError {this, "loc_b_Error", config().locbError, "Error on Loc b for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_phiError {this, "phi_Error", config().phiError, "Error on phi for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_thetaError {this, "theta_Error", config().thetaError, "Error on theta for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_qOverPError {this, "qOverP_Error", config().qOverPError, "Error on q/p for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_timeError {this, "time_Error", config().timeError, "Error on time for Acts::OrthogonalSeedFinder"};
 
     Service<ACTSGeo_service> m_ACTSGeoSvc {this};
 

--- a/src/global/tracking/TrackSeeding_factory.h
+++ b/src/global/tracking/TrackSeeding_factory.h
@@ -11,7 +11,7 @@
 #include <utility>
 #include <vector>
 
-#include "OrthogonalTrackSeedingConfig.h"
+#include "algorithms/tracking/OrthogonalTrackSeedingConfig.h"
 #include "algorithms/tracking/TrackSeeding.h"
 #include "extensions/jana/JOmniFactory.h"
 #include "services/geometry/acts/ACTSGeo_service.h"
@@ -29,33 +29,33 @@ private:
     PodioOutput<edm4eic::TrackParameters> m_parameters_output {this};
 
 
-    ParameterRef<float> m_rMax {this, "rMax", config().m_rMax, "max measurement radius for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_rMin {this, "rMin", config().m_rMin, "min measurement radius for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_deltaRMinTopSP {this, "deltaRMinTopSP", config().m_deltaRMinTopSP, "min distance in r between middle and top space point in one seed for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_deltaRMaxTopSP {this, "deltaRMaxTopSP", config().m_deltaRMaxTopSP, "max distance in r between middle and top space point in one seed for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_deltaRMinBottomSP {this, "deltaRMinBottomSP", config().m_deltaRMinBottomSP, "min distance in r between bottom and middle space point in one seed for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_deltaRMaxBottomSP {this, "deltaRMaxBottomSP", config().m_deltaRMaxBottomSP, "max distance in r between bottom and middle space point in one seed for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_collisionRegionMin {this, "collisionRegionMin", config().m_collisionRegionMin, "min location in z for collision region for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_collisionRegionMax {this, "collisionRegionMax", config().m_collisionRegionMax, "max location in z for collision region for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_zMax {this, "zMax", config().m_zMax, "Max z location for measurements for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_zMin {this, "zMin", config().m_zMin, "Min z location for measurements for Acts::OrthogonalSeedFinder"};
-    ParameterRef<unsigned int> m_maxSeedsPerSpM {this, "maxSeedsPerSpM", config().m_maxSeedsPerSpM, "Maximum number of seeds one space point can be the middle of for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_cotThetaMax {this, "cotThetaMax", config().m_cotThetaMax, "cot of maximum theta angle for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_sigmaScattering {this, "sigmaScattering", config().m_sigmaScattering, "number of sigmas of scattering angle to consider for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_radLengthPerSeed {this, "radLengthPerSeed", config().m_radLengthPerSeed, "Approximate number of radiation lengths one seed traverses for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_minPt {this, "minPt", config().m_minPt, "Minimum pT to search for for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_bFieldInZ {this, "bFieldInZ", config().m_bFieldInZ, "Value of B Field to use in kiloTesla for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_beamPosX {this, "beamPosX", config().m_beamPosX, "Beam position in x for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_beamPosY {this, "beamPosY", config().m_beamPosY, "Beam position in y for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_impactMax {this, "impactMax", config().m_impactMax, "maximum impact parameter allowed for seeds for Acts::OrthogonalSeedFinder. rMin should be larger than impactMax."};
-    ParameterRef<float> m_rMinMiddle {this, "rMinMiddle", config().m_rMinMiddle, "min radius for middle space point for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_rMaxMiddle {this, "rMaxMiddle", config().m_rMaxMiddle, "max radius for middle space point for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_loc_a_Error {this, "loc_a_Error", config().m_loc_a_Error, "Error on Loc a for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_loc_b_Error {this, "loc_b_Error", config().m_loc_b_Error, "Error on Loc b for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_phi_Error {this, "phi_Error", config().m_phi_Error, "Error on phi for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_theta_Error {this, "theta_Error", config().m_theta_Error, "Error on theta for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_qOverP_Error {this, "qOverP_Error", config().m_qOverP_Error, "Error on q/p for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_time_Error {this, "time_Error", config().m_time_Error, "Error on time for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_rMax {this, "rMax", config().rMax, "max measurement radius for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_rMin {this, "rMin", config().rMin, "min measurement radius for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_deltaRMinTopSP {this, "deltaRMinTopSP", config().deltaRMinTopSP, "min distance in r between middle and top space point in one seed for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_deltaRMaxTopSP {this, "deltaRMaxTopSP", config().deltaRMaxTopSP, "max distance in r between middle and top space point in one seed for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_deltaRMinBottomSP {this, "deltaRMinBottomSP", config().deltaRMinBottomSP, "min distance in r between bottom and middle space point in one seed for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_deltaRMaxBottomSP {this, "deltaRMaxBottomSP", config().deltaRMaxBottomSP, "max distance in r between bottom and middle space point in one seed for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_collisionRegionMin {this, "collisionRegionMin", config().collisionRegionMin, "min location in z for collision region for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_collisionRegionMax {this, "collisionRegionMax", config().collisionRegionMax, "max location in z for collision region for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_zMax {this, "zMax", config().zMax, "Max z location for measurements for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_zMin {this, "zMin", config().zMin, "Min z location for measurements for Acts::OrthogonalSeedFinder"};
+    ParameterRef<unsigned int> m_maxSeedsPerSpM {this, "maxSeedsPerSpM", config().maxSeedsPerSpM, "Maximum number of seeds one space point can be the middle of for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_cotThetaMax {this, "cotThetaMax", config().cotThetaMax, "cot of maximum theta angle for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_sigmaScattering {this, "sigmaScattering", config().sigmaScattering, "number of sigmas of scattering angle to consider for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_radLengthPerSeed {this, "radLengthPerSeed", config().radLengthPerSeed, "Approximate number of radiation lengths one seed traverses for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_minPt {this, "minPt", config().minPt, "Minimum pT to search for for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_bFieldInZ {this, "bFieldInZ", config().bFieldInZ, "Value of B Field to use in kiloTesla for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_beamPosX {this, "beamPosX", config().beamPosX, "Beam position in x for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_beamPosY {this, "beamPosY", config().beamPosY, "Beam position in y for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_impactMax {this, "impactMax", config().impactMax, "maximum impact parameter allowed for seeds for Acts::OrthogonalSeedFinder. rMin should be larger than impactMax."};
+    ParameterRef<float> m_rMinMiddle {this, "rMinMiddle", config().rMinMiddle, "min radius for middle space point for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_rMaxMiddle {this, "rMaxMiddle", config().rMaxMiddle, "max radius for middle space point for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_loc_a_Error {this, "loc_a_Error", config().loc_a_Error, "Error on Loc a for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_loc_b_Error {this, "loc_b_Error", config().loc_b_Error, "Error on Loc b for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_phi_Error {this, "phi_Error", config().phi_Error, "Error on phi for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_theta_Error {this, "theta_Error", config().theta_Error, "Error on theta for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_qOverP_Error {this, "qOverP_Error", config().qOverP_Error, "Error on q/p for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_time_Error {this, "time_Error", config().time_Error, "Error on time for Acts::OrthogonalSeedFinder"};
 
     Service<ACTSGeo_service> m_ACTSGeoSvc {this};
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Tidies the code so that the tracker configuration structs don't have the m_ tag. None of the other algorithm configuration structs are prefixed by m_ and it is my understanding that these are conventionally for class members which presumably they may have originally been before moving to a separate config.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No