### PR TITLE
PIDLookup: do not copy track sign into ReconstructedParticle's PDG field

### DIFF
--- a/src/algorithms/pid_lut/PIDLookup.cc
+++ b/src/algorithms/pid_lut/PIDLookup.cc
@@ -89,25 +89,25 @@ void PIDLookup::process(const Input& input, const Output& output) const {
 
       recopart.addToParticleIDs(partids_out->create(
         m_cfg.system,                // std::int32_t type
-        std::copysign(11, charge),   // std::int32_t PDG
+        11,                          // std::int32_t PDG
         0,                           // std::int32_t algorithmType
         static_cast<float>(entry->prob_electron) // float likelihood
       ));
       recopart.addToParticleIDs(partids_out->create(
         m_cfg.system,                // std::int32_t type
-        std::copysign(211, charge),  // std::int32_t PDG
+        211,                         // std::int32_t PDG
         0,                           // std::int32_t algorithmType
         static_cast<float>(entry->prob_pion) // float likelihood
       ));
       recopart.addToParticleIDs(partids_out->create(
         m_cfg.system,                // std::int32_t type
-        std::copysign(321, charge),  // std::int32_t PDG
+        321,                         // std::int32_t PDG
         0,                           // std::int32_t algorithmType
         static_cast<float>(entry->prob_kaon) // float likelihood
       ));
       recopart.addToParticleIDs(partids_out->create(
         m_cfg.system,                // std::int32_t type
-        std::copysign(2212, charge), // std::int32_t PDG
+        2212,                        // std::int32_t PDG
         0,                           // std::int32_t algorithmType
         static_cast<float>(entry->prob_proton) // float likelihood
       ));
@@ -130,7 +130,7 @@ void PIDLookup::process(const Input& input, const Output& output) const {
     }
 
     if (identified_pdg != 0) {
-      recopart.setPDG(std::copysign(identified_pdg, charge));
+      recopart.setPDG(identified_pdg);
     }
 
     if (identified_pdg != 0) {


### PR DESCRIPTION
This appears to be inconsistent with MCParticle's PDG, where codes are positive.

This was discovered in benchmark
https://github.com/eic/physics_benchmarks/blob/cd616f2a92e5d59f9e94c27d9ad0a1b8c18daeef/benchmarks/dis/analysis/truth_reconstruction.py#L56

Fixes: https://github.com/eic/physics_benchmarks/issues/7