### PR TITLE
fix: don't double-define logger LogLevel parameters

### DIFF
--- a/src/algorithms/fardetectors/FarDetectorLinearProjection.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearProjection.cc
@@ -1,15 +1,20 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2023, Simon Gardner
 
+#include <edm4eic/Cov6f.h>
+#include <edm4eic/TrackPoint.h>
+#include <edm4hep/Vector2f.h>
 #include <edm4hep/Vector3f.h>
-#include <edm4hep/utils/vector_utils.h>
-#include <edm4eic/vector_utils.h>
+#include <fmt/core.h>
+#include <podio/RelationRange.h>
+#include <Eigen/LU>
+#include <cmath>
+#include <cstdint>
+#include <gsl/pointers>
+#include <vector>
 
-#include "FarDetectorLinearProjection.h"
-#include "services/log/Log_service.h"
-#include <iterator>
-#include <algorithm>
-#include <map>
+#include "algorithms/fardetectors/FarDetectorLinearProjection.h"
+#include "algorithms/fardetectors/FarDetectorLinearProjectionConfig.h"
 
 
 

--- a/src/algorithms/fardetectors/FarDetectorLinearProjection.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearProjection.cc
@@ -7,7 +7,6 @@
 
 #include "FarDetectorLinearProjection.h"
 #include "services/log/Log_service.h"
-#include "extensions/spdlog/SpdlogExtensions.h"
 #include <iterator>
 #include <algorithm>
 #include <map>

--- a/src/algorithms/fardetectors/FarDetectorLinearProjection.h
+++ b/src/algorithms/fardetectors/FarDetectorLinearProjection.h
@@ -3,16 +3,16 @@
 
 #pragma once
 
-#include <DDRec/CellIDPositionConverter.h>
-#include <Eigen/Dense>
 // Event Model related classes
 #include <edm4eic/TrackParametersCollection.h>
 #include <edm4eic/TrackSegmentCollection.h>
+#include <Eigen/Core>
+#include <string>
+#include <string_view>
 
-#include <spdlog/logger.h>
-#include "FarDetectorLinearProjectionConfig.h"
-#include "algorithms/interfaces/WithPodConfig.h"
 #include "algorithms/algorithm.h"
