### PR TITLE
linux-eic-shell.yml: pass PIPELINE_NAME_CONTAINER

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -929,7 +929,9 @@ jobs:
           GITHUB_SHA=${{ github.event.pull_request.head.sha || github.sha }}
           GITHUB_PR=${{ github.event.pull_request.number }}
           EICRECON_VERSION="${{ github.event.pull_request.head.ref || github.ref_name }}"
-    - run: |
+          PIPELINE_NAME_CONTAINER=${{ github.repository }}: ${{ github.event.pull_request.title || github.ref_name }}
+    - name: Post a GitHub CI status
+      run: |
         gh api \
            --method POST \
           -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
This is needed to display a human-friendly pipeline name on eicweb.

https://eicweb.phy.anl.gov/containers/eic_container/-/commit/7d9d792dfcab74311dc5beea7bb45e965bb40df7