### PR TITLE
Remove outdated comment on mc-cluster associations

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -91,14 +91,6 @@ namespace eicrecon {
           }
         );
 
-        // FIXME: The code below fails for HcalEndcapPClusters. This does not happen for
-        // FIXME: all calorimeters. A brief scan of the code suggests this could be caused
-        // FIXME: by the CalorimeterHitDigi algorithm modifying the cellID for the raw hits.
-        // FIXME: Thus, the cellID values passed on through to here no longer match those
-        // FIXME: in the low-level truth hits. It likely works for other detectors because
-        // FIXME: their u_fields and u_refs members are left empty which effectively results
-        // FIXME: in the cellID being unchanged.
-
         // 2. find mchit with same CellID
         // find_if not working, https://github.com/AIDASoft/podio/pull/273
         //auto mchit = std::find_if(


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This PR removes an old comment left in the MCParticle-Cluster association code. The comment stated that the code doesn't work for HcalEndcapPClusters, However, this seems to be no longer the case.

### What kind of change does this PR introduce?
- [X] Bug fix (issue #1387 )
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [X] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [X] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No.

### Does this PR change default behavior?

No.