### PR TITLE
fix(ci): ubsan with silence_unsigned_overflow=1

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -42,7 +42,7 @@ env:
   clang-tidy-iwyu-CMAKE_BUILD_TYPE: Debug
   ASAN_OPTIONS: suppressions=${{ github.workspace }}/.github/asan.supp:malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:detect_stack_use_after_return=1:detect_odr_violation=1:new_delete_type_mismatch=0:intercept_tls_get_addr=0
   LSAN_OPTIONS: suppressions=${{ github.workspace }}/.github/lsan.supp
-  UBSAN_OPTIONS: suppressions=${{ github.workspace }}/.github/ubsan.supp:print_stacktrace=1
+  UBSAN_OPTIONS: suppressions=${{ github.workspace }}/.github/ubsan.supp:print_stacktrace=1:silence_unsigned_overflow=1
 
 jobs:
   env:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR suppresses unsigned integer overflow warnings by UBSan. These are virtually always in basic_string.h due to string comparisons, e.g. https://github.com/eic/EICrecon/actions/runs/8976184643/job/24652936018#step:8:125. They are noisy and detract from other UB, in particular when they appear on line 1.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.