### PR TITLE
fix: pass logger options from factory to algorithms-interfaced algorithms

### DIFF
--- a/src/factories/calorimetry/CalorimeterClusterRecoCoG_factory.h
+++ b/src/factories/calorimetry/CalorimeterClusterRecoCoG_factory.h
@@ -36,7 +36,7 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
-        m_algo->level((algorithms::LogLevel)logger()->level());
+        m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
         m_algo->applyConfig(config());
         m_algo->init();
     }

--- a/src/factories/calorimetry/CalorimeterHitReco_factory.h
+++ b/src/factories/calorimetry/CalorimeterHitReco_factory.h
@@ -40,7 +40,7 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
-        m_algo->level((algorithms::LogLevel)logger()->level());
+        m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
         m_algo->applyConfig(config());
         m_algo->init();
     }

--- a/src/factories/calorimetry/CalorimeterHitsMerger_factory.h
+++ b/src/factories/calorimetry/CalorimeterHitsMerger_factory.h
@@ -30,7 +30,7 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
-        m_algo->level((algorithms::LogLevel)logger()->level());
+        m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
         m_algo->applyConfig(config());
         m_algo->init();
     }

--- a/src/factories/calorimetry/CalorimeterIslandCluster_factory.h
+++ b/src/factories/calorimetry/CalorimeterIslandCluster_factory.h
@@ -40,7 +40,7 @@ public:
 
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
-        m_algo->level((algorithms::LogLevel)logger()->level());
+        m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
         // Remove spaces from adjacency matrix
         // cfg.adjacencyMatrix.erase(
         //  std::remove_if(cfg.adjacencyMatrix.begin(), cfg.adjacencyMatrix.end(), ::isspace), cfg.adjacencyMatrix.end());

--- a/src/factories/calorimetry/CalorimeterTruthClustering_factory.h
+++ b/src/factories/calorimetry/CalorimeterTruthClustering_factory.h
@@ -24,7 +24,7 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
-        m_algo->level((algorithms::LogLevel)logger()->level());
+        m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
         m_algo->init();
     }
 

--- a/src/factories/calorimetry/EnergyPositionClusterMerger_factory.h
+++ b/src/factories/calorimetry/EnergyPositionClusterMerger_factory.h
@@ -35,7 +35,7 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
-        m_algo->level((algorithms::LogLevel)logger()->level());
+        m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
         m_algo->applyConfig(config());
         m_algo->init();
     }

--- a/src/factories/calorimetry/HEXPLIT_factory.h
+++ b/src/factories/calorimetry/HEXPLIT_factory.h
@@ -27,7 +27,7 @@ class HEXPLIT_factory : public JOmniFactory<HEXPLIT_factory, HEXPLITConfig> {
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
-        m_algo->level((algorithms::LogLevel)logger()->level());
+        m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
         m_algo->applyConfig(config());
         m_algo->init();
     }

--- a/src/factories/calorimetry/ImagingClusterReco_factory.h
+++ b/src/factories/calorimetry/ImagingClusterReco_factory.h
@@ -31,7 +31,7 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
-        m_algo->level((algorithms::LogLevel)logger()->level());
+        m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
         m_algo->applyConfig(config());
         m_algo->init();
     }

--- a/src/factories/calorimetry/ImagingTopoCluster_factory.h
+++ b/src/factories/calorimetry/ImagingTopoCluster_factory.h
@@ -33,7 +33,7 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
-        m_algo->level((algorithms::LogLevel)logger()->level());
+        m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
         m_algo->applyConfig(config());
         m_algo->init();
     }

--- a/src/factories/calorimetry/TruthEnergyPositionClusterMerger_factory.h
+++ b/src/factories/calorimetry/TruthEnergyPositionClusterMerger_factory.h
@@ -29,7 +29,7 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
-        m_algo->level((algorithms::LogLevel)logger()->level());
+        m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
         m_algo->init();
     }
 

--- a/src/factories/digi/SiliconTrackerDigi_factory.h
+++ b/src/factories/digi/SiliconTrackerDigi_factory.h
@@ -28,6 +28,7 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
+        m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
         m_algo->applyConfig(config());
         m_algo->init(logger());
     }

--- a/src/factories/fardetectors/FarDetectorLinearTracking_factory.h
+++ b/src/factories/fardetectors/FarDetectorLinearTracking_factory.h
@@ -32,6 +32,7 @@ private:
   public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
+        m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
         m_algo->applyConfig(config());
         m_algo->init(logger());
     }

--- a/src/factories/fardetectors/FarDetectorTrackerCluster_factory.h
+++ b/src/factories/fardetectors/FarDetectorTrackerCluster_factory.h
@@ -33,6 +33,7 @@ public:
   void Configure() {
 
     m_algo = std::make_unique<AlgoT>(GetPrefix());
+    m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
     // Setup algorithm
     m_algo->applyConfig(config());
     m_algo->init(logger());

--- a/src/factories/fardetectors/MatrixTransferStatic_factory.h
+++ b/src/factories/fardetectors/MatrixTransferStatic_factory.h
@@ -58,6 +58,7 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
+        m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
         m_algo->applyConfig(config());
         m_algo->init();
     }

