### PR TITLE
feat: pre-commit fix in place (interactive use only)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
   rev: v1.3.5
   hooks:
   - id: clang-format
+    args: [-i]
 - repo: https://github.com/cheshirekow/cmake-format-precommit
   rev: v0.6.13
   hooks:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
We already have pre-commit enabled on command line and preventing code from being committed that fails clang-format. But it just prints out a diff to apply and doesn't apply it...

This PR applies the clang-format changes that are suggested.

Note: no automatic changes are applied by the CI workflows because of this change.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.