### PR TITLE
fix: ignore .DS_Store, .vscode, .idea, cmake-build-* in subdirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ plugins/*
 build/*
 install/*
 
+# macOS metadata
+.DS_Store
+
 ##### C++ basic gitignore #####
 
 # Prerequisites
@@ -50,14 +53,13 @@ install/*
 ##### i g n o r i n g   I D E s #####
 
 # Remove IntelliJ idea and CLion in particular from the project scope (it is a personal stuff of each developer)
-.idea/
+**/.idea/
 
 # The same to vscode
-.vscode/*
+**/.vscode/*
 
 # CMake CLion style
-cmake-build-*/
-src/cmake-build-*/
+**/cmake-build-*/
 
 # File-based project format
 *.iws


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Some files are not explicitly ignored, and can get mistakenly committed. This PR adds the macOS `.DS_Store` metadata files, and `.vscode/`, `.idea/`, `cmake-build-*/` also in subdirectories. See #1383.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.