### PR TITLE
fix: convert to algorithms logger, no m_log in each algorithm class

### DIFF
--- a/src/algorithms/digi/SiliconTrackerDigi.cc
+++ b/src/algorithms/digi/SiliconTrackerDigi.cc
@@ -20,10 +20,7 @@
 
 namespace eicrecon {
 
-void SiliconTrackerDigi::init(std::shared_ptr<spdlog::logger>& logger) {
-    // set logger
-    m_log = logger;
-
+void SiliconTrackerDigi::init() {
     // Create random gauss function
     m_gauss = [&](){
         return m_random.Gaus(0, m_cfg.timeResolution);
@@ -50,20 +47,20 @@ void SiliconTrackerDigi::process(
         double result_time = sim_hit.getTime() + time_smearing;
         auto hit_time_stamp = (std::int32_t) (result_time * 1e3);
 
-        m_log->debug("--------------------");
-        m_log->debug("Hit cellID   = {}", sim_hit.getCellID());
-        m_log->debug("   position  = ({:.2f}, {:.2f}, {:.2f})", sim_hit.getPosition().x, sim_hit.getPosition().y, sim_hit.getPosition().z);
-        m_log->debug("   xy_radius = {:.2f}", std::hypot(sim_hit.getPosition().x, sim_hit.getPosition().y));
-        m_log->debug("   momentum  = ({:.2f}, {:.2f}, {:.2f})", sim_hit.getMomentum().x, sim_hit.getMomentum().y, sim_hit.getMomentum().z);
-        m_log->debug("   edep = {:.2f}", sim_hit.getEDep());
-        m_log->debug("   time = {:.4f}[ns]", sim_hit.getTime());
-        m_log->debug("   particle time = {}[ns]", sim_hit.getMCParticle().getTime());
-        m_log->debug("   time smearing: {:.4f}, resulting time = {:.4f} [ns]", time_smearing, result_time);
-        m_log->debug("   hit_time_stamp: {} [~ps]", hit_time_stamp);
+        debug("--------------------");
+        debug("Hit cellID   = {}", sim_hit.getCellID());
+        debug("   position  = ({:.2f}, {:.2f}, {:.2f})", sim_hit.getPosition().x, sim_hit.getPosition().y, sim_hit.getPosition().z);
+        debug("   xy_radius = {:.2f}", std::hypot(sim_hit.getPosition().x, sim_hit.getPosition().y));
+        debug("   momentum  = ({:.2f}, {:.2f}, {:.2f})", sim_hit.getMomentum().x, sim_hit.getMomentum().y, sim_hit.getMomentum().z);
+        debug("   edep = {:.2f}", sim_hit.getEDep());
+        debug("   time = {:.4f}[ns]", sim_hit.getTime());
+        debug("   particle time = {}[ns]", sim_hit.getMCParticle().getTime());
+        debug("   time smearing: {:.4f}, resulting time = {:.4f} [ns]", time_smearing, result_time);
+        debug("   hit_time_stamp: {} [~ps]", hit_time_stamp);
 
 
         if (sim_hit.getEDep() < m_cfg.threshold) {
-            m_log->debug("  edep is below threshold of {:.2f} [keV]", m_cfg.threshold / dd4hep::keV);
+            debug("  edep is below threshold of {:.2f} [keV]", m_cfg.threshold / dd4hep::keV);
             continue;
         }
 
@@ -77,7 +74,7 @@ void SiliconTrackerDigi::process(
         } else {
             // There is previous values in the cell
             auto& hit = cell_hit_map[sim_hit.getCellID()];
-            m_log->debug("  Hit already exists in cell ID={}, prev. hit time: {}", sim_hit.getCellID(), hit.getTimeStamp());
+            debug("  Hit already exists in cell ID={}, prev. hit time: {}", sim_hit.getCellID(), hit.getTimeStamp());
 
             // keep earliest time for hit
             auto time_stamp = hit.getTimeStamp();

--- a/src/algorithms/digi/SiliconTrackerDigi.h
+++ b/src/algorithms/digi/SiliconTrackerDigi.h
@@ -5,12 +5,10 @@
 
 #include <TRandomGen.h>
 #include <algorithms/algorithm.h>
-#include <edm4eic/RawTrackerHitCollection.h>
 #include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
+#include <edm4eic/RawTrackerHitCollection.h>
 #include <edm4hep/SimTrackerHitCollection.h>
-#include <spdlog/logger.h>
 #include <functional>
-#include <memory>
 #include <string>
 #include <string_view>
 
@@ -19,42 +17,35 @@
 
 namespace eicrecon {
 
-  using SiliconTrackerDigiAlgorithm = algorithms::Algorithm<
-    algorithms::Input<
-      edm4hep::SimTrackerHitCollection
-    >,
-    algorithms::Output<
-      edm4eic::RawTrackerHitCollection,
-      edm4eic::MCRecoTrackerHitAssociationCollection
-    >
-  >;
+using SiliconTrackerDigiAlgorithm =
+    algorithms::Algorithm<algorithms::Input<edm4hep::SimTrackerHitCollection>,
+                          algorithms::Output<edm4eic::RawTrackerHitCollection,
+                                             edm4eic::MCRecoTrackerHitAssociationCollection>>;
 
-  class SiliconTrackerDigi
-  : public SiliconTrackerDigiAlgorithm,
-    public WithPodConfig<SiliconTrackerDigiConfig> {
+class SiliconTrackerDigi : public SiliconTrackerDigiAlgorithm,
+                           public WithPodConfig<SiliconTrackerDigiConfig> {
 
-  public:
-    SiliconTrackerDigi(std::string_view name)
+public:
+  SiliconTrackerDigi(std::string_view name)
       : SiliconTrackerDigiAlgorithm{name,
-                            {"inputHitCollection"},
-                            {"outputRawHitCollection","outputHitAssociations"},
-                            "Apply threshold, digitize within ADC range, "
-                            "convert time with smearing resolution."} {}
+                                    {"inputHitCollection"},
+                                    {"outputRawHitCollection", "outputHitAssociations"},
+                                    "Apply threshold, digitize within ADC range, "
+                                    "convert time with smearing resolution."} {}
 
-    void init() final;
-    void process(const Input&, const Output&) const final;
+  void init() final;
+  void process(const Input&, const Output&) const final;
 
-  private:
-    /** Random number generation*/
-    TRandomMixMax m_random;
-    std::function<double()> m_gauss;
+private:
+  /** Random number generation*/
+  TRandomMixMax m_random;
+  std::function<double()> m_gauss;
 
-    // FIXME replace with standard random engine
-    //std::default_random_engine generator; // TODO: need something more appropriate here
-    //std::normal_distribution<double> m_normDist; // defaults to mean=0, sigma=1
+  // FIXME replace with standard random engine
+  // std::default_random_engine generator; // TODO: need something more appropriate here
+  // std::normal_distribution<double> m_normDist; // defaults to mean=0, sigma=1
 
-    //algorithms::Generator m_rng = algorithms::RandomSvc::instance().generator();
+  // algorithms::Generator m_rng = algorithms::RandomSvc::instance().generator();
+};
 
-  };
-
-} // eicrecon
+} // namespace eicrecon

--- a/src/algorithms/digi/SiliconTrackerDigi.h
+++ b/src/algorithms/digi/SiliconTrackerDigi.h
@@ -41,13 +41,10 @@ namespace eicrecon {
                             "Apply threshold, digitize within ADC range, "
                             "convert time with smearing resolution."} {}
 
-    void init(std::shared_ptr<spdlog::logger>& logger);
+    void init() final;
     void process(const Input&, const Output&) const final;
 
   private:
-    /** algorithm logger */
-    std::shared_ptr<spdlog::logger> m_log;
-
     /** Random number generation*/
     TRandomMixMax m_random;
     std::function<double()> m_gauss;

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -25,9 +25,7 @@
 
 namespace eicrecon {
 
-    void FarDetectorLinearTracking::init(std::shared_ptr<spdlog::logger>& logger) {
-
-      m_log      = logger;
+    void FarDetectorLinearTracking::init() {
 
       // For changing how strongly each layer hit is in contributing to the fit
       m_layerWeights = Eigen::VectorXd::Constant(m_cfg.n_layer,1);
@@ -49,7 +47,7 @@ namespace eicrecon {
         // Check the number of input collections is correct
         int nCollections = inputhits.size();
         if(nCollections!=m_cfg.n_layer){
-          m_log->error("Wrong number of input collections passed to algorithm");
+          error("Wrong number of input collections passed to algorithm");
           return;
         }
 
@@ -58,7 +56,7 @@ namespace eicrecon {
         // TODO - Implement more sensible solution
         for(const auto& layerHits: inputhits){
           if((*layerHits).size()>m_cfg.layer_hits_max){
-            m_log->info("Too many hits in layer");
+            info("Too many hits in layer");
             return;
           }
         }
@@ -160,9 +158,9 @@ namespace eicrecon {
 
       double angle = std::acos(hitDiff.dot(m_optimumDirection));
 
-      m_log->debug("Vector: x={}, y={}, z={}",hitDiff.x(),hitDiff.y(),hitDiff.z());
-      m_log->debug("Optimum: x={}, y={}, z={}",m_optimumDirection.x(),m_optimumDirection.y(),m_optimumDirection.z());
-      m_log->debug("Angle: {}, Tolerance {}",angle,m_cfg.step_angle_tolerance);
+      debug("Vector: x={}, y={}, z={}",hitDiff.x(),hitDiff.y(),hitDiff.z());
+      debug("Optimum: x={}, y={}, z={}",m_optimumDirection.x(),m_optimumDirection.y(),m_optimumDirection.z());
+      debug("Angle: {}, Tolerance {}",angle,m_cfg.step_angle_tolerance);
 
       if(angle>m_cfg.step_angle_tolerance) return false;
 

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.h
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.h
@@ -3,63 +3,54 @@
 
 #pragma once
 
+#include <Eigen/Core>
 #include <algorithms/algorithm.h>
 #include <algorithms/interfaces/WithPodConfig.h>
 #include <edm4eic/TrackSegmentCollection.h>
 #include <edm4hep/TrackerHitCollection.h>
 #include <gsl/pointers>
-#include <memory>
 #include <string>
 #include <string_view>
 #include <vector>
-#include <Eigen/Core>
-#include <spdlog/logger.h>
+
 #include "FarDetectorLinearTrackingConfig.h"
 
 namespace eicrecon {
 
-    using FarDetectorLinearTrackingAlgorithm = algorithms::Algorithm<
-        algorithms::Input<
-            std::vector<edm4hep::TrackerHitCollection>
-        >,
-        algorithms::Output<
-            edm4eic::TrackSegmentCollection
-        >
-    >;
+using FarDetectorLinearTrackingAlgorithm =
+    algorithms::Algorithm<algorithms::Input<std::vector<edm4hep::TrackerHitCollection>>,
+                          algorithms::Output<edm4eic::TrackSegmentCollection>>;
 
-    class FarDetectorLinearTracking
-    : public FarDetectorLinearTrackingAlgorithm,
-      public WithPodConfig<FarDetectorLinearTrackingConfig>  {
+class FarDetectorLinearTracking : public FarDetectorLinearTrackingAlgorithm,
+                                  public WithPodConfig<FarDetectorLinearTrackingConfig> {
 
-    public:
-        FarDetectorLinearTracking(std::string_view name)
-            : FarDetectorLinearTrackingAlgorithm{name,
-                {"inputHitCollections"},
-                {"outputTrackSegments"},
-                "Fit track segments from hits in the tracker layers"} {}
+public:
+  FarDetectorLinearTracking(std::string_view name)
+      : FarDetectorLinearTrackingAlgorithm{name,
+                                           {"inputHitCollections"},
+                                           {"outputTrackSegments"},
+                                           "Fit track segments from hits in the tracker layers"} {}
 
-        /** One time initialization **/
-        void init() final;
+  /** One time initialization **/
+  void init() final;
 
-        /** Event by event processing **/
-        void process(const Input&, const Output&) const final;
+  /** Event by event processing **/
+  void process(const Input&, const Output&) const final;
 
-    private:
-        Eigen::VectorXd m_layerWeights;
+private:
+  Eigen::VectorXd m_layerWeights;
 
-        Eigen::Vector3d m_optimumDirection;
+  Eigen::Vector3d m_optimumDirection;
 
-        void buildMatrixRecursive(int level,
-                                 Eigen::MatrixXd* hitMatrix,
-                                 const std::vector<gsl::not_null<const edm4hep::TrackerHitCollection*>>& hits,
-                                 gsl::not_null<edm4eic::TrackSegmentCollection*> outputTracks) const;
+  void
+  buildMatrixRecursive(int level, Eigen::MatrixXd* hitMatrix,
+                       const std::vector<gsl::not_null<const edm4hep::TrackerHitCollection*>>& hits,
+                       gsl::not_null<edm4eic::TrackSegmentCollection*> outputTracks) const;
 
-        void checkHitCombination(Eigen::MatrixXd* hitMatrix,
-                                gsl::not_null<edm4eic::TrackSegmentCollection*> outputTracks) const;
+  void checkHitCombination(Eigen::MatrixXd* hitMatrix,
+                           gsl::not_null<edm4eic::TrackSegmentCollection*> outputTracks) const;
 
-        bool checkHitPair(const Eigen::Vector3d& hit1,
-                          const Eigen::Vector3d& hit2) const;
+  bool checkHitPair(const Eigen::Vector3d& hit1, const Eigen::Vector3d& hit2) const;
+};
 
-    };
-
-} // eicrecon
+} // namespace eicrecon

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.h
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.h
@@ -39,14 +39,12 @@ namespace eicrecon {
                 "Fit track segments from hits in the tracker layers"} {}
 
         /** One time initialization **/
-        void init(std::shared_ptr<spdlog::logger>& logger);
+        void init() final;
 
         /** Event by event processing **/
         void process(const Input&, const Output&) const final;
 
     private:
-        std::shared_ptr<spdlog::logger> m_log;
-
         Eigen::VectorXd m_layerWeights;
 
         Eigen::Vector3d m_optimumDirection;

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
@@ -23,9 +23,8 @@
 
 namespace eicrecon {
 
-  void FarDetectorTrackerCluster::init(std::shared_ptr<spdlog::logger>& log) {
+  void FarDetectorTrackerCluster::init() {
 
-    m_log = log;
     m_detector = algorithms::GeoSvc::instance().detector();
     m_cellid_converter = algorithms::GeoSvc::instance().cellIDPositionConverter();
 
@@ -37,14 +36,14 @@ namespace eicrecon {
       m_id_dec = m_detector->readout(m_cfg.readout).idSpec().decoder();
       if (!m_cfg.x_field.empty()) {
         m_x_idx = m_id_dec->index(m_cfg.x_field);
-        m_log->debug("Find layer field {}, index = {}",  m_cfg.x_field, m_x_idx);
+        debug("Find layer field {}, index = {}",  m_cfg.x_field, m_x_idx);
       }
       if (!m_cfg.y_field.empty()) {
         m_y_idx = m_id_dec->index(m_cfg.y_field);
-        m_log->debug("Find layer field {}, index = {}", m_cfg.y_field, m_y_idx);
+        debug("Find layer field {}, index = {}", m_cfg.y_field, m_y_idx);
       }
     } catch (...) {
-      m_log->error("Failed to load ID decoder for {}", m_cfg.readout);
+      error("Failed to load ID decoder for {}", m_cfg.readout);
       throw JException("Failed to load ID decoder");
     }
 

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
@@ -8,6 +8,7 @@
 #include <DD4hep/VolumeManager.h>
 #include <DD4hep/detail/SegmentationsInterna.h>
 #include <DDSegmentation/BitFieldCoder.h>
+#include <Evaluator/DD4hepUnits.h>
 #include <JANA/JException.h>
 #include <Math/GenVector/Cartesian3D.h>
 #include <Math/GenVector/DisplacementVector3D.h>
@@ -15,191 +16,186 @@
 #include <algorithms/geo.h>
 #include <edm4hep/Vector3d.h>
 #include <fmt/core.h>
-#include <sys/types.h>
 #include <gsl/pointers>
+#include <sys/types.h>
 
 #include "algorithms/fardetectors/FarDetectorTrackerCluster.h"
 #include "algorithms/fardetectors/FarDetectorTrackerClusterConfig.h"
 
 namespace eicrecon {
 
-  void FarDetectorTrackerCluster::init() {
+void FarDetectorTrackerCluster::init() {
 
-    m_detector = algorithms::GeoSvc::instance().detector();
-    m_cellid_converter = algorithms::GeoSvc::instance().cellIDPositionConverter();
+  m_detector         = algorithms::GeoSvc::instance().detector();
+  m_cellid_converter = algorithms::GeoSvc::instance().cellIDPositionConverter();
 
-    if (m_cfg.readout.empty()) {
-      throw JException("Readout is empty");
-    }
-    try {
-      m_seg    = m_detector->readout(m_cfg.readout).segmentation();
-      m_id_dec = m_detector->readout(m_cfg.readout).idSpec().decoder();
-      if (!m_cfg.x_field.empty()) {
-        m_x_idx = m_id_dec->index(m_cfg.x_field);
-        debug("Find layer field {}, index = {}",  m_cfg.x_field, m_x_idx);
-      }
-      if (!m_cfg.y_field.empty()) {
-        m_y_idx = m_id_dec->index(m_cfg.y_field);
-        debug("Find layer field {}, index = {}", m_cfg.y_field, m_y_idx);
-      }
-    } catch (...) {
-      error("Failed to load ID decoder for {}", m_cfg.readout);
-      throw JException("Failed to load ID decoder");
-    }
-
+  if (m_cfg.readout.empty()) {
+    throw JException("Readout is empty");
   }
-
-  void FarDetectorTrackerCluster::process(
-      const FarDetectorTrackerCluster::Input& input,
-      const FarDetectorTrackerCluster::Output& output) const {
-
-    const auto [inputHitsCollections] = input;
-    auto [outputClustersCollection]  = output;
-
-    //Loop over input and output collections - Any collection should only contain hits from a single surface
-    for(size_t i=0; i<inputHitsCollections.size(); i++){
-      auto inputHits = inputHitsCollections[i];
-      if(inputHits->size() == 0) continue;
-      auto outputClusters = outputClustersCollection[i];
-
-      // Make clusters
-      auto clusters = ClusterHits(*inputHits);
-
-      // Create TrackerHits from 2D cluster positions
-      ConvertClusters(clusters, *outputClusters);
-
+  try {
+    m_seg    = m_detector->readout(m_cfg.readout).segmentation();
+    m_id_dec = m_detector->readout(m_cfg.readout).idSpec().decoder();
+    if (!m_cfg.x_field.empty()) {
+      m_x_idx = m_id_dec->index(m_cfg.x_field);
+      debug("Find layer field {}, index = {}", m_cfg.x_field, m_x_idx);
     }
+    if (!m_cfg.y_field.empty()) {
+      m_y_idx = m_id_dec->index(m_cfg.y_field);
+      debug("Find layer field {}, index = {}", m_cfg.y_field, m_y_idx);
+    }
+  } catch (...) {
+    error("Failed to load ID decoder for {}", m_cfg.readout);
+    throw JException("Failed to load ID decoder");
   }
-
-  // Create vector of FDTrackerCluster from list of hits
-  std::vector<FDTrackerCluster> FarDetectorTrackerCluster::ClusterHits(const edm4eic::RawTrackerHitCollection& inputHits) const {
-
-    std::vector<FDTrackerCluster> clusters;
-
-    ROOT::VecOps::RVec<unsigned long>  id;
-    ROOT::VecOps::RVec<int>   x;
-    ROOT::VecOps::RVec<int>   y;
-    ROOT::VecOps::RVec<float> e;
-    ROOT::VecOps::RVec<float> t;
-
-    // Gather detector id positions
-    for(const auto& hit: inputHits){
-      auto cellID = hit.getCellID();
-      id.push_back(cellID);
-      x.push_back (m_id_dec->get( cellID, m_x_idx      ));
-      y.push_back (m_id_dec->get( cellID, m_y_idx      ));
-      e.push_back (hit.getCharge());
-      t.push_back (hit.getTimeStamp());
-    }
-
-    // Set up clustering variables
-    ROOT::VecOps::RVec<bool> available(id.size(), 1);
-    auto indices = Enumerate(id);
-
-    // Loop while there are unclustered hits
-    while(ROOT::VecOps::Any(available)){
-
-      dd4hep::Position localPos = {0,0,0};
-      float  weightSum = 0;
-
-      float esum   = 0;
-      float t0     = 0;
-      float tError = 0;
-      auto maxIndex = ROOT::VecOps::ArgMax(e*available);
-
-      available[maxIndex] = 0;
-
-      ROOT::VecOps::RVec<unsigned long> clusterList = {maxIndex};
-      ROOT::VecOps::RVec<float> clusterT;
-      std::vector<podio::ObjectID> clusterHits;
-
-      // Loop over hits, adding neighbouring hits as relevant
-      while(clusterList.size()){
-
-        // Takes first remaining hit in cluster list
-        auto index  = clusterList[0];
-
-        // Finds neighbours of cluster within time limit
-        auto filter = available*(abs(x-x[index])<=1)*(abs(y-y[index])<=1)*(abs(t-t[index])<m_cfg.hit_time_limit);
-
-        // Adds the found hits to the cluster
-        clusterList = Concatenate(clusterList,indices[filter]);
-
-        // Removes the found hits from the list of still available hits
-        available = available*(!filter);
-
-        // Removes current hit from remaining found cluster hits
-        clusterList.erase(clusterList.begin());
-
-        // Adds raw hit to TrackerHit contribution
-        clusterHits.push_back((inputHits)[index].getObjectID());
-
-        // Energy
-        auto hitE = e[index];
-        esum += hitE;
-        // TODO - See if now a single detector element is expected a better function is available.
-        auto pos = m_seg->position(id[index]);
-
-        //Weighted position
-        float weight = hitE; // TODO - Calculate appropriate weighting based on sensor charge sharing
-        weightSum += weight;
-        localPos  += pos*weight;
-
-        //Time
-        clusterT.push_back(t[index]);
-
-      }
-
-      // Finalise position
-      localPos/=weightSum;
-
-      // Finalise time
-      t0      = Mean(clusterT);
-      tError  = StdDev(clusterT); // TODO fold detector timing resolution into error
-
-      // Create cluster
-      clusters.push_back(FDTrackerCluster{
-        .cellID    = id[maxIndex],
-        .x         = localPos.x(),
-        .y         = localPos.y(),
-        .energy    = esum,
-        .time      = t0,
-        .timeError = tError,
-        .rawHits   = clusterHits
-      });
-
-
-    }
-
-    return clusters;
-
-  }
-
-  // Convert to global coordinates and create TrackerHits
-  void FarDetectorTrackerCluster::ConvertClusters(const std::vector<FDTrackerCluster>& clusters, edm4hep::TrackerHitCollection& outputClusters) const {
-
-    // Get context of first hit
-    const dd4hep::VolumeManagerContext* context = m_cellid_converter->findContext(clusters[0].cellID);
-
-    for(auto cluster: clusters){
-      auto hitPos = outputClusters.create();
-
-      auto globalPos = context->localToWorld({cluster.x,cluster.y,0});
-
-      // Set cluster members
-      hitPos.setCellID  (cluster.cellID);
-      hitPos.setPosition(edm4hep::Vector3d(globalPos.x()/dd4hep::mm,globalPos.y()/dd4hep::mm,globalPos.z()/dd4hep::mm));
-      hitPos.setEDep    (cluster.energy);
-      hitPos.setTime    (cluster.time);
-
-      // Add raw hits to cluster
-      for(auto hit: cluster.rawHits){
-        hitPos.addToRawHits(hit);
-      }
-
-    }
-
-  }
-
-
 }
+
+void FarDetectorTrackerCluster::process(const FarDetectorTrackerCluster::Input& input,
+                                        const FarDetectorTrackerCluster::Output& output) const {
+
+  const auto [inputHitsCollections] = input;
+  auto [outputClustersCollection]   = output;
+
+  // Loop over input and output collections - Any collection should only contain hits from a single
+  // surface
+  for (size_t i = 0; i < inputHitsCollections.size(); i++) {
+    auto inputHits = inputHitsCollections[i];
+    if (inputHits->size() == 0)
+      continue;
+    auto outputClusters = outputClustersCollection[i];
+
+    // Make clusters
+    auto clusters = ClusterHits(*inputHits);
+
+    // Create TrackerHits from 2D cluster positions
+    ConvertClusters(clusters, *outputClusters);
+  }
+}
+
+// Create vector of FDTrackerCluster from list of hits
+std::vector<FDTrackerCluster>
+FarDetectorTrackerCluster::ClusterHits(const edm4eic::RawTrackerHitCollection& inputHits) const {
+
+  std::vector<FDTrackerCluster> clusters;
+
+  ROOT::VecOps::RVec<unsigned long> id;
+  ROOT::VecOps::RVec<int> x;
+  ROOT::VecOps::RVec<int> y;
+  ROOT::VecOps::RVec<float> e;
+  ROOT::VecOps::RVec<float> t;
+
+  // Gather detector id positions
+  for (const auto& hit : inputHits) {
+    auto cellID = hit.getCellID();
+    id.push_back(cellID);
+    x.push_back(m_id_dec->get(cellID, m_x_idx));
+    y.push_back(m_id_dec->get(cellID, m_y_idx));
+    e.push_back(hit.getCharge());
+    t.push_back(hit.getTimeStamp());
+  }
+
+  // Set up clustering variables
+  ROOT::VecOps::RVec<bool> available(id.size(), 1);
+  auto indices = Enumerate(id);
+
+  // Loop while there are unclustered hits
+  while (ROOT::VecOps::Any(available)) {
+
+    dd4hep::Position localPos = {0, 0, 0};
+    float weightSum           = 0;
+
+    float esum    = 0;
+    float t0      = 0;
+    float tError  = 0;
+    auto maxIndex = ROOT::VecOps::ArgMax(e * available);
+
+    available[maxIndex] = 0;
+
+    ROOT::VecOps::RVec<unsigned long> clusterList = {maxIndex};
+    ROOT::VecOps::RVec<float> clusterT;
+    std::vector<podio::ObjectID> clusterHits;
+
+    // Loop over hits, adding neighbouring hits as relevant
+    while (clusterList.size()) {
+
+      // Takes first remaining hit in cluster list
+      auto index = clusterList[0];
+
+      // Finds neighbours of cluster within time limit
+      auto filter = available * (abs(x - x[index]) <= 1) * (abs(y - y[index]) <= 1) *
+                    (abs(t - t[index]) < m_cfg.hit_time_limit);
+
+      // Adds the found hits to the cluster
+      clusterList = Concatenate(clusterList, indices[filter]);
+
+      // Removes the found hits from the list of still available hits
+      available = available * (!filter);
+
+      // Removes current hit from remaining found cluster hits
+      clusterList.erase(clusterList.begin());
+
+      // Adds raw hit to TrackerHit contribution
+      clusterHits.push_back((inputHits)[index].getObjectID());
+
+      // Energy
+      auto hitE = e[index];
+      esum += hitE;
+      // TODO - See if now a single detector element is expected a better function is available.
+      auto pos = m_seg->position(id[index]);
+
+      // Weighted position
+      float weight = hitE; // TODO - Calculate appropriate weighting based on sensor charge sharing
+      weightSum += weight;
+      localPos += pos * weight;
+
+      // Time
+      clusterT.push_back(t[index]);
+    }
+
+    // Finalise position
+    localPos /= weightSum;
+
+    // Finalise time
+    t0     = Mean(clusterT);
+    tError = StdDev(clusterT); // TODO fold detector timing resolution into error
+
+    // Create cluster
+    clusters.push_back(FDTrackerCluster{.cellID    = id[maxIndex],
+                                        .x         = localPos.x(),
+                                        .y         = localPos.y(),
+                                        .energy    = esum,
+                                        .time      = t0,
+                                        .timeError = tError,
+                                        .rawHits   = clusterHits});
+  }
+
+  return clusters;
+}
+
+// Convert to global coordinates and create TrackerHits
+void FarDetectorTrackerCluster::ConvertClusters(
+    const std::vector<FDTrackerCluster>& clusters,
+    edm4hep::TrackerHitCollection& outputClusters) const {
+
+  // Get context of first hit
+  const dd4hep::VolumeManagerContext* context = m_cellid_converter->findContext(clusters[0].cellID);
+
+  for (auto cluster : clusters) {
+    auto hitPos = outputClusters.create();
+
+    auto globalPos = context->localToWorld({cluster.x, cluster.y, 0});
+
+    // Set cluster members
+    hitPos.setCellID(cluster.cellID);
+    hitPos.setPosition(edm4hep::Vector3d(globalPos.x() / dd4hep::mm, globalPos.y() / dd4hep::mm,
+                                         globalPos.z() / dd4hep::mm));
+    hitPos.setEDep(cluster.energy);
+    hitPos.setTime(cluster.time);
+
+    // Add raw hits to cluster
+    for (auto hit : cluster.rawHits) {
+      hitPos.addToRawHits(hit);
+    }
+  }
+}
+
+} // namespace eicrecon

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.h
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.h
@@ -53,7 +53,7 @@ namespace eicrecon {
                             "Simple weighted clustering of hits by x-y component of single detector element segmentation"} {}
 
     /** One time initialization **/
-    void init(std::shared_ptr<spdlog::logger>& logger);
+    void init() final;
 
     /** Event by event processing **/
     void process(const Input&, const Output&) const final;
@@ -67,7 +67,6 @@ namespace eicrecon {
   private:
       const dd4hep::Detector*         m_detector{nullptr};
       const dd4hep::BitFieldCoder*    m_id_dec{nullptr};
-      std::shared_ptr<spdlog::logger> m_log;
       const dd4hep::rec::CellIDPositionConverter* m_cellid_converter{nullptr};
       dd4hep::Segmentation     m_seg;
 

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.h
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.h
@@ -11,8 +11,6 @@
 #include <edm4eic/RawTrackerHitCollection.h>
 #include <edm4hep/TrackerHitCollection.h>
 #include <podio/ObjectID.h>
-#include <spdlog/logger.h>
-#include <memory>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -32,47 +30,41 @@ struct FDTrackerCluster {
 };
 namespace eicrecon {
 
-  using FarDetectorTrackerClusterAlgorithm = algorithms::Algorithm<
-    algorithms::Input<
-      std::vector<edm4eic::RawTrackerHitCollection>
-    >,
-    algorithms::Output<
-      std::vector<edm4hep::TrackerHitCollection>
-    >
-  >;
+using FarDetectorTrackerClusterAlgorithm =
+    algorithms::Algorithm<algorithms::Input<std::vector<edm4eic::RawTrackerHitCollection>>,
+                          algorithms::Output<std::vector<edm4hep::TrackerHitCollection>>>;
 
-  class FarDetectorTrackerCluster
-  : public FarDetectorTrackerClusterAlgorithm,
-    public WithPodConfig<FarDetectorTrackerClusterConfig>  {
+class FarDetectorTrackerCluster : public FarDetectorTrackerClusterAlgorithm,
+                                  public WithPodConfig<FarDetectorTrackerClusterConfig> {
 
-  public:
-    FarDetectorTrackerCluster(std::string_view name)
+public:
+  FarDetectorTrackerCluster(std::string_view name)
       : FarDetectorTrackerClusterAlgorithm{name,
-                            {"inputHitCollection"},
-                            {"outputClusterPositionCollection"},
-                            "Simple weighted clustering of hits by x-y component of single detector element segmentation"} {}
+                                           {"inputHitCollection"},
+                                           {"outputClusterPositionCollection"},
+                                           "Simple weighted clustering of hits by x-y component of "
+                                           "single detector element segmentation"} {}
 
-    /** One time initialization **/
-    void init() final;
+  /** One time initialization **/
+  void init() final;
 
-    /** Event by event processing **/
-    void process(const Input&, const Output&) const final;
+  /** Event by event processing **/
+  void process(const Input&, const Output&) const final;
 
-    /** Cluster hits **/
-    std::vector<FDTrackerCluster> ClusterHits(const edm4eic::RawTrackerHitCollection&) const;
+  /** Cluster hits **/
+  std::vector<FDTrackerCluster> ClusterHits(const edm4eic::RawTrackerHitCollection&) const;
 
-    /** Convert clusters to TrackerHits **/
-    void ConvertClusters(const std::vector<FDTrackerCluster>&, edm4hep::TrackerHitCollection&) const;
+  /** Convert clusters to TrackerHits **/
+  void ConvertClusters(const std::vector<FDTrackerCluster>&, edm4hep::TrackerHitCollection&) const;
 
-  private:
-      const dd4hep::Detector*         m_detector{nullptr};
-      const dd4hep::BitFieldCoder*    m_id_dec{nullptr};
-      const dd4hep::rec::CellIDPositionConverter* m_cellid_converter{nullptr};
-      dd4hep::Segmentation     m_seg;
+private:
+  const dd4hep::Detector* m_detector{nullptr};
+  const dd4hep::BitFieldCoder* m_id_dec{nullptr};
+  const dd4hep::rec::CellIDPositionConverter* m_cellid_converter{nullptr};
+  dd4hep::Segmentation m_seg;
 
-      int m_x_idx{0};
-      int m_y_idx{0};
+  int m_x_idx{0};
+  int m_y_idx{0};
+};
 
-  };
-
-} // eicrecon
+} // namespace eicrecon

--- a/src/algorithms/meta/CollectionCollector.h
+++ b/src/algorithms/meta/CollectionCollector.h
@@ -28,9 +28,7 @@ namespace eicrecon {
                           "Merge content of collections into one subset collection"
                       }{}
 
-    void init(std::shared_ptr<spdlog::logger>& logger){ // set logger
-      m_log      = logger;
-    };
+    void init() final { };
 
     void process(const typename CollectionCollector::Input& input, const typename CollectionCollector::Output& output) const final{
 
@@ -45,9 +43,6 @@ namespace eicrecon {
         }
       }
     }
-
-    private:
-      std::shared_ptr<spdlog::logger> m_log; // logger
 
   };
 } // eicrecon

--- a/src/algorithms/onnx/InclusiveKinematicsML.cc
+++ b/src/algorithms/onnx/InclusiveKinematicsML.cc
@@ -30,9 +30,7 @@ namespace eicrecon {
     return tensor;
   }
 
-  void InclusiveKinematicsML::init(std::shared_ptr<spdlog::logger>& logger) {
-    m_log = logger;
-
+  void InclusiveKinematicsML::init() {
     // onnxruntime setup
     Ort::Env env(ORT_LOGGING_LEVEL_WARNING, "inclusive-kinematics-ml");
     Ort::SessionOptions session_options;
@@ -41,19 +39,19 @@ namespace eicrecon {
 
       // print name/shape of inputs
       Ort::AllocatorWithDefaultOptions allocator;
-      m_log->debug("Input Node Name/Shape:");
+      debug("Input Node Name/Shape:");
       for (std::size_t i = 0; i < m_session.GetInputCount(); i++) {
         m_input_names.emplace_back(m_session.GetInputNameAllocated(i, allocator).get());
         m_input_shapes.emplace_back(m_session.GetInputTypeInfo(i).GetTensorTypeAndShapeInfo().GetShape());
-        m_log->debug("\t{} : {}", m_input_names.at(i), print_shape(m_input_shapes.at(i)));
+        debug("\t{} : {}", m_input_names.at(i), print_shape(m_input_shapes.at(i)));
       }
 
       // print name/shape of outputs
-      m_log->debug("Output Node Name/Shape:");
+      debug("Output Node Name/Shape:");
       for (std::size_t i = 0; i < m_session.GetOutputCount(); i++) {
         m_output_names.emplace_back(m_session.GetOutputNameAllocated(i, allocator).get());
         m_output_shapes.emplace_back(m_session.GetOutputTypeInfo(i).GetTensorTypeAndShapeInfo().GetShape());
-        m_log->debug("\t{} : {}", m_output_names.at(i), print_shape(m_output_shapes.at(i)));
+        debug("\t{} : {}", m_output_names.at(i), print_shape(m_output_shapes.at(i)));
       }
 
       // convert names to char*
@@ -65,7 +63,7 @@ namespace eicrecon {
                      [&](const std::string& str) { return str.c_str(); });
 
     } catch(std::exception& e) {
-      m_log->error(e.what());
+      error(e.what());
     }
   }
 
@@ -78,13 +76,13 @@ namespace eicrecon {
 
     // Require valid inputs
     if (electron->size() == 0 || da->size() == 0) {
-      m_log->debug("skipping because input collections have no entries");
+      debug("skipping because input collections have no entries");
       return;
     }
 
     // Assume model has 1 input nodes and 1 output node.
     if (m_input_names.size() != 1 || m_output_names.size() != 1) {
-      m_log->debug("skipping because model has incorrect input and output size");
+      debug("skipping because model has incorrect input and output size");
       return;
     }
 
@@ -98,7 +96,7 @@ namespace eicrecon {
 
     // Double-check the dimensions of the input tensor
     if (! input_tensors[0].IsTensor() || input_tensors[0].GetTensorTypeAndShapeInfo().GetShape() != m_input_shapes.front()) {
-      m_log->debug("skipping because input tensor shape incorrect");
+      debug("skipping because input tensor shape incorrect");
       return;
     }
 
@@ -109,7 +107,7 @@ namespace eicrecon {
 
       // Double-check the dimensions of the output tensors
       if (!output_tensors[0].IsTensor() || output_tensors.size() != m_output_names.size()) {
-        m_log->debug("skipping because output tensor shape incorrect");
+        debug("skipping because output tensor shape incorrect");
         return;
       }
 
@@ -120,7 +118,7 @@ namespace eicrecon {
       kin.setX(x);
 
     } catch (const Ort::Exception& exception) {
-      m_log->error("error running model inference: {}", exception.what());
+      error("error running model inference: {}", exception.what());
     }
   }
 

--- a/src/algorithms/onnx/InclusiveKinematicsML.h
+++ b/src/algorithms/onnx/InclusiveKinematicsML.h
@@ -4,11 +4,9 @@
 #pragma once
 
 #include <algorithms/algorithm.h>
+#include <cstdint>
 #include <edm4eic/InclusiveKinematicsCollection.h>
 #include <onnxruntime_cxx_api.h>
-#include <spdlog/logger.h>
-#include <cstdint>
-#include <memory>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -18,41 +16,35 @@
 
 namespace eicrecon {
 
-  using InclusiveKinematicsMLAlgorithm = algorithms::Algorithm<
-    algorithms::Input<
-      edm4eic::InclusiveKinematicsCollection,
-      edm4eic::InclusiveKinematicsCollection
-    >,
-    algorithms::Output<
-      edm4eic::InclusiveKinematicsCollection
-    >
-  >;
+using InclusiveKinematicsMLAlgorithm =
+    algorithms::Algorithm<algorithms::Input<edm4eic::InclusiveKinematicsCollection,
+                                            edm4eic::InclusiveKinematicsCollection>,
+                          algorithms::Output<edm4eic::InclusiveKinematicsCollection>>;
 
-  class InclusiveKinematicsML
-  : public InclusiveKinematicsMLAlgorithm,
-    public WithPodConfig<InclusiveKinematicsMLConfig> {
+class InclusiveKinematicsML : public InclusiveKinematicsMLAlgorithm,
+                              public WithPodConfig<InclusiveKinematicsMLConfig> {
 
-  public:
-    InclusiveKinematicsML(std::string_view name)
+public:
+  InclusiveKinematicsML(std::string_view name)
       : InclusiveKinematicsMLAlgorithm{name,
-                            {"inclusiveKinematicsElectron", "inclusiveKinematicsDA"},
-                            {"inclusiveKinematicsML"},
-                            "Determine inclusive kinematics using combined ML method."} {}
+                                       {"inclusiveKinematicsElectron", "inclusiveKinematicsDA"},
+                                       {"inclusiveKinematicsML"},
+                                       "Determine inclusive kinematics using combined ML method."} {
+  }
 
-    void init() final;
-    void process(const Input&, const Output&) const final;
+  void init() final;
+  void process(const Input&, const Output&) const final;
 
-  private:
-    mutable Ort::Session m_session{nullptr};
+private:
+  mutable Ort::Session m_session{nullptr};
 
-    std::vector<std::string> m_input_names;
-    std::vector<const char*> m_input_names_char;
-    std::vector<std::vector<std::int64_t>> m_input_shapes;
+  std::vector<std::string> m_input_names;
+  std::vector<const char*> m_input_names_char;
+  std::vector<std::vector<std::int64_t>> m_input_shapes;
 
-    std::vector<std::string> m_output_names;
-    std::vector<const char*> m_output_names_char;
-    std::vector<std::vector<std::int64_t>> m_output_shapes;
-
-  };
+  std::vector<std::string> m_output_names;
+  std::vector<const char*> m_output_names_char;
+  std::vector<std::vector<std::int64_t>> m_output_shapes;
+};
 
 } // namespace eicrecon

--- a/src/algorithms/onnx/InclusiveKinematicsML.h
+++ b/src/algorithms/onnx/InclusiveKinematicsML.h
@@ -39,12 +39,10 @@ namespace eicrecon {
                             {"inclusiveKinematicsML"},
                             "Determine inclusive kinematics using combined ML method."} {}
 
-    void init(std::shared_ptr<spdlog::logger>& logger);
+    void init() final;
     void process(const Input&, const Output&) const final;
 
   private:
-    std::shared_ptr<spdlog::logger> m_log;
-
     mutable Ort::Session m_session{nullptr};
 
     std::vector<std::string> m_input_names;

--- a/src/algorithms/pid/MergeTracks.cc
+++ b/src/algorithms/pid/MergeTracks.cc
@@ -15,11 +15,6 @@
 
 namespace eicrecon {
 
-void MergeTracks::init(std::shared_ptr<spdlog::logger>& logger)
-{
-  m_log = logger;
-}
-
 void MergeTracks::process(
     const MergeTracks::Input& input,
     const MergeTracks::Output& output) const {
@@ -28,7 +23,7 @@ void MergeTracks::process(
   auto [out_tracks] = output;
 
   // logging
-  m_log->trace("{:=^70}"," call MergeTracks::AlgorithmProcess ");
+  trace("{:=^70}"," call MergeTracks::AlgorithmProcess ");
 
   // check that all input collections have the same size
   std::unordered_map<std::size_t, std::size_t> in_track_collection_size_distribution;
@@ -40,7 +35,7 @@ void MergeTracks::process(
     std::transform(in_track_collections.begin(), in_track_collections.end(),
       std::back_inserter(in_track_collection_sizes),
       [](const auto& in_track_collection) { return in_track_collection->size(); });
-    m_log->error("cannot merge input track collections with different sizes {}", fmt::join(in_track_collection_sizes, ", "));
+    error("cannot merge input track collections with different sizes {}", fmt::join(in_track_collection_sizes, ", "));
     return;
   }
 

--- a/src/algorithms/pid/MergeTracks.cc
+++ b/src/algorithms/pid/MergeTracks.cc
@@ -3,66 +3,64 @@
 
 #include "MergeTracks.h"
 
+#include <algorithm>
+#include <cstddef>
 #include <edm4eic/TrackPoint.h>
 #include <fmt/core.h>
 #include <fmt/format.h>
-#include <podio/RelationRange.h>
-#include <algorithm>
-#include <cstddef>
+#include <gsl/pointers>
 #include <iterator>
+#include <podio/RelationRange.h>
 #include <unordered_map>
 #include <utility>
 
 namespace eicrecon {
 
-void MergeTracks::process(
-    const MergeTracks::Input& input,
-    const MergeTracks::Output& output) const {
+void MergeTracks::process(const MergeTracks::Input& input,
+                          const MergeTracks::Output& output) const {
 
   const auto [in_track_collections] = input;
-  auto [out_tracks] = output;
+  auto [out_tracks]                 = output;
 
   // logging
-  trace("{:=^70}"," call MergeTracks::AlgorithmProcess ");
+  trace("{:=^70}", " call MergeTracks::AlgorithmProcess ");
 
   // check that all input collections have the same size
   std::unordered_map<std::size_t, std::size_t> in_track_collection_size_distribution;
-  for(const auto& in_track_collection : in_track_collections) {
+  for (const auto& in_track_collection : in_track_collections) {
     ++in_track_collection_size_distribution[in_track_collection->size()];
   }
   if (in_track_collection_size_distribution.size() != 1) {
     std::vector<size_t> in_track_collection_sizes;
     std::transform(in_track_collections.begin(), in_track_collections.end(),
-      std::back_inserter(in_track_collection_sizes),
-      [](const auto& in_track_collection) { return in_track_collection->size(); });
-    error("cannot merge input track collections with different sizes {}", fmt::join(in_track_collection_sizes, ", "));
+                   std::back_inserter(in_track_collection_sizes),
+                   [](const auto& in_track_collection) { return in_track_collection->size(); });
+    error("cannot merge input track collections with different sizes {}",
+          fmt::join(in_track_collection_sizes, ", "));
     return;
   }
 
   // loop over track collection elements
   std::size_t n_tracks = in_track_collection_size_distribution.begin()->first;
-  for(std::size_t i_track=0; i_track<n_tracks; i_track++) {
+  for (std::size_t i_track = 0; i_track < n_tracks; i_track++) {
 
     // create a new output track, and a local container to hold its track points
     auto out_track = out_tracks->create();
     std::vector<edm4eic::TrackPoint> out_track_points;
 
     // loop over collections for this track, and add each track's points to `out_track_points`
-    for(const auto& in_track_collection : in_track_collections) {
+    for (const auto& in_track_collection : in_track_collections) {
       const auto& in_track = in_track_collection->at(i_track);
-      for(const auto& point : in_track.getPoints())
+      for (const auto& point : in_track.getPoints())
         out_track_points.push_back(point);
     }
 
     // sort all `out_track_points` by time
-    std::sort(
-        out_track_points.begin(),
-        out_track_points.end(),
-        [] (edm4eic::TrackPoint& a, edm4eic::TrackPoint& b) { return a.time < b.time; }
-        );
+    std::sort(out_track_points.begin(), out_track_points.end(),
+              [](edm4eic::TrackPoint& a, edm4eic::TrackPoint& b) { return a.time < b.time; });
 
     // add these sorted points to `out_track`
-    for(const auto& point : out_track_points)
+    for (const auto& point : out_track_points)
       out_track.addToPoints(point);
 
     /* FIXME: merge other members, such as `length` and `lengthError`;

--- a/src/algorithms/pid/MergeTracks.h
+++ b/src/algorithms/pid/MergeTracks.h
@@ -12,33 +12,26 @@
 // data model
 #include <algorithms/algorithm.h>
 #include <edm4eic/TrackSegmentCollection.h>
-#include <spdlog/logger.h>
-#include <memory>
+#include <string>
+#include <string_view>
 #include <vector>
 
 namespace eicrecon {
 
-  using MergeTracksAlgorithm = algorithms::Algorithm<
-    algorithms::Input<
-      std::vector<const edm4eic::TrackSegmentCollection>
-    >,
-    algorithms::Output<
-      edm4eic::TrackSegmentCollection
-    >
-  >;
+using MergeTracksAlgorithm =
+    algorithms::Algorithm<algorithms::Input<std::vector<const edm4eic::TrackSegmentCollection>>,
+                          algorithms::Output<edm4eic::TrackSegmentCollection>>;
 
-  class MergeTracks
-  : public MergeTracksAlgorithm {
+class MergeTracks : public MergeTracksAlgorithm {
 
-  public:
-    MergeTracks(std::string_view name)
+public:
+  MergeTracks(std::string_view name)
       : MergeTracksAlgorithm{name,
-                            {"inputTrackSegments"},
-                            {"outputTrackSegments"},
-                            "Effectively 'zip' the input track segments."} {}
+                             {"inputTrackSegments"},
+                             {"outputTrackSegments"},
+                             "Effectively 'zip' the input track segments."} {}
 
-    void init() final { };
-    void process(const Input&, const Output&) const final;
-
-  };
-}
+  void init() final{};
+  void process(const Input&, const Output&) const final;
+};
+} // namespace eicrecon

--- a/src/algorithms/pid/MergeTracks.h
+++ b/src/algorithms/pid/MergeTracks.h
@@ -37,11 +37,8 @@ namespace eicrecon {
                             {"outputTrackSegments"},
                             "Effectively 'zip' the input track segments."} {}
 
-    void init(std::shared_ptr<spdlog::logger>& logger);
+    void init() final { };
     void process(const Input&, const Output&) const final;
-
-    private:
-      std::shared_ptr<spdlog::logger> m_log;
 
   };
 }

--- a/src/algorithms/reco/HadronicFinalState.cc
+++ b/src/algorithms/reco/HadronicFinalState.cc
@@ -25,11 +25,10 @@ using ROOT::Math::PxPyPzEVector;
 
 namespace eicrecon {
 
-  void HadronicFinalState::init(std::shared_ptr<spdlog::logger>& logger) {
-    m_log = logger;
+  void HadronicFinalState::init() {
     // m_pidSvc = service("ParticleSvc");
     // if (!m_pidSvc) {
-    //   m_log->debug("Unable to locate Particle Service. "
+    //   debug("Unable to locate Particle Service. "
     //     "Make sure you have ParticleSvc in the configuration.");
     // }
   }
@@ -44,7 +43,7 @@ namespace eicrecon {
     // Get incoming electron beam
     const auto ei_coll = find_first_beam_electron(mcparts);
     if (ei_coll.size() == 0) {
-      m_log->debug("No beam electron found");
+      debug("No beam electron found");
       return;
     }
     const PxPyPzEVector ei(
@@ -58,7 +57,7 @@ namespace eicrecon {
     // Get incoming hadron beam
     const auto pi_coll = find_first_beam_hadron(mcparts);
     if (pi_coll.size() == 0) {
-      m_log->debug("No beam hadron found");
+      debug("No beam hadron found");
       return;
     }
     const PxPyPzEVector pi(
@@ -72,7 +71,7 @@ namespace eicrecon {
     // Get first scattered electron
     const auto ef_coll = find_first_scattered_electron(mcparts);
     if (ef_coll.size() == 0) {
-      m_log->debug("No truth scattered electron found");
+      debug("No truth scattered electron found");
       return;
     }
     // Associate first scattered electron with reconstructed electrons
@@ -87,7 +86,7 @@ namespace eicrecon {
       }
     }
     if (!(ef_assoc != rcassoc->end())) {
-      m_log->debug("Truth scattered electron not in reconstructed particles");
+      debug("Truth scattered electron not in reconstructed particles");
       return;
     }
     const auto ef_rc{ef_assoc->getRec()};
@@ -133,11 +132,11 @@ namespace eicrecon {
 
     // Sigma zero or negative
     if (sigma <= 0) {
-      m_log->debug("Sigma zero or negative");
+      debug("Sigma zero or negative");
       return;
     }
 
-    m_log->debug("sigma_h, pT_h, gamma_h = {},{},{}", hfs.getSigma(), hfs.getPT(), hfs.getGamma());
+    debug("sigma_h, pT_h, gamma_h = {},{},{}", hfs.getSigma(), hfs.getPT(), hfs.getGamma());
 
   }
 

--- a/src/algorithms/reco/HadronicFinalState.h
+++ b/src/algorithms/reco/HadronicFinalState.h
@@ -8,40 +8,30 @@
 #include <edm4eic/MCRecoParticleAssociationCollection.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/MCParticleCollection.h>
-#include <spdlog/logger.h>
-#include <memory>
 #include <string>
 #include <string_view>
 
-
 namespace eicrecon {
 
-  using HadronicFinalStateAlgorithm = algorithms::Algorithm<
-    algorithms::Input<
-      edm4hep::MCParticleCollection,
-      edm4eic::ReconstructedParticleCollection,
-      edm4eic::MCRecoParticleAssociationCollection
-    >,
-    algorithms::Output<
-      edm4eic::HadronicFinalStateCollection
-    >
-  >;
+using HadronicFinalStateAlgorithm = algorithms::Algorithm<
+    algorithms::Input<edm4hep::MCParticleCollection, edm4eic::ReconstructedParticleCollection,
+                      edm4eic::MCRecoParticleAssociationCollection>,
+    algorithms::Output<edm4eic::HadronicFinalStateCollection>>;
 
-  class HadronicFinalState
-  : public HadronicFinalStateAlgorithm {
+class HadronicFinalState : public HadronicFinalStateAlgorithm {
 
-  public:
-    HadronicFinalState(std::string_view name)
+public:
+  HadronicFinalState(std::string_view name)
       : HadronicFinalStateAlgorithm{name,
-                            {"MCParticles", "inputParticles", "inputAssociations"},
-                            {"hadronicFinalState"},
-                            "Calculate summed quantities of the hadronic final state."} {}
+                                    {"MCParticles", "inputParticles", "inputAssociations"},
+                                    {"hadronicFinalState"},
+                                    "Calculate summed quantities of the hadronic final state."} {}
 
-    void init() final;
-    void process(const Input&, const Output&) const final;
+  void init() final;
+  void process(const Input&, const Output&) const final;
 
-  private:
-    double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
-  };
+private:
+  double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
+};
 
 } // namespace eicrecon

--- a/src/algorithms/reco/HadronicFinalState.h
+++ b/src/algorithms/reco/HadronicFinalState.h
@@ -37,11 +37,10 @@ namespace eicrecon {
                             {"hadronicFinalState"},
                             "Calculate summed quantities of the hadronic final state."} {}
 
-    void init(std::shared_ptr<spdlog::logger>& logger);
+    void init() final;
     void process(const Input&, const Output&) const final;
 
   private:
-    std::shared_ptr<spdlog::logger> m_log;
     double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
   };
 

--- a/src/algorithms/reco/InclusiveKinematicsDA.cc
+++ b/src/algorithms/reco/InclusiveKinematicsDA.cc
@@ -23,8 +23,7 @@ using ROOT::Math::PxPyPzEVector;
 
 namespace eicrecon {
 
-  void InclusiveKinematicsDA::init(std::shared_ptr<spdlog::logger>& logger) {
-    m_log = logger;
+  void InclusiveKinematicsDA::init() {
     // m_pidSvc = service("ParticleSvc");
     // if (!m_pidSvc) {
     //   m_log->debug("Unable to locate Particle Service. "
@@ -42,7 +41,7 @@ namespace eicrecon {
     // Get incoming electron beam
     const auto ei_coll = find_first_beam_electron(mcparts);
     if (ei_coll.size() == 0) {
-      m_log->debug("No beam electron found");
+      debug("No beam electron found");
       return;
     }
     const PxPyPzEVector ei(
@@ -56,7 +55,7 @@ namespace eicrecon {
     // Get incoming hadron beam
     const auto pi_coll = find_first_beam_hadron(mcparts);
     if (pi_coll.size() == 0) {
-      m_log->debug("No beam hadron found");
+      debug("No beam hadron found");
       return;
     }
     const PxPyPzEVector pi(
@@ -83,7 +82,7 @@ namespace eicrecon {
 
     // Sigma zero or negative
     if (sigma_h <= 0) {
-      m_log->debug("Sigma zero or negative");
+      debug("Sigma zero or negative");
       return;
     }
 
@@ -96,7 +95,7 @@ namespace eicrecon {
     auto kin = kinematics->create(x_da, Q2_da, W_da, y_da, nu_da);
     kin.setScat(kf);
 
-    m_log->debug("x,Q2,W,y,nu = {},{},{},{},{}", kin.getX(),
+    debug("x,Q2,W,y,nu = {},{},{},{},{}", kin.getX(),
             kin.getQ2(), kin.getW(), kin.getY(), kin.getNu());
   }
 

--- a/src/algorithms/reco/InclusiveKinematicsDA.h
+++ b/src/algorithms/reco/InclusiveKinematicsDA.h
@@ -37,11 +37,10 @@ namespace eicrecon {
                             {"inclusiveKinematics"},
                             "Determine inclusive kinematics using double-angle method."} {}
 
-    void init(std::shared_ptr<spdlog::logger>& logger);
+    void init() final;
     void process(const Input&, const Output&) const final;
 
   private:
-    std::shared_ptr<spdlog::logger> m_log;
     double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
   };
 

--- a/src/algorithms/reco/InclusiveKinematicsDA.h
+++ b/src/algorithms/reco/InclusiveKinematicsDA.h
@@ -4,44 +4,35 @@
 #pragma once
 
 #include <algorithms/algorithm.h>
+#include <edm4eic/HadronicFinalStateCollection.h>
 #include <edm4eic/InclusiveKinematicsCollection.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/MCParticleCollection.h>
-#include <edm4eic/HadronicFinalStateCollection.h>
-#include <spdlog/logger.h>
-#include <memory>
 #include <string>
 #include <string_view>
 
-
 namespace eicrecon {
 
-  using InclusiveKinematicsDAAlgorithm = algorithms::Algorithm<
-    algorithms::Input<
-      edm4hep::MCParticleCollection,
-      edm4eic::ReconstructedParticleCollection,
-      edm4eic::HadronicFinalStateCollection
-    >,
-    algorithms::Output<
-      edm4eic::InclusiveKinematicsCollection
-    >
-  >;
+using InclusiveKinematicsDAAlgorithm = algorithms::Algorithm<
+    algorithms::Input<edm4hep::MCParticleCollection, edm4eic::ReconstructedParticleCollection,
+                      edm4eic::HadronicFinalStateCollection>,
+    algorithms::Output<edm4eic::InclusiveKinematicsCollection>>;
 
-  class InclusiveKinematicsDA
-  : public InclusiveKinematicsDAAlgorithm {
+class InclusiveKinematicsDA : public InclusiveKinematicsDAAlgorithm {
 
-  public:
-    InclusiveKinematicsDA(std::string_view name)
-      : InclusiveKinematicsDAAlgorithm{name,
-                            {"MCParticles", "scatteredElectron", "hadronicFinalState"},
-                            {"inclusiveKinematics"},
-                            "Determine inclusive kinematics using double-angle method."} {}
+public:
+  InclusiveKinematicsDA(std::string_view name)
+      : InclusiveKinematicsDAAlgorithm{
+            name,
+            {"MCParticles", "scatteredElectron", "hadronicFinalState"},
+            {"inclusiveKinematics"},
+            "Determine inclusive kinematics using double-angle method."} {}
 
-    void init() final;
-    void process(const Input&, const Output&) const final;
+  void init() final;
+  void process(const Input&, const Output&) const final;
 
-  private:
-    double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
-  };
+private:
+  double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
+};
 
 } // namespace eicrecon

--- a/src/algorithms/reco/InclusiveKinematicsElectron.cc
+++ b/src/algorithms/reco/InclusiveKinematicsElectron.cc
@@ -23,11 +23,10 @@ using ROOT::Math::PxPyPzEVector;
 
 namespace eicrecon {
 
-  void InclusiveKinematicsElectron::init(std::shared_ptr<spdlog::logger>& logger) {
-    m_log = logger;
+  void InclusiveKinematicsElectron::init() {
     // m_pidSvc = service("ParticleSvc");
     // if (!m_pidSvc) {
-    //   m_log->debug("Unable to locate Particle Service. "
+    //   debug("Unable to locate Particle Service. "
     //     "Make sure you have ParticleSvc in the configuration.");
     // }
   }
@@ -90,7 +89,7 @@ namespace eicrecon {
     // Get incoming electron beam
     const auto ei_coll = find_first_beam_electron(mcparts);
     if (ei_coll.size() == 0) {
-      m_log->debug("No beam electron found");
+      debug("No beam electron found");
       return;
     }
     const PxPyPzEVector ei(
@@ -104,7 +103,7 @@ namespace eicrecon {
     // Get incoming hadron beam
     const auto pi_coll = find_first_beam_hadron(mcparts);
     if (pi_coll.size() == 0) {
-      m_log->debug("No beam hadron found");
+      debug("No beam hadron found");
       return;
     }
     const PxPyPzEVector pi(
@@ -124,7 +123,7 @@ namespace eicrecon {
 
     // If no scattered electron was found
     if (electrons.size() == 0) {
-      m_log->debug("No scattered electron found");
+      debug("No scattered electron found");
       return;
     }
 
@@ -140,7 +139,7 @@ namespace eicrecon {
     auto kin = kinematics->create(x, Q2, W, y, nu);
     kin.setScat(escat->at(0));
 
-    m_log->debug("x,Q2,W,y,nu = {},{},{},{},{}", kin.getX(),
+    debug("x,Q2,W,y,nu = {},{},{},{},{}", kin.getX(),
             kin.getQ2(), kin.getW(), kin.getY(), kin.getNu());
   }
 

--- a/src/algorithms/reco/InclusiveKinematicsElectron.h
+++ b/src/algorithms/reco/InclusiveKinematicsElectron.h
@@ -4,44 +4,35 @@
 #pragma once
 
 #include <algorithms/algorithm.h>
+#include <edm4eic/HadronicFinalStateCollection.h>
 #include <edm4eic/InclusiveKinematicsCollection.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/MCParticleCollection.h>
-#include <edm4eic/HadronicFinalStateCollection.h>
-#include <spdlog/logger.h>
-#include <memory>
 #include <string>
 #include <string_view>
 
-
 namespace eicrecon {
 
-  using InclusiveKinematicsElectronAlgorithm = algorithms::Algorithm<
-    algorithms::Input<
-      edm4hep::MCParticleCollection,
-      edm4eic::ReconstructedParticleCollection,
-      edm4eic::HadronicFinalStateCollection
-    >,
-    algorithms::Output<
-      edm4eic::InclusiveKinematicsCollection
-    >
-  >;
+using InclusiveKinematicsElectronAlgorithm = algorithms::Algorithm<
+    algorithms::Input<edm4hep::MCParticleCollection, edm4eic::ReconstructedParticleCollection,
+                      edm4eic::HadronicFinalStateCollection>,
+    algorithms::Output<edm4eic::InclusiveKinematicsCollection>>;
 
-  class InclusiveKinematicsElectron
-  : public InclusiveKinematicsElectronAlgorithm {
+class InclusiveKinematicsElectron : public InclusiveKinematicsElectronAlgorithm {
 
-  public:
-    InclusiveKinematicsElectron(std::string_view name)
-      : InclusiveKinematicsElectronAlgorithm{name,
-                            {"MCParticles", "scatteredElectron", "hadronicFinalState"},
-                            {"inclusiveKinematics"},
-                            "Determine inclusive kinematics using electron method."} {}
+public:
+  InclusiveKinematicsElectron(std::string_view name)
+      : InclusiveKinematicsElectronAlgorithm{
+            name,
+            {"MCParticles", "scatteredElectron", "hadronicFinalState"},
+            {"inclusiveKinematics"},
+            "Determine inclusive kinematics using electron method."} {}
 
-    void init() final;
-    void process(const Input&, const Output&) const final;
+  void init() final;
+  void process(const Input&, const Output&) const final;
 
-  private:
-    double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
-  };
+private:
+  double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
+};
 
 } // namespace eicrecon

--- a/src/algorithms/reco/InclusiveKinematicsElectron.h
+++ b/src/algorithms/reco/InclusiveKinematicsElectron.h
@@ -37,11 +37,10 @@ namespace eicrecon {
                             {"inclusiveKinematics"},
                             "Determine inclusive kinematics using electron method."} {}
 
-    void init(std::shared_ptr<spdlog::logger>& logger);
+    void init() final;
     void process(const Input&, const Output&) const final;
 
   private:
-    std::shared_ptr<spdlog::logger> m_log;
     double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
   };
 

--- a/src/algorithms/reco/InclusiveKinematicsJB.cc
+++ b/src/algorithms/reco/InclusiveKinematicsJB.cc
@@ -20,11 +20,10 @@ using ROOT::Math::PxPyPzEVector;
 
 namespace eicrecon {
 
-  void InclusiveKinematicsJB::init(std::shared_ptr<spdlog::logger>& logger) {
-    m_log = logger;
+  void InclusiveKinematicsJB::init() {
     // m_pidSvc = service("ParticleSvc");
     // if (!m_pidSvc) {
-    //   m_log->debug("Unable to locate Particle Service. "
+    //   debug("Unable to locate Particle Service. "
     //     "Make sure you have ParticleSvc in the configuration.");
     // }
   }
@@ -39,7 +38,7 @@ namespace eicrecon {
     // Get incoming electron beam
     const auto ei_coll = find_first_beam_electron(mcparts);
     if (ei_coll.size() == 0) {
-      m_log->debug("No beam electron found");
+      debug("No beam electron found");
       return;
     }
     const PxPyPzEVector ei(
@@ -53,7 +52,7 @@ namespace eicrecon {
     // Get incoming hadron beam
     const auto pi_coll = find_first_beam_hadron(mcparts);
     if (pi_coll.size() == 0) {
-      m_log->debug("No beam hadron found");
+      debug("No beam hadron found");
       return;
     }
     const PxPyPzEVector pi(
@@ -71,7 +70,7 @@ namespace eicrecon {
 
     // Sigma zero or negative
     if (sigma_h <= 0) {
-      m_log->debug("Sigma zero or negative");
+      debug("Sigma zero or negative");
       return;
     }
 
@@ -84,7 +83,7 @@ namespace eicrecon {
     auto kin = kinematics->create(x_jb, Q2_jb, W_jb, y_jb, nu_jb);
     kin.setScat(escat->at(0));
 
-    m_log->debug("x,Q2,W,y,nu = {},{},{},{},{}", kin.getX(),
+    debug("x,Q2,W,y,nu = {},{},{},{},{}", kin.getX(),
             kin.getQ2(), kin.getW(), kin.getY(), kin.getNu());
   }
 

--- a/src/algorithms/reco/InclusiveKinematicsJB.h
+++ b/src/algorithms/reco/InclusiveKinematicsJB.h
@@ -4,44 +4,35 @@
 #pragma once
 
 #include <algorithms/algorithm.h>
+#include <edm4eic/HadronicFinalStateCollection.h>
 #include <edm4eic/InclusiveKinematicsCollection.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/MCParticleCollection.h>
-#include <edm4eic/HadronicFinalStateCollection.h>
-#include <spdlog/logger.h>
-#include <memory>
 #include <string>
 #include <string_view>
 
-
 namespace eicrecon {
 
-  using InclusiveKinematicsJBAlgorithm = algorithms::Algorithm<
-    algorithms::Input<
-      edm4hep::MCParticleCollection,
-      edm4eic::ReconstructedParticleCollection,
-      edm4eic::HadronicFinalStateCollection
-    >,
-    algorithms::Output<
-      edm4eic::InclusiveKinematicsCollection
-    >
-  >;
+using InclusiveKinematicsJBAlgorithm = algorithms::Algorithm<
+    algorithms::Input<edm4hep::MCParticleCollection, edm4eic::ReconstructedParticleCollection,
+                      edm4eic::HadronicFinalStateCollection>,
+    algorithms::Output<edm4eic::InclusiveKinematicsCollection>>;
 
-  class InclusiveKinematicsJB
-  : public InclusiveKinematicsJBAlgorithm {
+class InclusiveKinematicsJB : public InclusiveKinematicsJBAlgorithm {
 
-  public:
-    InclusiveKinematicsJB(std::string_view name)
-      : InclusiveKinematicsJBAlgorithm{name,
-                            {"MCParticles", "scatteredElectron", "hadronicFinalState"},
-                            {"inclusiveKinematics"},
-                            "Determine inclusive kinematics using Jacquet-Blondel method."} {}
+public:
+  InclusiveKinematicsJB(std::string_view name)
+      : InclusiveKinematicsJBAlgorithm{
+            name,
+            {"MCParticles", "scatteredElectron", "hadronicFinalState"},
+            {"inclusiveKinematics"},
+            "Determine inclusive kinematics using Jacquet-Blondel method."} {}
 
-    void init() final;
-    void process(const Input&, const Output&) const final;
+  void init() final;
+  void process(const Input&, const Output&) const final;
 
-  private:
-    double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
-  };
+private:
+  double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
+};
 
 } // namespace eicrecon

--- a/src/algorithms/reco/InclusiveKinematicsJB.h
+++ b/src/algorithms/reco/InclusiveKinematicsJB.h
@@ -37,11 +37,10 @@ namespace eicrecon {
                             {"inclusiveKinematics"},
                             "Determine inclusive kinematics using Jacquet-Blondel method."} {}
 
-    void init(std::shared_ptr<spdlog::logger>& logger);
+    void init() final;
     void process(const Input&, const Output&) const final;
 
   private:
-    std::shared_ptr<spdlog::logger> m_log;
     double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
   };
 

--- a/src/algorithms/reco/InclusiveKinematicsSigma.cc
+++ b/src/algorithms/reco/InclusiveKinematicsSigma.cc
@@ -22,11 +22,10 @@ using ROOT::Math::PxPyPzEVector;
 
 namespace eicrecon {
 
-  void InclusiveKinematicsSigma::init(std::shared_ptr<spdlog::logger>& logger) {
-    m_log = logger;
+  void InclusiveKinematicsSigma::init() {
     // m_pidSvc = service("ParticleSvc");
     // if (!m_pidSvc) {
-    //   m_log->debug("Unable to locate Particle Service. "
+    //   debug("Unable to locate Particle Service. "
     //     "Make sure you have ParticleSvc in the configuration.");
     // }
   }
@@ -41,7 +40,7 @@ namespace eicrecon {
     // Get incoming electron beam
     const auto ei_coll = find_first_beam_electron(mcparts);
     if (ei_coll.size() == 0) {
-      m_log->debug("No beam electron found");
+      debug("No beam electron found");
       return;
     }
     const PxPyPzEVector ei(
@@ -55,7 +54,7 @@ namespace eicrecon {
     // Get incoming hadron beam
     const auto pi_coll = find_first_beam_hadron(mcparts);
     if (pi_coll.size() == 0) {
-      m_log->debug("No beam hadron found");
+      debug("No beam hadron found");
       return;
     }
     const PxPyPzEVector pi(
@@ -82,7 +81,7 @@ namespace eicrecon {
     auto gamma_h = hfs->at(0).getGamma();
 
     if (sigma_h <= 0) {
-      m_log->debug("No scattered electron found or sigma zero or negative");
+      debug("No scattered electron found or sigma zero or negative");
       return;
     }
 
@@ -97,7 +96,7 @@ namespace eicrecon {
     auto kin = kinematics->create(x_sig, Q2_sig, W_sig, y_sig, nu_sig);
     kin.setScat(kf);
 
-    m_log->debug("x,Q2,W,y,nu = {},{},{},{},{}", kin.getX(),
+    debug("x,Q2,W,y,nu = {},{},{},{},{}", kin.getX(),
             kin.getQ2(), kin.getW(), kin.getY(), kin.getNu());
   }
 

--- a/src/algorithms/reco/InclusiveKinematicsSigma.h
+++ b/src/algorithms/reco/InclusiveKinematicsSigma.h
@@ -37,11 +37,10 @@ namespace eicrecon {
                             {"inclusiveKinematics"},
                             "Determine inclusive kinematics using Sigma method."} {}
 
-    void init(std::shared_ptr<spdlog::logger>& logger);
+    void init() final;
     void process(const Input&, const Output&) const final;
 
   private:
-    std::shared_ptr<spdlog::logger> m_log;
     double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
   };
 

--- a/src/algorithms/reco/InclusiveKinematicsSigma.h
+++ b/src/algorithms/reco/InclusiveKinematicsSigma.h
@@ -4,44 +4,35 @@
 #pragma once
 
 #include <algorithms/algorithm.h>
+#include <edm4eic/HadronicFinalStateCollection.h>
 #include <edm4eic/InclusiveKinematicsCollection.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/MCParticleCollection.h>
-#include <edm4eic/HadronicFinalStateCollection.h>
-#include <spdlog/logger.h>
-#include <memory>
 #include <string>
 #include <string_view>
 
-
 namespace eicrecon {
 
-  using InclusiveKinematicsSigmaAlgorithm = algorithms::Algorithm<
-    algorithms::Input<
-      edm4hep::MCParticleCollection,
-      edm4eic::ReconstructedParticleCollection,
-      edm4eic::HadronicFinalStateCollection
-    >,
-    algorithms::Output<
-      edm4eic::InclusiveKinematicsCollection
-    >
-  >;
+using InclusiveKinematicsSigmaAlgorithm = algorithms::Algorithm<
+    algorithms::Input<edm4hep::MCParticleCollection, edm4eic::ReconstructedParticleCollection,
+                      edm4eic::HadronicFinalStateCollection>,
+    algorithms::Output<edm4eic::InclusiveKinematicsCollection>>;
 
-  class InclusiveKinematicsSigma
-  : public InclusiveKinematicsSigmaAlgorithm {
+class InclusiveKinematicsSigma : public InclusiveKinematicsSigmaAlgorithm {
 
-  public:
-    InclusiveKinematicsSigma(std::string_view name)
-      : InclusiveKinematicsSigmaAlgorithm{name,
-                            {"MCParticles", "scatteredElectron", "hadronicFinalState"},
-                            {"inclusiveKinematics"},
-                            "Determine inclusive kinematics using Sigma method."} {}
+public:
+  InclusiveKinematicsSigma(std::string_view name)
+      : InclusiveKinematicsSigmaAlgorithm{
+            name,
+            {"MCParticles", "scatteredElectron", "hadronicFinalState"},
+            {"inclusiveKinematics"},
+            "Determine inclusive kinematics using Sigma method."} {}
 
-    void init() final;
-    void process(const Input&, const Output&) const final;
+  void init() final;
+  void process(const Input&, const Output&) const final;
 
-  private:
-    double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
-  };
+private:
+  double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
+};
 
 } // namespace eicrecon

--- a/src/algorithms/reco/InclusiveKinematicsTruth.cc
+++ b/src/algorithms/reco/InclusiveKinematicsTruth.cc
@@ -19,9 +19,7 @@ using ROOT::Math::PxPyPzEVector;
 
 namespace eicrecon {
 
-  void InclusiveKinematicsTruth::init(std::shared_ptr<spdlog::logger>& logger) {
-    m_log = logger;
-
+  void InclusiveKinematicsTruth::init() {
     // m_pidSvc = service("ParticleSvc");
     // if (!m_pidSvc) {
     //   error() << "Unable to locate Particle Service. "
@@ -47,7 +45,7 @@ namespace eicrecon {
     // Get incoming electron beam
     const auto ei_coll = find_first_beam_electron(mcparts);
     if (ei_coll.size() == 0) {
-      m_log->debug("No beam electron found");
+      debug("No beam electron found");
       return;
     }
     const auto ei_p = ei_coll[0].getMomentum();
@@ -58,7 +56,7 @@ namespace eicrecon {
     // Get incoming hadron beam
     const auto pi_coll = find_first_beam_hadron(mcparts);
     if (pi_coll.size() == 0) {
-      m_log->debug("No beam hadron found");
+      debug("No beam hadron found");
       return;
     }
     const auto pi_p = pi_coll[0].getMomentum();
@@ -73,7 +71,7 @@ namespace eicrecon {
     // the beam.
     const auto ef_coll = find_first_scattered_electron(mcparts);
     if (ef_coll.size() == 0) {
-      m_log->debug("No truth scattered electron found");
+      debug("No truth scattered electron found");
       return;
     }
     const auto ef_p = ef_coll[0].getMomentum();
@@ -91,7 +89,7 @@ namespace eicrecon {
     const auto W = sqrt(pi_mass*pi_mass + 2.*q_dot_pi - Q2);
     auto kin = kinematics->create(x, Q2, W, y, nu);
 
-    m_log->debug("x,Q2,W,y,nu = {},{},{},{},{}", kin.getX(),
+    debug("x,Q2,W,y,nu = {},{},{},{},{}", kin.getX(),
             kin.getQ2(), kin.getW(), kin.getY(), kin.getNu());
   }
 

--- a/src/algorithms/reco/InclusiveKinematicsTruth.h
+++ b/src/algorithms/reco/InclusiveKinematicsTruth.h
@@ -33,11 +33,10 @@ namespace eicrecon {
                             {"inclusiveKinematics"},
                             "Determine inclusive kinematics from truth information."} {}
 
-    void init(std::shared_ptr<spdlog::logger>& logger);
+    void init() final;
     void process(const Input&, const Output&) const final;
 
   private:
-    std::shared_ptr<spdlog::logger> m_log;
     double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
   };
 

--- a/src/algorithms/reco/InclusiveKinematicsTruth.h
+++ b/src/algorithms/reco/InclusiveKinematicsTruth.h
@@ -6,38 +6,30 @@
 #include <algorithms/algorithm.h>
 #include <edm4eic/InclusiveKinematicsCollection.h>
 #include <edm4hep/MCParticleCollection.h>
-#include <spdlog/logger.h>
-#include <memory>
 #include <string>
 #include <string_view>
 
-
 namespace eicrecon {
 
-  using InclusiveKinematicsTruthAlgorithm = algorithms::Algorithm<
-    algorithms::Input<
-      edm4hep::MCParticleCollection
-    >,
-    algorithms::Output<
-      edm4eic::InclusiveKinematicsCollection
-    >
-  >;
+using InclusiveKinematicsTruthAlgorithm =
+    algorithms::Algorithm<algorithms::Input<edm4hep::MCParticleCollection>,
+                          algorithms::Output<edm4eic::InclusiveKinematicsCollection>>;
 
-  class InclusiveKinematicsTruth
-  : public InclusiveKinematicsTruthAlgorithm {
+class InclusiveKinematicsTruth : public InclusiveKinematicsTruthAlgorithm {
 
-  public:
-    InclusiveKinematicsTruth(std::string_view name)
-      : InclusiveKinematicsTruthAlgorithm{name,
-                            {"MCParticles"},
-                            {"inclusiveKinematics"},
-                            "Determine inclusive kinematics from truth information."} {}
+public:
+  InclusiveKinematicsTruth(std::string_view name)
+      : InclusiveKinematicsTruthAlgorithm{
+            name,
+            {"MCParticles"},
+            {"inclusiveKinematics"},
+            "Determine inclusive kinematics from truth information."} {}
 
-    void init() final;
-    void process(const Input&, const Output&) const final;
+  void init() final;
+  void process(const Input&, const Output&) const final;
 
-  private:
-    double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
-  };
+private:
+  double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
+};
 
 } // namespace eicrecon

--- a/src/algorithms/reco/InclusiveKinematicseSigma.cc
+++ b/src/algorithms/reco/InclusiveKinematicseSigma.cc
@@ -23,11 +23,10 @@ using ROOT::Math::PxPyPzEVector;
 
 namespace eicrecon {
 
-  void InclusiveKinematicseSigma::init(std::shared_ptr<spdlog::logger>& logger) {
-    m_log = logger;
+  void InclusiveKinematicseSigma::init() {
     // m_pidSvc = service("ParticleSvc");
     // if (!m_pidSvc) {
-    //   m_log->debug("Unable to locate Particle Service. "
+    //   debug("Unable to locate Particle Service. "
     //     "Make sure you have ParticleSvc in the configuration.");
     // }
   }
@@ -42,7 +41,7 @@ namespace eicrecon {
     // Get incoming electron beam
     const auto ei_coll = find_first_beam_electron(mcparts);
     if (ei_coll.size() == 0) {
-      m_log->debug("No beam electron found");
+      debug("No beam electron found");
       return;
     }
     const PxPyPzEVector ei(
@@ -56,7 +55,7 @@ namespace eicrecon {
     // Get incoming hadron beam
     const auto pi_coll = find_first_beam_hadron(mcparts);
     if (pi_coll.size() == 0) {
-      m_log->debug("No beam hadron found");
+      debug("No beam hadron found");
       return;
     }
     const PxPyPzEVector pi(
@@ -83,7 +82,7 @@ namespace eicrecon {
     auto gamma_h = hfs->at(0).getGamma();
 
     if (sigma_h <= 0) {
-      m_log->debug("No scattered electron found or sigma zero or negative");
+      debug("No scattered electron found or sigma zero or negative");
       return;
     }
 
@@ -106,7 +105,7 @@ namespace eicrecon {
     kin.setScat(kf);
 
     // Debugging output
-    m_log->debug("x,Q2,W,y,nu = {},{},{},{},{}", kin.getX(),
+    debug("x,Q2,W,y,nu = {},{},{},{},{}", kin.getX(),
             kin.getQ2(), kin.getW(), kin.getY(), kin.getNu());
   }
 

--- a/src/algorithms/reco/InclusiveKinematicseSigma.h
+++ b/src/algorithms/reco/InclusiveKinematicseSigma.h
@@ -37,11 +37,10 @@ namespace eicrecon {
                             {"inclusiveKinematics"},
                             "Determine inclusive kinematics using e-Sigma method."} {}
 
-    void init(std::shared_ptr<spdlog::logger>& logger);
+    void init() final;
     void process(const Input&, const Output&) const final;
 
   private:
-    std::shared_ptr<spdlog::logger> m_log;
     double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
   };
 

--- a/src/algorithms/reco/InclusiveKinematicseSigma.h
+++ b/src/algorithms/reco/InclusiveKinematicseSigma.h
@@ -4,44 +4,35 @@
 #pragma once
 
 #include <algorithms/algorithm.h>
+#include <edm4eic/HadronicFinalStateCollection.h>
 #include <edm4eic/InclusiveKinematicsCollection.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/MCParticleCollection.h>
-#include <edm4eic/HadronicFinalStateCollection.h>
-#include <spdlog/logger.h>
-#include <memory>
 #include <string>
 #include <string_view>
 
-
 namespace eicrecon {
 
-  using InclusiveKinematicseSigmaAlgorithm = algorithms::Algorithm<
-    algorithms::Input<
-      edm4hep::MCParticleCollection,
-      edm4eic::ReconstructedParticleCollection,
-      edm4eic::HadronicFinalStateCollection
-    >,
-    algorithms::Output<
-      edm4eic::InclusiveKinematicsCollection
-    >
-  >;
+using InclusiveKinematicseSigmaAlgorithm = algorithms::Algorithm<
+    algorithms::Input<edm4hep::MCParticleCollection, edm4eic::ReconstructedParticleCollection,
+                      edm4eic::HadronicFinalStateCollection>,
+    algorithms::Output<edm4eic::InclusiveKinematicsCollection>>;
 
-  class InclusiveKinematicseSigma
-  : public InclusiveKinematicseSigmaAlgorithm {
+class InclusiveKinematicseSigma : public InclusiveKinematicseSigmaAlgorithm {
 
-  public:
-    InclusiveKinematicseSigma(std::string_view name)
-      : InclusiveKinematicseSigmaAlgorithm{name,
-                            {"MCParticles", "scatteredElectron", "hadronicFinalState"},
-                            {"inclusiveKinematics"},
-                            "Determine inclusive kinematics using e-Sigma method."} {}
+public:
+  InclusiveKinematicseSigma(std::string_view name)
+      : InclusiveKinematicseSigmaAlgorithm{
+            name,
+            {"MCParticles", "scatteredElectron", "hadronicFinalState"},
+            {"inclusiveKinematics"},
+            "Determine inclusive kinematics using e-Sigma method."} {}
 
-    void init() final;
-    void process(const Input&, const Output&) const final;
+  void init() final;
+  void process(const Input&, const Output&) const final;
 
-  private:
-    double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
-  };
+private:
+  double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
+};
 
 } // namespace eicrecon

--- a/src/algorithms/reco/JetReconstruction.cc
+++ b/src/algorithms/reco/JetReconstruction.cc
@@ -25,31 +25,30 @@ using namespace fastjet;
 namespace eicrecon {
 
   template <typename InputT>
-  void JetReconstruction<InputT>::init(std::shared_ptr<spdlog::logger> logger) {
+  void JetReconstruction<InputT>::init() {
 
-    m_log = logger;
-    m_log->trace("Initialized");
+    this->trace("Initialized");
 
     // if specified algorithm, recomb. scheme, or area type
     // are not defined, then issue error and throw exception
     try {
       m_mapJetAlgo.at(m_cfg.jetAlgo);
     } catch (std::out_of_range &out) {
-      m_log->error(" Unknown jet algorithm \"{}\" specified!", m_cfg.jetAlgo);
+      this->error(" Unknown jet algorithm \"{}\" specified!", m_cfg.jetAlgo);
       throw JException(out.what());
     }
 
     try {
       m_mapRecombScheme.at(m_cfg.recombScheme);
     } catch (std::out_of_range &out) {
-      m_log->error(" Unknown recombination scheme \"{}\" specified!", m_cfg.recombScheme);
+      this->error(" Unknown recombination scheme \"{}\" specified!", m_cfg.recombScheme);
       throw JException(out.what());
     }
 
     try {
       m_mapAreaType.at(m_cfg.areaType);
     } catch (std::out_of_range &out) {
-      m_log->error(" Unknown area type \"{}\" specified!", m_cfg.areaType);
+      this->error(" Unknown area type \"{}\" specified!", m_cfg.areaType);
       throw JException(out.what());
     }
 
@@ -65,7 +64,7 @@ namespace eicrecon {
           m_jet_def = std::make_unique<JetDefinition>(m_jet_plugin.get());
         }
         else {
-          m_log->error(" Unknown contributed FastJet algorithm \"{}\" specified!", m_cfg.jetContribAlgo);
+          this->error(" Unknown contributed FastJet algorithm \"{}\" specified!", m_cfg.jetContribAlgo);
           throw JException("Invalid contributed FastJet algorithm");
         }
         break;
@@ -93,7 +92,7 @@ namespace eicrecon {
     // Define jet area
     m_area_def = std::make_unique<AreaDefinition>(m_mapAreaType[m_cfg.areaType], GhostedAreaSpec(m_cfg.ghostMaxRap, m_cfg.numGhostRepeat, m_cfg.ghostArea));
 
-  }  // end 'init(std::shared_ptr<spdlog::logger>)'
+  }  // end 'init()'
 
   template <typename InputT>
   void JetReconstruction<InputT>::process(
@@ -123,22 +122,22 @@ namespace eicrecon {
 
     // Skip empty
     if (particles.empty()) {
-      m_log->trace("  Empty particle list.");
+      this->trace("  Empty particle list.");
       return;
     }
-    m_log->trace("  Number of particles: {}", particles.size());
+    this->trace("  Number of particles: {}", particles.size());
 
     // Run the clustering, extract the jets
     fastjet::ClusterSequenceArea m_clus_seq(particles, *m_jet_def, *m_area_def);
     std::vector<PseudoJet> jets = sorted_by_pt(m_clus_seq.inclusive_jets(m_cfg.minJetPt));
 
     // Print out some infos
-    m_log->trace("  Clustering with : {}", m_jet_def->description());
+    this->trace("  Clustering with : {}", m_jet_def->description());
 
     // loop over jets
     for (unsigned i = 0; i < jets.size(); i++) {
 
-      m_log->trace("  jet {}: pt = {}, y = {}, phi = {}", i, jets[i].pt(), jets[i].rap(), jets[i].phi());
+      this->trace("  jet {}: pt = {}, y = {}, phi = {}", i, jets[i].pt(), jets[i].rap(), jets[i].phi());
 
       // create jet to store in output collection
       edm4eic::MutableReconstructedParticle jet_output = jet_collection->create();

--- a/src/algorithms/reco/JetReconstruction.cc
+++ b/src/algorithms/reco/JetReconstruction.cc
@@ -6,9 +6,10 @@
 
 // for error handling
 #include <JANA/JException.h>
-#include <edm4hep/MCParticleCollection.h>// IWYU pragma: keep
+#include <edm4hep/MCParticleCollection.h> // IWYU pragma: keep
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
+#include <fastjet/ClusterSequenceArea.hh>
 #include <fastjet/GhostedAreaSpec.hh>
 // for fastjet objects
 #include <fastjet/PseudoJet.hh>
@@ -24,138 +25,141 @@ using namespace fastjet;
 
 namespace eicrecon {
 
-  template <typename InputT>
-  void JetReconstruction<InputT>::init() {
+template <typename InputT> void JetReconstruction<InputT>::init() {
 
-    this->trace("Initialized");
+  this->trace("Initialized");
 
-    // if specified algorithm, recomb. scheme, or area type
-    // are not defined, then issue error and throw exception
-    try {
-      m_mapJetAlgo.at(m_cfg.jetAlgo);
-    } catch (std::out_of_range &out) {
-      this->error(" Unknown jet algorithm \"{}\" specified!", m_cfg.jetAlgo);
-      throw JException(out.what());
+  // if specified algorithm, recomb. scheme, or area type
+  // are not defined, then issue error and throw exception
+  try {
+    m_mapJetAlgo.at(m_cfg.jetAlgo);
+  } catch (std::out_of_range& out) {
+    this->error(" Unknown jet algorithm \"{}\" specified!", m_cfg.jetAlgo);
+    throw JException(out.what());
+  }
+
+  try {
+    m_mapRecombScheme.at(m_cfg.recombScheme);
+  } catch (std::out_of_range& out) {
+    this->error(" Unknown recombination scheme \"{}\" specified!", m_cfg.recombScheme);
+    throw JException(out.what());
+  }
+
+  try {
+    m_mapAreaType.at(m_cfg.areaType);
+  } catch (std::out_of_range& out) {
+    this->error(" Unknown area type \"{}\" specified!", m_cfg.areaType);
+    throw JException(out.what());
+  }
+
+  // Choose jet definition based on no. of parameters
+  switch (m_mapJetAlgo[m_cfg.jetAlgo]) {
+
+  // contributed algorithms
+  case JetAlgorithm::plugin_algorithm:
+
+    // expand to other algorithms as required
+    if (m_cfg.jetContribAlgo == "Centauro") {
+      m_jet_plugin = std::make_unique<contrib::CentauroPlugin>(m_cfg.rJet);
+      m_jet_def    = std::make_unique<JetDefinition>(m_jet_plugin.get());
+    } else {
+      this->error(" Unknown contributed FastJet algorithm \"{}\" specified!", m_cfg.jetContribAlgo);
+      throw JException("Invalid contributed FastJet algorithm");
     }
+    break;
 
-    try {
-      m_mapRecombScheme.at(m_cfg.recombScheme);
-    } catch (std::out_of_range &out) {
-      this->error(" Unknown recombination scheme \"{}\" specified!", m_cfg.recombScheme);
-      throw JException(out.what());
+  // 0 parameter algorithms
+  case JetAlgorithm::ee_kt_algorithm:
+    m_jet_def = std::make_unique<JetDefinition>(m_mapJetAlgo[m_cfg.jetAlgo],
+                                                m_mapRecombScheme[m_cfg.recombScheme]);
+    break;
+
+  // 2 parameter algorithms
+  case JetAlgorithm::genkt_algorithm:
+    [[fallthrough]];
+
+  case JetAlgorithm::ee_genkt_algorithm:
+    m_jet_def = std::make_unique<JetDefinition>(m_mapJetAlgo[m_cfg.jetAlgo], m_cfg.rJet, m_cfg.pJet,
+                                                m_mapRecombScheme[m_cfg.recombScheme]);
+    break;
+
+  // all others have only 1 parameter
+  default:
+    m_jet_def = std::make_unique<JetDefinition>(m_mapJetAlgo[m_cfg.jetAlgo], m_cfg.rJet,
+                                                m_mapRecombScheme[m_cfg.recombScheme]);
+    break;
+
+  } // end switch (jet algorithm)
+
+  // Define jet area
+  m_area_def = std::make_unique<AreaDefinition>(
+      m_mapAreaType[m_cfg.areaType],
+      GhostedAreaSpec(m_cfg.ghostMaxRap, m_cfg.numGhostRepeat, m_cfg.ghostArea));
+
+} // end 'init()'
+
+template <typename InputT>
+void JetReconstruction<InputT>::process(
+    const typename JetReconstructionAlgorithm<InputT>::Input& input,
+    const typename JetReconstructionAlgorithm<InputT>::Output& output) const {
+  // Grab input collections
+  const auto [input_collection] = input;
+  auto [jet_collection]         = output;
+
+  // extract input momenta and collect into pseudojets
+  std::vector<PseudoJet> particles;
+  for (unsigned iInput = 0; const auto& input : *input_collection) {
+
+    // get 4-vector
+    const auto& momentum = input.getMomentum();
+    const auto& energy   = input.getEnergy();
+    const auto pt        = edm4hep::utils::magnitudeTransverse(momentum);
+
+    // Only cluster particles within the given pt Range
+    if ((pt > m_cfg.minCstPt) && (pt < m_cfg.maxCstPt)) {
+      particles.emplace_back(momentum.x, momentum.y, momentum.z, energy);
+      particles.back().set_user_index(iInput);
     }
+    ++iInput;
+  }
 
-    try {
-      m_mapAreaType.at(m_cfg.areaType);
-    } catch (std::out_of_range &out) {
-      this->error(" Unknown area type \"{}\" specified!", m_cfg.areaType);
-      throw JException(out.what());
-    }
-
-    // Choose jet definition based on no. of parameters
-    switch (m_mapJetAlgo[m_cfg.jetAlgo]) {
-
-      // contributed algorithms
-      case JetAlgorithm::plugin_algorithm:
-
-        // expand to other algorithms as required
-        if(m_cfg.jetContribAlgo == "Centauro"){
-          m_jet_plugin = std::make_unique<contrib::CentauroPlugin>(m_cfg.rJet);
-          m_jet_def = std::make_unique<JetDefinition>(m_jet_plugin.get());
-        }
-        else {
-          this->error(" Unknown contributed FastJet algorithm \"{}\" specified!", m_cfg.jetContribAlgo);
-          throw JException("Invalid contributed FastJet algorithm");
-        }
-        break;
-
-      // 0 parameter algorithms
-      case JetAlgorithm::ee_kt_algorithm:
-        m_jet_def = std::make_unique<JetDefinition>(m_mapJetAlgo[m_cfg.jetAlgo], m_mapRecombScheme[m_cfg.recombScheme]);
-        break;
-
-      // 2 parameter algorithms
-      case JetAlgorithm::genkt_algorithm:
-        [[fallthrough]];
-
-      case JetAlgorithm::ee_genkt_algorithm:
-        m_jet_def = std::make_unique<JetDefinition>(m_mapJetAlgo[m_cfg.jetAlgo], m_cfg.rJet, m_cfg.pJet, m_mapRecombScheme[m_cfg.recombScheme]);
-        break;
-
-      // all others have only 1 parameter
-      default:
-        m_jet_def = std::make_unique<JetDefinition>(m_mapJetAlgo[m_cfg.jetAlgo], m_cfg.rJet, m_mapRecombScheme[m_cfg.recombScheme]);
-        break;
-
-    }  // end switch (jet algorithm)
-
-    // Define jet area
-    m_area_def = std::make_unique<AreaDefinition>(m_mapAreaType[m_cfg.areaType], GhostedAreaSpec(m_cfg.ghostMaxRap, m_cfg.numGhostRepeat, m_cfg.ghostArea));
-
-  }  // end 'init()'
-
-  template <typename InputT>
-  void JetReconstruction<InputT>::process(
-                                  const typename JetReconstructionAlgorithm<InputT>::Input& input,
-                                  const typename JetReconstructionAlgorithm<InputT>::Output& output
-                                 ) const {
-    // Grab input collections
-    const auto [input_collection] = input;
-    auto [jet_collection] = output;
-
-    // extract input momenta and collect into pseudojets
-    std::vector<PseudoJet> particles;
-    for (unsigned iInput = 0; const auto& input : *input_collection) {
-
-      // get 4-vector
-      const auto& momentum = input.getMomentum();
-      const auto& energy = input.getEnergy();
-      const auto pt = edm4hep::utils::magnitudeTransverse(momentum);
-
-      // Only cluster particles within the given pt Range
-      if ((pt > m_cfg.minCstPt) && (pt < m_cfg.maxCstPt)) {
-        particles.emplace_back(momentum.x, momentum.y, momentum.z, energy);
-        particles.back().set_user_index(iInput);
-      }
-      ++iInput;
-    }
-
-    // Skip empty
-    if (particles.empty()) {
-      this->trace("  Empty particle list.");
-      return;
-    }
-    this->trace("  Number of particles: {}", particles.size());
-
-    // Run the clustering, extract the jets
-    fastjet::ClusterSequenceArea m_clus_seq(particles, *m_jet_def, *m_area_def);
-    std::vector<PseudoJet> jets = sorted_by_pt(m_clus_seq.inclusive_jets(m_cfg.minJetPt));
-
-    // Print out some infos
-    this->trace("  Clustering with : {}", m_jet_def->description());
-
-    // loop over jets
-    for (unsigned i = 0; i < jets.size(); i++) {
-
-      this->trace("  jet {}: pt = {}, y = {}, phi = {}", i, jets[i].pt(), jets[i].rap(), jets[i].phi());
-
-      // create jet to store in output collection
-      edm4eic::MutableReconstructedParticle jet_output = jet_collection->create();
-      jet_output.setMomentum(edm4hep::Vector3f(jets[i].px(), jets[i].py(), jets[i].pz()));
-      jet_output.setEnergy(jets[i].e());
-      jet_output.setMass(jets[i].m());
-
-      // link constituents to jet kinematic info
-      std::vector<PseudoJet> csts = jets[i].constituents();
-      for (unsigned j = 0; j < csts.size(); j++) {
-        jet_output.addToParticles(input_collection->at(csts[j].user_index()));
-      } // for constituent j
-    } // for jet i
-
-    // return the jets
+  // Skip empty
+  if (particles.empty()) {
+    this->trace("  Empty particle list.");
     return;
-  }  // end 'process(const T&)'
+  }
+  this->trace("  Number of particles: {}", particles.size());
 
-  template class JetReconstruction<edm4eic::ReconstructedParticle>;
+  // Run the clustering, extract the jets
+  fastjet::ClusterSequenceArea m_clus_seq(particles, *m_jet_def, *m_area_def);
+  std::vector<PseudoJet> jets = sorted_by_pt(m_clus_seq.inclusive_jets(m_cfg.minJetPt));
 
-}  // end namespace eicrecon
+  // Print out some infos
+  this->trace("  Clustering with : {}", m_jet_def->description());
+
+  // loop over jets
+  for (unsigned i = 0; i < jets.size(); i++) {
+
+    this->trace("  jet {}: pt = {}, y = {}, phi = {}", i, jets[i].pt(), jets[i].rap(),
+                jets[i].phi());
+
+    // create jet to store in output collection
+    edm4eic::MutableReconstructedParticle jet_output = jet_collection->create();
+    jet_output.setMomentum(edm4hep::Vector3f(jets[i].px(), jets[i].py(), jets[i].pz()));
+    jet_output.setEnergy(jets[i].e());
+    jet_output.setMass(jets[i].m());
+
+    // link constituents to jet kinematic info
+    std::vector<PseudoJet> csts = jets[i].constituents();
+    for (unsigned j = 0; j < csts.size(); j++) {
+      jet_output.addToParticles(input_collection->at(csts[j].user_index()));
+    } // for constituent j
+  }   // for jet i
+
+  // return the jets
+  return;
+} // end 'process(const T&)'
+
+template class JetReconstruction<edm4eic::ReconstructedParticle>;
+
+} // end namespace eicrecon

--- a/src/algorithms/reco/JetReconstruction.h
+++ b/src/algorithms/reco/JetReconstruction.h
@@ -6,9 +6,7 @@
 #include <algorithms/algorithm.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <fastjet/AreaDefinition.hh>
-#include <fastjet/ClusterSequenceArea.hh>
 #include <fastjet/JetDefinition.hh>
-#include <spdlog/logger.h>
 #include <map>
 #include <memory>
 #include <string>
@@ -20,85 +18,73 @@
 
 namespace eicrecon {
 
-    template <typename InputT>
-    using JetReconstructionAlgorithm = algorithms::Algorithm<
-      algorithms::Input<
-        typename InputT::collection_type
-        >,
-      algorithms::Output<
-        edm4eic::ReconstructedParticleCollection
-        >
-    >;
+template <typename InputT>
+using JetReconstructionAlgorithm =
+    algorithms::Algorithm<algorithms::Input<typename InputT::collection_type>,
+                          algorithms::Output<edm4eic::ReconstructedParticleCollection>>;
 
-    template <typename InputT>
-    class JetReconstruction
-      : public JetReconstructionAlgorithm<InputT>,
-        public WithPodConfig<JetReconstructionConfig> {
+template <typename InputT>
+class JetReconstruction : public JetReconstructionAlgorithm<InputT>,
+                          public WithPodConfig<JetReconstructionConfig> {
 
-    public:
+public:
+  JetReconstruction(std::string_view name)
+      : JetReconstructionAlgorithm<InputT>{
+            name,
+            {"inputReconstructedParticles"},
+            {"outputReconstructedParticles"},
+            "Performs jet reconstruction using a FastJet algorithm."} {}
 
-    JetReconstruction(std::string_view name) :
-      JetReconstructionAlgorithm<InputT> {
-        name,
-        {"inputReconstructedParticles"},
-        {"outputReconstructedParticles"},
-        "Performs jet reconstruction using a FastJet algorithm."
-      } {}
+public:
+  // algorithm initialization
+  void init() final;
 
-    public:
+  // run algorithm
+  void process(const typename eicrecon::JetReconstructionAlgorithm<InputT>::Input&,
+               const typename eicrecon::JetReconstructionAlgorithm<InputT>::Output&) const final;
 
-      // algorithm initialization
-      void init() final;
+private:
+  // fastjet components
+  std::unique_ptr<fastjet::JetDefinition> m_jet_def;
+  std::unique_ptr<fastjet::AreaDefinition> m_area_def;
+  std::unique_ptr<fastjet::JetDefinition::Plugin> m_jet_plugin;
 
-      // run algorithm
-      void process(const typename eicrecon::JetReconstructionAlgorithm<InputT>::Input&, const typename eicrecon::JetReconstructionAlgorithm<InputT>::Output&) const final;
+  // maps of user input onto fastjet options
+  std::map<std::string, fastjet::JetAlgorithm> m_mapJetAlgo = {
+      {"kt_algorithm", fastjet::JetAlgorithm::kt_algorithm},
+      {"cambridge_algorithm", fastjet::JetAlgorithm::cambridge_algorithm},
+      {"antikt_algorithm", fastjet::JetAlgorithm::antikt_algorithm},
+      {"genkt_algorithm", fastjet::JetAlgorithm::genkt_algorithm},
+      {"cambridge_for_passive_algorithm", fastjet::JetAlgorithm::cambridge_for_passive_algorithm},
+      {"genkt_for_passive_algorithm", fastjet::JetAlgorithm::genkt_for_passive_algorithm},
+      {"ee_kt_algorithm", fastjet::JetAlgorithm::ee_kt_algorithm},
+      {"ee_genkt_algorithm", fastjet::JetAlgorithm::ee_genkt_algorithm},
+      {"plugin_algorithm", fastjet::JetAlgorithm::plugin_algorithm}};
+  std::map<std::string, fastjet::RecombinationScheme> m_mapRecombScheme = {
+      {"E_scheme", fastjet::RecombinationScheme::E_scheme},
+      {"pt_scheme", fastjet::RecombinationScheme::pt_scheme},
+      {"pt2_scheme", fastjet::RecombinationScheme::pt2_scheme},
+      {"Et_scheme", fastjet::RecombinationScheme::Et_scheme},
+      {"Et2_scheme", fastjet::RecombinationScheme::Et2_scheme},
+      {"BIpt_scheme", fastjet::RecombinationScheme::BIpt_scheme},
+      {"BIpt2_scheme", fastjet::RecombinationScheme::BIpt2_scheme},
+      {"WTA_pt_scheme", fastjet::RecombinationScheme::WTA_pt_scheme},
+      {"WTA_modp_scheme", fastjet::RecombinationScheme::WTA_modp_scheme},
+      {"external_scheme", fastjet::RecombinationScheme::external_scheme}};
+  std::map<std::string, fastjet::AreaType> m_mapAreaType = {
+      {"active_area", fastjet::AreaType::active_area},
+      {"active_area_explicit_ghosts", fastjet::AreaType::active_area_explicit_ghosts},
+      {"one_ghost_passive_area", fastjet::AreaType::one_ghost_passive_area},
+      {"passive_area", fastjet::AreaType::passive_area},
+      {"voronoi_area", fastjet::AreaType::voronoi_area}};
 
-    private:
+  // default fastjet options
+  const struct defaults {
+    std::string jetAlgo;
+    std::string recombScheme;
+    std::string areaType;
+  } m_defaultFastjetOpts = {"antikt_algorithm", "E_scheme", "active_area"};
 
-      // fastjet components
-      std::unique_ptr<fastjet::JetDefinition> m_jet_def;
-      std::unique_ptr<fastjet::AreaDefinition> m_area_def;
-      std::unique_ptr<fastjet::JetDefinition::Plugin> m_jet_plugin;
+}; // end JetReconstruction definition
 
-      // maps of user input onto fastjet options
-      std::map<std::string, fastjet::JetAlgorithm> m_mapJetAlgo = {
-        {"kt_algorithm",                    fastjet::JetAlgorithm::kt_algorithm},
-        {"cambridge_algorithm",             fastjet::JetAlgorithm::cambridge_algorithm},
-        {"antikt_algorithm",                fastjet::JetAlgorithm::antikt_algorithm},
-        {"genkt_algorithm",                 fastjet::JetAlgorithm::genkt_algorithm},
-        {"cambridge_for_passive_algorithm", fastjet::JetAlgorithm::cambridge_for_passive_algorithm},
-        {"genkt_for_passive_algorithm",     fastjet::JetAlgorithm::genkt_for_passive_algorithm},
-        {"ee_kt_algorithm",                 fastjet::JetAlgorithm::ee_kt_algorithm},
-        {"ee_genkt_algorithm",              fastjet::JetAlgorithm::ee_genkt_algorithm},
-        {"plugin_algorithm",                fastjet::JetAlgorithm::plugin_algorithm}
-      };
-      std::map<std::string, fastjet::RecombinationScheme> m_mapRecombScheme = {
-        {"E_scheme",        fastjet::RecombinationScheme::E_scheme},
-        {"pt_scheme",       fastjet::RecombinationScheme::pt_scheme},
-        {"pt2_scheme",      fastjet::RecombinationScheme::pt2_scheme},
-        {"Et_scheme",       fastjet::RecombinationScheme::Et_scheme},
-        {"Et2_scheme",      fastjet::RecombinationScheme::Et2_scheme},
-        {"BIpt_scheme",     fastjet::RecombinationScheme::BIpt_scheme},
-        {"BIpt2_scheme",    fastjet::RecombinationScheme::BIpt2_scheme},
-        {"WTA_pt_scheme",   fastjet::RecombinationScheme::WTA_pt_scheme},
-        {"WTA_modp_scheme", fastjet::RecombinationScheme::WTA_modp_scheme},
-        {"external_scheme", fastjet::RecombinationScheme::external_scheme}
-      };
-      std::map<std::string, fastjet::AreaType> m_mapAreaType = {
-        {"active_area",                 fastjet::AreaType::active_area},
-        {"active_area_explicit_ghosts", fastjet::AreaType::active_area_explicit_ghosts},
-        {"one_ghost_passive_area",      fastjet::AreaType::one_ghost_passive_area},
-        {"passive_area",                fastjet::AreaType::passive_area},
-        {"voronoi_area",                fastjet::AreaType::voronoi_area}
-      };
-
-      // default fastjet options
-      const struct defaults {
-        std::string jetAlgo;
-        std::string recombScheme;
-        std::string areaType;
-      } m_defaultFastjetOpts = {"antikt_algorithm", "E_scheme", "active_area"};
-
-  };  // end JetReconstruction definition
-
-}  // end eicrecon namespace
+} // namespace eicrecon

--- a/src/algorithms/reco/JetReconstruction.h
+++ b/src/algorithms/reco/JetReconstruction.h
@@ -48,14 +48,12 @@ namespace eicrecon {
     public:
 
       // algorithm initialization
-      void init(std::shared_ptr<spdlog::logger> logger);
+      void init() final;
 
       // run algorithm
       void process(const typename eicrecon::JetReconstructionAlgorithm<InputT>::Input&, const typename eicrecon::JetReconstructionAlgorithm<InputT>::Output&) const final;
 
     private:
-
-      std::shared_ptr<spdlog::logger> m_log;
 
       // fastjet components
       std::unique_ptr<fastjet::JetDefinition> m_jet_def;

--- a/src/algorithms/reco/TransformBreitFrame.cc
+++ b/src/algorithms/reco/TransformBreitFrame.cc
@@ -20,14 +20,6 @@
 
 namespace eicrecon {
 
-  void TransformBreitFrame::init(std::shared_ptr<spdlog::logger> logger) {
-
-    m_log = logger;
-    m_log->trace("Initialized");
-
-  }  // end 'init(std::shared_ptr<spdlog::logger>)'
-
-
   void TransformBreitFrame::process(
                                     const TransformBreitFrame::Input& input,
                                     const TransformBreitFrame::Output& output
@@ -42,7 +34,7 @@ namespace eicrecon {
     // Get incoming electron beam
     const auto ei_coll = find_first_beam_electron(mcpart);
     if (ei_coll.size() == 0) {
-      m_log->debug("No beam electron found");
+      debug("No beam electron found");
       return;
     }
     const PxPyPzEVector e_initial(
@@ -56,7 +48,7 @@ namespace eicrecon {
     // Get incoming hadron beam
     const auto pi_coll = find_first_beam_hadron(mcpart);
     if (pi_coll.size() == 0) {
-      m_log->debug("No beam hadron found");
+      debug("No beam hadron found");
       return;
     }
     const PxPyPzEVector p_initial(
@@ -67,11 +59,11 @@ namespace eicrecon {
         m_crossingAngle)
       );
 
-    m_log->debug("electron energy, proton energy = {},{}",e_initial.E(),p_initial.E());
+    debug("electron energy, proton energy = {},{}",e_initial.E(),p_initial.E());
 
     // Get the event kinematics, set up transform
     if (kine->size() == 0) {
-      m_log->debug("No kinematics found");
+      debug("No kinematics found");
       return;
     }
 
@@ -82,15 +74,15 @@ namespace eicrecon {
 
     // Use relation to get reconstructed scattered electron
     const PxPyPzEVector e_final = edm4hep::utils::detail::p4(evt_kin.getScat(),&edm4hep::utils::UseEnergy);
-    m_log->debug("scattered electron in lab frame px,py,pz,E = {},{},{},{}",
+    debug("scattered electron in lab frame px,py,pz,E = {},{},{},{}",
                  e_final.Px(),e_final.Py(),e_final.Pz(),e_final.E());
 
     // Set up the transformation
     const PxPyPzEVector virtual_photon = (e_initial - e_final);
-    m_log->debug("virtual photon in lab frame px,py,pz,E = {},{},{},{}",
+    debug("virtual photon in lab frame px,py,pz,E = {},{},{},{}",
                  virtual_photon.Px(),virtual_photon.Py(),virtual_photon.Pz(),virtual_photon.E());
 
-    m_log->debug("x, Q^2 = {},{}",meas_x,meas_Q2);
+    debug("x, Q^2 = {},{}",meas_x,meas_Q2);
 
     // Set up the transformation (boost) to the Breit frame
     const auto P3 = p_initial.Vect();
@@ -116,9 +108,9 @@ namespace eicrecon {
     e_final_breit = breitRot*e_final_breit;
     virtual_photon_breit = breitRot*virtual_photon_breit;
 
-    m_log->debug("incoming hadron in Breit frame px,py,pz,E = {},{},{},{}",
+    debug("incoming hadron in Breit frame px,py,pz,E = {},{},{},{}",
                  p_initial_breit.Px(),p_initial_breit.Py(),p_initial_breit.Pz(),p_initial_breit.E());
-    m_log->debug("virtual photon in Breit frame px,py,pz,E = {},{},{},{}",
+    debug("virtual photon in Breit frame px,py,pz,E = {},{},{},{}",
                  virtual_photon_breit.Px(),virtual_photon_breit.Py(),virtual_photon_breit.Pz(),virtual_photon_breit.E());
 
     // look over the input particles and transform

--- a/src/algorithms/reco/TransformBreitFrame.h
+++ b/src/algorithms/reco/TransformBreitFrame.h
@@ -42,14 +42,13 @@ namespace eicrecon {
       } {}
 
       // algorithm initialization
-      void init(std::shared_ptr<spdlog::logger> logger);
+      void init() final { };
 
       // run algorithm
       void process(const Input&, const Output&) const final;
 
     private:
 
-      std::shared_ptr<spdlog::logger> m_log;
       double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
 
   };  // end TransformBreitFrame definition

--- a/src/algorithms/reco/TransformBreitFrame.h
+++ b/src/algorithms/reco/TransformBreitFrame.h
@@ -7,8 +7,6 @@
 #include <edm4eic/InclusiveKinematicsCollection.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/MCParticleCollection.h>
-#include <spdlog/logger.h>
-#include <memory>
 #include <string>
 #include <string_view>
 
@@ -16,41 +14,30 @@
 
 namespace eicrecon {
 
-   using TransformBreitFrameAlgorithm = algorithms::Algorithm<
-     algorithms::Input<
-       edm4hep::MCParticleCollection,
-       edm4eic::InclusiveKinematicsCollection,
-       edm4eic::ReconstructedParticleCollection
-       >,
-     algorithms::Output<
-       edm4eic::ReconstructedParticleCollection
-       >
-   >;
+using TransformBreitFrameAlgorithm = algorithms::Algorithm<
+    algorithms::Input<edm4hep::MCParticleCollection, edm4eic::InclusiveKinematicsCollection,
+                      edm4eic::ReconstructedParticleCollection>,
+    algorithms::Output<edm4eic::ReconstructedParticleCollection>>;
 
-  class TransformBreitFrame
-    : public TransformBreitFrameAlgorithm,
-      public WithPodConfig<NoConfig> {
+class TransformBreitFrame : public TransformBreitFrameAlgorithm, public WithPodConfig<NoConfig> {
 
-    public:
+public:
+  TransformBreitFrame(std::string_view name)
+      : TransformBreitFrameAlgorithm{
+            name,
+            {"inputMCParticles", "inputInclusiveKinematics", "inputReconstructedParticles"},
+            {"outputReconstructedParticles"},
+            "Transforms a set of particles from the lab frame to the Breit frame"} {}
 
-    TransformBreitFrame(std::string_view name) :
-      TransformBreitFrameAlgorithm {
-        name,
-        {"inputMCParticles", "inputInclusiveKinematics", "inputReconstructedParticles"},
-        {"outputReconstructedParticles"},
-        "Transforms a set of particles from the lab frame to the Breit frame"
-      } {}
+  // algorithm initialization
+  void init() final{};
 
-      // algorithm initialization
-      void init() final { };
+  // run algorithm
+  void process(const Input&, const Output&) const final;
 
-      // run algorithm
-      void process(const Input&, const Output&) const final;
+private:
+  double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
 
-    private:
+}; // end TransformBreitFrame definition
 
-      double m_proton{0.93827}, m_neutron{0.93957}, m_electron{0.000510998928}, m_crossingAngle{-0.025};
-
-  };  // end TransformBreitFrame definition
-
-}  // end eicrecon namespace
+} // namespace eicrecon

--- a/src/factories/digi/SiliconTrackerDigi_factory.h
+++ b/src/factories/digi/SiliconTrackerDigi_factory.h
@@ -30,7 +30,7 @@ public:
         m_algo = std::make_unique<AlgoT>(GetPrefix());
         m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
         m_algo->applyConfig(config());
-        m_algo->init(logger());
+        m_algo->init();
     }
 
     void ChangeRun(int64_t run_number) {

--- a/src/factories/fardetectors/FarDetectorLinearProjection_factory.h
+++ b/src/factories/fardetectors/FarDetectorLinearProjection_factory.h
@@ -29,7 +29,7 @@ private:
   public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
-        m_algo->level((algorithms::LogLevel)logger()->level());
+        m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
         m_algo->applyConfig(config());
         m_algo->init();
     }

--- a/src/factories/fardetectors/FarDetectorLinearTracking_factory.h
+++ b/src/factories/fardetectors/FarDetectorLinearTracking_factory.h
@@ -33,7 +33,7 @@ private:
         m_algo = std::make_unique<AlgoT>(GetPrefix());
         m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
         m_algo->applyConfig(config());
-        m_algo->init(logger());
+        m_algo->init();
     }
 
     void ChangeRun(int64_t run_number) {

--- a/src/factories/fardetectors/FarDetectorMLReconstruction_factory.h
+++ b/src/factories/fardetectors/FarDetectorMLReconstruction_factory.h
@@ -39,7 +39,7 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
-        m_algo->level((algorithms::LogLevel)logger()->level());
+        m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
         m_algo->applyConfig(config());
         m_algo->init();
     }

--- a/src/factories/fardetectors/FarDetectorTrackerCluster_factory.h
+++ b/src/factories/fardetectors/FarDetectorTrackerCluster_factory.h
@@ -36,7 +36,7 @@ public:
     m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
     // Setup algorithm
     m_algo->applyConfig(config());
-    m_algo->init(logger());
+    m_algo->init();
 
   }
 

--- a/src/factories/meta/CollectionCollector_factory.h
+++ b/src/factories/meta/CollectionCollector_factory.h
@@ -22,7 +22,7 @@ public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(this->GetPrefix());
         m_algo->level(static_cast<algorithms::LogLevel>(this->logger()->level()));
-        m_algo->init(this->logger());
+        m_algo->init();
     }
 
     void ChangeRun(int64_t run_number) {

--- a/src/factories/reco/HadronicFinalState_factory.h
+++ b/src/factories/reco/HadronicFinalState_factory.h
@@ -32,7 +32,8 @@ private:
 public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(this->GetPrefix());
-        m_algo->init(this->logger());
+        m_algo->level(static_cast<algorithms::LogLevel>(this->logger()->level()));
+        m_algo->init();
     }
 
     void ChangeRun(int64_t run_number) {

--- a/src/factories/reco/InclusiveKinematicsML_factory.h
+++ b/src/factories/reco/InclusiveKinematicsML_factory.h
@@ -34,7 +34,7 @@ public:
         m_algo = std::make_unique<AlgoT>(GetPrefix());
         m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
         m_algo->applyConfig(config());
-        m_algo->init(logger());
+        m_algo->init();
     }
 
     void ChangeRun(int64_t run_number) {

--- a/src/factories/reco/InclusiveKinematicsReconstructed_factory.h
+++ b/src/factories/reco/InclusiveKinematicsReconstructed_factory.h
@@ -33,7 +33,7 @@ public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(this->GetPrefix());
         m_algo->level(static_cast<algorithms::LogLevel>(this->logger()->level()));
-        m_algo->init(this->logger());
+        m_algo->init();
     }
 
     void ChangeRun(int64_t run_number) {

--- a/src/factories/reco/InclusiveKinematicsTruth_factory.h
+++ b/src/factories/reco/InclusiveKinematicsTruth_factory.h
@@ -30,7 +30,7 @@ public:
     void Configure() {
         m_algo = std::make_unique<AlgoT>(GetPrefix());
         m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
-        m_algo->init(logger());
+        m_algo->init();
     }
 
     void ChangeRun(int64_t run_number) {

--- a/src/factories/reco/JetReconstruction_factory.h
+++ b/src/factories/reco/JetReconstruction_factory.h
@@ -46,7 +46,7 @@ namespace eicrecon {
         m_algo = std::make_unique<Algo>(this->GetPrefix());
         m_algo->level(static_cast<algorithms::LogLevel>(this->logger()->level()));
         m_algo->applyConfig(FactoryT::config());
-        m_algo->init(FactoryT::logger());
+        m_algo->init();
       }
 
       void ChangeRun(int64_t run_number) {

--- a/src/factories/reco/TransformBreitFrame_factory.h
+++ b/src/factories/reco/TransformBreitFrame_factory.h
@@ -38,7 +38,7 @@ namespace eicrecon {
       void Configure() {
         m_algo = std::make_unique<Algo>(GetPrefix());
         m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
-        m_algo->init(logger());
+        m_algo->init();
       }
 
       void ChangeRun(int64_t run_number) {

--- a/src/global/pid/MergeTrack_factory.h
+++ b/src/global/pid/MergeTrack_factory.h
@@ -33,7 +33,7 @@ public:
     void Configure() {
         m_algo = std::make_unique<MergeTracks>(GetPrefix());
         m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
-        m_algo->init(logger());
+        m_algo->init();
     }
 
     void ChangeRun(int64_t run_number) { }

--- a/src/tests/algorithms_test/pid_MergeTracks.cc
+++ b/src/tests/algorithms_test/pid_MergeTracks.cc
@@ -21,9 +21,8 @@ TEST_CASE("the PID MergeTracks algorithm runs", "[MergeTracks]") {
 
   // initialize algorithm
   //----------------------------------------------------------
-  std::shared_ptr<spdlog::logger> logger = spdlog::default_logger()->clone("MergeTracks");
-  logger->set_level(spdlog::level::debug);
-  algo.init(logger);
+  algo.level(algorithms::LogLevel::kDebug);
+  algo.init();
 
   // helper functions and objects
   //----------------------------------------------------------

--- a/src/tests/algorithms_test/pid_MergeTracks.cc
+++ b/src/tests/algorithms_test/pid_MergeTracks.cc
@@ -1,16 +1,15 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2023, Christopher Dilks
 
+#include <algorithms/logger.h>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <cmath>
 #include <edm4eic/TrackPoint.h>
 #include <edm4eic/TrackSegmentCollection.h>
 #include <edm4hep/Vector3f.h>
-#include <spdlog/common.h>
-#include <spdlog/logger.h>
-#include <spdlog/spdlog.h>
-#include <cmath>
+#include <gsl/pointers>
 #include <memory>
 #include <vector>
 
@@ -31,12 +30,12 @@ TEST_CASE("the PID MergeTracks algorithm runs", "[MergeTracks]") {
   struct Point {
     decltype(edm4eic::TrackPoint::position) position;
     decltype(edm4eic::TrackPoint::momentum) momentum;
-    decltype(edm4eic::TrackPoint::time)     time;
+    decltype(edm4eic::TrackPoint::time) time;
   };
 
-  auto make_track = [] (auto& coll, std::vector<Point> points) {
+  auto make_track = [](auto& coll, std::vector<Point> points) {
     auto trk = coll->create();
-    for(auto& point : points) {
+    for (auto& point : points) {
       edm4eic::TrackPoint trk_point;
       trk_point.position = point.position;
       trk_point.momentum = point.momentum;
@@ -45,14 +44,11 @@ TEST_CASE("the PID MergeTracks algorithm runs", "[MergeTracks]") {
     }
   };
 
-  auto track_length = [] (auto trk) {
+  auto track_length = [](auto trk) {
     auto a = trk.getPoints(0);
-    auto b = trk.getPoints(trk.points_size()-1);
-    return std::hypot(
-        a.position.x - b.position.x,
-        a.position.y - b.position.y,
-        a.position.z - b.position.z
-        );
+    auto b = trk.getPoints(trk.points_size() - 1);
+    return std::hypot(a.position.x - b.position.x, a.position.y - b.position.y,
+                      a.position.z - b.position.z);
   };
 
   // inputs
@@ -72,112 +68,101 @@ TEST_CASE("the PID MergeTracks algorithm runs", "[MergeTracks]") {
   auto collection2 = std::make_unique<edm4eic::TrackSegmentCollection>();
 
   // track0
-  make_track(collection0, { // horizontal
-      { {0, 0, 0}, {1, 0, 0}, 1 }, // { position, momentum, time }
-      { {1, 0, 0}, {1, 0, 0}, 2 }
-      });
-  make_track(collection1, { // horizontal
-      { {2, 0, 0}, {1, 0, 0}, 3 },
-      { {3, 0, 0}, {1, 0, 0}, 4 }
-      });
-  make_track(collection2, { // horizontal
-      { {4, 0, 0}, {1, 0, 0}, 5 },
-      { {5, 0, 0}, {1, 0, 0}, 6 }
-      });
+  make_track(collection0, {                           // horizontal
+                           {{0, 0, 0}, {1, 0, 0}, 1}, // { position, momentum, time }
+                           {{1, 0, 0}, {1, 0, 0}, 2}});
+  make_track(collection1, {// horizontal
+                           {{2, 0, 0}, {1, 0, 0}, 3},
+                           {{3, 0, 0}, {1, 0, 0}, 4}});
+  make_track(collection2, {// horizontal
+                           {{4, 0, 0}, {1, 0, 0}, 5},
+                           {{5, 0, 0}, {1, 0, 0}, 6}});
 
   // track1
-  make_track(collection0, { // horizontal
-      { {0, 0, 0}, {1, 0, 0}, 1 },
-      { {1, 0, 0}, {1, 0, 0}, 2 }
-      });
-  make_track(collection1, { // empty
-      { }
-      });
-  make_track(collection2, { // one point
-      { {2, 0, 0}, {1, 0, 0}, 3 }
-      });
+  make_track(collection0, {// horizontal
+                           {{0, 0, 0}, {1, 0, 0}, 1},
+                           {{1, 0, 0}, {1, 0, 0}, 2}});
+  make_track(collection1, {// empty
+                           {}});
+  make_track(collection2, {// one point
+                           {{2, 0, 0}, {1, 0, 0}, 3}});
 
   // track2
-  make_track(collection0, { // vertical
-      { {0, 0, 0}, {0, 1, 0}, 1 },
-      { {0, 1, 0}, {0, 1, 0}, 2 }
-      });
-  make_track(collection1, { // horizontal
-      { {0, 1, 0}, {1, 0, 0}, 3 },
-      { {1, 1, 0}, {1, 0, 0}, 4 }
-      });
-  make_track(collection2, { // vertical
-      { {1, 1, 0}, {0, 1, 0}, 5 },
-      { {1, 2, 0}, {0, 1, 0}, 6 }
-      });
+  make_track(collection0, {// vertical
+                           {{0, 0, 0}, {0, 1, 0}, 1},
+                           {{0, 1, 0}, {0, 1, 0}, 2}});
+  make_track(collection1, {// horizontal
+                           {{0, 1, 0}, {1, 0, 0}, 3},
+                           {{1, 1, 0}, {1, 0, 0}, 4}});
+  make_track(collection2, {// vertical
+                           {{1, 1, 0}, {0, 1, 0}, 5},
+                           {{1, 2, 0}, {0, 1, 0}, 6}});
 
   // track3
-  make_track(collection0, { // horizontal
-      { {1, 0, 0}, {1, 0, 0}, 2 },
-      { {0, 0, 0}, {1, 0, 0}, 1 }
-      });
-  make_track(collection1, { // horizontal
-      { {3, 0, 0}, {1, 0, 0}, 4 },
-      { {4, 0, 0}, {1, 0, 0}, 5 }
-      });
-  make_track(collection2, { // horizontal
-      { {5, 0, 0}, {1, 0, 0}, 6 },
-      { {2, 0, 0}, {1, 0, 0}, 3 }
-      });
+  make_track(collection0, {// horizontal
+                           {{1, 0, 0}, {1, 0, 0}, 2},
+                           {{0, 0, 0}, {1, 0, 0}, 1}});
+  make_track(collection1, {// horizontal
+                           {{3, 0, 0}, {1, 0, 0}, 4},
+                           {{4, 0, 0}, {1, 0, 0}, 5}});
+  make_track(collection2, {// horizontal
+                           {{5, 0, 0}, {1, 0, 0}, 6},
+                           {{2, 0, 0}, {1, 0, 0}, 3}});
 
   // tests
   //----------------------------------------------------------
 
   SECTION("merge tracks from 1 collection") {
     // run algorithm
-    std::vector<gsl::not_null<const edm4eic::TrackSegmentCollection*>> colls = { collection0.get() };
+    std::vector<gsl::not_null<const edm4eic::TrackSegmentCollection*>> colls = {collection0.get()};
     // create output collection
     auto trks = std::make_unique<edm4eic::TrackSegmentCollection>();
     algo.process({colls}, {trks.get()});
     // input collection(s) size == output collection size
     REQUIRE(trks->size() == colls.front()->size());
     // track length: from endpoints
-    REQUIRE_THAT( track_length(trks->at(0)), Catch::Matchers::WithinAbs(1, EPSILON) );
-    REQUIRE_THAT( track_length(trks->at(1)), Catch::Matchers::WithinAbs(1, EPSILON) );
-    REQUIRE_THAT( track_length(trks->at(2)), Catch::Matchers::WithinAbs(1, EPSILON) );
-    REQUIRE_THAT( track_length(trks->at(3)), Catch::Matchers::WithinAbs(1, EPSILON) );
+    REQUIRE_THAT(track_length(trks->at(0)), Catch::Matchers::WithinAbs(1, EPSILON));
+    REQUIRE_THAT(track_length(trks->at(1)), Catch::Matchers::WithinAbs(1, EPSILON));
+    REQUIRE_THAT(track_length(trks->at(2)), Catch::Matchers::WithinAbs(1, EPSILON));
+    REQUIRE_THAT(track_length(trks->at(3)), Catch::Matchers::WithinAbs(1, EPSILON));
     // track length: from algorithm // FIXME when implemented in `MergeTracks`
-    for(const auto& trk : *trks)
-      REQUIRE_THAT( trk.getLength(), Catch::Matchers::WithinAbs(0, EPSILON) );
+    for (const auto& trk : *trks)
+      REQUIRE_THAT(trk.getLength(), Catch::Matchers::WithinAbs(0, EPSILON));
   }
 
   SECTION("merge tracks from 2 collections") {
     // run algorithm
-    std::vector<gsl::not_null<const edm4eic::TrackSegmentCollection*>> colls = { collection0.get(), collection1.get() };
+    std::vector<gsl::not_null<const edm4eic::TrackSegmentCollection*>> colls = {collection0.get(),
+                                                                                collection1.get()};
     auto trks = std::make_unique<edm4eic::TrackSegmentCollection>();
     algo.process({colls}, {trks.get()});
     // input collection(s) size == output collection size
     REQUIRE(trks->size() == colls.front()->size());
     // track length: from endpoints
-    REQUIRE_THAT( track_length(trks->at(0)), Catch::Matchers::WithinAbs(3, EPSILON) );
-    REQUIRE_THAT( track_length(trks->at(1)), Catch::Matchers::WithinAbs(1, EPSILON) );
-    REQUIRE_THAT( track_length(trks->at(2)), Catch::Matchers::WithinAbs(std::hypot(1,1), EPSILON) );
-    REQUIRE_THAT( track_length(trks->at(3)), Catch::Matchers::WithinAbs(4, EPSILON) );
+    REQUIRE_THAT(track_length(trks->at(0)), Catch::Matchers::WithinAbs(3, EPSILON));
+    REQUIRE_THAT(track_length(trks->at(1)), Catch::Matchers::WithinAbs(1, EPSILON));
+    REQUIRE_THAT(track_length(trks->at(2)), Catch::Matchers::WithinAbs(std::hypot(1, 1), EPSILON));
+    REQUIRE_THAT(track_length(trks->at(3)), Catch::Matchers::WithinAbs(4, EPSILON));
     // track length: from algorithm // FIXME when implemented in `MergeTracks`
-    for(const auto& trk : *trks)
-      REQUIRE_THAT( trk.getLength(), Catch::Matchers::WithinAbs(0, EPSILON) );
+    for (const auto& trk : *trks)
+      REQUIRE_THAT(trk.getLength(), Catch::Matchers::WithinAbs(0, EPSILON));
   }
 
   SECTION("merge tracks from 3 collections") {
     // run algorithm
-    std::vector<gsl::not_null<const edm4eic::TrackSegmentCollection*>> colls = { collection0.get(), collection1.get(), collection2.get() };
+    std::vector<gsl::not_null<const edm4eic::TrackSegmentCollection*>> colls = {
+        collection0.get(), collection1.get(), collection2.get()};
     auto trks = std::make_unique<edm4eic::TrackSegmentCollection>();
     algo.process({colls}, {trks.get()});
     // input collection(s) size == output collection size
     REQUIRE(trks->size() == colls.front()->size());
     // track length: from endpoints
-    REQUIRE_THAT( track_length(trks->at(0)), Catch::Matchers::WithinAbs(5, EPSILON) );
-    REQUIRE_THAT( track_length(trks->at(1)), Catch::Matchers::WithinAbs(2, EPSILON) );
-    REQUIRE_THAT( track_length(trks->at(2)), Catch::Matchers::WithinAbs(std::hypot(1,2), EPSILON) );
-    REQUIRE_THAT( track_length(trks->at(3)), Catch::Matchers::WithinAbs(5, EPSILON) );
+    REQUIRE_THAT(track_length(trks->at(0)), Catch::Matchers::WithinAbs(5, EPSILON));
+    REQUIRE_THAT(track_length(trks->at(1)), Catch::Matchers::WithinAbs(2, EPSILON));
+    REQUIRE_THAT(track_length(trks->at(2)), Catch::Matchers::WithinAbs(std::hypot(1, 2), EPSILON));
+    REQUIRE_THAT(track_length(trks->at(3)), Catch::Matchers::WithinAbs(5, EPSILON));
     // track length: from algorithm // FIXME when implemented in `MergeTracks`
-    for(const auto& trk : *trks)
-      REQUIRE_THAT( trk.getLength(), Catch::Matchers::WithinAbs(0, EPSILON) );
+    for (const auto& trk : *trks)
+      REQUIRE_THAT(trk.getLength(), Catch::Matchers::WithinAbs(0, EPSILON));
   }
-
 }

--- a/src/tests/algorithms_test/tracking_SiliconSimpleCluster.cc
+++ b/src/tests/algorithms_test/tracking_SiliconSimpleCluster.cc
@@ -24,9 +24,6 @@
 TEST_CASE( "the clustering algorithm runs", "[FarDetectorTrackerCluster]" ) {
   eicrecon::FarDetectorTrackerCluster algo("FarDetectorTrackerCluster");
 
-  std::shared_ptr<spdlog::logger> logger = spdlog::default_logger()->clone("FarDetectorTrackerCluster");
-  logger->set_level(spdlog::level::trace);
-
   eicrecon::FarDetectorTrackerClusterConfig cfg;
   cfg.hit_time_limit = 10.0 * edm4eic::unit::ns;
   cfg.readout    = "MockTrackerHits";
@@ -37,7 +34,8 @@ TEST_CASE( "the clustering algorithm runs", "[FarDetectorTrackerCluster]" ) {
   auto id_desc = detector->readout(cfg.readout).idSpec();
 
   algo.applyConfig(cfg);
-  algo.init(logger);
+  algo.level(algorithms::LogLevel::kTrace);
+  algo.init();
 
   SECTION( "on a single pixel" ) {
     edm4eic::RawTrackerHitCollection hits_coll;

--- a/src/tests/algorithms_test/tracking_SiliconSimpleCluster.cc
+++ b/src/tests/algorithms_test/tracking_SiliconSimpleCluster.cc
@@ -5,158 +5,143 @@
 #include <DD4hep/IDDescriptor.h>
 #include <DD4hep/Readout.h>
 #include <algorithms/geo.h>
+#include <algorithms/logger.h>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 #include <edm4eic/RawTrackerHitCollection.h>
 #include <edm4eic/unit_system.h>
-#include <podio/ObjectID.h>
-#include <spdlog/common.h>
-#include <spdlog/logger.h>
-#include <spdlog/spdlog.h>
 #include <gsl/pointers>
-#include <memory>
+#include <podio/ObjectID.h>
 #include <utility>
 #include <vector>
 
 #include "algorithms/fardetectors/FarDetectorTrackerCluster.h"
 #include "algorithms/fardetectors/FarDetectorTrackerClusterConfig.h"
 
-TEST_CASE( "the clustering algorithm runs", "[FarDetectorTrackerCluster]" ) {
+TEST_CASE("the clustering algorithm runs", "[FarDetectorTrackerCluster]") {
   eicrecon::FarDetectorTrackerCluster algo("FarDetectorTrackerCluster");
 
   eicrecon::FarDetectorTrackerClusterConfig cfg;
   cfg.hit_time_limit = 10.0 * edm4eic::unit::ns;
-  cfg.readout    = "MockTrackerHits";
-  cfg.x_field    = "x";
-  cfg.y_field    = "y";
+  cfg.readout        = "MockTrackerHits";
+  cfg.x_field        = "x";
+  cfg.y_field        = "y";
 
   auto detector = algorithms::GeoSvc::instance().detector();
-  auto id_desc = detector->readout(cfg.readout).idSpec();
+  auto id_desc  = detector->readout(cfg.readout).idSpec();
 
   algo.applyConfig(cfg);
   algo.level(algorithms::LogLevel::kTrace);
   algo.init();
 
-  SECTION( "on a single pixel" ) {
+  SECTION("on a single pixel") {
     edm4eic::RawTrackerHitCollection hits_coll;
-    hits_coll.create(
-      id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
-      5.0, // int32 charge,
-      0.0  // int32 timeStamp
+    hits_coll.create(id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
+                     5.0,                                                   // int32 charge,
+                     0.0                                                    // int32 timeStamp
     );
 
     std::vector<FDTrackerCluster> clusterPositions = algo.ClusterHits(hits_coll);
 
-    REQUIRE( clusterPositions.size() == 1 );
-    REQUIRE( clusterPositions[0].rawHits.size() == 1 );
-    REQUIRE( clusterPositions[0].x == 0.0 );
-    REQUIRE( clusterPositions[0].y == 0.0 );
-    REQUIRE( clusterPositions[0].energy == 5.0 );
-    REQUIRE( clusterPositions[0].time == 0.0 );
+    REQUIRE(clusterPositions.size() == 1);
+    REQUIRE(clusterPositions[0].rawHits.size() == 1);
+    REQUIRE(clusterPositions[0].x == 0.0);
+    REQUIRE(clusterPositions[0].y == 0.0);
+    REQUIRE(clusterPositions[0].energy == 5.0);
+    REQUIRE(clusterPositions[0].time == 0.0);
   }
 
-  SECTION( "on two separated pixels" ) {
+  SECTION("on two separated pixels") {
     edm4eic::RawTrackerHitCollection hits_coll;
     hits_coll.create(
-      id_desc.encode({{"system", 255}, {"x", 0}, {"y", 10}}), // std::uint64_t cellID,
-      5.0, // int32 charge,
-      5.0  // int32 timeStamp
+        id_desc.encode({{"system", 255}, {"x", 0}, {"y", 10}}), // std::uint64_t cellID,
+        5.0,                                                    // int32 charge,
+        5.0                                                     // int32 timeStamp
     );
     hits_coll.create(
-      id_desc.encode({{"system", 255}, {"x", 10}, {"y", 0}}), // std::uint64_t cellID,
-      5.0, // int32 charge,
-      5.0  // int32 timeStamp
+        id_desc.encode({{"system", 255}, {"x", 10}, {"y", 0}}), // std::uint64_t cellID,
+        5.0,                                                    // int32 charge,
+        5.0                                                     // int32 timeStamp
     );
 
     std::vector<FDTrackerCluster> clusterPositions = algo.ClusterHits(hits_coll);
 
-    REQUIRE( clusterPositions.size() == 2 );
-    REQUIRE( clusterPositions[0].rawHits.size() == 1 );
-    REQUIRE( clusterPositions[1].rawHits.size() == 1 );
+    REQUIRE(clusterPositions.size() == 2);
+    REQUIRE(clusterPositions[0].rawHits.size() == 1);
+    REQUIRE(clusterPositions[1].rawHits.size() == 1);
   }
 
-  SECTION( "on two adjacent pixels" ) {
+  SECTION("on two adjacent pixels") {
     edm4eic::RawTrackerHitCollection hits_coll;
-    hits_coll.create(
-      id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
-      5.0, // int32 charge,
-      5.0 // int32 timeStamp
+    hits_coll.create(id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
+                     5.0,                                                   // int32 charge,
+                     5.0                                                    // int32 timeStamp
     );
-    hits_coll.create(
-      id_desc.encode({{"system", 255}, {"x", 1}, {"y", 0}}), // std::uint64_t cellID,
-      5.0, // int32 charge,
-      5.0 // int32 timeStamp
+    hits_coll.create(id_desc.encode({{"system", 255}, {"x", 1}, {"y", 0}}), // std::uint64_t cellID,
+                     5.0,                                                   // int32 charge,
+                     5.0                                                    // int32 timeStamp
     );
 
     std::vector<FDTrackerCluster> clusterPositions = algo.ClusterHits(hits_coll);
 
-    REQUIRE( clusterPositions.size() == 1 );
-    REQUIRE( clusterPositions[0].rawHits.size() == 2 );
-    REQUIRE( clusterPositions[0].x == 0.5 );
-
+    REQUIRE(clusterPositions.size() == 1);
+    REQUIRE(clusterPositions[0].rawHits.size() == 2);
+    REQUIRE(clusterPositions[0].x == 0.5);
   }
 
-  SECTION( "on two adjacent pixels outwith the time separation" ) {
+  SECTION("on two adjacent pixels outwith the time separation") {
     edm4eic::RawTrackerHitCollection hits_coll;
-    hits_coll.create(
-      id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
-      5.0, // int32 charge,
-      0.0 // int32 timeStamp
+    hits_coll.create(id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
+                     5.0,                                                   // int32 charge,
+                     0.0                                                    // int32 timeStamp
     );
-    hits_coll.create(
-      id_desc.encode({{"system", 255}, {"x", 1}, {"y", 0}}), // std::uint64_t cellID,
-      5.0, // int32 charge,
-      1.1 * cfg.hit_time_limit // int32 timeStamp
+    hits_coll.create(id_desc.encode({{"system", 255}, {"x", 1}, {"y", 0}}), // std::uint64_t cellID,
+                     5.0,                                                   // int32 charge,
+                     1.1 * cfg.hit_time_limit                               // int32 timeStamp
     );
 
     std::vector<FDTrackerCluster> clusterPositions = algo.ClusterHits(hits_coll);
 
-    REQUIRE( clusterPositions.size() == 2 );
-    REQUIRE( clusterPositions[0].rawHits.size() == 1 );
-    REQUIRE( clusterPositions[1].rawHits.size() == 1 );
+    REQUIRE(clusterPositions.size() == 2);
+    REQUIRE(clusterPositions[0].rawHits.size() == 1);
+    REQUIRE(clusterPositions[1].rawHits.size() == 1);
   }
 
-
-  SECTION( "run on three adjacent pixels" ) {
+  SECTION("run on three adjacent pixels") {
 
     // Check I and L shape clusters
-    auto pixel3       = GENERATE(std::vector<int>{2,0}, std::vector<int>{1,1});
-    auto pixelCharges = GENERATE(std::vector<int>{5,10,5}, std::vector<int>{10,5,5});
-    float pixel2Time    = GENERATE_COPY(0, 1.1 * cfg.hit_time_limit);
+    auto pixel3       = GENERATE(std::vector<int>{2, 0}, std::vector<int>{1, 1});
+    auto pixelCharges = GENERATE(std::vector<int>{5, 10, 5}, std::vector<int>{10, 5, 5});
+    float pixel2Time  = GENERATE_COPY(0, 1.1 * cfg.hit_time_limit);
 
     edm4eic::RawTrackerHitCollection hits_coll;
-    hits_coll.create(
-      id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
-      pixelCharges[0], // int32 charge,
-      0.0 // int32 timeStamp
+    hits_coll.create(id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
+                     pixelCharges[0],                                       // int32 charge,
+                     0.0                                                    // int32 timeStamp
+    );
+    hits_coll.create(id_desc.encode({{"system", 255}, {"x", 1}, {"y", 0}}), // std::uint64_t cellID,
+                     pixelCharges[1],                                       // int32 charge,
+                     pixel2Time                                             // int32 timeStamp
     );
     hits_coll.create(
-      id_desc.encode({{"system", 255}, {"x", 1}, {"y", 0}}), // std::uint64_t cellID,
-      pixelCharges[1], // int32 charge,
-      pixel2Time // int32 timeStamp
-    );
-    hits_coll.create(
-      id_desc.encode({{"system", 255}, {"x", pixel3[0]}, {"y", pixel3[1]}}), // std::uint64_t cellID,
-      pixelCharges[2], // int32 charge,
-      0.0 // int32 timeStamp
+        id_desc.encode(
+            {{"system", 255}, {"x", pixel3[0]}, {"y", pixel3[1]}}), // std::uint64_t cellID,
+        pixelCharges[2],                                            // int32 charge,
+        0.0                                                         // int32 timeStamp
     );
 
     std::vector<FDTrackerCluster> clusterPositions = algo.ClusterHits(hits_coll);
 
-    if(pixel2Time < cfg.hit_time_limit) {
-      REQUIRE( clusterPositions.size() == 1 );
-      REQUIRE( clusterPositions[0].rawHits.size() == 3 );
+    if (pixel2Time < cfg.hit_time_limit) {
+      REQUIRE(clusterPositions.size() == 1);
+      REQUIRE(clusterPositions[0].rawHits.size() == 3);
+    } else if (pixel3[0] == 2) {
+      REQUIRE(clusterPositions.size() == 3);
+      REQUIRE(clusterPositions[0].rawHits.size() == 1);
+      REQUIRE(clusterPositions[1].rawHits.size() == 1);
+      REQUIRE(clusterPositions[2].rawHits.size() == 1);
+    } else {
+      REQUIRE(clusterPositions.size() == 2);
     }
-    else if(pixel3[0] == 2){
-      REQUIRE( clusterPositions.size() == 3 );
-      REQUIRE( clusterPositions[0].rawHits.size() == 1 );
-      REQUIRE( clusterPositions[1].rawHits.size() == 1 );
-      REQUIRE( clusterPositions[2].rawHits.size() == 1 );
-    }
-    else {
-      REQUIRE( clusterPositions.size() == 2 );
-    }
-
-
   }
 }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR moves a lot of algorithms and factories over to using the internal logger functionality that comes with the algorithms interface. It means that individual algorithms don't need to initialize their own `m_log`. It also means that these algorithms are now properly conformant to the algorithms interface, i.e. `init()` and `process(input, output) const`.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.