### PR TITLE
fix: include vector_utils in ImagingClusterReco

### DIFF
--- a/src/algorithms/calorimetry/ImagingClusterReco.h
+++ b/src/algorithms/calorimetry/ImagingClusterReco.h
@@ -23,6 +23,7 @@
 // Event Model related classes
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
+#include <edm4hep/utils/vector_utils.h>
 #include <edm4eic/CalorimeterHitCollection.h>
 #include <edm4eic/ClusterCollection.h>
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
ImagingClusterReco uses multiplication of Vector3f with float, which is defined in vector_utils. IWYU has trouble with operators.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: fails to compile when header is used separately, not in BEMC.cc) 
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.