### PR TITLE
LOWQ2: link to algorithms_fardetectors_library

### DIFF
--- a/src/detectors/LOWQ2/CMakeLists.txt
+++ b/src/detectors/LOWQ2/CMakeLists.txt
@@ -16,6 +16,5 @@ plugin_glob_all(${PLUGIN_NAME})
 plugin_add_dd4hep(${PLUGIN_NAME})
 plugin_add_event_model(${PLUGIN_NAME})
 
-# Add include directories (works same as target_include_directories)
-plugin_include_directories(${PLUGIN_NAME} SYSTEM PUBLIC ${podio_INCLUDE_DIR}
-                           ${EDM4EIC_INCLUDE_DIR})
+# Add libraries (works same as target_include_directories)
+plugin_link_libraries(${PLUGIN_NAME} algorithms_fardetectors_library)


### PR DESCRIPTION
Building inside the container, EICrecon doesn't work:
```
    install/lib/EICrecon/plugins/LOWQ2.so  =>  Loading failure: install/lib/EICrecon/plugins/LOWQ2.so: undefined symbol: _ZTVN8eicrecon27FarDetectorLinearProjectionE
    /usr/local/plugins/JANA/LOWQ2.so  =>  File not found
    /usr/local/plugins/LOWQ2.so  =>  File not found
```