### PR TITLE
fix: ensure USE_ONNX=OFF can compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,7 @@ endif()
 option(USE_ONNX "Compile with ONNX support" ON)
 if(${USE_ONNX})
   find_package(onnxruntime CONFIG)
+  add_compile_definitions(USE_ONNX)
 endif()
 
 # Add CMake additional functionality:

--- a/src/global/reco/CMakeLists.txt
+++ b/src/global/reco/CMakeLists.txt
@@ -26,9 +26,8 @@ plugin_glob_all(${PLUGIN_NAME})
 
 # Add libraries (same as target_include_directories but for both plugin and
 # library)
-plugin_link_libraries(
-  ${PLUGIN_NAME} algorithms_digi_library algorithms_tracking_library
-  algorithms_reco_library)
+plugin_link_libraries(${PLUGIN_NAME} algorithms_digi_library
+                      algorithms_tracking_library algorithms_reco_library)
 if(USE_ONNX)
   plugin_link_libraries(${PLUGIN_NAME} algorithms_onnx_library)
 endif()

--- a/src/global/reco/CMakeLists.txt
+++ b/src/global/reco/CMakeLists.txt
@@ -28,4 +28,7 @@ plugin_glob_all(${PLUGIN_NAME})
 # library)
 plugin_link_libraries(
   ${PLUGIN_NAME} algorithms_digi_library algorithms_tracking_library
-  algorithms_onnx_library algorithms_reco_library)
+  algorithms_reco_library)
+if(USE_ONNX)
+  plugin_link_libraries(${PLUGIN_NAME} algorithms_onnx_library)
+endif()

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -28,7 +28,9 @@
 #include "factories/meta/CollectionCollector_factory.h"
 #include "factories/meta/FilterMatching_factory.h"
 #include "factories/reco/FarForwardNeutronReconstruction_factory.h"
+#ifdef USE_ONNX
 #include "factories/reco/InclusiveKinematicsML_factory.h"
+#endif
 #if EDM4EIC_VERSION_MAJOR >= 6
 #include "factories/reco/InclusiveKinematicsReconstructed_factory.h"
 #endif
@@ -183,6 +185,7 @@ void InitPlugin(JApplication *app) {
         app
     ));
 
+#ifdef USE_ONNX
     app->Add(new JOmniFactoryGeneratorT<InclusiveKinematicsML_factory>(
         "InclusiveKinematicsML",
         {
@@ -194,6 +197,7 @@ void InitPlugin(JApplication *app) {
         },
         app
     ));
+#endif
 #endif
 
     app->Add(new JOmniFactoryGeneratorT<ReconstructedElectrons_factory>(


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR passes USE_ONNX as a compile definition and guards use of ONNX functionality with an ifdef.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: compilation failure when USE_ONNX=OFF)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.