### PR TITLE
treewide: fix "Immutable objects can only be added to subset collections" exception

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -151,7 +151,7 @@ namespace eicrecon {
 }
 
 //------------------------------------------------------------------------
-std::optional<edm4eic::Cluster> CalorimeterClusterRecoCoG::reconstruct(const edm4eic::ProtoCluster& pcl) const {
+std::optional<edm4eic::MutableCluster> CalorimeterClusterRecoCoG::reconstruct(const edm4eic::ProtoCluster& pcl) const {
   edm4eic::MutableCluster cl;
   cl.setNhits(pcl.hits_size());
 

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
@@ -80,7 +80,7 @@ namespace eicrecon {
     std::function<double(double, double, double, int)> weightFunc;
 
   private:
-    std::optional<edm4eic::Cluster> reconstruct(const edm4eic::ProtoCluster& pcl) const;
+    std::optional<edm4eic::MutableCluster> reconstruct(const edm4eic::ProtoCluster& pcl) const;
   };
 
 } // eicrecon

--- a/src/algorithms/calorimetry/ImagingClusterReco.h
+++ b/src/algorithms/calorimetry/ImagingClusterReco.h
@@ -146,7 +146,7 @@ namespace eicrecon {
 
   private:
 
-    static std::vector<edm4eic::Cluster> reconstruct_cluster_layers(const edm4eic::ProtoCluster& pcl) {
+    static std::vector<edm4eic::MutableCluster> reconstruct_cluster_layers(const edm4eic::ProtoCluster& pcl) {
         const auto& hits = pcl.getHits();
         const auto& weights = pcl.getWeights();
         // using map to have hits sorted by layer
@@ -162,7 +162,7 @@ namespace eicrecon {
         }
 
         // create layers
-        std::vector<edm4eic::Cluster> cl_layers;
+        std::vector<edm4eic::MutableCluster> cl_layers;
         for (const auto &[lid, layer_hits]: layer_map) {
             auto layer = reconstruct_layer(layer_hits);
             cl_layers.push_back(layer);
@@ -170,7 +170,7 @@ namespace eicrecon {
         return cl_layers;
     }
 
-    static edm4eic::Cluster reconstruct_layer(const std::vector<std::pair<const edm4eic::CalorimeterHit, float>>& hits) {
+    static edm4eic::MutableCluster reconstruct_layer(const std::vector<std::pair<const edm4eic::CalorimeterHit, float>>& hits) {
         edm4eic::MutableCluster layer;
         layer.setType(Jug::Reco::ClusterType::kClusterSlice);
         // Calculate averages
@@ -268,7 +268,7 @@ namespace eicrecon {
         return cluster;
     }
 
-    std::pair<double /* polar */, double /* azimuthal */> fit_track(const std::vector<edm4eic::Cluster> &layers) const {
+    std::pair<double /* polar */, double /* azimuthal */> fit_track(const std::vector<edm4eic::MutableCluster> &layers) const {
         int nrows = 0;
         decltype(edm4eic::ClusterData::position) mean_pos{0, 0, 0};
         for (const auto &layer: layers) {

--- a/src/algorithms/reco/MatchClusters.cc
+++ b/src/algorithms/reco/MatchClusters.cc
@@ -163,7 +163,7 @@ std::map<int, edm4eic::Cluster> MatchClusters::indexedClusters(
 
 // reconstruct a neutral cluster
 // (for now assuming the vertex is at (0,0,0))
-edm4eic::ReconstructedParticle MatchClusters::reconstruct_neutral(
+edm4eic::MutableReconstructedParticle MatchClusters::reconstruct_neutral(
         const edm4eic::Cluster *cluster, const double mass, const int32_t pdg) const {
 
     const float energy = cluster->getEnergy();

--- a/src/algorithms/reco/MatchClusters.h
+++ b/src/algorithms/reco/MatchClusters.h
@@ -63,7 +63,7 @@ namespace eicrecon {
 
       // reconstruct a neutral cluster
       // (for now assuming the vertex is at (0,0,0))
-      edm4eic::ReconstructedParticle reconstruct_neutral(
+      edm4eic::MutableReconstructedParticle reconstruct_neutral(
         const edm4eic::Cluster *cluster,
         const double mass, const int32_t pdg) const;
 


### PR DESCRIPTION
This fixes compatibility with PODIO 00-17-04+ where check

https://github.com/AIDASoft/podio/blob/5964958a9b151ea3637342e1e9aad1629f6de7a6/python/templates/Collection.cc.jinja2#L161C34-L161C91

was implemented as a part of the

https://github.com/AIDASoft/podio/commit/e5a13c2b8382c6969c6b3a6092de7adda0fd33f0

Fixes: #1366