+#include "algorithms/fardetectors/FarDetectorLinearProjectionConfig.h"
+#include "algorithms/interfaces/WithPodConfig.h"
 
 namespace eicrecon {
 

--- a/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.cc
@@ -33,7 +33,6 @@
 #include <vector>
 
 #include "benchmarks/reconstruction/lfhcal_studies/clusterizer_MA.h"
-#include "extensions/spdlog/SpdlogExtensions.h"
 #include "services/geometry/dd4hep/DD4hep_service.h"
 #include "services/log/Log_service.h"
 #include "services/rootfile/RootFile_service.h"
@@ -48,13 +47,9 @@ void femc_studiesProcessor::Init() {
   // ===============================================================================================
   // Get JANA application and seup general variables
   // ===============================================================================================
-  auto *app          = GetApplication();
+  auto *app = GetApplication();
 
-  std::string log_level_str = "info";
-  m_log                     = app->GetService<Log_service>()->logger(plugin_name);
-  app->SetDefaultParameter(plugin_name + ":LogLevel", log_level_str,
-                           "LogLevel: trace, debug, info, warn, err, critical, off");
-  m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
+  m_log = app->GetService<Log_service>()->logger(plugin_name);
 
   // Ask service locator a file to write histograms to
   auto root_file_service = app->GetService<RootFile_service>();

--- a/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
@@ -33,7 +33,6 @@
 #include <vector>
 
 #include "clusterizer_MA.h"
-#include "extensions/spdlog/SpdlogExtensions.h"
 #include "services/geometry/dd4hep/DD4hep_service.h"
 #include "services/log/Log_service.h"
 #include "services/rootfile/RootFile_service.h"
@@ -48,13 +47,9 @@ void lfhcal_studiesProcessor::Init() {
   // ===============================================================================================
   // Get JANA application and seup general variables
   // ===============================================================================================
-  auto app          = GetApplication();
+  auto app = GetApplication();
 
-  std::string log_level_str = "info";
-  m_log                     = app->GetService<Log_service>()->logger(plugin_name);
-  app->SetDefaultParameter(plugin_name + ":LogLevel", log_level_str,
-                           "LogLevel: trace, debug, info, warn, err, critical, off");
-  m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
+  m_log = app->GetService<Log_service>()->logger(plugin_name);
 
   // Ask service locator for the DD4hep geometry
   auto dd4hep_service = app->GetService<DD4hep_service>();

--- a/src/benchmarks/reconstruction/tracking_efficiency/TrackingEfficiency_processor.cc
+++ b/src/benchmarks/reconstruction/tracking_efficiency/TrackingEfficiency_processor.cc
@@ -23,7 +23,6 @@
 #include <string>
 #include <vector>
 
-#include "extensions/spdlog/SpdlogExtensions.h"
 #include "services/log/Log_service.h"
 #include "services/rootfile/RootFile_service.h"
 
@@ -57,11 +56,8 @@ void TrackingEfficiency_processor::Init()
     // Create a directory for this plugin. And subdirectories for series of histograms
     m_dir_main = file->mkdir(plugin_name.c_str());
 
-    // Get log level from user parameter or default
-    std::string log_level_str = "info";
+    // Get logger
     m_log = app->GetService<Log_service>()->logger(plugin_name);
-    app->SetDefaultParameter(plugin_name + ":LogLevel", log_level_str, "LogLevel: trace, debug, info, warn, err, critical, off");
-    m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
 }
 
 

--- a/src/benchmarks/reconstruction/tracking_occupancy/TrackingOccupancy_processor.cc
+++ b/src/benchmarks/reconstruction/tracking_occupancy/TrackingOccupancy_processor.cc
@@ -4,7 +4,6 @@
 #include <JANA/JEvent.h>
 #include <JANA/Services/JGlobalRootLock.h>
 #include <TDirectory.h>
-#include <spdlog/logger.h>
 #include <string>
 
 #include "benchmarks/reconstruction/tracking_occupancy/HitReconstructionAnalysis.h"

--- a/src/benchmarks/reconstruction/tracking_occupancy/TrackingOccupancy_processor.cc
+++ b/src/benchmarks/reconstruction/tracking_occupancy/TrackingOccupancy_processor.cc
@@ -9,7 +9,6 @@
 
 #include "benchmarks/reconstruction/tracking_occupancy/HitReconstructionAnalysis.h"
 #include "benchmarks/reconstruction/tracking_occupancy/TrackingOccupancyAnalysis.h"
-#include "extensions/spdlog/SpdlogExtensions.h"
 #include "services/log/Log_service.h"
 #include "services/rootfile/RootFile_service.h"
 
@@ -47,11 +46,8 @@ void TrackingOccupancy_processor::Init()
     m_occupancy_analysis.init(app, m_dir_main);
     m_hit_reco_analysis.init(app, m_dir_main);
 
-    // Get log level from user parameter or default
-    std::string log_level_str = "info";
+    // Get logger
     m_log = app->GetService<Log_service>()->logger(plugin_name);
-    app->SetDefaultParameter(plugin_name + ":LogLevel", log_level_str, "LogLevel: trace, debug, info, warn, err, critical, off");
-    m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
 }
 
 

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -10,18 +10,17 @@
  * which might be changed by user parameters.
  */
 
-#include "services/io/podio/datamodel_glue.h"
 #include <JANA/CLI/JVersion.h>
 #include <JANA/JMultifactory.h>
 #include <JANA/JEvent.h>
 #include <spdlog/spdlog.h>
-#include "extensions/spdlog/SpdlogExtensions.h"
+
+#include "services/io/podio/datamodel_glue.h"
 #include "services/log/Log_service.h"
 
 #include <string>
 #include <vector>
 
-using namespace eicrecon;
 struct EmptyConfig {};
 
 template <typename AlgoT, typename ConfigT=EmptyConfig>
@@ -527,13 +526,8 @@ public:
             output->CreateHelperFactory(*this);
         }
 
-        // Obtain logger
+        // Obtain logger (defines the parameter option)
         m_logger = m_app->GetService<Log_service>()->logger(m_prefix);
