### PR TITLE
fix(ci): use correct detector-info hash

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -313,7 +313,7 @@ jobs:
     - name: Get detector info
       id: detector-info
       run: |
-        info=/cvmfs/singularity.opensciencegrid.org/eicweb/${{ env.platform }}:${{ env.release }}/etc/jug_info
+        file=/cvmfs/singularity.opensciencegrid.org/eicweb/${{ env.platform }}:${{ env.release }}/etc/jug_info
         test -f ${file}
         grep ' epic@' ${file}
         hash=$(grep ' epic@' ${file} | sha256sum)

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -304,24 +304,37 @@ jobs:
         name: codecov_report
         path: build/codecov_report/
 
+  detector-info:
+    runs-on: ubuntu-latest
+    outputs:
+      hash: ${{ steps.detector-info.outputs.hash }}
+    steps:
+    - uses: cvmfs-contrib/github-action-cvmfs@v4
+    - name: Get detector info
+      id: detector-info
+      run: |
+        info=/cvmfs/singularity.opensciencegrid.org/eicweb/${{ env.platform }}:${{ env.release }}/etc/jug_info
+        test -f ${file}
+        grep ' epic@' ${file}
+        hash=$(grep ' epic@' ${file} | sha256sum)
+        echo "hash=${hash%% *}" | tee $GITHUB_OUTPUT
+
   npsim-gun:
     runs-on: ubuntu-latest
+    needs:
+    - detector-info
     strategy:
       matrix:
         particle: [pi, e]
         detector_config: [craterlake]
     steps:
     - uses: cvmfs-contrib/github-action-cvmfs@v4
-    - name: Get detector info
-      id: detector_info
-      run: |
-        grep epic/nightly /cvmfs/singularity.opensciencegrid.org/eicweb/jug_xl\:nightly/etc/jug_info | sed 's/.*: .*-\(.*\)/hash=\1/g' >> $GITHUB_OUTPUT
     - name: Retrieve simulation files
       id: retrieve_simulation_files
       uses: actions/cache@v4
       with:
         path: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
-        key: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root-${{ steps.detector_info.outputs.hash }}
+        key: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root-${{ needs.detector-info.outputs.hash }}
     - name: Produce simulation files
       uses: eic/run-cvmfs-osg-eic-shell@main
       if: steps.retrieve_simulation_files.outputs.cache-hit != 'true'
@@ -338,6 +351,8 @@ jobs:
 
   npsim-gun-EcalLumiSpec:
     runs-on: ubuntu-latest
+    needs:
+    - detector-info
     strategy:
       matrix:
         particle: [e]
@@ -347,16 +362,12 @@ jobs:
       with:
         filter: "tree:0"
     - uses: cvmfs-contrib/github-action-cvmfs@v4
-    - name: Get detector info
-      id: detector_info
-      run: |
-        grep epic/nightly /cvmfs/singularity.opensciencegrid.org/eicweb/jug_xl\:nightly/etc/jug_info | sed 's/.*: .*-\(.*\)/hash=\1/g' >> $GITHUB_OUTPUT
     - name: Retrieve simulation files
       id: retrieve_simulation_files
       uses: actions/cache@v4
       with:
         path: sim_${{ matrix.particle }}_EcalLumiSpec_${{ matrix.detector_config }}.edm4hep.root
-        key: sim_${{ matrix.particle }}_EcalLumiSpec_${{ matrix.detector_config }}.edm4hep.root-${{ steps.detector_info.outputs.hash }}
+        key: sim_${{ matrix.particle }}_EcalLumiSpec_${{ matrix.detector_config }}.edm4hep.root-${{ needs.detector-info.outputs.hash }}
     - name: Produce simulation files
       uses: eic/run-cvmfs-osg-eic-shell@main
       if: steps.retrieve_simulation_files.outputs.cache-hit != 'true'
@@ -374,6 +385,8 @@ jobs:
 
   npsim-dis:
     runs-on: ubuntu-latest
+    needs:
+    - detector-info
     strategy:
       matrix:
         beam: [10x100, 18x275]
@@ -381,16 +394,12 @@ jobs:
         detector_config: [craterlake]
     steps:
     - uses: cvmfs-contrib/github-action-cvmfs@v4
-    - name: Get detector info
-      id: detector_info
-      run: |
-        grep epic/nightly /cvmfs/singularity.opensciencegrid.org/eicweb/jug_xl\:nightly/etc/jug_info | sed 's/.*: .*-\(.*\)/hash=\1/g' >> $GITHUB_OUTPUT
     - name: Retrieve simulation files
       id: retrieve_simulation_files
       uses: actions/cache@v4
       with:
         path: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
