### PR TITLE
 Introduce MCBeamNeutron and MCBeamHadron Collections

### DIFF
--- a/src/global/beam/beam.cc
+++ b/src/global/beam/beam.cc
@@ -14,6 +14,7 @@
 #include "algorithms/meta/SubDivideFunctors.h"
 #include "extensions/jana/JOmniFactoryGeneratorT.h"
 #include "factories/meta/SubDivideCollection_factory.h"
+#include "factories/meta/CollectionCollector_factory.h"
 
 extern "C" {
   void InitPlugin(JApplication *app) {
@@ -22,8 +23,8 @@ extern "C" {
     using namespace eicrecon;
 
     // Divide MCParticle collection based on generator status and PDG
-    std::vector<std::string> outCollections{"MCBeamElectrons","MCBeamProtons","MCScatteredElectrons","MCScatteredProtons"};
-    std::vector<std::vector<int>> values{{4,11},{4,2212},{1,11},{1,2212}};
+    std::vector<std::string> outCollections{"MCBeamElectrons","MCBeamProtons","MCBeamNeutrons","MCScatteredElectrons","MCScatteredProtons","MCScatteredNeutrons"};
+    std::vector<std::vector<int>> values{{4,11},{4,2212},{4,2112},{1,11},{1,2212},{1,2112}};
 
     app->Add(new JOmniFactoryGeneratorT<SubDivideCollection_factory<edm4hep::MCParticle>>(
         "BeamParticles",
@@ -35,6 +36,15 @@ extern "C" {
         app
       )
     );
+
+    // Combine beam protons and neutrons into beam hadrons
+    app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4hep::MCParticle>>(
+        "MCBeamHadrons",
+        {"MCBeamProtons","MCBeamNeutrons"},
+        {"MCBeamHadrons"},
+        app
+      )
+    ); 
 
   }
 }

--- a/src/global/beam/beam.cc
+++ b/src/global/beam/beam.cc
@@ -5,16 +5,16 @@
 
 #include <JANA/JApplication.h>
 #include <edm4hep/MCParticleCollection.h>
-#include <algorithm>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
 #include "algorithms/interfaces/WithPodConfig.h"
 #include "algorithms/meta/SubDivideFunctors.h"
 #include "extensions/jana/JOmniFactoryGeneratorT.h"
-#include "factories/meta/SubDivideCollection_factory.h"
 #include "factories/meta/CollectionCollector_factory.h"
+#include "factories/meta/SubDivideCollection_factory.h"
 
 extern "C" {
   void InitPlugin(JApplication *app) {

--- a/src/global/beam/beam.cc
+++ b/src/global/beam/beam.cc
@@ -44,7 +44,7 @@ extern "C" {
         {"MCBeamHadrons"},
         app
       )
-    ); 
+    );
 
   }
 }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Adds MCBeamNeutron and MCBeamHadron collections. This matches the current use case in beam.h rather than only providing the protons.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No