### PR TITLE
fix: use correct EDM headers in TruthEnergyPositionClusterMerger

### DIFF
--- a/src/algorithms/calorimetry/TruthEnergyPositionClusterMerger.h
+++ b/src/algorithms/calorimetry/TruthEnergyPositionClusterMerger.h
@@ -8,6 +8,7 @@
 #include <spdlog/spdlog.h>
 
 // Event Model related classes
+#include <DD4hep/DD4hepUnits.h>
 #include <edm4eic/ClusterCollection.h>
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <edm4hep/MCParticleCollection.h>

--- a/src/algorithms/calorimetry/TruthEnergyPositionClusterMerger.h
+++ b/src/algorithms/calorimetry/TruthEnergyPositionClusterMerger.h
@@ -8,9 +8,9 @@
 #include <spdlog/spdlog.h>
 
 // Event Model related classes
-#include <edm4hep/MCParticle.h>
-#include <edm4eic/Cluster.h>
-#include <edm4eic/MCRecoClusterParticleAssociation.h>
+#include <edm4eic/ClusterCollection.h>
+#include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
+#include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/utils/vector_utils.h>
 
 #include "algorithms/interfaces/WithPodConfig.h"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR ensures that we are including collection headers in TruthEnergyPositionClusterMerger, not just data type headers.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.