-        key: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root-${{ steps.detector_info.outputs.hash }}
+        key: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root-${{ needs.detector-info.outputs.hash }}
     - name: Produce simulation files
       uses: eic/run-cvmfs-osg-eic-shell@main
       if: steps.retrieve_simulation_files.outputs.cache-hit != 'true'
@@ -408,22 +417,20 @@ jobs:
 
   npsim-minbias:
     runs-on: ubuntu-latest
+    needs:
+    - detector-info
     strategy:
       matrix:
         beam: [5x41, 10x100, 18x275]
         detector_config: [craterlake]
     steps:
     - uses: cvmfs-contrib/github-action-cvmfs@v4
-    - name: Get detector info
-      id: detector_info
-      run: |
-        grep epic/nightly /cvmfs/singularity.opensciencegrid.org/eicweb/jug_xl\:nightly/etc/jug_info | sed 's/.*: .*-\(.*\)/hash=\1/g' >> $GITHUB_OUTPUT
     - name: Retrieve simulation files
       id: retrieve_simulation_files
       uses: actions/cache@v4
       with:
         path: sim_dis_${{matrix.beam}}_minQ2=0_${{ matrix.detector_config }}.edm4hep.root
-        key: sim_dis_${{matrix.beam}}_minQ2=0_${{ matrix.detector_config }}.edm4hep.root-${{ steps.detector_info.outputs.hash }}
+        key: sim_dis_${{matrix.beam}}_minQ2=0_${{ matrix.detector_config }}.edm4hep.root-${{ needs.detector-info.outputs.hash }}
     - name: Produce simulation files
       uses: eic/run-cvmfs-osg-eic-shell@main
       if: steps.retrieve_simulation_files.outputs.cache-hit != 'true'


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes how we determine the detector hash that tells us when we have to rerun the npsim part of the pipeline to make sure our simulation and reconstruction are using the same geometry.

Due to changes in the containers (epic now in spack), the previous approach returns nothing for any geometry
```console
grep epic/nightly /cvmfs/singularity.opensciencegrid.org/eicweb/jug_xl\:nightly/etc/jug_info | sed 's/.*: .*-\(.*\)/hash=\1/g'
```

The new approach takes the hash of, e.g.
```console
$ grep ' epic@' /cvmfs/singularity.opensciencegrid.org/eicweb/jug_xl:nightly/etc/jug_info
 - [+] gqyaoru epic@23.10.0
 - [+] l6jmpez epic@23.11.0
 - [+] m4h7dpf epic@23.12.0
 - [+] malsskd epic@24.02.0
 - [+] ey2eyus epic@24.02.1
 - [+] wtzurj6 epic@24.03.0
 - [+] 3bqnqno epic@24.03.1
 - [+] ybvec7w epic@24.04.0
 - [+] nterp3c epic@24.05.0
 - [+] t6777ht epic@24.05.2
 - [+] u6ap7qw epic@git.8c40e0ba534f9c3bd7cac3bfcbb46c785b368643=main
 - gqyaoru epic@23.10.0~ipo artifacts=epic_craterlake build_system=cmake build_type=Release generator=make
 - l6jmpez epic@23.11.0~ipo artifacts=epic_craterlake build_system=cmake build_type=Release generator=make
 - m4h7dpf epic@23.12.0~ipo artifacts=epic_craterlake build_system=cmake build_type=Release generator=make
 - malsskd epic@24.02.0~ipo artifacts=epic_craterlake build_system=cmake build_type=Release generator=make
 - ey2eyus epic@24.02.1~ipo artifacts=epic_craterlake build_system=cmake build_type=Release generator=make
 - wtzurj6 epic@24.03.0~ipo artifacts=epic_craterlake build_system=cmake build_type=Release generator=make
 - 3bqnqno epic@24.03.1~ipo artifacts=epic_craterlake build_system=cmake build_type=Release generator=make
 - ybvec7w epic@24.04.0~ipo artifacts=epic_craterlake build_system=cmake build_type=Release generator=make
 - nterp3c epic@24.05.0~ipo artifacts=epic_craterlake build_system=cmake build_type=Release generator=make
 - t6777ht epic@24.05.2~ipo artifacts=epic_craterlake build_system=cmake build_type=Release generator=make
 - u6ap7qw epic@git.8c40e0ba534f9c3bd7cac3bfcbb46c785b368643=main~ipo artifacts=epic_craterlake build_system=cmake build_type=Release generator=make
```

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.