### PR TITLE
Inject Low-Q2 electrons into tracking

### DIFF
--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -251,6 +251,14 @@ void InitPlugin(JApplication *app) {
             app
             ));
 
+     // Add central and other tracks
+    app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track>>(
+            "CombinedTracks",
+            {"CentralCKFTracks", "TaggerTrackerTracks"},
+            {"CombinedTracks"},
+            app
+            ));
+
      // linking of reconstructed particles to PID objects
      TracksToParticlesConfig link_cfg {
        .momentumRelativeTolerance = 100.0, /// Matching momentum effectively disabled
@@ -261,7 +269,7 @@ void InitPlugin(JApplication *app) {
      app->Add(new JOmniFactoryGeneratorT<TracksToParticles_factory>(
              "ChargedParticlesWithAssociations",
              {"MCParticles",                                    // edm4hep::MCParticle
-             "CentralCKFTracks",                                // edm4eic::Track
+             "CombinedTracks",                                // edm4eic::Track
              },
              {"ReconstructedChargedWithoutPIDParticles",                  //
               "ReconstructedChargedWithoutPIDParticleAssociations"        // edm4eic::MCRecoParticleAssociation

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -3,8 +3,8 @@
 
 #include <DD4hep/Detector.h>
 #include <JANA/JApplication.h>
-#include <edm4eic/Track.h>
-#include <edm4eic/TrackerHit.h>
+#include <edm4eic/TrackCollection.h>
+#include <edm4eic/TrackerHitCollection.h>
 #include <algorithm>
 #include <gsl/pointers>
 #include <map>

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -3,6 +3,7 @@
 
 #include <DD4hep/Detector.h>
 #include <JANA/JApplication.h>
+#include <edm4eic/Track.h>
 #include <edm4eic/TrackerHit.h>
 #include <algorithm>
 #include <gsl/pointers>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Injects the LowQ2 tracks into the tracking workflow so they can finally be used like any other particle.

This might not be the best place to add the information from the events in the longer term as there will may be some extra looping over calorimeter and pid hits which aren't possible. At the moment though there isn't another easy place to add them while there is a mix of ReconstructedChargedParticles and ReconstructedParticles used in different places.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
Low-Q2 electrons should show up in ReconstructedParticle collections and easily identifiable in the InclusiveKinematics collections 