### PR TITLE
JEventProcessorPODIO: deprecate podio:output_include_collections parameter

### DIFF
--- a/.github/iwyu.imp
+++ b/.github/iwyu.imp
@@ -30,6 +30,7 @@
   { include: ['<JANA/JApplicationFwd.h>', private, '<JANA/JApplication.h>', public] },
 
   # the rest
+  { include: ['<bits/chrono.h>', private, '<chrono>', public] },
   { include: ['<bits/std_abs.h>', private, '<math.h>', public] },
   { include: ['<bits/utility.h>', private, '<tuple>', public] },
   # https://github.com/include-what-you-use/include-what-you-use/issues/166

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -10,7 +10,6 @@
 #include <podio/CollectionBase.h>
 #include <podio/Frame.h>
 #include <spdlog/common.h>
-// IWYU pragma: no_include <bits/chrono.h>
 #include <chrono>
 #include <exception>
 #include <thread>

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -11,7 +11,9 @@
 #include <podio/CollectionBase.h>
 #include <podio/Frame.h>
 #include <spdlog/common.h>
+#include <chrono>
 #include <exception>
+#include <thread>
 
 #include "services/log/Log_service.h"
 
@@ -43,7 +45,7 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
     );
 
     // Get the list of output collections to include/exclude
-    std::vector<std::string> output_include_collections={
+    std::vector<std::string> output_collections={
             // Header and other metadata
             "EventHeader",
 
@@ -297,9 +299,20 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "DIRCSeededParticleIDs",
     };
     std::vector<std::string> output_exclude_collections;  // need to get as vector, then convert to set
+    std::string output_include_collections = "DEPRECATED";
     japp->SetDefaultParameter(
             "podio:output_include_collections",
             output_include_collections,
+            "DEPRECATED. Use podio:output_collections instead."
+    );
+    if (output_include_collections != "DEPRECATED") {
+      output_collections.clear();
+      JParameterManager::Parse(output_include_collections, output_collections);
+      m_output_include_collections_set = true;
+    }
+    japp->SetDefaultParameter(
+            "podio:output_collections",
+            output_collections,
             "Comma separated list of collection names to write out. If not set, all collections will be written (including ones from input file). Don't set this and use PODIO:OUTPUT_EXCLUDE_COLLECTIONS to write everything except a selection."
     );
     japp->SetDefaultParameter(
@@ -313,8 +326,8 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "Comma separated list of collection names to print to screen, e.g. for debugging."
     );
 
-    m_output_include_collections = std::set<std::string>(output_include_collections.begin(),
-                                                         output_include_collections.end());
+    m_output_collections = std::set<std::string>(output_collections.begin(),
+                                                 output_collections.end());
     m_output_exclude_collections = std::set<std::string>(output_exclude_collections.begin(),
                                                          output_exclude_collections.end());
 
@@ -330,6 +343,12 @@ void JEventProcessorPODIO::Init() {
     // TODO: NWB: Verify that output file is writable NOW, rather than after event processing completes.
     //       I definitely don't trust PODIO to do this for me.
 
+    if (m_output_include_collections_set) {
+      m_log->error("The podio:output_include_collections was provided, but is deprecated. Use podio:output_collections instead.");
+      using namespace std::chrono_literals;
+      std::this_thread::sleep_for(10s);
+    }
+
 }
 
 
@@ -338,7 +357,7 @@ void JEventProcessorPODIO::FindCollectionsToWrite(const std::shared_ptr<const JE
     // Set up the set of collections_to_write.
     std::vector<std::string> all_collections = event->GetAllCollectionNames();
 
-    if (m_output_include_collections.empty()) {
+    if (m_output_collections.empty()) {
         // User has not specified an include list, so we include _all_ PODIO collections present in the first event.
         for (const std::string& col : all_collections) {
             if (m_output_exclude_collections.find(col) == m_output_exclude_collections.end()) {
@@ -354,7 +373,7 @@ void JEventProcessorPODIO::FindCollectionsToWrite(const std::shared_ptr<const JE
         // We match up the include list with what is actually present in the event
         std::set<std::string> all_collections_set = std::set<std::string>(all_collections.begin(), all_collections.end());
 
-        for (const auto& col : m_output_include_collections) {
+        for (const auto& col : m_output_collections) {
             if (m_output_exclude_collections.find(col) == m_output_exclude_collections.end()) {
                 // Included and not excluded
                 if (all_collections_set.find(col) == all_collections_set.end()) {
@@ -488,5 +507,11 @@ void JEventProcessorPODIO::Process(const std::shared_ptr<const JEvent> &event) {
 }
 
 void JEventProcessorPODIO::Finish() {
+    if (m_output_include_collections_set) {
+      m_log->error("The podio:output_include_collections was provided, but is deprecated. Use podio:output_collections instead.");
+      using namespace std::chrono_literals;
+      std::this_thread::sleep_for(10s);
+    }
+
     m_writer->finish();
 }

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -344,6 +344,7 @@ void JEventProcessorPODIO::Init() {
 
     if (m_output_include_collections_set) {
       m_log->error("The podio:output_include_collections was provided, but is deprecated. Use podio:output_collections instead.");
+      // Adding a delay to ensure users notice the deprecation warning.
       using namespace std::chrono_literals;
       std::this_thread::sleep_for(10s);
     }
@@ -508,6 +509,7 @@ void JEventProcessorPODIO::Process(const std::shared_ptr<const JEvent> &event) {
 void JEventProcessorPODIO::Finish() {
     if (m_output_include_collections_set) {
       m_log->error("The podio:output_include_collections was provided, but is deprecated. Use podio:output_collections instead.");
+      // Adding a delay to ensure users notice the deprecation warning.
       using namespace std::chrono_literals;
       std::this_thread::sleep_for(10s);
     }

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -1,16 +1,16 @@
 
 #include "JEventProcessorPODIO.h"
 
-#include <edm4eic/EDM4eicVersion.h>
-
 #include <JANA/JApplication.h>
 #include <JANA/JLogger.h>
 #include <JANA/Services/JParameterManager.h>
 #include <JANA/Utils/JTypeInfo.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <fmt/core.h>
 #include <podio/CollectionBase.h>
 #include <podio/Frame.h>
 #include <spdlog/common.h>
+// IWYU pragma: no_include <bits/chrono.h>
 #include <chrono>
 #include <exception>
 #include <thread>

--- a/src/services/io/podio/JEventProcessorPODIO.h
+++ b/src/services/io/podio/JEventProcessorPODIO.h
@@ -30,10 +30,11 @@ public:
     bool m_is_first_event = true;
     bool m_user_included_collections = false;
     std::shared_ptr<spdlog::logger> m_log;
+    bool m_output_include_collections_set = false;
 
     std::string m_output_file = "podio_output.root";
     std::string m_output_file_copy_dir = "";
-    std::set<std::string> m_output_include_collections;  // config. parameter
+    std::set<std::string> m_output_collections;  // config. parameter
     std::set<std::string> m_output_exclude_collections;  // config. parameter
     std::vector<std::string> m_collections_to_write;  // derived from above config. parameters
     std::vector<std::string> m_collections_to_print;


### PR DESCRIPTION
This is a follow up on a resolution from #1323

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No