### PR TITLE
fix(ci): add src/tests plugins as CI jobs

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -481,6 +481,56 @@ jobs:
           cmake --build MyCustomPlugin/build -j $(getconf _NPROCESSORS_ONLN) --target install
           $PWD/install/bin/eicrecon -Pplugins=MyCustomPlugin -Ppodio:output_file=rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -Pplugins=dump_flags,janadot -Pdump_flags:json=${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json -Pjana:warmup_timeout=0 -Pjana:timeout=0
 
+  eicrecon-test-plugins:
+    runs-on: ubuntu-latest
+    needs:
+    - build
+    - npsim-gun
+    strategy:
+      matrix:
+        CC: [gcc]
+        particle: [e]
+        detector_config: [craterlake]
+        test_plugins:
+        - geometry_navigation_test
+        - reco_test
+        - tracking_test
+        - track_propagation_test
+    steps:
+    - name: mmap rnd_bits workaround
+      # https://github.com/actions/runner/issues/3207#issuecomment-2000066889
+      run: |
+        sudo sysctl -w vm.mmap_rnd_bits=28
+    - name: Checkout .github
+      uses: actions/checkout@v4
+      with:
+        sparse-checkout: .github
+    - name: Download install directory
+      uses: actions/download-artifact@v4
+      with:
+        name: install-${{ matrix.CC }}-eic-shell-Release
+    - name: Unarchive install directory
+      run: tar -xaf install.tar.zst
+    - uses: actions/download-artifact@v4
+      with:
+        name: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
+    - uses: cvmfs-contrib/github-action-cvmfs@v4
+    - name: Run EICrecon
+      uses: eic/run-cvmfs-osg-eic-shell@main
+      with:
+        platform-release: "${{ env.platform-release }}"
+        setup: "/opt/detector/epic-${{ env.detector-version }}/setup.sh"
+        run: |
+          export DETECTOR_CONFIG=${DETECTOR}_${{ matrix.detector_config }}
+          export LD_LIBRARY_PATH=$PWD/install/lib:$LD_LIBRARY_PATH
+          export JANA_PLUGIN_PATH=$PWD/install/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
+          $PWD/install/bin/eicrecon -Pplugins=${{ matrix.test_plugins }} -Phistsfile=rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}_${{ matrix.test_plugins }}.hists.root -Ppodio:output_file=rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -Pplugins=dump_flags,janadot -Pdump_flags:json=${{ matrix.particle }}_${{ matrix.detector_config }}_flags.json -Pjana:warmup_timeout=0 -Pjana:timeout=0
+    - uses: actions/upload-artifact@v4
+      with:
+        name: rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}_${{ matrix.test_plugins }}.hists.root
+        path: rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}_${{ matrix.test_plugins }}.hists.root
+        if-no-files-found: error
+
   eicrecon-benchmarks-plugins:
     runs-on: ubuntu-latest
     needs:

--- a/src/tests/track_propagation_test/TrackPropagationTest_processor.cc
+++ b/src/tests/track_propagation_test/TrackPropagationTest_processor.cc
@@ -22,6 +22,7 @@
 
 #include "TrackPropagationTest_processor.h"
 #include "services/geometry/acts/ACTSGeo_service.h"
+#include "services/geometry/dd4hep/DD4hep_service.h"
 #include "services/rootfile/RootFile_service.h"
 
 
@@ -60,11 +61,10 @@ void TrackPropagationTest_processor::Init()
     // Get log level from user parameter or default
     InitLogger(app, plugin_name);
 
+    auto dd4hep_service = GetApplication()->GetService<DD4hep_service>();
     auto acts_service = GetApplication()->GetService<ACTSGeo_service>();
 
-    auto detector = dd4hep::Detector::make_unique("");
-
-    m_propagation_algo.init(detector.get(), acts_service->actsGeoProvider(), logger());
+    m_propagation_algo.init(dd4hep_service->detector(), acts_service->actsGeoProvider(), logger());
 
     // Create HCal surface that will be used for propagation
     auto transform = Acts::Transform3::Identity();

--- a/src/tests/track_propagation_test/TrackPropagationTest_processor.cc
+++ b/src/tests/track_propagation_test/TrackPropagationTest_processor.cc
@@ -4,7 +4,6 @@
 #include <Acts/Surfaces/RadialBounds.hpp>
 #include <Acts/Surfaces/Surface.hpp>
 #include <ActsExamples/EventData/Trajectories.hpp>
-#include <DD4hep/Detector.h>
 #include <JANA/JApplication.h>
 #include <JANA/JEvent.h>
 #include <JANA/JException.h>
@@ -12,6 +11,7 @@
 #include <edm4eic/TrackPoint.h>
 #include <edm4hep/Vector3f.h>
 #include <fmt/core.h>
+#include <gsl/pointers>
 #include <spdlog/logger.h>
 #include <stddef.h>
 #include <Eigen/Geometry>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
We don't test what's in src/tests, to a large degree (exception is the catch unit tests), and this leads to code issues, e.g. #1385.

This PR adds the test plugins in src/tests to a CI job. ~~It won't actually catch #1385 until we stop silently eating exceptions...~~ It catches #1385 now, https://github.com/eic/EICrecon/actions/runs/8726213766/job/23941043650#step:8:676.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: failures like #1385 are not caught)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.