### PR TITLE
[Backport v1.14] Inject Low-Q2 electrons into tracking

### DIFF
--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -3,7 +3,8 @@
 
 #include <DD4hep/Detector.h>
 #include <JANA/JApplication.h>
-#include <edm4eic/TrackerHit.h>
+#include <edm4eic/TrackCollection.h>
+#include <edm4eic/TrackerHitCollection.h>
 #include <algorithm>
 #include <gsl/pointers>
 #include <map>
@@ -251,6 +252,14 @@ void InitPlugin(JApplication *app) {
             app
             ));
 
+     // Add central and other tracks
+    app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track>>(
+            "CombinedTracks",
+            {"CentralCKFTracks", "TaggerTrackerTracks"},
+            {"CombinedTracks"},
+            app
+            ));
+
      // linking of reconstructed particles to PID objects
      TracksToParticlesConfig link_cfg {
        .momentumRelativeTolerance = 100.0, /// Matching momentum effectively disabled
@@ -261,7 +270,7 @@ void InitPlugin(JApplication *app) {
      app->Add(new JOmniFactoryGeneratorT<TracksToParticles_factory>(
              "ChargedParticlesWithAssociations",
              {"MCParticles",                                    // edm4hep::MCParticle
-             "CentralCKFTracks",                                // edm4eic::Track
+             "CombinedTracks",                                // edm4eic::Track
              },
              {"ReconstructedChargedWithoutPIDParticles",                  //
               "ReconstructedChargedWithoutPIDParticleAssociations"        // edm4eic::MCRecoParticleAssociation


### PR DESCRIPTION
# Description
Backport of #1491 to `v1.14`.