### PR TITLE
linux-eic-shell.yml: remove configurations with minq2=1

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -371,12 +371,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        beam: [5x41, 10x100, 18x275]
-        minq2: [1, 1000]
+        beam: [10x100, 18x275]
+        minq2: [1000]
         detector_config: [craterlake]
-        exclude:
-        - beam: 5x41
-          minq2: 1000
     steps:
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - name: Get detector info
@@ -809,12 +806,14 @@ jobs:
     strategy:
       matrix:
         CC: [clang]
-        beam: [5x41, 10x100, 18x275]
-        minq2: [0, 1, 1000]
+        beam: [10x100, 18x275]
+        minq2: [0, 1000]
         detector_config: [craterlake]
-        exclude:
-        - beam: 5x41
-          minq2: 1000
+        include:
+        - CC: clang
+          beam: 5x41
+          minq2: 0
+          detector_config: craterlake
     steps:
     - name: mmap rnd_bits workaround
       # https://github.com/actions/runner/issues/3207#issuecomment-2000066889


### PR DESCRIPTION
We are having issues with hosting capybara reports with too many files produced (collect-docs fails).