### PR TITLE
[v1.13] pid_lut: avoid overwriting PDG

### DIFF
--- a/src/algorithms/pid_lut/PIDLookup.cc
+++ b/src/algorithms/pid_lut/PIDLookup.cc
@@ -129,7 +129,9 @@ void PIDLookup::process(const Input& input, const Output& output) const {
       }
     }
 
-    recopart.setPDG(std::copysign(identified_pdg, charge));
+    if (identified_pdg != 0) {
+      recopart.setPDG(std::copysign(identified_pdg, charge));
+    }
 
     if (identified_pdg != 0) {
       trace("randomized PDG is {}", recopart.getPDG());


### PR DESCRIPTION
This is a hotfix for PDG derived by roll of a dice being overwritten. This became a problem when factories were chained and now results in coverage limited to DRICH:

![image](https://github.com/eic/EICrecon/assets/245573/e4328a7c-6198-4e68-9300-d4094736bb0b)

(cherry picked from commit 5a703aa9b028b720cfd2a1a7c96e93ed26e1807e)