### PR TITLE
feat: fix compilation for Acts versions from v33 up to v35

### DIFF
--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -19,12 +19,24 @@
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
 #include <Acts/EventData/VectorTrackContainer.hpp>
 #include <Acts/Geometry/GeometryIdentifier.hpp>
+#if Acts_VERSION_MAJOR >= 34
+#include "Acts/Propagator/AbortList.hpp"
+#include "Acts/Propagator/EigenStepper.hpp"
+#include "Acts/Propagator/MaterialInteractor.hpp"
+#include "Acts/Propagator/Navigator.hpp"
+#endif
 #include <Acts/Propagator/Propagator.hpp>
+#if Acts_VERSION_MAJOR >= 34
+#include "Acts/Propagator/StandardAborters.hpp"
+#endif
 #include <Acts/Surfaces/PerigeeSurface.hpp>
 #include <Acts/Surfaces/Surface.hpp>
 #include <Acts/TrackFitting/GainMatrixSmoother.hpp>
 #include <Acts/TrackFitting/GainMatrixUpdater.hpp>
 #include <Acts/Utilities/Logger.hpp>
+#if Acts_VERSION_MAJOR >= 34
+#include "Acts/Utilities/TrackHelpers.hpp"
+#endif
 #include <ActsExamples/EventData/IndexSourceLink.hpp>
 #include <ActsExamples/EventData/Measurement.hpp>
 #include <ActsExamples/EventData/MeasurementCalibration.hpp>
