### PR TITLE
TracksToParticles: avoid initializing mass from truth

### DIFF
--- a/src/algorithms/tracking/TracksToParticles.cc
+++ b/src/algorithms/tracking/TracksToParticles.cc
@@ -128,8 +128,6 @@ namespace eicrecon {
             auto rec_part = parts->create();
             rec_part.addToTracks(track);
             auto referencePoint = rec_part.getReferencePoint();
-            // float time          = 0;
-            float mass = 0;
             if (best_match >= 0) {
                 trace("Best match is found and is: {}", best_match);
                 mc_prt_is_consumed[best_match] = true;
@@ -138,8 +136,6 @@ namespace eicrecon {
                         static_cast<float>(best_mc_part.getVertex().x),
                         static_cast<float>(best_mc_part.getVertex().y),
                         static_cast<float>(best_mc_part.getVertex().z)}; // @TODO: not sure if vertex/reference point makes sense here
-                // time                 = mcpart.getTime();
-                mass = best_mc_part.getMass();
             }
 
             rec_part.setType(static_cast<int16_t>(best_match >= 0 ? 0 : -1)); // @TODO: determine type codes
@@ -147,7 +143,7 @@ namespace eicrecon {
             rec_part.setMomentum(mom);
             rec_part.setReferencePoint(referencePoint);
             rec_part.setCharge(charge_rec);
-            rec_part.setMass(mass);
+            rec_part.setMass(0.);
             rec_part.setGoodnessOfPID(0); // assume no PID until proven otherwise
             // rec_part.covMatrix()  // @TODO: covariance matrix on 4-momentum
 

--- a/src/algorithms/tracking/TracksToParticles.cc
+++ b/src/algorithms/tracking/TracksToParticles.cc
@@ -139,7 +139,7 @@ namespace eicrecon {
             }
 
             rec_part.setType(static_cast<int16_t>(best_match >= 0 ? 0 : -1)); // @TODO: determine type codes
-            rec_part.setEnergy((float) std::hypot(edm4hep::utils::magnitude(mom), mass));
+            rec_part.setEnergy(edm4hep::utils::magnitude(mom));
             rec_part.setMomentum(mom);
             rec_part.setReferencePoint(referencePoint);
             rec_part.setCharge(charge_rec);


### PR DESCRIPTION
People were confused by us removing truth PDG in ReconstructedParticles, so we better remove this too, before it is relied upon for too much.

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
Yes