### PR TITLE
feat: set track relation for calorimeter and DRICH propagations

### DIFF
--- a/src/algorithms/tracking/TrackPropagation.h
+++ b/src/algorithms/tracking/TrackPropagation.h
@@ -12,8 +12,10 @@
 #include <ActsExamples/EventData/Track.hpp>
 #include <ActsExamples/EventData/Trajectories.hpp>
 #include <DD4hep/Detector.h>
+#include <edm4eic/TrackCollection.h>
 #include <edm4eic/TrackPoint.h>
 #include <edm4eic/TrackSegmentCollection.h>
+#include <edm4eic/TrajectoryCollection.h>
 #include <spdlog/logger.h>
 #include <memory>
 #include <tuple>
@@ -40,34 +42,43 @@ namespace eicrecon {
         void init(const dd4hep::Detector* detector, std::shared_ptr<const ActsGeometryProvider> geo_svc, std::shared_ptr<spdlog::logger> logger);
 
         void process(
-                const std::tuple<const std::vector<const ActsExamples::Trajectories*>, const std::vector<const ActsExamples::ConstTrackContainer*>> input,
+                const std::tuple<const edm4eic::TrackCollection&, const std::vector<const ActsExamples::Trajectories*>, const std::vector<const ActsExamples::ConstTrackContainer*>> input,
                 const std::tuple<edm4eic::TrackSegmentCollection*> output) const {
 
-            const auto [acts_trajectories, acts_tracks] = input;
+            const auto [tracks, acts_trajectories, acts_tracks] = input;
             auto [propagated_tracks] = output;
 
-            for (auto traj: acts_trajectories) {
-                edm4eic::MutableTrackSegment this_propagated_track;
-                for(auto& surf : m_target_surfaces) {
-                    auto prop_point = propagate(traj, surf);
+            for (size_t i = 0; auto traj: acts_trajectories) {
+                auto this_propagated_track = propagated_tracks->create();
+                if (tracks.size() == acts_trajectories.size()) {
+                    m_log->trace("track segment connected to track {}", i);
+                    this_propagated_track.setTrack(tracks[i]);
+                }
+                for (auto& surf : m_target_surfaces) {
+                    auto prop_point = propagate(
+                        tracks.size() == acts_trajectories.size() ? tracks[i] : edm4eic::Track{},
+                        traj, surf);
                     if (!prop_point) continue;
                     prop_point->surface = surf->geometryId().layer();
                     prop_point->system  = surf->geometryId().extra();
                     this_propagated_track.addToPoints(*prop_point);
                 }
-                propagated_tracks->push_back(this_propagated_track);
+                ++i;
             }
         }
 
         /** Propagates a single trajectory to a given surface */
-        std::unique_ptr<edm4eic::TrackPoint> propagate(const ActsExamples::Trajectories *, const std::shared_ptr<const Acts::Surface>& targetSurf) const;
+        std::unique_ptr<edm4eic::TrackPoint> propagate(
+            const edm4eic::Track&,
+            const ActsExamples::Trajectories*,
+            const std::shared_ptr<const Acts::Surface>& targetSurf) const;
 
         /** Propagates a collection of trajectories to a list of surfaces, and returns the full `TrackSegment`;
          * @param trajectories the input collection of trajectories
          * @return the resulting collection of propagated tracks
          */
         void propagateToSurfaceList(
-            const std::tuple<const std::vector<const ActsExamples::Trajectories*>, const std::vector<const ActsExamples::ConstTrackContainer*>> input,
+            const std::tuple<const edm4eic::TrackCollection&, const std::vector<const ActsExamples::Trajectories*>, const std::vector<const ActsExamples::ConstTrackContainer*>> input,
             const std::tuple<edm4eic::TrackSegmentCollection*> output) const;
 
     private:

--- a/src/algorithms/tracking/TrackPropagation.h
+++ b/src/algorithms/tracking/TrackPropagation.h
@@ -15,8 +15,9 @@
 #include <edm4eic/TrackCollection.h>
 #include <edm4eic/TrackPoint.h>
 #include <edm4eic/TrackSegmentCollection.h>
-#include <edm4eic/TrajectoryCollection.h>
+#include <fmt/core.h>
 #include <spdlog/logger.h>
+#include <stddef.h>
 #include <memory>
 #include <tuple>
 #include <vector>

--- a/src/detectors/DRICH/DRICH.cc
+++ b/src/detectors/DRICH/DRICH.cc
@@ -145,14 +145,14 @@ extern "C" {
     // charged particle tracks
     app->Add(new JOmniFactoryGeneratorT<RichTrack_factory>(
           "DRICHAerogelTracks",
-          {"CentralCKFActsTrajectories", "CentralCKFActsTracks"},
+          {"CentralCKFTracks", "CentralCKFActsTrajectories", "CentralCKFActsTracks"},
           {"DRICHAerogelTracks"},
           aerogel_track_cfg,
           app
           ));
     app->Add(new JOmniFactoryGeneratorT<RichTrack_factory>(
           "DRICHGasTracks",
-          {"CentralCKFActsTrajectories", "CentralCKFActsTracks"},
+          {"CentralCKFTracks", "CentralCKFActsTrajectories", "CentralCKFActsTracks"},
           {"DRICHGasTracks"},
           gas_track_cfg,
           app

--- a/src/global/pid/RichTrack_factory.h
+++ b/src/global/pid/RichTrack_factory.h
@@ -30,6 +30,7 @@ private:
     using AlgoT = eicrecon::TrackPropagation;
     std::unique_ptr<AlgoT> m_algo;
 
+    PodioInput<edm4eic::Track> m_tracks_input {this};
     Input<ActsExamples::Trajectories> m_acts_trajectories_input {this};
     Input<ActsExamples::ConstTrackContainer> m_acts_tracks_input {this};
     PodioOutput<edm4eic::TrackSegment> m_track_segments_output {this};
@@ -53,7 +54,7 @@ public:
 
     void Process(int64_t run_number, uint64_t event_number) {
         m_algo->propagateToSurfaceList(
-            {m_acts_trajectories_input(), m_acts_tracks_input()},
+            {*m_tracks_input(), m_acts_trajectories_input(), m_acts_tracks_input()},
             {m_track_segments_output().get()}
         );
     }

--- a/src/global/tracking/TrackPropagation_factory.h
+++ b/src/global/tracking/TrackPropagation_factory.h
@@ -27,6 +27,7 @@ private:
     using AlgoT = eicrecon::TrackPropagation;
     std::unique_ptr<AlgoT> m_algo;
 
+    PodioInput<edm4eic::Track> m_tracks_input {this};
     Input<ActsExamples::Trajectories> m_acts_trajectories_input {this};
     Input<ActsExamples::ConstTrackContainer> m_acts_tracks_input {this};
     PodioOutput<edm4eic::TrackSegment> m_track_segments_output {this};
@@ -46,7 +47,7 @@ public:
 
     void Process(int64_t run_number, uint64_t event_number) {
         m_algo->process(
-            {m_acts_trajectories_input(), m_acts_tracks_input()},
+            {*m_tracks_input(), m_acts_trajectories_input(), m_acts_tracks_input()},
             {m_track_segments_output().get()}
         );
     }

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -138,7 +138,7 @@ void InitPlugin(JApplication *app) {
 
     app->Add(new JOmniFactoryGeneratorT<TrackPropagation_factory>(
             "CalorimeterTrackPropagator",
-            {"CentralCKFActsTrajectories", "CentralCKFActsTracks"},
+            {"CentralCKFTracks", "CentralCKFActsTrajectories", "CentralCKFActsTracks"},
             {"CalorimeterTrackProjections"},
             {
                 .target_surfaces{

--- a/src/tests/track_propagation_test/TrackPropagationTest_processor.cc
+++ b/src/tests/track_propagation_test/TrackPropagationTest_processor.cc
@@ -8,6 +8,7 @@
 #include <JANA/JEvent.h>
 #include <JANA/JException.h>
 #include <JANA/Services/JGlobalRootLock.h>
+#include <edm4eic/TrackCollection.h>
 #include <edm4eic/TrackPoint.h>
 #include <edm4hep/Vector3f.h>
 #include <fmt/core.h>

--- a/src/tests/track_propagation_test/TrackPropagationTest_processor.cc
+++ b/src/tests/track_propagation_test/TrackPropagationTest_processor.cc
@@ -99,7 +99,7 @@ void TrackPropagationTest_processor::Process(const std::shared_ptr<const JEvent>
         std::unique_ptr<edm4eic::TrackPoint> projection_point;
         try {
             // >>> try to propagate to surface <<<
-            projection_point = m_propagation_algo.propagate(trajectory, m_hcal_surface);
+            projection_point = m_propagation_algo.propagate(edm4eic::Track{}, trajectory, m_hcal_surface);
         }
         catch(std::exception &e) {
             throw JException(e.what());


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The tracks propagated to the calorimeter surfaces and the DRICH aerogel and gas surfaces did not contain the relation to the track.

This PR adds the track relations to CalorimeterTrackProjections and the DRICH{Aerogel,Gas}Tracks collections.

Note the methodology here. We don't use edm4eic::Tracks to do the propagation, so this here relies on keeping the order in the edm4eic::Tracks and ActsExamples::Trajectories.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: no track relations in projections)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.