-
-        // Configure logger. Priority = [JParameterManager, system log level]
-        std::string default_log_level = eicrecon::LogLevelToString(m_logger->level());
-        m_app->SetDefaultParameter(m_prefix + ":LogLevel", default_log_level, "LogLevel: trace, debug, info, warn, err, critical, off");
-        m_logger->set_level(eicrecon::ParseLogLevel(default_log_level));
     }
 
     void Init() override {

--- a/src/extensions/spdlog/SpdlogMixin.h
+++ b/src/extensions/spdlog/SpdlogMixin.h
@@ -51,14 +51,7 @@ namespace eicrecon {
         void InitLogger(JApplication* app, const std::string &param_prefix, const std::string &default_level = "") {
 
             // Logger. Get plugin level sub-log
-            m_log = app->GetService<Log_service>()->logger(param_prefix);
-
-            // Get log level from user parameter or default
-            std::string log_level_str = default_level.empty() ?         // did user provide default level?
-                                        eicrecon::LogLevelToString(m_log->level()) :   //
-                                        default_level;
-            app->SetDefaultParameter(param_prefix + ":LogLevel", log_level_str, "LogLevel: trace, debug, info, warn, err, critical, off");
-            m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
+            m_log = app->GetService<Log_service>()->logger(param_prefix, default_level);
         }
 
     public:

--- a/src/extensions/spdlog/SpdlogMixin.h
+++ b/src/extensions/spdlog/SpdlogMixin.h
@@ -30,6 +30,8 @@ namespace eicrecon {
          *      };
          */
     public:
+        using level = Log_service::level;
+
         /**
          * Initializes logger through current LogService
          * @param app - JApplication pointer, as obtained from GetApplication()
@@ -48,7 +50,7 @@ namespace eicrecon {
          *
          *  will create "BTRK:TrackerHits" logger and check -PBTRK:TrackerHits:LogLevel user parameter
          */
-        void InitLogger(JApplication* app, const std::string &param_prefix, const std::string &default_level = "") {
+        void InitLogger(JApplication* app, const std::string &param_prefix, const level default_level = level::info) {
 
             // Logger. Get plugin level sub-log
             m_log = app->GetService<Log_service>()->logger(param_prefix, default_level);

--- a/src/services/geometry/acts/ACTSGeo_service.cc
+++ b/src/services/geometry/acts/ACTSGeo_service.cc
@@ -16,7 +16,6 @@
 #include <string>
 
 #include "ActsGeometryProvider.h"
-#include "extensions/spdlog/SpdlogExtensions.h"
 #include "services/geometry/dd4hep/DD4hep_service.h"
 #include "services/log/Log_service.h"
 
@@ -90,7 +89,7 @@ std::shared_ptr<const ActsGeometryProvider> ACTSGeo_service::actsGeoProvider() {
             m_acts_provider->setGridView(gridView);
 
             // Initialize m_acts_provider
-            m_acts_provider->initialize(m_dd4hepGeo, material_map_file, m_log, m_init_log);
+            m_acts_provider->initialize(m_dd4hepGeo, material_map_file, m_log, m_log);
 
             // Enable ticker back
             m_app->SetTicker(tickerEnabled);
@@ -108,20 +107,7 @@ std::shared_ptr<const ActsGeometryProvider> ACTSGeo_service::actsGeoProvider() {
 void ACTSGeo_service::acquire_services(JServiceLocator * srv_locator) {
 
     auto log_service = srv_locator->get<Log_service>();
-
-    // ACTS general log level:
     m_log = log_service->logger("acts");
-    std::string log_level_str = log_service->getDefaultLevelStr();
-    m_app->SetDefaultParameter("acts:LogLevel", log_level_str, "log_level: trace, debug, info, warn, error, critical, off");
-    m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
-    m_log->info("Acts GENERAL log level is set to {} ({})", log_level_str, fmt::underlying(m_log->level()));
-
-    // ACTS init log level (geometry conversion):
-    m_init_log = log_service->logger("acts_init");
-    std::string init_log_level_str = eicrecon::LogLevelToString(m_log->level());  // set general acts log level, if not given by user
-    m_app->SetDefaultParameter("acts:InitLogLevel", init_log_level_str, "log_level: trace, debug, info, warn, error, critical, off");
-    m_init_log->set_level(eicrecon::ParseLogLevel(init_log_level_str));
-    m_init_log->info("Acts INIT log level is set to {} ({})", log_level_str, fmt::underlying(m_init_log->level()));
 
     // DD4Hep geometry
     auto dd4hep_service = srv_locator->get<DD4hep_service>();

--- a/src/services/geometry/acts/ACTSGeo_service.cc
+++ b/src/services/geometry/acts/ACTSGeo_service.cc
@@ -7,8 +7,6 @@
 
 #include <Acts/Visualization/ViewConfig.hpp>
 #include <JANA/JException.h>
-#include <fmt/core.h>
-#include <fmt/format.h>
 #include <array>
 #include <exception>
 #include <gsl/pointers>

--- a/src/services/geometry/acts/ACTSGeo_service.h
+++ b/src/services/geometry/acts/ACTSGeo_service.h
@@ -35,5 +35,4 @@ private:
 
     // General acts log
     std::shared_ptr<spdlog::logger> m_log;
-    std::shared_ptr<spdlog::logger> m_init_log;
 };

--- a/src/services/geometry/dd4hep/DD4hep_service.cc
+++ b/src/services/geometry/dd4hep/DD4hep_service.cc
@@ -18,7 +18,6 @@
 #include <vector>
 
 #include "DD4hep_service.h"
-#include "extensions/spdlog/SpdlogExtensions.h"
 #include "services/log/Log_service.h"
 
 //----------------------------------------------------------------
@@ -28,9 +27,6 @@ void DD4hep_service::acquire_services(JServiceLocator *srv_locator) {
     // logging service
     auto log_service = srv_locator->get<Log_service>();
     m_log = log_service->logger("dd4hep");
-    std::string log_level_str{"info"};
-    m_app->SetDefaultParameter("dd4hep:LogLevel", log_level_str, "Log level for DD4hep_service");
-    m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
 
     // Set the DD4hep print level to be quieter by default, but let user adjust it
     std::string print_level_str{"WARNING"};

--- a/src/services/geometry/richgeo/RichGeo_service.cc
+++ b/src/services/geometry/richgeo/RichGeo_service.cc
@@ -11,7 +11,6 @@
 #include <exception>
 #include <gsl/pointers>
 
-#include "extensions/spdlog/SpdlogExtensions.h"
 #include "services/geometry/dd4hep/DD4hep_service.h"
 #include "services/geometry/richgeo/ActsGeo.h"
 #include "services/geometry/richgeo/IrtGeo.h"
@@ -26,10 +25,6 @@ void RichGeo_service::acquire_services(JServiceLocator *srv_locator) {
   // logging service
   auto log_service = srv_locator->get<Log_service>();
   m_log = log_service->logger("richgeo");
-  std::string log_level_str = "info";
-  m_app->SetDefaultParameter("richgeo:LogLevel", log_level_str, "Log level for RichGeo_service");
-  m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
-  m_log->debug("RichGeo log level is set to {} ({})", log_level_str, fmt::underlying(m_log->level()));
 
   // DD4Hep geometry service
   auto dd4hep_service = srv_locator->get<DD4hep_service>();

--- a/src/services/geometry/richgeo/RichGeo_service.cc
+++ b/src/services/geometry/richgeo/RichGeo_service.cc
@@ -6,7 +6,6 @@
 #include <JANA/JException.h>
 #include <ctype.h>
 #include <fmt/core.h>
-#include <fmt/format.h>
 #include <algorithm>
 #include <exception>
 #include <gsl/pointers>

--- a/src/services/log/Log_service.cc
+++ b/src/services/log/Log_service.cc
@@ -31,7 +31,9 @@ Log_service::Log_service(JApplication *app) {
 Log_service::~Log_service() {};
 
 
-std::shared_ptr<spdlog::logger> Log_service::logger(const std::string &name, const std::string &default_level) {
+std::shared_ptr<spdlog::logger> Log_service::logger(
+        const std::string &name,
+        const std::optional<level> default_level) {
 
     try {
         std::lock_guard<std::recursive_mutex> locker(m_lock);
@@ -44,7 +46,7 @@ std::shared_ptr<spdlog::logger> Log_service::logger(const std::string &name, con
 
             // Set log level for this named logger allowing user to specify as config. parameter
             // e.g. EcalEndcapPRecHits:LogLevel
-            std::string log_level_str = default_level.empty() ? m_log_level_str : default_level;
+            std::string log_level_str = default_level ? eicrecon::LogLevelToString(default_level.value()) : m_log_level_str;
             m_application->SetDefaultParameter(name+":LogLevel", log_level_str, "log_level for "+name+": trace, debug, info, warn, error, critical, off");
             logger->set_level(eicrecon::ParseLogLevel(log_level_str));
         }
@@ -55,6 +57,6 @@ std::shared_ptr<spdlog::logger> Log_service::logger(const std::string &name, con
     }
 }
 
-spdlog::level::level_enum Log_service::getDefaultLevel() {return spdlog::default_logger()->level();}
+Log_service::level Log_service::getDefaultLevel() {return spdlog::default_logger()->level();}
 
 std::string Log_service::getDefaultLevelStr() {return eicrecon::LogLevelToString(getDefaultLevel());}

--- a/src/services/log/Log_service.cc
+++ b/src/services/log/Log_service.cc
@@ -31,7 +31,7 @@ Log_service::Log_service(JApplication *app) {
 Log_service::~Log_service() {};
 
 
-std::shared_ptr<spdlog::logger> Log_service::logger(const std::string &name) {
+std::shared_ptr<spdlog::logger> Log_service::logger(const std::string &name, const std::string &default_level) {
 
     try {
         std::lock_guard<std::recursive_mutex> locker(m_lock);
@@ -44,7 +44,7 @@ std::shared_ptr<spdlog::logger> Log_service::logger(const std::string &name) {
 
             // Set log level for this named logger allowing user to specify as config. parameter
             // e.g. EcalEndcapPRecHits:LogLevel
-            std::string log_level_str = m_log_level_str;
+            std::string log_level_str = default_level.empty() ? m_log_level_str : default_level;
             m_application->SetDefaultParameter(name+":LogLevel", log_level_str, "log_level for "+name+": trace, debug, info, warn, error, critical, off");
             logger->set_level(eicrecon::ParseLogLevel(log_level_str));
         }

--- a/src/services/log/Log_service.h
+++ b/src/services/log/Log_service.h
@@ -7,6 +7,7 @@
 #include <spdlog/logger.h>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 
 /**
@@ -15,18 +16,24 @@
 class Log_service : public JService
 {
 public:
+    using level = spdlog::level::level_enum;
+
+public:
     explicit Log_service(JApplication *app);
     ~Log_service();
 
-    virtual std::shared_ptr<spdlog::logger> logger(const std::string &name, const std::string &default_level = "");
+    /** Get a named logger with optional level
+     * When no level is specified, the service default is used **/
+    virtual std::shared_ptr<spdlog::logger> logger(
+        const std::string &name,
+        const std::optional<level> default_level = std::nullopt);
 
     /** Gets the default level for all loggers
      * The log level is set from user parameters or is 'info'**/
-    virtual spdlog::level::level_enum getDefaultLevel();
+    virtual level getDefaultLevel();
 
     /** Gets std::string version of the default log level **/
     virtual std::string getDefaultLevelStr();
-
 
 private:
 

--- a/src/services/log/Log_service.h
+++ b/src/services/log/Log_service.h
@@ -18,7 +18,7 @@ public:
     explicit Log_service(JApplication *app);
     ~Log_service();
 
-    virtual std::shared_ptr<spdlog::logger> logger(const std::string &name);
+    virtual std::shared_ptr<spdlog::logger> logger(const std::string &name, const std::string &default_level = "");
 
     /** Gets the default level for all loggers
      * The log level is set from user parameters or is 'info'**/

--- a/src/tests/tracking_test/TrackingTest_processor.cc
+++ b/src/tests/tracking_test/TrackingTest_processor.cc
@@ -21,7 +21,6 @@
 #include <vector>
 
 #include "services/io/podio/datamodel_glue.h" // IWYU pragma: keep (templated JEvent::GetCollection<T> needs PodioTypeMap)
-#include "extensions/spdlog/SpdlogExtensions.h"
 #include "services/log/Log_service.h"
 #include "services/rootfile/RootFile_service.h"
 
@@ -58,10 +57,7 @@ void TrackingTest_processor::Init()
     m_dir_main = file->mkdir(plugin_name.c_str());
 
     // Get log level from user parameter or default
-    std::string log_level_str = "info";
     m_log = app->GetService<Log_service>()->logger(plugin_name);
-    app->SetDefaultParameter(plugin_name + ":LogLevel", log_level_str, "LogLevel: trace, debug, info, warn, err, critical, off");
-    m_log->set_level(eicrecon::ParseLogLevel(log_level_str));
     for(auto pair: app->GetJParameterManager()->GetAllParameters()) {
         m_log->info("{:<20} | {}", pair.first, pair.second->GetDescription());
     }

--- a/src/utilities/dump_flags/DumpFlags_processor.cc
+++ b/src/utilities/dump_flags/DumpFlags_processor.cc
@@ -5,6 +5,7 @@
 #include <JANA/JException.h>
 #include <JANA/Services/JParameterManager.h>
 #include <fmt/core.h>
+#include <spdlog/common.h>
 #include <spdlog/logger.h>
 #include <spdlog/spdlog.h>
 #include <string.h>

--- a/src/utilities/dump_flags/DumpFlags_processor.cc
+++ b/src/utilities/dump_flags/DumpFlags_processor.cc
@@ -37,7 +37,7 @@ void DumpFlags_processor::Init()
     app->SetDefaultParameter("dump_flags:screen", m_print_to_screen, "If not empty, print summary to screen at end of job");
 
 
-    InitLogger(app, "dump_flags", "info");
+    InitLogger(app, "dump_flags", level::info);
 }
 
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The Log_service::logger(name) call defines name:LogLevel already, so callers don't need to do this anymore. That removes the need for SpdlogExtensions.h includes in factories.

This PR removes the double defines, removes the headers, and also unifies the Acts loggers, so we don't have one for init and one for regular.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.