### PR TITLE
PIDLookup: fix incorrect PDG convention - electron should not be -11

### DIFF
--- a/src/algorithms/pid_lut/PIDLookup.cc
+++ b/src/algorithms/pid_lut/PIDLookup.cc
@@ -130,7 +130,7 @@ void PIDLookup::process(const Input& input, const Output& output) const {
     }
 
     if (identified_pdg != 0) {
-      recopart.setPDG(std::copysign(identified_pdg, (identified_pdg == 11) ? charge : -charge));
+      recopart.setPDG(std::copysign(identified_pdg, (identified_pdg == 11) ? -charge : charge));
     }
 
     if (identified_pdg != 0) {

--- a/src/algorithms/pid_lut/PIDLookup.cc
+++ b/src/algorithms/pid_lut/PIDLookup.cc
@@ -89,7 +89,7 @@ void PIDLookup::process(const Input& input, const Output& output) const {
 
       recopart.addToParticleIDs(partids_out->create(
         m_cfg.system,                // std::int32_t type
-        std::copysign(11, charge),   // std::int32_t PDG
+        std::copysign(11, -charge),  // std::int32_t PDG
         0,                           // std::int32_t algorithmType
         static_cast<float>(entry->prob_electron) // float likelihood
       ));

--- a/src/algorithms/pid_lut/PIDLookup.cc
+++ b/src/algorithms/pid_lut/PIDLookup.cc
@@ -130,7 +130,7 @@ void PIDLookup::process(const Input& input, const Output& output) const {
     }
 
     if (identified_pdg != 0) {
-      recopart.setPDG(std::copysign(identified_pdg, charge));
+      recopart.setPDG(std::copysign(identified_pdg, (identified_pdg == 11) ? charge : -charge));
     }
 
     if (identified_pdg != 0) {


### PR DESCRIPTION
Second iteration on #1442. None of the hadrons should be affected by convention, but electron is one of exceptions.

This was discovered in benchmark
https://github.com/eic/physics_benchmarks/blob/cd616f2a92e5d59f9e94c27d9ad0a1b8c18daeef/benchmarks/dis/analysis/truth_reconstruction.py#L56

Fixes: https://github.com/eic/physics_benchmarks/issues/7