### PR TITLE
linux-eic-shell.yml: use github.event.merge_group.base_ref

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -107,6 +107,7 @@ jobs:
              ccache-${{ matrix.CC }}-${{ matrix.release }}-${{ matrix.CMAKE_BUILD_TYPE }}-${{ github.ref_name }}-
              ccache-${{ matrix.CC }}-${{ matrix.release }}-${{ matrix.CMAKE_BUILD_TYPE }}-${{ github.head_ref }}-
              ccache-${{ matrix.CC }}-${{ matrix.release }}-${{ matrix.CMAKE_BUILD_TYPE }}-${{ github.base_ref }}-
+             ccache-${{ matrix.CC }}-${{ matrix.release }}-${{ matrix.CMAKE_BUILD_TYPE }}-${{ github.event.merge_group.base_ref }}-
              ccache-${{ matrix.CC }}-${{ matrix.release }}-${{ matrix.CMAKE_BUILD_TYPE }}-
              ccache-${{ matrix.CC }}-${{ matrix.release }}-
              ccache-${{ matrix.CC }}-
@@ -717,7 +718,7 @@ jobs:
       id: download_previous_artifact
       uses: dawidd6/action-download-artifact@v3
       with:
-        branch: ${{ github.base_ref || github.ref_name }}
+        branch: ${{ github.base_ref || github.event.merge_group.base_ref || github.ref_name }}
         path: ref/
         name: rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
         workflow: ".github/workflows/linux-eic-shell.yml"
@@ -882,7 +883,7 @@ jobs:
       id: download_previous_artifact
       uses: dawidd6/action-download-artifact@v3
       with:
-        branch: ${{ github.base_ref || github.ref_name }}
+        branch: ${{ github.base_ref || github.event.merge_group.base_ref || github.ref_name }}
         path: ref/
         name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root
         workflow: ".github/workflows/linux-eic-shell.yml"


### PR DESCRIPTION
`github.base_ref` doesn't work for merge_group: https://github.com/eic/EICrecon/actions/runs/9120955781/job/25084018811#step:13:21

It's put after github.base_ref, so that we can later test if this can be reverted by re-running with enabled debug logging.