### PR TITLE
WIP: Modified JEventProcessorPODIO::Process to acquire lock only when need…

### DIFF
--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -372,7 +372,7 @@ void JEventProcessorPODIO::FindCollectionsToWrite(const std::shared_ptr<const JE
 void JEventProcessorPODIO::Process(const std::shared_ptr<const JEvent> &event) {
 
     std::unique_lock<std::mutex> lock(m_mutex, std::defer_lock);
-    lock.lock(); 
+    lock.lock();
     if (m_is_first_event) {
         FindCollectionsToWrite(event);
         m_is_first_event = false;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR introduces changes to the `JEventProcessorPODIO::Process` to limit the scope of locks, enabling the use of JANA's parallelism and improving the performance by avoiding unnecessary serialization of events.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No, this PR does not introduce breaking changes. Users do not need to make any changes to their existing code.

### Does this PR change default behavior?
Yes, the PR changes the default behavior by enabling JANA's parallelism through the use of `std::unique_lock` with `std::defer_lock`, allowing sections of the code to run in parallel rather than in sequence. The main change is the introduction of `std::unique_lock` with `std::defer_lock` to manage the mutex locking more precisely, allowing for better parallelism by unlocking the mutex during non-critical sections of the code.