### PR TITLE
CalorimeterClusterRecoCoG: set intrinsic{Phi,Theta}

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -324,17 +324,14 @@ std::optional<edm4eic::MutableCluster> CalorimeterClusterRecoCoG::reconstruct(co
   cl.addToShapeParameters( eigenValues_3D[1].real() ); // 3D x-y-z cluster width 2
   cl.addToShapeParameters( eigenValues_3D[2].real() ); // 3D x-y-z cluster width 3
 
-  if (axis_z != 0) {
+  if (m_cfg.longitudinalShowerInfoAvailable) {
     cl.setIntrinsicPhi(atan2(axis_y, axis_x));
     cl.setIntrinsicTheta(atan2(std::hypot(axis_x, axis_y), axis_z));
+    // TODO intrinsicDirectionError
   } else {
-    // best estimate on the cluster direction is the cluster position
-    // for simple 2D CoG clustering
-    cl.setIntrinsicTheta(edm4hep::utils::anglePolar(cl.getPosition()));
-    cl.setIntrinsicPhi(edm4hep::utils::angleAzimuthal(cl.getPosition()));
+    cl.setIntrinsicTheta(NAN);
+    cl.setIntrinsicPhi(NAN);
   }
-  // TODO intrinsicDirectionError
-
 
   return std::move(cl);
 }

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -326,7 +326,7 @@ std::optional<edm4eic::MutableCluster> CalorimeterClusterRecoCoG::reconstruct(co
 
   if (axis_z != 0) {
     cl.setIntrinsicPhi(atan2(axis_y, axis_x));
-    cl.setIntrinsicTheta(atan2(std::hypot(axis_x, axis_y), axis_z);
+    cl.setIntrinsicTheta(atan2(std::hypot(axis_x, axis_y), axis_z));
   } else {
     // best estimate on the cluster direction is the cluster position
     // for simple 2D CoG clustering

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -228,12 +228,6 @@ std::optional<edm4eic::MutableCluster> CalorimeterClusterRecoCoG::reconstruct(co
 
   // Additional convenience variables
 
-  // best estimate on the cluster direction is the cluster position
-  // for simple 2D CoG clustering
-  cl.setIntrinsicTheta(edm4hep::utils::anglePolar(cl.getPosition()));
-  cl.setIntrinsicPhi(edm4hep::utils::angleAzimuthal(cl.getPosition()));
-  // TODO errors
-
   //_______________________________________
   // Calculate cluster profile:
   //    radius,
@@ -329,10 +323,19 @@ std::optional<edm4eic::MutableCluster> CalorimeterClusterRecoCoG::reconstruct(co
   cl.addToShapeParameters( eigenValues_3D[0].real() ); // 3D x-y-z cluster width 1
   cl.addToShapeParameters( eigenValues_3D[1].real() ); // 3D x-y-z cluster width 2
   cl.addToShapeParameters( eigenValues_3D[2].real() ); // 3D x-y-z cluster width 3
-  //last 3 shape parameters are the components of the axis direction
-  cl.addToShapeParameters( axis_x );
-  cl.addToShapeParameters( axis_y );
-  cl.addToShapeParameters( axis_z );
+
+  if (axis_z != 0) {
+    cl.setIntrinsicPhi(atan2(axis_y, axis_x));
+    cl.setIntrinsicTheta(atan2(std::hypot(axis_x, axis_y), axis_z);
+  } else {
+    // best estimate on the cluster direction is the cluster position
+    // for simple 2D CoG clustering
+    cl.setIntrinsicTheta(edm4hep::utils::anglePolar(cl.getPosition()));
+    cl.setIntrinsicPhi(edm4hep::utils::angleAzimuthal(cl.getPosition()));
+  }
+  // TODO intrinsicDirectionError
+
+
   return std::move(cl);
 }
 

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoGConfig.h
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoGConfig.h
@@ -23,6 +23,8 @@ namespace eicrecon {
         std::vector<double> logWeightBaseCoeffs{};
         double logWeightBase_Eref = 50 * dd4hep::MeV;
 
+        bool longitudinalShowerInfoAvailable = false;
+
         // Constrain the cluster position eta to be within
         // the eta of the contributing hits. This is useful to avoid edge effects
         // for endcaps.

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -97,6 +97,7 @@ extern "C" {
                .energyWeight = "log",
                .sampFrac = 1.0,
                .logWeightBase = 6.2,
+               .longitudinalShowerInfoAvailable = true,
                .enableEtaBounds = false
              },
             app   // TODO: Remove me once fixed

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -117,6 +117,7 @@ extern "C" {
               .energyWeight = "log",
               .sampFrac = 0.0257,
               .logWeightBase = 3.6,
+              .longitudinalShowerInfoAvailable = true,
               .enableEtaBounds = true
             },
             app   // TODO: Remove me once fixed
@@ -134,6 +135,7 @@ extern "C" {
               .energyWeight = "log",
               .sampFrac = 0.0257,
               .logWeightBase = 6.2,
+              .longitudinalShowerInfoAvailable = true,
               .enableEtaBounds = false,
             },
             app   // TODO: Remove me once fixed
@@ -230,6 +232,7 @@ extern "C" {
               .energyWeight = "log",
               .sampFrac = 1.0,
               .logWeightBase = 4.5,
+              .longitudinalShowerInfoAvailable = true,
               .enableEtaBounds = false
             },
             app   // TODO: Remove me once fixed
@@ -247,6 +250,7 @@ extern "C" {
               .energyWeight = "log",
               .sampFrac = 1.0,
               .logWeightBase = 4.5,
+              .longitudinalShowerInfoAvailable = true,
               .enableEtaBounds = false,
             },
             app   // TODO: Remove me once fixed

--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -85,6 +85,7 @@ extern "C" {
               .energyWeight = "log",
               .sampFrac = 0.701,
               .logWeightBase = 3.6,
+              .longitudinalShowerInfoAvailable = true,
               .enableEtaBounds = false
             },
             app   // TODO: Remove me once fixed
@@ -102,6 +103,7 @@ extern "C" {
               .energyWeight = "log",
               .sampFrac = 0.701,
               .logWeightBase = 6.2,
+              .longitudinalShowerInfoAvailable = true,
               .enableEtaBounds = false,
             },
             app   // TODO: Remove me once fixed
@@ -193,6 +195,7 @@ extern "C" {
             .sampFrac = 0.0203,
             .logWeightBaseCoeffs={5.0,0.65,0.31},
             .logWeightBase_Eref=50*dd4hep::GeV,
+            .longitudinalShowerInfoAvailable = true,
           },
           app   // TODO: Remove me once fixed
         ));
@@ -228,6 +231,7 @@ extern "C" {
               .energyWeight = "log",
               .sampFrac = 1.0,
               .logWeightBase = 3.6,
+              .longitudinalShowerInfoAvailable = true,
               .enableEtaBounds = false
             },
             app   // TODO: Remove me once fixed
@@ -244,6 +248,7 @@ extern "C" {
               .energyWeight = "log",
               .sampFrac = 0.0203,
               .logWeightBase = 6.2,
+              .longitudinalShowerInfoAvailable = true,
               .enableEtaBounds = false,
             },
             app   // TODO: Remove me once fixed

--- a/src/factories/calorimetry/CalorimeterClusterRecoCoG_factory.h
+++ b/src/factories/calorimetry/CalorimeterClusterRecoCoG_factory.h
@@ -29,6 +29,7 @@ private:
     ParameterRef<double> m_logWeightBase {this, "logWeightBase", config().logWeightBase};
     ParameterRef<std::vector<double>> m_logWeightBaseCoeffs {this, "logWeightBaseCoeffs", config().logWeightBaseCoeffs};
     ParameterRef<double> m_logWeightBase_Eref {this, "logWeightBase_Eref", config().logWeightBase_Eref};
+    ParameterRef<bool> m_longitudinalShowerInfoAvailable {this, "longitudinalShowerInfoAvailable", config().longitudinalShowerInfoAvailable};
     ParameterRef<bool> m_enableEtaBounds {this, "enableEtaBounds", config().enableEtaBounds};
 
     Service<AlgorithmsInit_service> m_algorithmsInit {this};

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
@@ -64,7 +64,7 @@ TEST_CASE( "the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]" )
   hit1.setLocal(position);
   pclust.addToHits(hit1);
 
-  position={0,0, 1*dd4hep::mm};
+  position={0, 0, 1 * dd4hep::mm};
   auto hit2 = hits_coll.create();
   hit2.setCellID(0);
   hit2.setEnergy(0.1*dd4hep::GeV);
@@ -76,7 +76,7 @@ TEST_CASE( "the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]" )
   hit2.setLocal(position);
   pclust.addToHits(hit2);
 
-  position={0,0, 2*dd4hep::mm};
+  position={-1 * dd4hep::mm, 0, 2 * dd4hep::mm};
   auto hit3 = hits_coll.create();//0, 0.1*dd4hep::GeV, 0,0,0,position, {0,0,0}, 0,0, position);
   hit3.setCellID(0);
   hit3.setEnergy(0.1*dd4hep::GeV);
@@ -98,9 +98,8 @@ TEST_CASE( "the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]" )
 
   for (auto clust : *clust_coll){
     // require that this cluster's axis is 0,0,1
-    REQUIRE(clust.getShapeParameters()[7] == 0);
-    REQUIRE(clust.getShapeParameters()[8] == 0);
-    REQUIRE(abs(clust.getShapeParameters()[9]) == 1);
+    REQUIRE(clust.getIntrinsicTheta() == 0);
+    REQUIRE(clust.getIntrinsicPhi() == -M_PI);
   }
 
 

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
@@ -39,7 +39,7 @@ TEST_CASE( "the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]" )
   CalorimeterClusterRecoCoGConfig cfg;
   cfg.energyWeight = "log";
   cfg.sampFrac = 0.0203;
-  cfg.logWeightBaseCoeffs = {5.0,0.65,0.31},
+  cfg.logWeightBaseCoeffs = {5.0,0.65,0.31};
   cfg.logWeightBase_Eref = 50*dd4hep::GeV;
   cfg.longitudinalShowerInfoAvailable = true;
 

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
@@ -38,9 +38,10 @@ TEST_CASE( "the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]" )
 
   CalorimeterClusterRecoCoGConfig cfg;
   cfg.energyWeight = "log";
-  cfg.sampFrac = 0.0203,
-  cfg.logWeightBaseCoeffs={5.0,0.65,0.31},
-  cfg.logWeightBase_Eref=50*dd4hep::GeV,
+  cfg.sampFrac = 0.0203;
+  cfg.logWeightBaseCoeffs = {5.0,0.65,0.31},
+  cfg.logWeightBase_Eref = 50*dd4hep::GeV;
+  cfg.longitudinalShowerInfoAvailable = true;
 
 
   algo.applyConfig(cfg);

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
@@ -91,7 +91,8 @@ TEST_CASE( "the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]" )
 
   for (auto clust : *clust_coll){
     REQUIRE_THAT(clust.getIntrinsicTheta(), Catch::Matchers::WithinAbs(M_PI / 4, EPSILON));
-    REQUIRE_THAT(clust.getIntrinsicPhi(), Catch::Matchers::WithinAbs(M_PI, EPSILON));
+    // std::abs() checks if we land on -M_PI
+    REQUIRE_THAT(std::abs(clust.getIntrinsicPhi()), Catch::Matchers::WithinAbs(M_PI, EPSILON));
   }
 
 

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
@@ -63,6 +63,7 @@ TEST_CASE( "the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]" )
   hit1.setDimension({0,0,0});
   hit1.setLocal(position);
   pclust.addToHits(hit1);
+  pclust.addToWeights(1);
 
   position={-1 * dd4hep::mm, 0, 2 * dd4hep::mm};
   auto hit2 = hits_coll.create();
@@ -75,6 +76,7 @@ TEST_CASE( "the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]" )
   hit2.setDimension({0,0,0});
   hit2.setLocal(position);
   pclust.addToHits(hit2);
+  pclust.addToWeights(1);
 
   // Constructing input and output as per the algorithm's expected signature
   auto input = std::make_tuple(&pclust_coll, &simhits);

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
@@ -91,7 +91,7 @@ TEST_CASE( "the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]" )
 
   for (auto clust : *clust_coll){
     REQUIRE_THAT(clust.getIntrinsicTheta(), Catch::Matchers::WithinAbs(M_PI * 3 / 4, EPSILON));
-    REQUIRE_THAT(clust.getIntrinsicPhi(), Catch::Matchers::WithinAbs(-M_PI, EPSILON));
+    REQUIRE_THAT(clust.getIntrinsicPhi(), Catch::Matchers::WithinAbs(0, EPSILON));
   }
 
 

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
@@ -13,7 +13,6 @@
 #include <edm4hep/SimCalorimeterHitCollection.h>
 #include <edm4hep/Vector3f.h>                      // for Vector3f
 #include <math.h>
-#include <podio/RelationRange.h>
 #include <spdlog/common.h>                         // for level_enum
 #include <spdlog/logger.h>                         // for logger
 #include <spdlog/spdlog.h>                         // for default_logger

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
@@ -4,6 +4,8 @@
 
 #include <Evaluator/DD4hepUnits.h>                 // for MeV, mm, keV, ns
 #include <catch2/catch_test_macros.hpp>            // for AssertionHandler, operator""_catch_sr, StringRef, REQUIRE, operator<, operator==, operator>, TEST_CASE
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <edm4eic/CalorimeterHitCollection.h>      // for CalorimeterHitCollection, MutableCalorimeterHit, CalorimeterHitMutableCollectionIterator
 #include <edm4eic/ClusterCollection.h>
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
@@ -28,6 +30,8 @@ using eicrecon::CalorimeterClusterRecoCoGConfig;
 using edm4eic::CalorimeterHit;
 
 TEST_CASE( "the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]" ) {
+  const float EPSILON = 1e-5;
+
   CalorimeterClusterRecoCoG algo("CalorimeterClusterRecoCoG");
 
   std::shared_ptr<spdlog::logger> logger = spdlog::default_logger()->clone("CalorimeterClusterRecoCoG");
@@ -86,9 +90,8 @@ TEST_CASE( "the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]" )
 
 
   for (auto clust : *clust_coll){
-    // require that this cluster's axis is 0,0,1
-    REQUIRE(clust.getIntrinsicTheta() == M_PI * 3 / 4);
-    REQUIRE(clust.getIntrinsicPhi() == -M_PI);
+    REQUIRE_THAT(clust.getIntrinsicTheta(), Catch::Matchers::WithinAbs(M_PI * 3 / 4, EPSILON));
+    REQUIRE_THAT(clust.getIntrinsicPhi(), Catch::Matchers::WithinAbs(-M_PI, EPSILON));
   }
 
 

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
@@ -51,7 +51,7 @@ TEST_CASE( "the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]" )
 
   //create a protocluster with 3 hits
   auto pclust = pclust_coll.create();
-  edm4hep::Vector3f position({0,0,0*dd4hep::mm});
+  edm4hep::Vector3f position({0, 0, 1 *dd4hep::mm});
 
   auto hit1 = hits_coll.create();
   hit1.setCellID(0);
@@ -64,7 +64,7 @@ TEST_CASE( "the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]" )
   hit1.setLocal(position);
   pclust.addToHits(hit1);
 
-  position={0, 0, 1 * dd4hep::mm};
+  position={-1 * dd4hep::mm, 0, 2 * dd4hep::mm};
   auto hit2 = hits_coll.create();
   hit2.setCellID(0);
   hit2.setEnergy(0.1*dd4hep::GeV);
@@ -75,19 +75,6 @@ TEST_CASE( "the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]" )
   hit2.setDimension({0,0,0});
   hit2.setLocal(position);
   pclust.addToHits(hit2);
-
-  position={-1 * dd4hep::mm, 0, 2 * dd4hep::mm};
-  auto hit3 = hits_coll.create();//0, 0.1*dd4hep::GeV, 0,0,0,position, {0,0,0}, 0,0, position);
-  hit3.setCellID(0);
-  hit3.setEnergy(0.1*dd4hep::GeV);
-  hit3.setEnergyError(0);
-  hit3.setTime(0);
-  hit3.setTimeError(0);
-  hit3.setPosition(position);
-  hit3.setDimension({0,0,0});
-  hit3.setLocal(position);
-  pclust.addToHits(hit3);
-  pclust.addToWeights(1);pclust.addToWeights(1);pclust.addToWeights(1);
 
   // Constructing input and output as per the algorithm's expected signature
   auto input = std::make_tuple(&pclust_coll, &simhits);

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
@@ -89,8 +89,8 @@ TEST_CASE( "the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]" )
 
 
   for (auto clust : *clust_coll){
-    REQUIRE_THAT(clust.getIntrinsicTheta(), Catch::Matchers::WithinAbs(M_PI * 3 / 4, EPSILON));
-    REQUIRE_THAT(clust.getIntrinsicPhi(), Catch::Matchers::WithinAbs(0, EPSILON));
+    REQUIRE_THAT(clust.getIntrinsicTheta(), Catch::Matchers::WithinAbs(M_PI / 4, EPSILON));
+    REQUIRE_THAT(clust.getIntrinsicPhi(), Catch::Matchers::WithinAbs(M_PI, EPSILON));
   }
 
 

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
@@ -98,7 +98,7 @@ TEST_CASE( "the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]" )
 
   for (auto clust : *clust_coll){
     // require that this cluster's axis is 0,0,1
-    REQUIRE(clust.getIntrinsicTheta() == 0);
+    REQUIRE(clust.getIntrinsicTheta() == M_PI * 3 / 4);
     REQUIRE(clust.getIntrinsicPhi() == -M_PI);
   }
 


### PR DESCRIPTION
This partially reverts effect of #1391. The clusterShape has become a way to extend EDM without going through extending it. We should sort those variable out into proper members, this is a first step.