### PR TITLE
JetReconstructionConfig: reduce default ghost area to 0.01

### DIFF
--- a/src/algorithms/reco/JetReconstructionConfig.h
+++ b/src/algorithms/reco/JetReconstructionConfig.h
@@ -16,7 +16,7 @@ namespace eicrecon {
     double      maxCstPt       = 100. * dd4hep::GeV;  // maximum pT of objects fed to clsuter sequence
     double      minJetPt       = 1.0 * dd4hep::GeV;   // minimum jet pT
     double      ghostMaxRap    = 3.5;                 // maximum rapidity of ghosts
-    double      ghostArea      = 0.001;               // area per ghost
+    double      ghostArea      = 0.01;                // area per ghost
     int         numGhostRepeat = 1;                   // number of times a ghost is reused per grid site
     std::string jetAlgo        = "antikt_algorithm";  // jet finding algorithm
     std::string recombScheme   = "E_scheme";          // particle recombination scheme


### PR DESCRIPTION
This is also the default in FastJet
https://fastjet.fr/repo/doxygen-3.4.2/namespacefastjet_1_1gas.html

Some measurements for a trivial e- reconstruction:

Before:
```
Elapsed (wall clock) time (h:mm:ss or m:ss): 10:25.74
```
After:
```
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:42.34
```

Closes: #1348
Credit for suggestion goes to @rosijreed 