### PR TITLE
linux-eic-shell.yml: use github.head_ref

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -102,11 +102,11 @@ jobs:
       uses: actions/cache@v4
       with:
         path: .ccache
-        key: ccache-${{ matrix.CC }}-${{ matrix.release }}-${{ matrix.CMAKE_BUILD_TYPE }}-${{ github.event.pull_request.head.ref || github.ref_name }}-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+        key: ccache-${{ matrix.CC }}-${{ matrix.release }}-${{ matrix.CMAKE_BUILD_TYPE }}-${{ github.head_ref || github.ref_name }}-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
         restore-keys: |
              ccache-${{ matrix.CC }}-${{ matrix.release }}-${{ matrix.CMAKE_BUILD_TYPE }}-${{ github.ref_name }}-
-             ccache-${{ matrix.CC }}-${{ matrix.release }}-${{ matrix.CMAKE_BUILD_TYPE }}-${{ github.event.pull_request.head.ref }}-
-             ccache-${{ matrix.CC }}-${{ matrix.release }}-${{ matrix.CMAKE_BUILD_TYPE }}-${{ github.event.pull_request.base.ref }}-
+             ccache-${{ matrix.CC }}-${{ matrix.release }}-${{ matrix.CMAKE_BUILD_TYPE }}-${{ github.head_ref }}-
+             ccache-${{ matrix.CC }}-${{ matrix.release }}-${{ matrix.CMAKE_BUILD_TYPE }}-${{ github.base_ref }}-
              ccache-${{ matrix.CC }}-${{ matrix.release }}-${{ matrix.CMAKE_BUILD_TYPE }}-
              ccache-${{ matrix.CC }}-${{ matrix.release }}-
              ccache-${{ matrix.CC }}-
@@ -717,7 +717,7 @@ jobs:
       id: download_previous_artifact
       uses: dawidd6/action-download-artifact@v3
       with:
-        branch: ${{ github.event.pull_request.base.ref || github.ref_name }}
+        branch: ${{ github.base_ref || github.ref_name }}
         path: ref/
         name: rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
         workflow: ".github/workflows/linux-eic-shell.yml"
@@ -882,7 +882,7 @@ jobs:
       id: download_previous_artifact
       uses: dawidd6/action-download-artifact@v3
       with:
-        branch: ${{ github.event.pull_request.base.ref || github.ref_name }}
+        branch: ${{ github.base_ref || github.ref_name }}
         path: ref/
         name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root
         workflow: ".github/workflows/linux-eic-shell.yml"


### PR DESCRIPTION
The documentation https://docs.github.com/en/actions/learn-github-actions/contexts#github-context says that it only works for pull_request*, but there is some hope that it can inherit from merge_group payload too https://docs.github.com/en/webhooks/webhook-events-and-payloads#merge_group . Then that would fix issues with missing capybara references on main: https://github.com/eic/EICrecon/issues/1264

Fixes: #1264