### PR TITLE
Use protoclusters for track cluster merger

### DIFF
--- a/src/algorithms/calorimetry/TrackClusterMergeSplitter.cc
+++ b/src/algorithms/calorimetry/TrackClusterMergeSplitter.cc
@@ -412,7 +412,7 @@ namespace eicrecon {
     for (auto hit : clust.getHits()) {
       eClust += hit.getEnergy();
     }
-    return eClust;
+    return eClust / m_cfg.sampFrac;
 
   }  // end 'get_cluster_energy(edm4eic::ProtoCluster&)'
 
@@ -423,8 +423,14 @@ namespace eicrecon {
   // --------------------------------------------------------------------------
   edm4hep::Vector3f TrackClusterMergeSplitter::get_cluster_position(const edm4eic::ProtoCluster& clust) const {
 
+    // grab total energy
+    const float eClust = get_cluster_energy(clust) * m_cfg.sampFrac;
+
+    // calculate energy-weighted center
     edm4hep::Vector3f position(0., 0., 0.);
-    /* TODO fill in */
+    for (auto hit : clust.getHits()) {
+      position = position + (hit.getPosition() * (hit.getEnergy() / eClust));
+    }
     return position;
 
   }  // end 'get_cluster_position(edm4eic::ProtoCluster&)'

--- a/src/algorithms/calorimetry/TrackClusterMergeSplitter.h
+++ b/src/algorithms/calorimetry/TrackClusterMergeSplitter.h
@@ -16,7 +16,7 @@
 #include <DDRec/CellIDPositionConverter.h>
 // edm4eic types
 #include <edm4eic/TrackPoint.h>
-#include <edm4eic/ClusterCollection.h>
+#include <edm4eic/ProtoClusterCollection.h>
 #include <edm4eic/TrackSegmentCollection.h>
 // for algorithm configuration
 #include "algorithms/interfaces/WithPodConfig.h"
@@ -33,7 +33,8 @@ namespace eicrecon {
   typedef std::map<int, int> MapOneToOne;
   typedef std::map<int, std::vector<int>> MapOneToMany;
   typedef std::vector<edm4eic::TrackPoint> VecTrkPoint;
-  typedef std::vector<edm4eic::Cluster> VecCluster;
+  typedef std::vector<edm4eic::ProtoCluster> VecCluster;
+
 
 
   // --------------------------------------------------------------------------
@@ -41,11 +42,11 @@ namespace eicrecon {
   // --------------------------------------------------------------------------
   using TrackClusterMergeSplitterAlgorithm = algorithms::Algorithm<
     algorithms::Input<
-      edm4eic::ClusterCollection,
+      edm4eic::ProtoClusterCollection,
       edm4eic::TrackSegmentCollection
     >,
     algorithms::Output<
-      edm4eic::ClusterCollection
+      edm4eic::ProtoClusterCollection
     >
   >;
 
@@ -54,9 +55,9 @@ namespace eicrecon {
   // --------------------------------------------------------------------------
   //! Track-Based Cluster Merger/Splitter
   // --------------------------------------------------------------------------
-  /*! An algorithm which takes a collection of reconstructed clusters,
-   *  matches track projections, and then decides to merge or split
-   *  those clusters based on average E/p from simulations.
+  /*! An algorithm which takes a collection of proto-clusters, matches
+   *  track projections, and then decides to merge or split those proto-
+   *  clusters based on average E/p from simulations.
    *
    *  Heavily inspired by Eur. Phys. J. C (2017) 77:466
    */
@@ -71,8 +72,8 @@ namespace eicrecon {
       TrackClusterMergeSplitter(std::string_view name) :
         TrackClusterMergeSplitterAlgorithm {
           name,
-          {"InputClusterCollection", "InputTrackProjections"},
-          {"OutputClusterCollection"},
+          {"InputProtoClusterCollection", "InputTrackProjections"},
+          {"OutputProtoClusterCollection"},
           "Merges or splits clusters based on tracks projected to them."
         } {}
 
@@ -85,9 +86,11 @@ namespace eicrecon {
       // private methods
       void reset_bookkeepers() const;
       void get_projections(const edm4eic::TrackSegmentCollection* projections, const edm4eic::CalorimeterHit& cluster) const;
-      void match_clusters_to_tracks(const edm4eic::ClusterCollection* clusters) const;
-      void merge_clusters(const edm4eic::TrackPoint& matched_trk, const VecCluster& to_merge, edm4eic::MutableCluster& merged_clust) const;
-      void copy_cluster(const edm4eic::Cluster& old_clust, edm4eic::MutableCluster& new_clust) const;
+      void match_clusters_to_tracks(const edm4eic::ProtoClusterCollection* clusters) const;
+      void merge_clusters(const edm4eic::TrackPoint& matched_trk, const VecCluster& to_merge, edm4eic::MutableProtoCluster& merged_clust) const;
+      void copy_cluster(const edm4eic::ProtoCluster& old_clust, edm4eic::MutableProtoCluster& new_clust) const;
+      float get_cluster_energy(const edm4eic::ProtoCluster& clust) const;
+      edm4hep::Vector3f get_cluster_position(const edm4eic::ProtoCluster& clust) const;
 
       // additional services
       const dd4hep::Detector* m_detector {NULL};

--- a/src/algorithms/calorimetry/TrackClusterMergeSplitterConfig.h
+++ b/src/algorithms/calorimetry/TrackClusterMergeSplitterConfig.h
@@ -11,7 +11,6 @@ namespace eicrecon {
     double avgEP     = 1.0;  // mean E/p
     double sigEP     = 1.0;  // rms of E/p
     double drAdd     = 0.4;  // window to add clusters
-    double logBase   = 6.2;  // base for CoG calculation
     double sampFrac  = 1.0;  // allows for sampling fraction correction
     double distScale = 1.0;  // scale for hit-track distance
 

--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -188,7 +188,6 @@ extern "C" {
               .avgEP = 1.0,
               .sigEP = 1.0,
               .drAdd = 0.4,
-              .logBase = 6.2,
               .sampFrac = 1.0,
               .distScale = 1.0
             },

--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -179,10 +179,10 @@ extern "C" {
 
         app->Add(
           new JOmniFactoryGeneratorT<TrackClusterMergeSplitter_factory>(
-            "HcalBarrelSplitMergeClusters",
-            {"HcalBarrelClusters",
+            "HcalBarrelSplitMergeProtoClusters",
+            {"HcalBarrelIslandProtoClusters",
              "CalorimeterTrackProjections"},
-            {"HcalBarrelSplitMergeClusters"},
+            {"HcalBarrelSplitMergeProtoClusters"},
             {
               .minSigCut = -1,
               .avgEP = 1.0,
@@ -193,6 +193,23 @@ extern "C" {
               .distScale = 1.0
             },
             app   // TODO: remove me once fixed
+          )
+        );
+
+        app->Add(
+          new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
+             "HcalBarrelSplitMergeClusters",
+            {"HcalBarrelSplitMergeProtoClusters",        // edm4eic::ProtoClusterCollection
+             "HcalBarrelHits"},                          // edm4hep::SimCalorimeterHitCollection
+            {"HcalBarrelSplitMergeClusters",             // edm4eic::Cluster
+             "HcalBarrelSplitMergeClusterAssociations"}, // edm4eic::MCRecoClusterParticleAssociation
+            {
+              .energyWeight = "log",
+              .sampFrac = 1.0,
+              .logWeightBase = 6.2,
+              .enableEtaBounds = false
+            },
+            app   // TODO: Remove me once fixed
           )
         );
 

--- a/src/factories/calorimetry/TrackClusterMergeSplitter_factory.h
+++ b/src/factories/calorimetry/TrackClusterMergeSplitter_factory.h
@@ -37,7 +37,6 @@ namespace eicrecon {
       ParameterRef<double> m_avgEP {this, "avgEP", config().avgEP};
       ParameterRef<double> m_sigEP {this, "sigEP", config().sigEP};
       ParameterRef<double> m_drAdd {this, "drAdd", config().drAdd};
-      ParameterRef<double> m_logBase {this, "logBase", config().logBase};
       ParameterRef<double> m_sampFrac {this, "sampFrac", config().sampFrac};
       ParameterRef<double> m_distScale {this, "distScale", config().distScale};
 

--- a/src/factories/calorimetry/TrackClusterMergeSplitter_factory.h
+++ b/src/factories/calorimetry/TrackClusterMergeSplitter_factory.h
@@ -26,11 +26,11 @@ namespace eicrecon {
       std::unique_ptr<AlgoT> m_algo;
 
       // input collections
-      PodioInput<edm4eic::Cluster> m_clusters_input {this};
+      PodioInput<edm4eic::ProtoCluster> m_protoclusters_input {this};
       PodioInput<edm4eic::TrackSegment> m_track_projections_input {this};
 
       // output collections
-      PodioOutput<edm4eic::Cluster> m_clusters_output {this};
+      PodioOutput<edm4eic::ProtoCluster> m_protoclusters_output {this};
 
       // parameter bindings
       ParameterRef<double> m_minSigCut {this, "minSigCut", config().minSigCut};
@@ -59,8 +59,8 @@ namespace eicrecon {
 
       void Process(int64_t run_number, uint64_t event_number) {
         m_algo -> process(
-          {m_clusters_input(), m_track_projections_input()},
-          {m_clusters_output().get()}
+          {m_protoclusters_input(), m_track_projections_input()},
+          {m_protoclusters_output().get()}
         );
       }
 

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -259,6 +259,7 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "HcalBarrelClusters",
             "HcalBarrelClusterAssociations",
             "HcalBarrelSplitMergeClusters",
+            "HcalBarrelSplitMergeClusterAssociations",
             "B0ECalRawHits",
             "B0ECalRecHits",
             "B0ECalClusters",


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This PR converts the proposed track-based cluster merger algorithm to operate on protoclusters and produce protoclusters rather than reconstructed clusters.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [X] Other: implement changes to a feature branch

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

n/a

### Does this PR change default behavior?

n/a