@@ -178,7 +190,9 @@ namespace eicrecon {
         ActsExamples::PassThroughCalibrator pcalibrator;
         ActsExamples::MeasurementCalibratorAdapter calibrator(pcalibrator, *measurements);
         Acts::GainMatrixUpdater kfUpdater;
+#if Acts_VERSION_MAJOR < 34
         Acts::GainMatrixSmoother kfSmoother;
+#endif
         Acts::MeasurementSelector measSel{m_sourcelinkSelectorCfg};
 
         Acts::CombinatorialKalmanFilterExtensions<Acts::VectorMultiTrajectory>
@@ -188,9 +202,11 @@ namespace eicrecon {
         extensions.updater.connect<
                 &Acts::GainMatrixUpdater::operator()<Acts::VectorMultiTrajectory>>(
                 &kfUpdater);
+#if Acts_VERSION_MAJOR < 34
         extensions.smoother.connect<
                 &Acts::GainMatrixSmoother::operator()<Acts::VectorMultiTrajectory>>(
                 &kfSmoother);
+#endif
         extensions.measurementSelector.connect<
                 &Acts::MeasurementSelector::select<Acts::VectorMultiTrajectory>>(
                 &measSel);
@@ -202,9 +218,27 @@ namespace eicrecon {
         slAccessorDelegate.connect<&ActsExamples::IndexSourceLinkAccessor::range>(&slAccessor);
 
         // Set the CombinatorialKalmanFilter options
+#if Acts_VERSION_MAJOR < 34
         CKFTracking::TrackFinderOptions options(
                 m_geoctx, m_fieldctx, m_calibctx, slAccessorDelegate,
                 extensions, pOptions, &(*pSurface));
+#else
+        CKFTracking::TrackFinderOptions options(
+                m_geoctx, m_fieldctx, m_calibctx, slAccessorDelegate,
+                extensions, pOptions);
+#endif
+
+#if Acts_VERSION_MAJOR >= 34
+        Acts::Propagator<Acts::EigenStepper<>, Acts::Navigator> extrapolator(
+            Acts::EigenStepper<>(m_BField),
+            Acts::Navigator({m_geoSvc->trackingGeometry()},
+                            logger().cloneWithSuffix("Navigator")),
+            logger().cloneWithSuffix("Propagator"));
+
+        Acts::PropagatorOptions<Acts::ActionList<Acts::MaterialInteractor>,
+                                Acts::AbortList<Acts::EndOfWorldReached>>
+            extrapolationOptions(m_geoctx, m_fieldctx);
+#endif
 
         // Create track container
         auto trackContainer = std::make_shared<Acts::VectorTrackContainer>();
@@ -232,6 +266,27 @@ namespace eicrecon {
             // Set seed number for all found tracks
             auto& tracksForSeed = result.value();
             for (auto& track : tracksForSeed) {
+
+#if Acts_VERSION_MAJOR >=34
+                auto smoothingResult = Acts::smoothTrack(m_geoctx, track, logger());
+                if (!smoothingResult.ok()) {
+                    ACTS_ERROR("Smoothing for seed "
+                        << iseed << " and track " << track.index()
+                        << " failed with error " << smoothingResult.error());
+                    continue;
+                }
+
+                auto extrapolationResult = Acts::extrapolateTrackToReferenceSurface(
+                    track, *pSurface, extrapolator, extrapolationOptions,
+                    Acts::TrackExtrapolationStrategy::firstOrLast, logger());
+                if (!extrapolationResult.ok()) {
+                    ACTS_ERROR("Extrapolation for seed "
+                        << iseed << " and track " << track.index()
+                        << " failed with error " << extrapolationResult.error());
+                    continue;
+                }
+#endif
+
                 seedNumber(track) = iseed;
             }
         }

--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -7,7 +7,9 @@
 #include <Acts/Definitions/TrackParametrization.hpp>
 #include <Acts/Definitions/Units.hpp>
 #include <Acts/EventData/GenericBoundTrackParameters.hpp>
+#if Acts_VERSION_MAJOR < 36
 #include <Acts/EventData/Measurement.hpp>
+#endif
 #include <Acts/EventData/MultiTrajectory.hpp>
 #include <Acts/EventData/ParticleHypothesis.hpp>
 #if Acts_VERSION_MAJOR >= 32
@@ -144,7 +146,13 @@ namespace eicrecon {
             cov(0, 1) = meas2D.getCovariance().xy;
             cov(1, 0) = meas2D.getCovariance().xy;
 
-            auto measurement = Acts::makeMeasurement(Acts::SourceLink{sourceLink}, loc, cov, Acts::eBoundLoc0, Acts::eBoundLoc1);
+#if Acts_VERSION_MAJOR >= 36
+            auto measurement = ActsExamples::makeFixedSizeMeasurement(
+              Acts::SourceLink{sourceLink}, loc, cov, Acts::eBoundLoc0, Acts::eBoundLoc1);
+#else
+            auto measurement = Acts::makeMeasurement(
+              Acts::SourceLink{sourceLink}, loc, cov, Acts::eBoundLoc0, Acts::eBoundLoc1);
+#endif
             measurements->emplace_back(std::move(measurement));
 
             hit_index++;

--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -10,6 +10,9 @@
 #include <Acts/EventData/Measurement.hpp>
 #include <Acts/EventData/MultiTrajectory.hpp>
 #include <Acts/EventData/ParticleHypothesis.hpp>
+#if Acts_VERSION_MAJOR >= 32
+#include "Acts/EventData/ProxyAccessor.hpp"
+#endif
 #include <Acts/EventData/SourceLink.hpp>
 #include <Acts/EventData/TrackContainer.hpp>
 #include <Acts/EventData/TrackProxy.hpp>
@@ -210,7 +213,11 @@ namespace eicrecon {
 
         // Add seed number column
         acts_tracks.addColumn<unsigned int>("seed");
+#if Acts_VERSION_MAJOR >= 32
+        Acts::ProxyAccessor<unsigned int> seedNumber("seed");
+#else
         Acts::TrackAccessor<unsigned int> seedNumber("seed");
+#endif
 
         // Loop over seeds
         for (std::size_t iseed = 0; iseed < acts_init_trk_params.size(); ++iseed) {
@@ -251,8 +258,11 @@ namespace eicrecon {
         auto& constTracks = *(constTracks_v.front());
 
         // Seed number column accessor
+#if Acts_VERSION_MAJOR >= 32
+        const Acts::ConstProxyAccessor<unsigned int> constSeedNumber("seed");
+#else
         const Acts::ConstTrackAccessor<unsigned int> constSeedNumber("seed");
-
+#endif
 
         // Prepare the output data with MultiTrajectory, per seed
         std::vector<ActsExamples::Trajectories*> acts_trajectories;

--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -7,9 +7,7 @@
 #include <Acts/Definitions/TrackParametrization.hpp>
 #include <Acts/Definitions/Units.hpp>
 #include <Acts/EventData/GenericBoundTrackParameters.hpp>
-#if Acts_VERSION_MAJOR < 36
 #include <Acts/EventData/Measurement.hpp>
-#endif
 #include <Acts/EventData/MultiTrajectory.hpp>
 #include <Acts/EventData/ParticleHypothesis.hpp>
 #if Acts_VERSION_MAJOR >= 32
@@ -146,13 +144,7 @@ namespace eicrecon {
             cov(0, 1) = meas2D.getCovariance().xy;
             cov(1, 0) = meas2D.getCovariance().xy;
 
-#if Acts_VERSION_MAJOR >= 36
-            auto measurement = ActsExamples::makeFixedSizeMeasurement(
-              Acts::SourceLink{sourceLink}, loc, cov, Acts::eBoundLoc0, Acts::eBoundLoc1);
-#else
-            auto measurement = Acts::makeMeasurement(
-              Acts::SourceLink{sourceLink}, loc, cov, Acts::eBoundLoc0, Acts::eBoundLoc1);
-#endif
+            auto measurement = Acts::makeMeasurement(Acts::SourceLink{sourceLink}, loc, cov, Acts::eBoundLoc0, Acts::eBoundLoc1);
             measurements->emplace_back(std::move(measurement));
 
             hit_index++;

--- a/src/algorithms/tracking/DD4hepBField.h
+++ b/src/algorithms/tracking/DD4hepBField.h
@@ -43,7 +43,11 @@ namespace eicrecon::BField {
 
     Acts::MagneticFieldProvider::Cache makeCache(const Acts::MagneticFieldContext& mctx) const override
     {
+#if Acts_VERSION_MAJOR >= 32
+      return Acts::MagneticFieldProvider::Cache(std::in_place_type<Cache>, mctx);
+#else
       return Acts::MagneticFieldProvider::Cache::make<Cache>(mctx);
+#endif
     }
 
     /** construct constant magnetic field from field vector.

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -140,8 +140,12 @@ std::unique_ptr<edm4eic::VertexCollection> eicrecon::IterativeVertexFinder::prod
  #if Acts_VERSION_MAJOR >= 33
   finderCfg.extractParameters.connect<&Acts::InputTrack::extractParameters>();
   finderCfg.trackLinearizer.connect<&Linearizer::linearizeTrack>(&linearizer);
+  #if Acts_VERSION_MAJOR >= 36
+  finderCfg.field = m_BField;
+  #else
   finderCfg.field = std::shared_ptr<Acts::MagneticFieldProvider>(
     const_cast<eicrecon::BField::DD4hepBField*>(m_BField.get()));
+  #endif
  #endif
   VertexFinder finder(std::move(finderCfg));
 #else

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -72,7 +72,7 @@ std::unique_ptr<edm4eic::VertexCollection> eicrecon::IterativeVertexFinder::prod
 #endif
 #if Acts_VERSION_MAJOR >= 33
   using VertexSeeder         = Acts::ZScanVertexFinder;
-  using VertexFinder         = Acts::IterativeVertexFinder<VertexFitter>;
+  using VertexFinder         = Acts::IterativeVertexFinder;
   using VertexFinderOptions  = Acts::VertexingOptions;
 #else
   using VertexSeeder         = Acts::ZScanVertexFinder<VertexFitter>;

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -13,7 +13,11 @@
 #include <Acts/EventData/TrackParameters.hpp>
 #include <Acts/Propagator/EigenStepper.hpp>
 #include <Acts/Propagator/Propagator.hpp>
+#if Acts_VERSION_MAJOR >= 32
+#include <Acts/Propagator/VoidNavigator.hpp>
+#else
 #include <Acts/Propagator/detail/VoidPropagatorComponents.hpp>
+#endif
 #include <Acts/Utilities/Logger.hpp>
 #include <Acts/Utilities/Result.hpp>
 #include <Acts/Utilities/VectorHelpers.hpp>
@@ -69,8 +73,13 @@ std::unique_ptr<edm4eic::VertexCollection> eicrecon::IterativeVertexFinder::prod
   Acts::EigenStepper<> stepper(m_BField);
 
   // Set up propagator with void navigator
+#if Acts_VERSION_MAJOR >= 32
+  auto propagator = std::make_shared<Propagator>(
+    stepper, Acts::VoidNavigator{}, logger().cloneWithSuffix("Prop"));
+#else
   auto propagator = std::make_shared<Propagator>(
     stepper, Acts::detail::VoidNavigator{}, logger().cloneWithSuffix("Prop"));
+#endif
   Acts::PropagatorOptions opts(m_geoctx, m_fieldctx);
 
   // Setup the vertex fitter

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -66,16 +66,13 @@ std::unique_ptr<edm4eic::VertexCollection> eicrecon::IterativeVertexFinder::prod
   using Linearizer        = Acts::HelicalTrackLinearizer;
   using VertexFitter      = Acts::FullBilloirVertexFitter;
   using ImpactPointEstimator = Acts::ImpactPointEstimator;
-#else
-  using Linearizer        = Acts::HelicalTrackLinearizer<Propagator>;
-  using VertexFitter      = Acts::FullBilloirVertexFitter<Acts::BoundTrackParameters, Linearizer>;
-  using ImpactPointEstimator = Acts::ImpactPointEstimator<Acts::BoundTrackParameters, Propagator>;
-#endif
-#if Acts_VERSION_MAJOR >= 33
   using VertexSeeder         = Acts::ZScanVertexFinder;
   using VertexFinder         = Acts::IterativeVertexFinder;
   using VertexFinderOptions  = Acts::VertexingOptions;
 #else
+  using Linearizer        = Acts::HelicalTrackLinearizer<Propagator>;
+  using VertexFitter      = Acts::FullBilloirVertexFitter<Acts::BoundTrackParameters, Linearizer>;
+  using ImpactPointEstimator = Acts::ImpactPointEstimator<Acts::BoundTrackParameters, Propagator>;
   using VertexSeeder         = Acts::ZScanVertexFinder<VertexFitter>;
   using VertexFinder         = Acts::IterativeVertexFinder<VertexFitter, VertexSeeder>;
   using VertexFinderOptions  = Acts::VertexingOptions<Acts::BoundTrackParameters>;

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -127,10 +127,11 @@ std::unique_ptr<edm4eic::VertexCollection> eicrecon::IterativeVertexFinder::prod
     }
   }
 
-  std::vector<Acts::Vertex<Acts::BoundTrackParameters>> vertices;
 #if Acts_VERSION_MAJOR >= 33
+  std::vector<Acts::Vertex> vertices;
   auto result = finder.find(inputTracks, finderOpts, state);
 #else
+  std::vector<Acts::Vertex<Acts::BoundTrackParameters>> vertices;
   auto result = finder.find(inputTrackPointers, finderOpts, state);
 #endif
   if (result.ok()) {

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -13,6 +13,7 @@
 #include <Acts/EventData/TrackParameters.hpp>
 #include <Acts/Propagator/EigenStepper.hpp>
 #include <Acts/Propagator/Propagator.hpp>
+#include <boost/move/utility_core.hpp>
 #if Acts_VERSION_MAJOR >= 32
 #include <Acts/Propagator/VoidNavigator.hpp>
 #else

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -138,12 +138,8 @@ std::unique_ptr<edm4eic::VertexCollection> eicrecon::IterativeVertexFinder::prod
  #if Acts_VERSION_MAJOR >= 33
   finderCfg.extractParameters.connect<&Acts::InputTrack::extractParameters>();
   finderCfg.trackLinearizer.connect<&Linearizer::linearizeTrack>(&linearizer);
-  #if Acts_VERSION_MAJOR >= 36
-  finderCfg.field = m_BField;
-  #else
   finderCfg.field = std::shared_ptr<Acts::MagneticFieldProvider>(
     const_cast<eicrecon::BField::DD4hepBField*>(m_BField.get()));
-  #endif
  #endif
   VertexFinder finder(std::move(finderCfg));
 #else

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -66,7 +66,11 @@ std::unique_ptr<edm4eic::VertexCollection> eicrecon::IterativeVertexFinder::prod
   using ImpactPointEstimator = Acts::ImpactPointEstimator<Acts::BoundTrackParameters, Propagator>;
   using VertexSeeder         = Acts::ZScanVertexFinder<VertexFitter>;
   using VertexFinder         = Acts::IterativeVertexFinder<VertexFitter, VertexSeeder>;
+#if Acts_VERSION_MAJOR >= 33
+  using VertexFinderOptions  = Acts::VertexingOptions;
+#else
   using VertexFinderOptions  = Acts::VertexingOptions<Acts::BoundTrackParameters>;
+#endif
 
   ACTS_LOCAL_LOGGER(eicrecon::getSpdlogLogger("IVF", m_log));
 

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -138,8 +138,12 @@ std::unique_ptr<edm4eic::VertexCollection> eicrecon::IterativeVertexFinder::prod
  #if Acts_VERSION_MAJOR >= 33
   finderCfg.extractParameters.connect<&Acts::InputTrack::extractParameters>();
   finderCfg.trackLinearizer.connect<&Linearizer::linearizeTrack>(&linearizer);
+  #if Acts_VERSION_MAJOR >= 36
+  finderCfg.field = m_BField;
+  #else
   finderCfg.field = std::shared_ptr<Acts::MagneticFieldProvider>(
     const_cast<eicrecon::BField::DD4hepBField*>(m_BField.get()));
+  #endif
  #endif
   VertexFinder finder(std::move(finderCfg));
 #else

--- a/src/algorithms/tracking/SpacePoint.h
+++ b/src/algorithms/tracking/SpacePoint.h
@@ -11,7 +11,7 @@ class SpacePoint : public edm4eic::TrackerHit
  public:
   const Acts::Surface *m_surface = nullptr;
 
- SpacePoint(const TrackerHit& hit) : TrackerHit(hit) {}
+  SpacePoint(const TrackerHit& hit) : TrackerHit(hit) {}
 
   void setSurface(std::shared_ptr<const ActsGeometryProvider> m_geoSvc)
     {
@@ -35,6 +35,9 @@ class SpacePoint : public edm4eic::TrackerHit
       (std::pow(x(), 2) + std::pow(y(), 2));
   }
   float varianceZ() const { return getPositionError().zz; }
+
+  float t() const { return getTime(); }
+  float varianceT() const { return getTimeError(); }
 
   bool isOnSurface() const {
     if (m_surface == nullptr) {

--- a/src/algorithms/tracking/TrackProjector.cc
+++ b/src/algorithms/tracking/TrackProjector.cc
@@ -101,7 +101,8 @@ namespace eicrecon {
                         boundParams);
                 auto jacobian = trackstate.referenceSurface().boundToFreeJacobian(
                         m_geo_provider->getActsGeometryContext(),
-                        freeParams
+                        freeParams.template segment<3>(Acts::eFreePos0),
+                        freeParams.template segment<3>(Acts::eFreeDir0)
                 );
 #else
                 auto jacobian = trackstate.referenceSurface().boundToFreeJacobian(

--- a/src/algorithms/tracking/TrackProjector.cc
+++ b/src/algorithms/tracking/TrackProjector.cc
@@ -80,24 +80,36 @@ namespace eicrecon {
                     m_nCalibrated++;
                 }
 
-                // get track state parameters and their covariances
-                const auto &parameter = trackstate.predicted();
-                const auto &covariance = trackstate.predictedCovariance();
+                // get track state bound parameters and their boundCovs
+                const auto &boundParams = trackstate.predicted();
+                const auto &boundCov = trackstate.predictedCovariance();
 
                 // convert local to global
                 auto global = trackstate.referenceSurface().localToGlobal(
                         m_geo_provider->getActsGeometryContext(),
-                        {parameter[Acts::eBoundLoc0], parameter[Acts::eBoundLoc1]},
+                        {boundParams[Acts::eBoundLoc0], boundParams[Acts::eBoundLoc1]},
                         Acts::makeDirectionFromPhiTheta(
-                            parameter[Acts::eBoundPhi],
-                            parameter[Acts::eBoundTheta]
+                            boundParams[Acts::eBoundPhi],
+                            boundParams[Acts::eBoundTheta]
                         )
                 );
+
+#if Acts_VERSION_MAJOR >= 34
+                auto freeParams = Acts::detail::transformBoundToFreeParameters(
+                        trackstate.referenceSurface(),
+                        m_geo_provider->getActsGeometryContext(),
+                        boundParams);
                 auto jacobian = trackstate.referenceSurface().boundToFreeJacobian(
                         m_geo_provider->getActsGeometryContext(),
-                        parameter
+                        freeParams
                 );
-                auto free_covariance = jacobian * covariance * jacobian.transpose();
+#else
+                auto jacobian = trackstate.referenceSurface().boundToFreeJacobian(
+                        m_geo_provider->getActsGeometryContext(),
+                        boundParams
+                );
+#endif
+                auto freeCov = jacobian * boundCov * jacobian.transpose();
 
                 // global position
                 const decltype(edm4eic::TrackPoint::position) position{
@@ -108,45 +120,45 @@ namespace eicrecon {
 
                 // local position
                 const decltype(edm4eic::TrackParametersData::loc) loc{
-                        static_cast<float>(parameter[Acts::eBoundLoc0]),
-                        static_cast<float>(parameter[Acts::eBoundLoc1])
+                        static_cast<float>(boundParams[Acts::eBoundLoc0]),
+                        static_cast<float>(boundParams[Acts::eBoundLoc1])
                 };
                 const edm4eic::Cov2f locError{
-                        static_cast<float>(covariance(Acts::eBoundLoc0, Acts::eBoundLoc0)),
-                        static_cast<float>(covariance(Acts::eBoundLoc1, Acts::eBoundLoc1)),
-                        static_cast<float>(covariance(Acts::eBoundLoc0, Acts::eBoundLoc1))
+                        static_cast<float>(boundCov(Acts::eBoundLoc0, Acts::eBoundLoc0)),
+                        static_cast<float>(boundCov(Acts::eBoundLoc1, Acts::eBoundLoc1)),
+                        static_cast<float>(boundCov(Acts::eBoundLoc0, Acts::eBoundLoc1))
                 };
                 const decltype(edm4eic::TrackPoint::positionError) positionError{
-                        static_cast<float>(free_covariance(Acts::eFreePos0, Acts::eFreePos0)),
-                        static_cast<float>(free_covariance(Acts::eFreePos1, Acts::eFreePos1)),
-                        static_cast<float>(free_covariance(Acts::eFreePos2, Acts::eFreePos2)),
-                        static_cast<float>(free_covariance(Acts::eFreePos0, Acts::eFreePos1)),
-                        static_cast<float>(free_covariance(Acts::eFreePos0, Acts::eFreePos2)),
-                        static_cast<float>(free_covariance(Acts::eFreePos1, Acts::eFreePos2)),
+                        static_cast<float>(freeCov(Acts::eFreePos0, Acts::eFreePos0)),
+                        static_cast<float>(freeCov(Acts::eFreePos1, Acts::eFreePos1)),
+                        static_cast<float>(freeCov(Acts::eFreePos2, Acts::eFreePos2)),
+                        static_cast<float>(freeCov(Acts::eFreePos0, Acts::eFreePos1)),
+                        static_cast<float>(freeCov(Acts::eFreePos0, Acts::eFreePos2)),
+                        static_cast<float>(freeCov(Acts::eFreePos1, Acts::eFreePos2)),
                 };
 
                 // momentum
                 const decltype(edm4eic::TrackPoint::momentum) momentum = edm4hep::utils::sphericalToVector(
-                        static_cast<float>(1.0 / std::abs(parameter[Acts::eBoundQOverP])),
-                        static_cast<float>(parameter[Acts::eBoundTheta]),
-                        static_cast<float>(parameter[Acts::eBoundPhi])
+                        static_cast<float>(1.0 / std::abs(boundParams[Acts::eBoundQOverP])),
+                        static_cast<float>(boundParams[Acts::eBoundTheta]),
+                        static_cast<float>(boundParams[Acts::eBoundPhi])
                 );
                 const decltype(edm4eic::TrackPoint::momentumError) momentumError{
-                        static_cast<float>(covariance(Acts::eBoundTheta, Acts::eBoundTheta)),
-                        static_cast<float>(covariance(Acts::eBoundPhi, Acts::eBoundPhi)),
-                        static_cast<float>(covariance(Acts::eBoundQOverP, Acts::eBoundQOverP)),
-                        static_cast<float>(covariance(Acts::eBoundTheta, Acts::eBoundPhi)),
-                        static_cast<float>(covariance(Acts::eBoundTheta, Acts::eBoundQOverP)),
-                        static_cast<float>(covariance(Acts::eBoundPhi, Acts::eBoundQOverP))
+                        static_cast<float>(boundCov(Acts::eBoundTheta, Acts::eBoundTheta)),
+                        static_cast<float>(boundCov(Acts::eBoundPhi, Acts::eBoundPhi)),
+                        static_cast<float>(boundCov(Acts::eBoundQOverP, Acts::eBoundQOverP)),
+                        static_cast<float>(boundCov(Acts::eBoundTheta, Acts::eBoundPhi)),
+                        static_cast<float>(boundCov(Acts::eBoundTheta, Acts::eBoundQOverP)),
+                        static_cast<float>(boundCov(Acts::eBoundPhi, Acts::eBoundQOverP))
                 };
-                const float time{static_cast<float>(parameter(Acts::eBoundTime))};
-                const float timeError{sqrt(static_cast<float>(covariance(Acts::eBoundTime, Acts::eBoundTime)))};
-                const float theta(parameter[Acts::eBoundTheta]);
-                const float phi(parameter[Acts::eBoundPhi]);
+                const float time{static_cast<float>(boundParams(Acts::eBoundTime))};
+                const float timeError{sqrt(static_cast<float>(boundCov(Acts::eBoundTime, Acts::eBoundTime)))};
+                const float theta(boundParams[Acts::eBoundTheta]);
+                const float phi(boundParams[Acts::eBoundPhi]);
                 const decltype(edm4eic::TrackPoint::directionError) directionError{
-                        static_cast<float>(covariance(Acts::eBoundTheta, Acts::eBoundTheta)),
-                        static_cast<float>(covariance(Acts::eBoundPhi, Acts::eBoundPhi)),
-                        static_cast<float>(covariance(Acts::eBoundTheta, Acts::eBoundPhi))
+                        static_cast<float>(boundCov(Acts::eBoundTheta, Acts::eBoundTheta)),
+                        static_cast<float>(boundCov(Acts::eBoundPhi, Acts::eBoundPhi)),
+                        static_cast<float>(boundCov(Acts::eBoundTheta, Acts::eBoundPhi))
                 };
                 const float pathLength = static_cast<float>(trackstate.pathLength());
                 const float pathLengthError = 0;
@@ -191,12 +203,12 @@ namespace eicrecon {
                 m_log->debug("  ******************************");
 
                 // Local position on the reference surface.
-                //m_log->debug("parameter[eBoundLoc0] = {}", parameter[Acts::eBoundLoc0]);
-                //m_log->debug("parameter[eBoundLoc1] = {}", parameter[Acts::eBoundLoc1]);
-                //m_log->debug("parameter[eBoundPhi] = {}", parameter[Acts::eBoundPhi]);
-                //m_log->debug("parameter[eBoundTheta] = {}", parameter[Acts::eBoundTheta]);
-                //m_log->debug("parameter[eBoundQOverP] = {}", parameter[Acts::eBoundQOverP]);
-                //m_log->debug("parameter[eBoundTime] = {}", parameter[Acts::eBoundTime]);
+                //m_log->debug("boundParams[eBoundLoc0] = {}", boundParams[Acts::eBoundLoc0]);
+                //m_log->debug("boundParams[eBoundLoc1] = {}", boundParams[Acts::eBoundLoc1]);
+                //m_log->debug("boundParams[eBoundPhi] = {}", boundParams[Acts::eBoundPhi]);
+                //m_log->debug("boundParams[eBoundTheta] = {}", boundParams[Acts::eBoundTheta]);
+                //m_log->debug("boundParams[eBoundQOverP] = {}", boundParams[Acts::eBoundQOverP]);
+                //m_log->debug("boundParams[eBoundTime] = {}", boundParams[Acts::eBoundTime]);
                 //m_log->debug("predicted variables: {}", trackstate.predicted());
             });
 

--- a/src/algorithms/tracking/TrackProjector.cc
+++ b/src/algorithms/tracking/TrackProjector.cc
@@ -95,7 +95,7 @@ namespace eicrecon {
                 );
 
 #if Acts_VERSION_MAJOR >= 34
-                auto freeParams = Acts::detail::transformBoundToFreeParameters(
+                auto freeParams = Acts::transformBoundToFreeParameters(
                         trackstate.referenceSurface(),
                         m_geo_provider->getActsGeometryContext(),
                         boundParams);

--- a/src/algorithms/tracking/TrackProjector.h
+++ b/src/algorithms/tracking/TrackProjector.h
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include "ActsGeometryProvider.h"
-#include "algorithms/interfaces/WithPodConfig.h"
 
 
 namespace eicrecon {

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -120,6 +120,15 @@ std::unique_ptr<edm4eic::TrackParametersCollection> eicrecon::TrackSeeding::prod
 
   Acts::SeedFinderOrthogonal<eicrecon::SpacePoint> finder(m_seedFinderConfig); // FIXME move into class scope
 
+#if Acts_VERSION_MAJOR >= 32
+  std::function<std::tuple<Acts::Vector3, Acts::Vector2, std::optional<Acts::ActsScalar>>(
+      const eicrecon::SpacePoint *sp)>
+      create_coordinates = [](const eicrecon::SpacePoint *sp) {
+        Acts::Vector3 position(sp->x(), sp->y(), sp->z());
+        Acts::Vector2 variance(sp->varianceR(), sp->varianceZ());
+        return std::make_tuple(position, variance, sp->t());
+      };
+#else
   std::function<std::pair<Acts::Vector3, Acts::Vector2>(
       const eicrecon::SpacePoint *sp)>
       create_coordinates = [](const eicrecon::SpacePoint *sp) {
@@ -127,6 +136,7 @@ std::unique_ptr<edm4eic::TrackParametersCollection> eicrecon::TrackSeeding::prod
         Acts::Vector2 variance(sp->varianceR(), sp->varianceZ());
         return std::make_pair(position, variance);
       };
+#endif
 
   eicrecon::SeedContainer seeds = finder.createSeeds(m_seedFinderOptions, spacePoints, create_coordinates);
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This adapts our tracking algorithms to any Acts version between v31 and v36 (to be released, so additional refactors may hit the Acts main branch that would need porting).

The commits in this branch are topologically ordered with reference to the commit message title, Acts PR number, and version validity. All commits compile individually, but no event-for-event validation has been performed.

The support for mulitple versions is done by somewhat extensive use of preprocessor directives based on `Acts_VERSION_MAJOR`.

Builds with:
- v32.1.0: https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/3481513#L3103
- v33.1.0: https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/3482111#L3549
- v34.1.0: https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/3482134#L3699
- v35.0.0: locally, but not yet in eic_container since this requires #1520 and related eic-spack PRs first

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: Acts versions are released faster than we can keep up with)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.