### PR TITLE
Make TaggerTracker and/or central tracks optional

### DIFF
--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -253,12 +253,12 @@ void InitPlugin(JApplication *app) {
             ));
 
 
-    
+
     std::vector<std::string> input_track_collections;
     //Check size of input_collections to determine if CentralCKFTracks should be added to the input_track_collections
     if (input_collections.size() > 0) {
         input_track_collections.push_back("CentralCKFTracks");
-    }    
+    }
     //Check if the TaggerTracker readout is present in the current configuration
     if (readouts.find("TaggerTrackerHits") != readouts.end()) {
         input_track_collections.push_back("TaggerTrackerTracks");

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -252,10 +252,22 @@ void InitPlugin(JApplication *app) {
             app
             ));
 
-     // Add central and other tracks
+
+    
+    std::vector<std::string> input_track_collections;
+    //Check size of input_collections to determine if CentralCKFTracks should be added to the input_track_collections
+    if (input_collections.size() > 0) {
+        input_track_collections.push_back("CentralCKFTracks");
+    }    
+    //Check if the TaggerTracker readout is present in the current configuration
+    if (readouts.find("TaggerTrackerHits") != readouts.end()) {
+        input_track_collections.push_back("TaggerTrackerTracks");
+    }
+
+    // Add central and other tracks
     app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track>>(
             "CombinedTracks",
-            {"CentralCKFTracks", "TaggerTrackerTracks"},
+            input_track_collections,
             {"CombinedTracks"},
             app
             ));


### PR DESCRIPTION
This should restore the ability to write out tracks from the central detector while using an xml configuration which doesn't contain the far-backward detectors (and vise versa)