### PR TITLE
Add associations between tracker Raw and Sim hits

### DIFF
--- a/src/algorithms/digi/SiliconTrackerDigi.cc
+++ b/src/algorithms/digi/SiliconTrackerDigi.cc
@@ -36,7 +36,7 @@ void SiliconTrackerDigi::process(
         const SiliconTrackerDigi::Output& output) const {
 
     const auto [sim_hits] = input;
-    auto [raw_hits] = output;
+    auto [raw_hits,associations] = output;
 
     // A map of unique cellIDs with temporary structure RawHit
     std::unordered_map<std::uint64_t, edm4eic::MutableRawTrackerHit> cell_hit_map;
@@ -90,6 +90,16 @@ void SiliconTrackerDigi::process(
 
     for (auto item : cell_hit_map) {
         raw_hits->push_back(item.second);
+
+	// set association
+	auto hitassoc = associations->create();
+	hitassoc.setWeight(1.0);
+	hitassoc.setRawHit(item.second);
+
+	for (const auto& sim_hit : *sim_hits) {
+		if(item.first == sim_hit.getCellID()) hitassoc.addToSimHits(sim_hit);	
+	}
+
     }
 }
 

--- a/src/algorithms/digi/SiliconTrackerDigi.cc
+++ b/src/algorithms/digi/SiliconTrackerDigi.cc
@@ -91,14 +91,14 @@ void SiliconTrackerDigi::process(
     for (auto item : cell_hit_map) {
         raw_hits->push_back(item.second);
 
-	// set association
-	auto hitassoc = associations->create();
-	hitassoc.setWeight(1.0);
-	hitassoc.setRawHit(item.second);
+        // set association
+        auto hitassoc = associations->create();
+        hitassoc.setWeight(1.0);
+        hitassoc.setRawHit(item.second);
 
-	for (const auto& sim_hit : *sim_hits) {
-		if(item.first == sim_hit.getCellID()) hitassoc.addToSimHits(sim_hit);	
-	}
+        for (const auto& sim_hit : *sim_hits) {
+                if(item.first == sim_hit.getCellID()) hitassoc.addToSimHits(sim_hit);
+        }
 
     }
 }

--- a/src/algorithms/digi/SiliconTrackerDigi.cc
+++ b/src/algorithms/digi/SiliconTrackerDigi.cc
@@ -91,13 +91,14 @@ void SiliconTrackerDigi::process(
     for (auto item : cell_hit_map) {
         raw_hits->push_back(item.second);
 
-        // set association
-        auto hitassoc = associations->create();
-        hitassoc.setWeight(1.0);
-        hitassoc.setRawHit(item.second);
-
         for (const auto& sim_hit : *sim_hits) {
-                if(item.first == sim_hit.getCellID()) hitassoc.addToSimHits(sim_hit);
+          if (item.first == sim_hit.getCellID()) {
+            // set association
+            auto hitassoc = associations->create();
+            hitassoc.setWeight(1.0);
+            hitassoc.setRawHit(item.second);
+            hitassoc.addToSimHits(sim_hit);
+          }
         }
 
     }

--- a/src/algorithms/digi/SiliconTrackerDigi.h
+++ b/src/algorithms/digi/SiliconTrackerDigi.h
@@ -6,6 +6,7 @@
 #include <TRandomGen.h>
 #include <algorithms/algorithm.h>
 #include <edm4eic/RawTrackerHitCollection.h>
+#include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
 #include <edm4hep/SimTrackerHitCollection.h>
 #include <spdlog/logger.h>
 #include <functional>
@@ -23,7 +24,8 @@ namespace eicrecon {
       edm4hep::SimTrackerHitCollection
     >,
     algorithms::Output<
-      edm4eic::RawTrackerHitCollection
+      edm4eic::RawTrackerHitCollection,
+      edm4eic::MCRecoTrackerHitAssociationCollection
     >
   >;
 
@@ -35,7 +37,7 @@ namespace eicrecon {
     SiliconTrackerDigi(std::string_view name)
       : SiliconTrackerDigiAlgorithm{name,
                             {"inputHitCollection"},
-                            {"outputRawHitCollection"},
+                            {"outputRawHitCollection","outputHitAssociations"},
                             "Apply threshold, digitize within ADC range, "
                             "convert time with smearing resolution."} {}
 

--- a/src/detectors/B0TRK/B0TRK.cc
+++ b/src/detectors/B0TRK/B0TRK.cc
@@ -21,8 +21,13 @@ void InitPlugin(JApplication *app) {
     // Digitization
     app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
         "B0TrackerRawHits",
-        {"B0TrackerHits"},
-        {"B0TrackerRawHits"},
+        {
+	  "B0TrackerHits"
+	},
+        {
+	  "B0TrackerRawHits",
+	  "B0TrackerHitAssociations"
+	},
         {
             .threshold = 10.0 * dd4hep::keV,
             .timeResolution = 8,

--- a/src/detectors/B0TRK/B0TRK.cc
+++ b/src/detectors/B0TRK/B0TRK.cc
@@ -22,12 +22,12 @@ void InitPlugin(JApplication *app) {
     app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
         "B0TrackerRawHits",
         {
-	  "B0TrackerHits"
-	},
+          "B0TrackerHits"
+        },
         {
-	  "B0TrackerRawHits",
-	  "B0TrackerHitAssociations"
-	},
+          "B0TrackerRawHits",
+          "B0TrackerHitAssociations"
+        },
         {
             .threshold = 10.0 * dd4hep::keV,
             .timeResolution = 8,

--- a/src/detectors/BTOF/BTOF.cc
+++ b/src/detectors/BTOF/BTOF.cc
@@ -22,12 +22,12 @@ void InitPlugin(JApplication *app) {
     app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
         "TOFBarrelRawHit",
         {
-	  "TOFBarrelHits"
-	},
+          "TOFBarrelHits"
+        },
         {
-	  "TOFBarrelRawHit",
-	  "TOFBarrelHitAssociations"
-	},
+          "TOFBarrelRawHit",
+          "TOFBarrelHitAssociations"
+        },
         {
             .threshold = 6.0 * dd4hep::keV,
             .timeResolution = 0.025,    // [ns]

--- a/src/detectors/BTOF/BTOF.cc
+++ b/src/detectors/BTOF/BTOF.cc
@@ -21,8 +21,13 @@ void InitPlugin(JApplication *app) {
     // Digitization
     app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
         "TOFBarrelRawHit",
-        {"TOFBarrelHits"},
-        {"TOFBarrelRawHit"},
+        {
+	  "TOFBarrelHits"
+	},
+        {
+	  "TOFBarrelRawHit",
+	  "TOFBarrelHitAssociations"
+	},
         {
             .threshold = 6.0 * dd4hep::keV,
             .timeResolution = 0.025,    // [ns]

--- a/src/detectors/BTRK/BTRK.cc
+++ b/src/detectors/BTRK/BTRK.cc
@@ -22,12 +22,12 @@ void InitPlugin(JApplication *app) {
     app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
         "SiBarrelRawHits",
         {
-	  "SiBarrelHits"
-	},
+          "SiBarrelHits"
+        },
         {
-	  "SiBarrelRawHits",
-	  "SiBarrelHitAssociations"
-	},
+          "SiBarrelRawHits",
+          "SiBarrelHitAssociations"
+        },
         {
             .threshold = 0.54 * dd4hep::keV,
         },

--- a/src/detectors/BTRK/BTRK.cc
+++ b/src/detectors/BTRK/BTRK.cc
@@ -21,8 +21,13 @@ void InitPlugin(JApplication *app) {
     // Digitization
     app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
         "SiBarrelRawHits",
-        {"SiBarrelHits"},
-        {"SiBarrelRawHits"},
+        {
+	  "SiBarrelHits"
+	},
+        {
+	  "SiBarrelRawHits",
+	  "SiBarrelHitAssociations"
+	},
         {
             .threshold = 0.54 * dd4hep::keV,
         },

--- a/src/detectors/BVTX/BVTX.cc
+++ b/src/detectors/BVTX/BVTX.cc
@@ -27,7 +27,7 @@ void InitPlugin(JApplication *app) {
         {
           "SiBarrelVertexRawHits",
           "SiBarrelVertexHitAssociations"
-	},
+        },
         {
             .threshold = 0.54 * dd4hep::keV,
         },

--- a/src/detectors/BVTX/BVTX.cc
+++ b/src/detectors/BVTX/BVTX.cc
@@ -21,8 +21,13 @@ void InitPlugin(JApplication *app) {
     // Digitization
     app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
         "SiBarrelVertexRawHits",
-        {"VertexBarrelHits"},
-        {"SiBarrelVertexRawHits"},
+        {
+          "VertexBarrelHits"
+        },
+        {
+          "SiBarrelVertexRawHits",
+          "SiBarrelVertexHitAssociations"
+	},
         {
             .threshold = 0.54 * dd4hep::keV,
         },

--- a/src/detectors/ECTOF/ECTOF.cc
+++ b/src/detectors/ECTOF/ECTOF.cc
@@ -25,7 +25,7 @@ void InitPlugin(JApplication *app) {
         "TOFEndcapHits"},
       {
         "TOFEndcapRawHits",
-	"TOFEndcapHitAssociations"
+        "TOFEndcapHitAssociations"
       },
       {
         .threshold = 6.0 * dd4hep::keV,

--- a/src/detectors/ECTOF/ECTOF.cc
+++ b/src/detectors/ECTOF/ECTOF.cc
@@ -21,8 +21,12 @@ void InitPlugin(JApplication *app) {
     // Digitization
     app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
       "TOFEndcapRawHits",
-      {"TOFEndcapHits"},
-      {"TOFEndcapRawHits"},
+      {
+        "TOFEndcapHits"},
+      {
+        "TOFEndcapRawHits",
+	"TOFEndcapHitAssociations"
+      },
       {
         .threshold = 6.0 * dd4hep::keV,
         .timeResolution = 0.025,

--- a/src/detectors/ECTRK/ECTRK.cc
+++ b/src/detectors/ECTRK/ECTRK.cc
@@ -21,8 +21,13 @@ void InitPlugin(JApplication *app) {
     // Digitization
     app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
         "SiEndcapTrackerRawHits",
-        {"TrackerEndcapHits"},
-        {"SiEndcapTrackerRawHits"},
+        {
+	  "TrackerEndcapHits"
+        },
+        {
+	  "SiEndcapTrackerRawHits",
+	  "SiEndcapHitAssociations"
+	},
         {
             .threshold = 0.54 * dd4hep::keV,
         },

--- a/src/detectors/ECTRK/ECTRK.cc
+++ b/src/detectors/ECTRK/ECTRK.cc
@@ -22,12 +22,12 @@ void InitPlugin(JApplication *app) {
     app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
         "SiEndcapTrackerRawHits",
         {
-	  "TrackerEndcapHits"
+          "TrackerEndcapHits"
         },
         {
-	  "SiEndcapTrackerRawHits",
-	  "SiEndcapHitAssociations"
-	},
+          "SiEndcapTrackerRawHits",
+          "SiEndcapHitAssociations"
+        },
         {
             .threshold = 0.54 * dd4hep::keV,
         },

--- a/src/detectors/FOFFMTRK/FOFFMTRK.cc
+++ b/src/detectors/FOFFMTRK/FOFFMTRK.cc
@@ -24,8 +24,13 @@ void InitPlugin(JApplication *app) {
         //Digitized hits, especially for thresholds
         app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
         "ForwardOffMTrackerRawHits",
-        {"ForwardOffMTrackerHits"},
-        {"ForwardOffMTrackerRawHits"},
+        {
+	  "ForwardOffMTrackerHits"
+	},
+        {
+	  "ForwardOffMTrackerRawHits",
+	  "ForwardOffMTrackerHitAssociations"
+	},
         {
             .threshold = 10.0 * dd4hep::keV,
             .timeResolution = 8,

--- a/src/detectors/FOFFMTRK/FOFFMTRK.cc
+++ b/src/detectors/FOFFMTRK/FOFFMTRK.cc
@@ -25,12 +25,12 @@ void InitPlugin(JApplication *app) {
         app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
         "ForwardOffMTrackerRawHits",
         {
-	  "ForwardOffMTrackerHits"
-	},
+          "ForwardOffMTrackerHits"
+        },
         {
-	  "ForwardOffMTrackerRawHits",
-	  "ForwardOffMTrackerHitAssociations"
-	},
+          "ForwardOffMTrackerRawHits",
+          "ForwardOffMTrackerHitAssociations"
+        },
         {
             .threshold = 10.0 * dd4hep::keV,
             .timeResolution = 8,

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -28,12 +28,12 @@ extern "C" {
     app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
          "TaggerTrackerRawHits",
          {
-	   "TaggerTrackerHits"
-	 },
+           "TaggerTrackerHits"
+         },
          {
-	   "TaggerTrackerRawHits",
-	   "TaggerTrackerHitAssociations"
-	 },
+           "TaggerTrackerRawHits",
+           "TaggerTrackerHitAssociations"
+         },
          {
            .threshold = 1.5 * dd4hep::keV,
            .timeResolution = 2 * dd4hep::ns,

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -27,8 +27,13 @@ extern "C" {
     // Digitization of silicon hits
     app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
          "TaggerTrackerRawHits",
-         {"TaggerTrackerHits"},
-         {"TaggerTrackerRawHits"},
+         {
+	   "TaggerTrackerHits"
+	 },
+         {
+	   "TaggerTrackerRawHits",
+	   "TaggerTrackerHitAssociations"
+	 },
          {
            .threshold = 1.5 * dd4hep::keV,
            .timeResolution = 2 * dd4hep::ns,

--- a/src/detectors/MPGD/MPGD.cc
+++ b/src/detectors/MPGD/MPGD.cc
@@ -21,8 +21,13 @@ void InitPlugin(JApplication *app) {
     // Digitization
     app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
         "MPGDBarrelRawHits",
-        {"MPGDBarrelHits"},
-        {"MPGDBarrelRawHits"},
+        {
+	  "MPGDBarrelHits"
+	},
+        {
+	  "MPGDBarrelRawHits",
+	  "MPGDBarrelHitAssociations"
+	},
         {
             .threshold = 0.25 * dd4hep::keV,
             .timeResolution = 10,
@@ -44,8 +49,13 @@ void InitPlugin(JApplication *app) {
     // Digitization
     app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
         "OuterMPGDBarrelRawHits",
-        {"OuterMPGDBarrelHits"},
-        {"OuterMPGDBarrelRawHits"},
+        {
+	  "OuterMPGDBarrelHits"
+	},
+        {
+	  "OuterMPGDBarrelRawHits",
+	  "OuterMPGDBarrelHitAssociations"
+	},
         {
             .threshold = 0.25 * dd4hep::keV,
             .timeResolution = 10,
@@ -67,8 +77,13 @@ void InitPlugin(JApplication *app) {
     // Digitization
     app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
         "BackwardMPGDEndcapRawHits",
-        {"BackwardMPGDEndcapHits"},
-        {"BackwardMPGDEndcapRawHits"},
+        {
+	  "BackwardMPGDEndcapHits"
+	},
+        {
+	  "BackwardMPGDEndcapRawHits",
+	  "BackwardMPGDEndcapAssociations"
+	},
         {
             .threshold = 0.25 * dd4hep::keV,
             .timeResolution = 10,
@@ -90,8 +105,13 @@ void InitPlugin(JApplication *app) {
     // Digitization
     app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
         "ForwardMPGDEndcapRawHits",
-        {"ForwardMPGDEndcapHits"},
-        {"ForwardMPGDEndcapRawHits"},
+        {
+	  "ForwardMPGDEndcapHits"
+	},
+        {
+	  "ForwardMPGDEndcapRawHits",
+	  "ForwardMPGDHitAssociations"
+	},
         {
             .threshold = 0.25 * dd4hep::keV,
             .timeResolution = 10,

--- a/src/detectors/MPGD/MPGD.cc
+++ b/src/detectors/MPGD/MPGD.cc
@@ -22,12 +22,12 @@ void InitPlugin(JApplication *app) {
     app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
         "MPGDBarrelRawHits",
         {
-	  "MPGDBarrelHits"
-	},
+          "MPGDBarrelHits"
+        },
         {
-	  "MPGDBarrelRawHits",
-	  "MPGDBarrelHitAssociations"
-	},
+          "MPGDBarrelRawHits",
+          "MPGDBarrelHitAssociations"
+        },
         {
             .threshold = 0.25 * dd4hep::keV,
             .timeResolution = 10,
@@ -50,12 +50,12 @@ void InitPlugin(JApplication *app) {
     app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
         "OuterMPGDBarrelRawHits",
         {
-	  "OuterMPGDBarrelHits"
-	},
+          "OuterMPGDBarrelHits"
+        },
         {
-	  "OuterMPGDBarrelRawHits",
-	  "OuterMPGDBarrelHitAssociations"
-	},
+          "OuterMPGDBarrelRawHits",
+          "OuterMPGDBarrelHitAssociations"
+        },
         {
             .threshold = 0.25 * dd4hep::keV,
             .timeResolution = 10,
@@ -78,12 +78,12 @@ void InitPlugin(JApplication *app) {
     app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
         "BackwardMPGDEndcapRawHits",
         {
-	  "BackwardMPGDEndcapHits"
-	},
+          "BackwardMPGDEndcapHits"
+        },
         {
-	  "BackwardMPGDEndcapRawHits",
-	  "BackwardMPGDEndcapAssociations"
-	},
+          "BackwardMPGDEndcapRawHits",
+          "BackwardMPGDEndcapAssociations"
+        },
         {
             .threshold = 0.25 * dd4hep::keV,
             .timeResolution = 10,
@@ -106,12 +106,12 @@ void InitPlugin(JApplication *app) {
     app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
         "ForwardMPGDEndcapRawHits",
         {
-	  "ForwardMPGDEndcapHits"
-	},
+          "ForwardMPGDEndcapHits"
+        },
         {
-	  "ForwardMPGDEndcapRawHits",
-	  "ForwardMPGDHitAssociations"
-	},
+          "ForwardMPGDEndcapRawHits",
+          "ForwardMPGDHitAssociations"
+        },
         {
             .threshold = 0.25 * dd4hep::keV,
             .timeResolution = 10,

--- a/src/detectors/RPOTS/RPOTS.cc
+++ b/src/detectors/RPOTS/RPOTS.cc
@@ -25,12 +25,12 @@ void InitPlugin(JApplication *app) {
         app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
         "ForwardRomanPotRawHits",
         {
-	  "ForwardRomanPotHits"
-	},
+          "ForwardRomanPotHits"
+        },
         {
-	  "ForwardRomanPotRawHits",
-	  "ForwardRomanPotHitAssociations"
-	},
+          "ForwardRomanPotRawHits",
+          "ForwardRomanPotHitAssociations"
+        },
         {
             .threshold = 10.0 * dd4hep::keV,
             .timeResolution = 8,

--- a/src/detectors/RPOTS/RPOTS.cc
+++ b/src/detectors/RPOTS/RPOTS.cc
@@ -24,8 +24,13 @@ void InitPlugin(JApplication *app) {
         //Digitized hits, especially for thresholds
         app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
         "ForwardRomanPotRawHits",
-        {"ForwardRomanPotHits"},
-        {"ForwardRomanPotRawHits"},
+        {
+	  "ForwardRomanPotHits"
+	},
+        {
+	  "ForwardRomanPotRawHits",
+	  "ForwardRomanPotHitAssociations"
+	},
         {
             .threshold = 10.0 * dd4hep::keV,
             .timeResolution = 8,

--- a/src/factories/digi/SiliconTrackerDigi_factory.h
+++ b/src/factories/digi/SiliconTrackerDigi_factory.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "algorithms/digi/SiliconTrackerDigi.h"
+#include "services/algorithms_init/AlgorithmsInit_service.h"
 #include "extensions/jana/JOmniFactory.h"
 
 
@@ -17,10 +18,14 @@ private:
     std::unique_ptr<AlgoT> m_algo;
 
     PodioInput<edm4hep::SimTrackerHit> m_sim_hits_input {this};
+
     PodioOutput<edm4eic::RawTrackerHit> m_raw_hits_output {this};
+    PodioOutput<edm4eic::MCRecoTrackerHitAssociation> m_assoc_output {this};
 
     ParameterRef<double> m_threshold {this, "threshold", config().threshold};
     ParameterRef<double> m_timeResolution {this, "timeResolution", config().timeResolution};
+
+    Service<AlgorithmsInit_service> m_algorithmsInit {this};
 
 public:
     void Configure() {
@@ -33,7 +38,8 @@ public:
     }
 
     void Process(int64_t run_number, uint64_t event_number) {
-        m_algo->process({m_sim_hits_input()}, {m_raw_hits_output().get()});
+        m_algo->process({m_sim_hits_input()},
+			{m_raw_hits_output().get(),m_assoc_output().get()});
     }
 };
 

--- a/src/factories/digi/SiliconTrackerDigi_factory.h
+++ b/src/factories/digi/SiliconTrackerDigi_factory.h
@@ -25,8 +25,6 @@ private:
     ParameterRef<double> m_threshold {this, "threshold", config().threshold};
     ParameterRef<double> m_timeResolution {this, "timeResolution", config().timeResolution};
 
-    Service<AlgorithmsInit_service> m_algorithmsInit {this};
-
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());

--- a/src/factories/digi/SiliconTrackerDigi_factory.h
+++ b/src/factories/digi/SiliconTrackerDigi_factory.h
@@ -39,7 +39,7 @@ public:
 
     void Process(int64_t run_number, uint64_t event_number) {
         m_algo->process({m_sim_hits_input()},
-			{m_raw_hits_output().get(),m_assoc_output().get()});
+                        {m_raw_hits_output().get(),m_assoc_output().get()});
     }
 };
 

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -68,9 +68,9 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "VertexBarrelHits",
             "TrackerEndcapHits",
 
-	    "SiBarrelHitAssociations",
-	    "SiBarrelVertexHitAssociations",
-	    "SiEndcapHitAssociations",
+            "SiBarrelHitAssociations",
+            "SiBarrelVertexHitAssociations",
+            "SiEndcapHitAssociations",
 
             // TOF
             "TOFBarrelRecHit",
@@ -82,8 +82,8 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "TOFBarrelHits",
             "TOFEndcapHits",
 
-	    "TOFBarrelHitAssociations",
-	    "TOFEndcapHitAssociations",
+            "TOFBarrelHitAssociations",
+            "TOFEndcapHitAssociations",
 
             // DRICH
             "DRICHRawHits",
@@ -113,29 +113,29 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "BackwardMPGDEndcapHits",
             "ForwardMPGDEndcapHits",
 
-	    "MPGDBarrelHitAssociations",
-	    "OuterMPGDBarrelHitAssociations",
-	    "BackwardMPGDEndcapAssociations",
-	    "ForwardMPGDHitAssociations",
+            "MPGDBarrelHitAssociations",
+            "OuterMPGDBarrelHitAssociations",
+            "BackwardMPGDEndcapAssociations",
+            "ForwardMPGDHitAssociations",
 
             // LOWQ2 hits
             "TaggerTrackerRawHits",
-	    "TaggerTrackerHitAssociations",
+            "TaggerTrackerHitAssociations",
 
             // Forward & Far forward hits
             "B0TrackerRecHits",
             "B0TrackerRawHits",
             "B0TrackerHits",
-	    "B0TrackerHitAssociations",
+            "B0TrackerHitAssociations",
 
             "ForwardRomanPotRecHits",
             "ForwardOffMTrackerRecHits",
-            
+
             "ForwardRomanPotRecParticles",
             "ForwardOffMRecParticles",
-	    
-	    "ForwardRomanPotHitAssociations",
-	    "ForwardOffMTrackerHitAssociations",	
+
+            "ForwardRomanPotHitAssociations",
+            "ForwardOffMTrackerHitAssociations",
 
             // Reconstructed data
             "GeneratedParticles",

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -68,6 +68,10 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "VertexBarrelHits",
             "TrackerEndcapHits",
 
+	    "SiBarrelHitAssociations",
+	    "SiBarrelVertexHitAssociations",
+	    "SiEndcapHitAssociations",
+
             // TOF
             "TOFBarrelRecHit",
             "TOFEndcapRecHits",
@@ -77,6 +81,10 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
 
             "TOFBarrelHits",
             "TOFEndcapHits",
+
+	    "TOFBarrelHitAssociations",
+	    "TOFEndcapHitAssociations",
+
             // DRICH
             "DRICHRawHits",
             "DRICHRawHitsAssociations",
@@ -104,18 +112,30 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "OuterMPGDBarrelHits",
             "BackwardMPGDEndcapHits",
             "ForwardMPGDEndcapHits",
+
+	    "MPGDBarrelHitAssociations",
+	    "OuterMPGDBarrelHitAssociations",
+	    "BackwardMPGDEndcapAssociations",
+	    "ForwardMPGDHitAssociations",
+
             // LOWQ2 hits
             "TaggerTrackerRawHits",
+	    "TaggerTrackerHitAssociations",
 
             // Forward & Far forward hits
             "B0TrackerRecHits",
             "B0TrackerRawHits",
             "B0TrackerHits",
+	    "B0TrackerHitAssociations",
+
             "ForwardRomanPotRecHits",
             "ForwardOffMTrackerRecHits",
-            //
+            
             "ForwardRomanPotRecParticles",
             "ForwardOffMRecParticles",
+	    
+	    "ForwardRomanPotHitAssociations",
+	    "ForwardOffMTrackerHitAssociations",	
 
             // Reconstructed data
             "GeneratedParticles",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This fills the `edm4eic::MCRecoTrackerHitAssociation` for each tracking detector. This should allow us to more easily implement track to MCParticle hit-based matching.

An example of the result for 1 single-muon event and one subsystem (SVT endcap) is shown below:

```
SiEndcapHitAssociations = (vector<edm4eic::MCRecoTrackerHitAssociationData>*)0x559bcc564160
 SiEndcapHitAssociations.weight = 1.000000, 1.000000, 1.000000, 1.000000
 SiEndcapHitAssociations.simHits_begin = 0, 1, 2, 3
 SiEndcapHitAssociations.simHits_end = 1, 2, 3, 4
 _SiEndcapHitAssociations_simHits = (vector<podio::ObjectID>*)0x559bcc5a96a0
 _SiEndcapHitAssociations_simHits.index = 2, 3, 1, 0
 _SiEndcapHitAssociations_simHits.collectionID = 1948551886, 1948551886, 1948551886, 1948551886
 _SiEndcapHitAssociations_rawHit = (vector<podio::ObjectID>*)0x559bcc5eebe0
 _SiEndcapHitAssociations_rawHit.index = 0, 1, 2, 3
 _SiEndcapHitAssociations_rawHit.collectionID = 1932353945, 1932353945, 1932353945, 1932353945
 SiEndcapTrackerRawHits = (vector<edm4eic::RawTrackerHitData>*)0x559bcc610460
 SiEndcapTrackerRawHits.cellID = 16923118878035329862, 17280310082315273286, 16544254001764418118, 16186218179280814405
 SiEndcapTrackerRawHits.charge = 12, 11, 8, 15
 SiEndcapTrackerRawHits.timeStamp = -6769, 16333, 17563, 16
 SiEndcapTrackerRecHits = (vector<edm4eic::TrackerHitData>*)0x559bc5a2b160
 SiEndcapTrackerRecHits.cellID = 16923118878035329862, 17280310082315273286, 16544254001764418118, 16186218179280814405
 SiEndcapTrackerRecHits.position.x = -46.624271, -58.748764, -34.917282, -23.603687
 SiEndcapTrackerRecHits.position.y = -112.486023, -138.429794, -86.344360, -59.997082
 SiEndcapTrackerRecHits.position.z = -849.864990, -1049.864990, -649.864990, -449.864990
 SiEndcapTrackerRecHits.positionError.xx = 0.000033, 0.000033, 0.000033, 0.000033
 SiEndcapTrackerRecHits.positionError.yy = 0.000033, 0.000033, 0.000033, 0.000033
 SiEndcapTrackerRecHits.positionError.zz = 0.000000, 0.000000, 0.000000, 0.000000
 SiEndcapTrackerRecHits.time = -6.769000, 16.333000, 17.563000, 0.016000
 SiEndcapTrackerRecHits.timeError = 10.000000, 10.000000, 10.000000, 10.000000
 SiEndcapTrackerRecHits.edep = 0.000012, 0.000011, 0.000008, 0.000015
 SiEndcapTrackerRecHits.edepError = 0.000000, 0.000000, 0.000000, 0.000000
 TrackerEndcapHits = (vector<edm4hep::SimTrackerHitData>*)0x559bc20326e0
 TrackerEndcapHits.cellID = 16186218179280814405, 16544254001764418118, 16923118878035329862, 17280310082315273286
 TrackerEndcapHits.EDep = 0.000015, 0.000008, 0.000012, 0.000011
 TrackerEndcapHits.time = 1.516304, 2.190398, 2.864473, 3.538543
 TrackerEndcapHits.pathLength = 0.040409, 0.040409, 0.040408, 0.040408
 TrackerEndcapHits.quality = 0, 0, 0, 0
 TrackerEndcapHits.position.x = -23.6101, -34.9112, -46.6319, -58.7455
 TrackerEndcapHits.position.y = -59.9919, -86.3539, -112.488, -138.43
 TrackerEndcapHits.position.z = -449.865, -649.865, -849.865, -1049.87
 TrackerEndcapHits.momentum.x = -0.282981, -0.295752, -0.305873, -0.315357
 TrackerEndcapHits.momentum.y = -0.678451, -0.672997, -0.667216, -0.662762
 TrackerEndcapHits.momentum.z = -5.127204, -5.127089, -5.127127, -5.127013
 _TrackerEndcapHits_MCParticle = (vector<podio::ObjectID>*)0x559bcce57ce0
 _TrackerEndcapHits_MCParticle.index = 0, 0, 0, 0
 _TrackerEndcapHits_MCParticle.collectionID = 2714477136, 2714477136, 2714477136, 2714477136
```

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, it writes out the` edm4eic::MCRecoTrackerHitAssociation collection`.