--- a/src/factories/meta/CollectionCollector_factory.h
+++ b/src/factories/meta/CollectionCollector_factory.h
@@ -21,6 +21,7 @@ public:
 
     void Configure() {
         m_algo = std::make_unique<AlgoT>(this->GetPrefix());
+        m_algo->level(static_cast<algorithms::LogLevel>(this->logger()->level()));
         m_algo->init(this->logger());
     }
 

--- a/src/factories/meta/FilterMatching_factory.h
+++ b/src/factories/meta/FilterMatching_factory.h
@@ -27,6 +27,7 @@ class FilterMatching_factory : public JOmniFactory<FilterMatching_factory<ToFilt
   public:
     void Configure() {
       m_algo = std::make_unique<AlgoT>(this->GetPrefix());
+      m_algo->level(static_cast<algorithms::LogLevel>(this->logger()->level()));
       m_algo->init();
     }
 

--- a/src/factories/meta/SubDivideCollection_factory.h
+++ b/src/factories/meta/SubDivideCollection_factory.h
@@ -28,6 +28,7 @@ class SubDivideCollection_factory : public JOmniFactory<SubDivideCollection_fact
 public:
     void Configure() {
       m_algo = std::make_unique<AlgoT>(this->GetPrefix());
+      m_algo->level(static_cast<algorithms::LogLevel>(this->logger()->level()));
       m_algo->applyConfig(this->config());
       m_algo->init();
     }

--- a/src/factories/reco/InclusiveKinematicsML_factory.h
+++ b/src/factories/reco/InclusiveKinematicsML_factory.h
@@ -32,6 +32,7 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
+        m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
         m_algo->applyConfig(config());
         m_algo->init(logger());
     }

--- a/src/factories/reco/InclusiveKinematicsReconstructed_factory.h
+++ b/src/factories/reco/InclusiveKinematicsReconstructed_factory.h
@@ -32,6 +32,7 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(this->GetPrefix());
+        m_algo->level(static_cast<algorithms::LogLevel>(this->logger()->level()));
         m_algo->init(this->logger());
     }
 

--- a/src/factories/reco/InclusiveKinematicsTruth_factory.h
+++ b/src/factories/reco/InclusiveKinematicsTruth_factory.h
@@ -29,6 +29,7 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
+        m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
         m_algo->init(logger());
     }
 

--- a/src/factories/reco/JetReconstruction_factory.h
+++ b/src/factories/reco/JetReconstruction_factory.h
@@ -44,6 +44,7 @@ namespace eicrecon {
 
       void Configure() {
         m_algo = std::make_unique<Algo>(this->GetPrefix());
+        m_algo->level(static_cast<algorithms::LogLevel>(this->logger()->level()));
         m_algo->applyConfig(FactoryT::config());
         m_algo->init(FactoryT::logger());
       }

--- a/src/factories/reco/TransformBreitFrame_factory.h
+++ b/src/factories/reco/TransformBreitFrame_factory.h
@@ -37,7 +37,7 @@ namespace eicrecon {
 
       void Configure() {
         m_algo = std::make_unique<Algo>(GetPrefix());
-        m_algo->level((algorithms::LogLevel)logger()->level());
+        m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
         m_algo->init(logger());
       }
 

--- a/src/global/digi/PhotoMultiplierHitDigi_factory.h
+++ b/src/global/digi/PhotoMultiplierHitDigi_factory.h
@@ -56,6 +56,7 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
+        m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
 
         // Initialize richgeo ReadoutGeo and set random CellID visitor lambda (if a RICH)
         if (GetPluginName() == "DRICH" || GetPluginName() == "PFRICH") {

--- a/src/global/pid/MergeTrack_factory.h
+++ b/src/global/pid/MergeTrack_factory.h
@@ -36,6 +36,7 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<MergeTracks>(GetPrefix());
+        m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
         m_algo->init(logger());
     }
 

--- a/src/global/reco/MatchClusters_factory.h
+++ b/src/global/reco/MatchClusters_factory.h
@@ -42,7 +42,7 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<MatchClusters>(GetPrefix());
-        m_algo->level((algorithms::LogLevel)logger()->level());
+        m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
         m_algo->init();
     }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
With the switch to the algorithms interface, we need to explicitly pass the logger level from the JOmniFactory to the algorithm, i.e. `m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));`. Only this allows the algorithm to use the log level that is specified on the command line.

This PR adds the necessary line for those factories that use algorithms-interfaced algorithms. There may be other factories that I overlooked. Not sure how to fail compilation when we don't do this.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: `-PDRICH:DRICHRawHits:LogLevel=trace` ignored)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.