### PR TITLE
Update FHCAL.cc: Tweak parameters of recon in Insert

### DIFF
--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -83,7 +83,7 @@ extern "C" {
         {
           .MIP = 800. * dd4hep::keV,
           .Emin_in_MIPs=0.1,
-          .tmax=50 * dd4hep::ns,
+          .tmax=150 * dd4hep::ns,
         },
         app   // TODO: Remove me once fixed
       ));
@@ -99,7 +99,7 @@ extern "C" {
               .minClusterHitEdep = 100.0 * dd4hep::keV,
               .minClusterCenterEdep = 11.0 * dd4hep::MeV,
               .minClusterEdep = 11.0 * dd4hep::MeV,
-              .minClusterNhits = 10,
+              .minClusterNhits = 100,
           },
           app   // TODO: Remove me once fixed
       ));


### PR DESCRIPTION
changed time cut in HEXPLIT algorithm to 150 ns and min number of (subcell) hits per protocluster in topo clustering to 100.

### Briefly, what does this PR introduce?
Tweaks some of the parameters in the reconstruction in the Insert.   The first of these loosens the timing cut for hits in the insert.  The second requires there to be more hits in a cluster candidate (since we're dealing with subcell hits instead of normal cell-level hits)

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [X] Other: parameter tweaking

### Please check if this PR fulfills the following:
- [X] Tests for the changes have been added
- [X] Documentation has been added / updated
- [X] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
yes.  