### PR TITLE
ImagingTopoCluster: fix Init printouts by adding missing break statements

### DIFF
--- a/src/algorithms/calorimetry/ImagingTopoCluster.h
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.h
@@ -103,12 +103,13 @@ namespace eicrecon {
                "Global [eta, phi] distance between hits <= [{:.4f}, {:.4f} rad].",
                m_cfg.neighbourLayersRange, layerDistEtaPhi[0], layerDistEtaPhi[1]
                );
-
+          break;
         case ImagingTopoClusterConfig::ELayerMode::xy:
           info("Neighbour layers clustering (same sector and layer id within +- {:d}: "
                "Local [x, y] distance between hits <= [{:.4f}, {:.4f} rad].",
                m_cfg.neighbourLayersRange, layerDistXY[0], layerDistXY[1]
                );
+           break;
         default:
           error("Unknown layer mode.");
         }

--- a/src/algorithms/calorimetry/ImagingTopoCluster.h
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.h
@@ -109,7 +109,7 @@ namespace eicrecon {
                "Local [x, y] distance between hits <= [{:.4f}, {:.4f} rad].",
                m_cfg.neighbourLayersRange, layerDistXY[0], layerDistXY[1]
                );
-           break;
+          break;
         default:
           error("Unknown layer mode.");
         }


### PR DESCRIPTION
Fixed an issue where "break" is not included in a case/break statement.

### Briefly, what does this PR introduce?
When initializing the ImagingTopoCluster algorithm, there is a switch statement wherein different things are printed to inform the user what the parameters are (depending on the layer mode).  This lacked breaks for the cases, causing the other print statements to be executed.  This patch fixes it.  

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no.  no
### Does this PR change default behavior?
yes.  only prints out the information about the cuts for defining neighbors that is relevent based on the layer mode.  