### PR TITLE
[Backport v1.13] JetReconstructionConfig: reduce default ghost area to 0.01

### DIFF
--- a/src/algorithms/reco/JetReconstructionConfig.h
+++ b/src/algorithms/reco/JetReconstructionConfig.h
@@ -16,7 +16,7 @@ namespace eicrecon {
     double      maxCstPt       = 100. * dd4hep::GeV;  // maximum pT of objects fed to clsuter sequence
     double      minJetPt       = 1.0 * dd4hep::GeV;   // minimum jet pT
     double      ghostMaxRap    = 3.5;                 // maximum rapidity of ghosts
-    double      ghostArea      = 0.001;               // area per ghost
+    double      ghostArea      = 0.01;                // area per ghost
     int         numGhostRepeat = 1;                   // number of times a ghost is reused per grid site
     std::string jetAlgo        = "antikt_algorithm";  // jet finding algorithm
     std::string recombScheme   = "E_scheme";          // particle recombination scheme


### PR DESCRIPTION
# Description
Backport of #1446 to `v1.13`.