### PR TITLE
fix: require AlgorithmsInit_service in IrtCherenkovParticleID for ParticleSvc

### DIFF
--- a/src/global/pid/IrtCherenkovParticleID_factory.h
+++ b/src/global/pid/IrtCherenkovParticleID_factory.h
@@ -15,6 +15,7 @@
 #include "algorithms/pid/IrtCherenkovParticleID.h"
 #include "algorithms/pid/IrtCherenkovParticleIDConfig.h"
 #include "extensions/jana/JOmniFactory.h"
+#include "services/algorithms_init/AlgorithmsInit_service.h"
 #include "services/geometry/richgeo/RichGeo_service.h"
 
 namespace eicrecon {
@@ -50,6 +51,7 @@ private:
     ParameterRef<bool> m_cheatPhotonVertex {this, "cheatPhotonVertex", config().cheatPhotonVertex, ""};
     ParameterRef<bool> m_cheatTrueRadiator {this, "cheatTrueRadiator", config().cheatTrueRadiator, ""};
 
+    Service<AlgorithmsInit_service> m_algorithmsInit {this};
     Service<RichGeo_service> m_RichGeoSvc {this};
 
 public:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR should(?) fix the drich_fixed_eta reconstruction benchmark error in https://eicweb.phy.anl.gov/EIC/benchmarks/reconstruction_benchmarks/-/jobs/3441830. Unfortunately I can't reproduce the issue locally (it always works). The CI pipeline will have to tell if this works...

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://eicweb.phy.anl.gov/EIC/benchmarks/reconstruction_benchmarks/-/jobs/3441830)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.