### PR TITLE
fix: do not warn about `BOOST_ROOT`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,9 @@
 
 cmake_minimum_required(VERSION 3.24)
 
+# 3.27: find_package() uses upper-case <PACKAGENAME>_ROOT variables
+cmake_policy(SET CMP0144 NEW)
+
 project(EICrecon)
 
 # CMake includes


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Boost defines the environment variable `BOOST_ROOT`, which violates the older CMake case-sensitivity syntax for `find_package(Boost)`. Therefore, in CMake 3.27, the policy was changed to also look at uppercase `<PACKAGENAME>_ROOT` environment variables. In `eic-shell`, where we have such a newer version, this generates a build warning since the new policy is available but it is not explicitly enabled or disabled.

This PR explicitly enables the policy in those CMake versions that support it. This doesn't affect running in `eic-shell` other than hiding the warning. Outside `eic-shell`, for newer CMake versions (>= 3.27), it should only increase the likelihood that the correct Boost version is found without having to hint it on the command line. For older CMake versions (>= 3.24, but < 3.27), there be no effect since unknown policies are ignored by design.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: warning during CMake config, e.g. https://github.com/eic/EICrecon/actions/runs/9042332624/job/24848722623#step:8:161)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.