### PR TITLE
fixed LFHCAL adjacency matrix

### DIFF
--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -186,7 +186,7 @@ extern "C" {
         // Magic constants:
         //  54 - number of modules in a row/column
         //  2  - number of towers in a module
-	// sign for towerx and towery now *negative*, needed to restore linearity with global X and Y (PAS)
+        // sign for towerx and towery now *negative*, needed to restore linearity with global X and Y (PAS)
         std::string cellIdx_1  = "(54*2-moduleIDx_1*2-towerx_1)";
         std::string cellIdx_2  = "(54*2-moduleIDx_2*2-towerx_2)";
         std::string cellIdy_1  = "(54*2-moduleIDy_1*2-towery_1)";

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -186,10 +186,11 @@ extern "C" {
         // Magic constants:
         //  54 - number of modules in a row/column
         //  2  - number of towers in a module
-        std::string cellIdx_1  = "(54*2-moduleIDx_1*2+towerx_1)";
-        std::string cellIdx_2  = "(54*2-moduleIDx_2*2+towerx_2)";
-        std::string cellIdy_1  = "(54*2-moduleIDy_1*2+towery_1)";
-        std::string cellIdy_2  = "(54*2-moduleIDy_2*2+towery_2)";
+	// sign for towerx and towery now *negative*, needed to restore linearity with global X and Y (PAS)
+        std::string cellIdx_1  = "(54*2-moduleIDx_1*2-towerx_1)";
+        std::string cellIdx_2  = "(54*2-moduleIDx_2*2-towerx_2)";
+        std::string cellIdy_1  = "(54*2-moduleIDy_1*2-towery_1)";
+        std::string cellIdy_2  = "(54*2-moduleIDy_2*2-towery_2)";
         std::string cellIdz_1  = "rlayerz_1";
         std::string cellIdz_2  = "rlayerz_2";
         std::string deltaX     = Form("abs(%s-%s)", cellIdx_2.data(), cellIdx_1.data());

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -186,7 +186,7 @@ extern "C" {
         // Magic constants:
         //  54 - number of modules in a row/column
         //  2  - number of towers in a module
-        // sign for towerx and towery now *negative*, needed to restore linearity with global X and Y (PAS)
+        // sign for towerx and towery now *negative*, needed to restore linearity with global X and Y
         std::string cellIdx_1  = "(54*2-moduleIDx_1*2-towerx_1)";
         std::string cellIdx_2  = "(54*2-moduleIDx_2*2-towerx_2)";
         std::string cellIdy_1  = "(54*2-moduleIDy_1*2-towery_1)";


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Fix to LFHCAL adjacency matrix, which was splitting essentially all clusters before, due to a sign flip in the local towerx,y convention

### What kind of change does this PR introduce?
- [X] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [X] Documentation has been added / updated - brief comment in code
- [X] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No changes needed - rather people should see better LFHCAL clustering behavior
### Does this PR change default behavior?
Yes, since it avoids splitting clusters in the LFHCAL
