### PR TITLE
Update the localDistXZ paramter in BEMC.cc

### DIFF
--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -79,7 +79,7 @@ extern "C" {
           "EcalBarrelScFiProtoClusters", {"EcalBarrelScFiRecHits"}, {"EcalBarrelScFiProtoClusters"},
           {
             .sectorDist = 50. * dd4hep::mm,
-            .localDistXZ = {40 * dd4hep::mm, 40 * dd4hep::mm},
+            .localDistXZ = {80 * dd4hep::mm, 80 * dd4hep::mm},
             .splitCluster = false,
             .minClusterHitEdep = 5.0 * dd4hep::MeV,
             .minClusterCenterEdep = 100.0 * dd4hep::MeV,


### PR DESCRIPTION
The clustering parameter, localDistXZ  is changed from {40 mm, 40mm} to {80mm, 80mm}. 

### Briefly, what does this PR introduce?
Minimizes the cluster splitting at the pseudorapidities corresponding to forward and backward region. The results can be seen here:
https://docs.google.com/presentation/d/1DympCgYqOKZBqyOqESEXCtlv073pGnkf266O1KRoba8/edit?usp=sharing

### What kind of change does this PR introduce?
- [x] Bug fix (issue #1289 __)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [x] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
