### PR TITLE
fix: CentralCKFActsTrajectories is the collection with ActsExamples::Trajectories

### DIFF
--- a/src/tests/track_propagation_test/TrackPropagationTest_processor.cc
+++ b/src/tests/track_propagation_test/TrackPropagationTest_processor.cc
@@ -88,7 +88,7 @@ void TrackPropagationTest_processor::Process(const std::shared_ptr<const JEvent>
     m_log->trace("TrackPropagationTest_processor event");
 
     // Get trajectories from tracking
-    auto trajectories = event->Get<ActsExamples::Trajectories>("CentralCKFTrajectories");
+    auto trajectories = event->Get<ActsExamples::Trajectories>("CentralCKFActsTrajectories");
 
     // Iterate over trajectories
     m_log->debug("Propagating through {} trajectories", trajectories.size());


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes an issue in src/tests/track_propagation_test where CentralCKFTrajectories were attempted to be cast into ActsExamples::Trajectories. Instead, CentralCKFActsTrajectories should be retrieved and cast into ActsExamples::Trajectories.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.