### PR TITLE
linux-eic-shell.yml: remove eicrecon-test-plugins[reco_test]

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -556,7 +556,6 @@ jobs:
         detector_config: [craterlake]
         test_plugins:
         - geometry_navigation_test
-        - reco_test
         - tracking_test
         - track_propagation_test
     steps:


### PR DESCRIPTION
Was removed in https://github.com/eic/EICrecon/pull/1427, where the tests got away
```
[INFO] JPluginLoader: Initializing plugin "/usr/local/lib/EICrecon/plugins/reco_test.so"
```
Once nightly had hit cvmfs, that wouldn't work anymore.