### PR TITLE
fix: revert RandomSvc back to std::default_random_engine

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -159,15 +159,15 @@ void CalorimeterHitDigi::process(
 
         // safety check
         const double eResRel = (edep > m_cfg.threshold)
-                ? m_rng.gaussian<double>(0., 1.) * std::sqrt(
+                ? m_gaussian(m_generator) * std::sqrt(
                      std::pow(m_cfg.eRes[0] / std::sqrt(edep), 2) +
                      std::pow(m_cfg.eRes[1], 2) +
                      std::pow(m_cfg.eRes[2] / (edep), 2)
                   )
                 : 0;
-        double    ped     = m_cfg.pedMeanADC + m_rng.gaussian<double>(0., 1.) * m_cfg.pedSigmaADC;
+        double    ped     = m_cfg.pedMeanADC + m_gaussian(m_generator) * m_cfg.pedSigmaADC;
         unsigned long long adc     = std::llround(ped + edep * m_cfg.corrMeanScale * ( 1.0 + eResRel) / m_cfg.dyRangeADC * m_cfg.capADC);
-        unsigned long long tdc     = std::llround((time + m_rng.gaussian<double>(0., 1.) * tRes) * stepTDC);
+        unsigned long long tdc     = std::llround((time + m_gaussian(m_generator) * tRes) * stepTDC);
 
         if (edep> 1.e-3) trace("E sim {} \t adc: {} \t time: {}\t maxtime: {} \t tdc: {}", edep, adc, time, m_cfg.capTime, tdc);
         rawhits->create(

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.h
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.h
@@ -15,9 +15,9 @@
 
 #include <algorithms/algorithm.h>
 #include <algorithms/geo.h>
-#include <algorithms/random.h>
 #include <edm4hep/RawCalorimeterHitCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
+#include <random>
 #include <stdint.h>
 #include <string>
 #include <string_view>
@@ -60,7 +60,9 @@ namespace eicrecon {
 
   private:
     const algorithms::GeoSvc& m_geo = algorithms::GeoSvc::instance();
-    algorithms::Generator m_rng = algorithms::RandomSvc::instance().generator();
+
+    mutable std::default_random_engine m_generator;
+    mutable std::normal_distribution<double> m_gaussian;
 
   };
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR reverts the RandomSvc back to an adhoc implementation.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: RandomSvc not random)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Hopefully makes calorimeter digitization truly (pseudo-)random again...