### PR TITLE
LUMISPECCAL: LumiSpecCALHits -> EcalLumiSpecHits

### DIFF
--- a/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
+++ b/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
@@ -24,7 +24,7 @@ extern "C" {
         InitJANAPlugin(app);
 
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-          "EcalLumiSpecRawHits", {"LumiSpecCALHits"}, {"EcalLumiSpecRawHits"},
+          "EcalLumiSpecRawHits", {"EcalLumiSpecHits"}, {"EcalLumiSpecRawHits"},
           {
             .eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV}, // flat 2%
             .tRes = 0.0 * dd4hep::ns,
@@ -34,7 +34,7 @@ extern "C" {
             .pedSigmaADC = 1,
             .resolutionTDC = 10 * dd4hep::picosecond,
             .corrMeanScale = 1.0,
-            .readout = "LumiSpecCALHits",
+            .readout = "EcalLumiSpecHits",
           },
           app   // TODO: Remove me once fixed
         ));
@@ -49,20 +49,19 @@ extern "C" {
             .thresholdFactor = 0.0,
             .thresholdValue = 2.0,
             .sampFrac = 1.0,
-            .readout = "LumiSpecCALHits",
-            .sectorField = "sector",
+            .readout = "EcalLumiSpecHits",
           },
           app   // TODO: Remove me once fixed
         ));
         app->Add(new JOmniFactoryGeneratorT<CalorimeterTruthClustering_factory>(
-          "EcalLumiSpecTruthProtoClusters", {"EcalLumiSpecRecHits", "LumiSpecCALHits"}, {"EcalLumiSpecTruthProtoClusters"},
+          "EcalLumiSpecTruthProtoClusters", {"EcalLumiSpecRecHits", "EcalLumiSpecHits"}, {"EcalLumiSpecTruthProtoClusters"},
           app   // TODO: Remove me once fixed
         ));
         app->Add(new JOmniFactoryGeneratorT<CalorimeterIslandCluster_factory>(
           "EcalLumiSpecIslandProtoClusters", {"EcalLumiSpecRecHits"}, {"EcalLumiSpecIslandProtoClusters"},
           {
             .adjacencyMatrix = "(sector_1 == sector_2) && ((abs(floor(module_1 / 10) - floor(module_2 / 10)) + abs(fmod(module_1, 10) - fmod(module_2, 10))) == 1)",
-            .readout = "LumiSpecCALHits",
+            .readout = "EcalLumiSpecHits",
             .sectorDist = 0.0 * dd4hep::cm,
             .splitCluster=true,
             .minClusterHitEdep = 1.0 * dd4hep::MeV,
@@ -77,7 +76,7 @@ extern "C" {
           new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
              "EcalLumiSpecClusters",
             {"EcalLumiSpecIslandProtoClusters",  // edm4eic::ProtoClusterCollection
-             "LumiSpecCALHits"},                 // edm4hep::SimCalorimeterHitCollection
+             "EcalLumiSpecHits"},                // edm4hep::SimCalorimeterHitCollection
             {"EcalLumiSpecClusters",             // edm4eic::Cluster
              "EcalLumiSpecClusterAssociations"}, // edm4eic::MCRecoClusterParticleAssociation
             {
@@ -94,7 +93,7 @@ extern "C" {
           new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
              "EcalLumiSpecTruthClusters",
             {"EcalLumiSpecTruthProtoClusters",        // edm4eic::ProtoClusterCollection
-             "LumiSpecCALHits"},                      // edm4hep::SimCalorimeterHitCollection
+             "EcalLumiSpecHits"},                     // edm4hep::SimCalorimeterHitCollection
             {"EcalLumiSpecTruthClusters",             // edm4eic::Cluster
              "EcalLumiSpecTruthClusterAssociations"}, // edm4eic::MCRecoClusterParticleAssociation
             {


### PR DESCRIPTION
### Briefly, what does this PR introduce?

The LumiSpecCAL name is from deprecated `$DETECTOR_PATH/compact/far_backward/lumi/spec_homo_cal.xml` that was replaced by the `spec_ScFi_cal.xml` in https://github.com/eic/epic/commit/eaf7f8089c16ef4e935e97c671e957f82942fea4#diff-9ff1b47fbddbe9afe982f6dc6cce5c5f43a15362ff43fa4216c0b4f34a4bd72eR10.

This PR brings EICrecon in accordance to the geometry change. The sector field is deprecated and is removed as part of this change.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
Yes