### PR TITLE
cmake: use CONFIG mode for onnxruntime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,7 +222,7 @@ endif()
 # ONNX Runtime
 option(USE_ONNX "Compile with ONNX support" ON)
 if(${USE_ONNX})
-  find_package(onnxruntime)
+  find_package(onnxruntime CONFIG)
 endif()
 
 # Add CMake additional functionality:

--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -381,7 +381,7 @@ endmacro()
 macro(plugin_add_onnxruntime _name)
 
   if(NOT onnxruntime_FOUND)
-    find_package(onnxruntime)
+    find_package(onnxruntime CONFIG)
   endif()
 
   # Add libraries


### PR DESCRIPTION
This prevents EICrecon from picking up Findonnxruntime.cmake from Acts. The actual onnxruntime only ever provided the config, to my best knowledge.