### PR TITLE
Fix: Correct ZDC LYSO Sampling Fraction

### DIFF
--- a/src/algorithms/reco/FarForwardNeutronReconstructionConfig.h
+++ b/src/algorithms/reco/FarForwardNeutronReconstructionConfig.h
@@ -9,7 +9,7 @@ namespace eicrecon {
     /** Correction factors for the Hcal */
     std::vector<double>      scale_corr_coeff_hcal={-0.0756, -1.91,  2.30};
     /** Correction factors for the (optional) Ecal */
-    std::vector<double>      scale_corr_coeff_ecal={-0.0756, -1.91,  2.30};
+    std::vector<double>      scale_corr_coeff_ecal={0.3186, -2.72,  3.28};
   };
 
 } // eicrecon

--- a/src/algorithms/reco/FarForwardNeutronReconstructionConfig.h
+++ b/src/algorithms/reco/FarForwardNeutronReconstructionConfig.h
@@ -7,9 +7,9 @@ namespace eicrecon {
 
   struct FarForwardNeutronReconstructionConfig {
     /** Correction factors for the Hcal */
-    std::vector<double>      scale_corr_coeff_hcal={-0.0756, -1.91,  2.30};
+    std::vector<double>      scale_corr_coeff_hcal={-0.0756, -1.91, 2.30};
     /** Correction factors for the (optional) Ecal */
-    std::vector<double>      scale_corr_coeff_ecal={0.3186, -2.72,  3.28};
+    std::vector<double>      scale_corr_coeff_ecal={-0.352, -1.34, 1.61};
   };
 
 } // eicrecon

--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -83,7 +83,7 @@ extern "C" {
              "EcalFarForwardZDCTruthClusterAssociations"}, // edm4eic::MCRecoClusterParticleAssociation
             {
               .energyWeight = "log",
-              .sampFrac = 0.701,
+              .sampFrac = 1.0,
               .logWeightBase = 3.6,
               .enableEtaBounds = false
             },
@@ -100,7 +100,7 @@ extern "C" {
              "EcalFarForwardZDCClusterAssociations"}, // edm4eic::MCRecoClusterParticleAssociation
             {
               .energyWeight = "log",
-              .sampFrac = 0.701,
+              .sampFrac = 1.0,
               .logWeightBase = 6.2,
               .enableEtaBounds = false,
             },

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -300,7 +300,7 @@ void InitPlugin(JApplication *app) {
           {"ReconstructedFarForwardZDCNeutrons"}, // edm4eic::ReconstrutedParticleCollection,
           {
             .scale_corr_coeff_hcal={-0.0756, -1.91,  2.30},
-            .scale_corr_coeff_ecal={-0.0756, -1.91,  2.30}
+            .scale_corr_coeff_ecal={0.3186, -2.72, 3.28}
           },
           app   // TODO: Remove me once fixed
     ));

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -299,8 +299,8 @@ void InitPlugin(JApplication *app) {
            {"HcalFarForwardZDCClusters","EcalFarForwardZDCClusters"},  // edm4eic::ClusterCollection
           {"ReconstructedFarForwardZDCNeutrons"}, // edm4eic::ReconstrutedParticleCollection,
           {
-            .scale_corr_coeff_hcal={-0.0756, -1.91,  2.30},
-            .scale_corr_coeff_ecal={0.3186, -2.72, 3.28}
+            .scale_corr_coeff_hcal={-0.0756, -1.91, 2.30},
+            .scale_corr_coeff_ecal={-0.352, -1.34, 1.61}
           },
           app   // TODO: Remove me once fixed
     ));


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This sets the sampling fraction of the ZDC LYSO calorimeter back to unity, since it is a homogenous calorimeter. This will give more accurate reconstruction for low-energy photons.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @sebouh137 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
Yes, for ZDC LYSO clusters
