### PR TITLE
fix: prepend target include directories

### DIFF
--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -130,11 +130,11 @@ endmacro()
 # target_include_directories for both a plugin and a library
 macro(plugin_include_directories _name)
   if(${_name}_WITH_PLUGIN)
-    target_include_directories(${_name}_plugin ${ARGN})
+    target_include_directories(${_name}_plugin BEFORE ${ARGN})
   endif(${_name}_WITH_PLUGIN)
 
   if(${_name}_WITH_LIBRARY)
-    target_include_directories(${_name}_library ${ARGN})
+    target_include_directories(${_name}_library BEFORE ${ARGN})
   endif(${_name}_WITH_LIBRARY)
 endmacro()
 
@@ -288,6 +288,11 @@ macro(plugin_add_acts _name)
   get_filename_component(ActsCore_PATH ${ActsCore_LOCATION} DIRECTORY)
 
   # Add libraries (works same as target_include_directories)
+  plugin_include_directories(
+    ${PLUGIN_NAME}
+    PUBLIC
+    $<TARGET_PROPERTY:ActsCore,INTERFACE_INCLUDE_DIRECTORIES>
+  )
   plugin_link_libraries(
     ${PLUGIN_NAME}
     ActsCore
@@ -376,7 +381,7 @@ macro(plugin_add_fastjet _name)
   endif()
 
   # Add include directories
-  plugin_include_directories(${PLUGIN_NAME} SYSTEM PUBLIC
+  plugin_include_directories(${PLUGIN_NAME} PUBLIC
                              ${FASTJET_INCLUDE_DIRS})
 
   # Add libraries
@@ -392,7 +397,7 @@ macro(plugin_add_fastjettools _name)
   endif()
 
   # Add include directories
-  plugin_include_directories(${PLUGIN_NAME} SYSTEM PUBLIC
+  plugin_include_directories(${PLUGIN_NAME} PUBLIC
                              ${FJTOOLS_INCLUDE_DIRS})
 
   # Add libraries
@@ -408,7 +413,7 @@ macro(plugin_add_fastjetcontrib _name)
   endif()
 
   # Add include directories
-  plugin_include_directories(${PLUGIN_NAME} SYSTEM PUBLIC
+  plugin_include_directories(${PLUGIN_NAME} PUBLIC
                              ${FJCONTRIB_INCLUDE_DIRS})
 
   # Add libraries

--- a/src/benchmarks/reconstruction/femc_studies/CMakeLists.txt
+++ b/src/benchmarks/reconstruction/femc_studies/CMakeLists.txt
@@ -17,12 +17,3 @@ plugin_add_acts(${PLUGIN_NAME})
 # correctly sets sources for ${_name}_plugin and ${_name}_library targets Adds
 # headers to the correct installation directory
 plugin_glob_all(${PLUGIN_NAME})
-
-# Add include directories (same as target_include_directories but for both
-# plugin and library)
-plugin_include_directories(${PLUGIN_NAME} SYSTEM PUBLIC ${ROOT_INCLUDE_DIRS})
-
-# Add libraries (same as target_include_directories but for both plugin and
-# library)
-plugin_link_libraries(${PLUGIN_NAME} ${ROOT_LIBRARIES} ActsCore
-                      EDM4EIC::edm4eic)

--- a/src/benchmarks/reconstruction/lfhcal_studies/CMakeLists.txt
+++ b/src/benchmarks/reconstruction/lfhcal_studies/CMakeLists.txt
@@ -17,12 +17,3 @@ plugin_add_acts(${PLUGIN_NAME})
 # correctly sets sources for ${_name}_plugin and ${_name}_library targets Adds
 # headers to the correct installation directory
 plugin_glob_all(${PLUGIN_NAME})
-
-# Add include directories (same as target_include_directories but for both
-# plugin and library)
-plugin_include_directories(${PLUGIN_NAME} SYSTEM PUBLIC ${ROOT_INCLUDE_DIRS})
-
-# Add libraries (same as target_include_directories but for both plugin and
-# library)
-plugin_link_libraries(${PLUGIN_NAME} ${ROOT_LIBRARIES} ActsCore
-                      EDM4EIC::edm4eic)

--- a/src/benchmarks/reconstruction/tracking_occupancy/CMakeLists.txt
+++ b/src/benchmarks/reconstruction/tracking_occupancy/CMakeLists.txt
@@ -17,12 +17,3 @@ plugin_add_acts(${PLUGIN_NAME})
 # correctly sets sources for ${_name}_plugin and ${_name}_library targets Adds
 # headers to the correct installation directory
 plugin_glob_all(${PLUGIN_NAME})
-
-# Add include directories (same as target_include_directories but for both
-# plugin and library)
-plugin_include_directories(${PLUGIN_NAME} SYSTEM PUBLIC ${ROOT_INCLUDE_DIRS})
-
-# Add libraries (same as target_include_directories but for both plugin and
-# library)
-plugin_link_libraries(${PLUGIN_NAME} ${ROOT_LIBRARIES} ActsCore
-                      EDM4EIC::edm4eic)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Instead of appending target_include_directories, this PR prepend them. That ensures that compiles with custom software dependencies are not finding `/opt/local/include` headers first.

Now we get (note `/home/wdconinc/git/acts/install/include` before `/opt/local/include`):
<code>
[ 14%] Building CXX object src/algorithms/tracking/CMakeFiles/algorithms_tracking_library.dir/AmbiguitySolver.cc.o
cd /home/wdconinc/git/EICrecon/build/src/algorithms/tracking && /usr/bin/clang++ -DActs_VERSION_MAJOR=32 -DBOOST_SPIRIT_USE_PHOENIX_V3 -DDD4HEP_USE_XERCESC -DFMT_SHARED -DHAVE_PODIO -DJANA2_HAVE_PODIO=1 -DJANA2_HAVE_ROOT=1 -DPODIO_ENABLE_RNTUPLE=0 -DSPDLOG_COMPILED_LIB -DSPDLOG_FMT_EXTERNAL -DSPDLOG_SHARED_LIB -DUSE_ONNX -Dalgorithms_tracking_library_EXPORTS -I/home/wdconinc/git/EICrecon/src/algorithms/tracking -I/home/wdconinc/git/EICrecon/build/include -I/home/wdconinc/git/EICrecon/src -isystem /home/wdconinc/git/acts/install/include -isystem /opt/local/include -isystem /opt/local/include/eigen3 -isystem /opt/local/include/root -isystem /opt/software/linux-debian12-x86_64_v2/gcc-12.2.0/xerces-c-3.2.5-5j6nth35rmn64gt3xwnsbqhsexfyjxy2/include -O3 -DNDEBUG -std=c++20 -fPIC -MD -MT src/algorithms/tracking/CMakeFiles/algorithms_tracking_library.dir/AmbiguitySolver.cc.o -MF CMakeFiles/algorithms_tracking_library.dir/AmbiguitySolver.cc.o.d -o CMakeFiles/algorithms_tracking_library.dir/AmbiguitySolver.cc.o -c /home/wdconinc/git/EICrecon/src/algorithms/tracking/AmbiguitySolver.cc
</code>
(after `cmake -Bbuild -S. --fresh -DActs_ROOT=$HOME/git/acts/install/lib/cmake/`)

Previously, this picked up the headers in `/opt/local/include` but still tried to link to the `Acts_ROOT` libraries, leading to linking failures (and, worse, runtime issues).

Also:
- rm unnecessary includes in reconstruction benchmarks,
- rm unnecessary SYSTEM in fastjet and tools.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.