### PR TITLE
Add one-to-one relation with raw tracker/calorimeter hit for reconstructed tracker/calorimeter hit

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -21,6 +21,7 @@
 #include <Math/GenVector/Cartesian3D.h>
 #include <Math/GenVector/DisplacementVector3D.h>
 #include <algorithms/service.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <fmt/core.h>
 #include <fmt/format.h>
 #include <algorithm>

--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -266,7 +266,10 @@ void CalorimeterHitReco::process(
         const decltype(edm4eic::CalorimeterHitData::local) local_position(pos.x() / dd4hep::mm, pos.y() / dd4hep::mm,
                                                                        pos.z() / dd4hep::mm);
 
-        auto recohit = recohits->create(
+#if EDM4EIC_VERSION_MAJOR >= 7
+        auto recohit =
+#endif
+        recohits->create(
             rh.getCellID(),
             energy,
             0,

--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -266,7 +266,7 @@ void CalorimeterHitReco::process(
         const decltype(edm4eic::CalorimeterHitData::local) local_position(pos.x() / dd4hep::mm, pos.y() / dd4hep::mm,
                                                                        pos.z() / dd4hep::mm);
 
-        recohits->create(
+        auto recohit = recohits->create(
             rh.getCellID(),
             energy,
             0,
@@ -278,7 +278,7 @@ void CalorimeterHitReco::process(
             lid,
             local_position);
 #if EDM4EIC_VERSION_MAJOR >= 7
-        recohits->setRawHit(rh);
+        recohit->setRawHit(rh);
 #endif
     }
 }

--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -276,6 +276,7 @@ void CalorimeterHitReco::process(
             sid,
             lid,
             local_position);
+        recohits->setRawHit(rh); 
     }
 }
 

--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -276,7 +276,7 @@ void CalorimeterHitReco::process(
             sid,
             lid,
             local_position);
-        recohits->setRawHit(rh); 
+        recohits->setRawHit(rh);
     }
 }
 

--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -278,7 +278,7 @@ void CalorimeterHitReco::process(
             lid,
             local_position);
 #if EDM4EIC_VERSION_MAJOR >= 7
-        recohit->setRawHit(rh);
+        recohit.setRawHit(rh);
 #endif
     }
 }

--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -276,6 +276,7 @@ void CalorimeterHitReco::process(
             sid,
             lid,
             local_position);
+        recohits->setRawHit(rh);
     }
 }
 

--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -277,7 +277,9 @@ void CalorimeterHitReco::process(
             sid,
             lid,
             local_position);
+#if EDM4EIC_VERSION_MAJOR >= 7
         recohits->setRawHit(rh);
+#endif
     }
 }
 

--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -276,7 +276,6 @@ void CalorimeterHitReco::process(
             sid,
             lid,
             local_position);
-        recohits->setRawHit(rh);
     }
 }
 

--- a/src/algorithms/tracking/TrackerHitReconstruction.cc
+++ b/src/algorithms/tracking/TrackerHitReconstruction.cc
@@ -75,7 +75,9 @@ std::unique_ptr<edm4eic::TrackerHitCollection> TrackerHitReconstruction::process
             m_cfg.timeResolution,                            // in ns
             static_cast<float>(raw_hit.getCharge() / 1.0e6),   // Collected energy (GeV)
             0.0F);                                       // Error on the energy
-        rec_hits->setRawHit(raw_hit);
+#if EDM4EIC_VERSION_MAJOR >= 7
+                rec_hits->setRawHit(raw_hit);
+#endif
 
     }
 

--- a/src/algorithms/tracking/TrackerHitReconstruction.cc
+++ b/src/algorithms/tracking/TrackerHitReconstruction.cc
@@ -67,7 +67,10 @@ std::unique_ptr<edm4eic::TrackerHitCollection> TrackerHitReconstruction::process
         //      - XYZ segmentation: xx -> sigma_x, yy-> sigma_y, zz -> sigma_z, tt -> 0
         //    This is properly in line with how we get the local coordinates for the hit
         //    in the TrackerSourceLinker.
-        auto rec_hit = rec_hits->create(
+ #if EDM4EIC_VERSION_MAJOR >= 7
+       auto rec_hit =
+ #endif
+       rec_hits->create(
             raw_hit.getCellID(), // Raw DD4hep cell ID
             edm4hep::Vector3f{static_cast<float>(pos.x() / mm), static_cast<float>(pos.y() / mm), static_cast<float>(pos.z() / mm)}, // mm
             edm4eic::CovDiag3f{get_variance(dim[0] / mm), get_variance(dim[1] / mm), // variance (see note above)

--- a/src/algorithms/tracking/TrackerHitReconstruction.cc
+++ b/src/algorithms/tracking/TrackerHitReconstruction.cc
@@ -67,7 +67,7 @@ std::unique_ptr<edm4eic::TrackerHitCollection> TrackerHitReconstruction::process
         //      - XYZ segmentation: xx -> sigma_x, yy-> sigma_y, zz -> sigma_z, tt -> 0
         //    This is properly in line with how we get the local coordinates for the hit
         //    in the TrackerSourceLinker.
-        rec_hits->create(
+        auto rec_hit = rec_hits->create(
             raw_hit.getCellID(), // Raw DD4hep cell ID
             edm4hep::Vector3f{static_cast<float>(pos.x() / mm), static_cast<float>(pos.y() / mm), static_cast<float>(pos.z() / mm)}, // mm
             edm4eic::CovDiag3f{get_variance(dim[0] / mm), get_variance(dim[1] / mm), // variance (see note above)
@@ -77,7 +77,7 @@ std::unique_ptr<edm4eic::TrackerHitCollection> TrackerHitReconstruction::process
             static_cast<float>(raw_hit.getCharge() / 1.0e6),   // Collected energy (GeV)
             0.0F);                                       // Error on the energy
 #if EDM4EIC_VERSION_MAJOR >= 7
-        rec_hits->setRawHit(raw_hit);
+        rec_hit.setRawHit(raw_hit);
 #endif
 
     }

--- a/src/algorithms/tracking/TrackerHitReconstruction.cc
+++ b/src/algorithms/tracking/TrackerHitReconstruction.cc
@@ -7,6 +7,7 @@
 #include <Math/GenVector/Cartesian3D.h>
 #include <Math/GenVector/DisplacementVector3D.h>
 #include <edm4eic/CovDiag3f.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4hep/Vector3f.h>
 #include <fmt/core.h>
 #include <spdlog/common.h>

--- a/src/algorithms/tracking/TrackerHitReconstruction.cc
+++ b/src/algorithms/tracking/TrackerHitReconstruction.cc
@@ -76,7 +76,7 @@ std::unique_ptr<edm4eic::TrackerHitCollection> TrackerHitReconstruction::process
             static_cast<float>(raw_hit.getCharge() / 1.0e6),   // Collected energy (GeV)
             0.0F);                                       // Error on the energy
 #if EDM4EIC_VERSION_MAJOR >= 7
-                rec_hits->setRawHit(raw_hit);
+        rec_hits->setRawHit(raw_hit);
 #endif
 
     }

--- a/src/algorithms/tracking/TrackerHitReconstruction.cc
+++ b/src/algorithms/tracking/TrackerHitReconstruction.cc
@@ -75,6 +75,7 @@ std::unique_ptr<edm4eic::TrackerHitCollection> TrackerHitReconstruction::process
             m_cfg.timeResolution,                            // in ns
             static_cast<float>(raw_hit.getCharge() / 1.0e6),   // Collected energy (GeV)
             0.0F);                                       // Error on the energy
+        rec_hits->setRawHit(raw_hit);
 
     }
 

--- a/src/factories/calorimetry/CalorimeterHitDigi_factory.h
+++ b/src/factories/calorimetry/CalorimeterHitDigi_factory.h
@@ -18,6 +18,7 @@ private:
 
     PodioInput<edm4hep::SimCalorimeterHit> m_hits_input {this};
     PodioOutput<edm4hep::RawCalorimeterHit> m_hits_output {this};
+    PodioOutput<edm4eic::MCRecoCalorimeterHitAssociation> m_assoc_output {this};
 
     ParameterRef<std::vector<double>> m_energyResolutions {this, "energyResolutions", config().eRes};
     ParameterRef<double> m_timeResolution {this, "timeResolution", config().tRes};

--- a/src/factories/calorimetry/CalorimeterHitDigi_factory.h
+++ b/src/factories/calorimetry/CalorimeterHitDigi_factory.h
@@ -18,7 +18,6 @@ private:
 
     PodioInput<edm4hep::SimCalorimeterHit> m_hits_input {this};
     PodioOutput<edm4hep::RawCalorimeterHit> m_hits_output {this};
-    PodioOutput<edm4eic::MCRecoCalorimeterHitAssociation> m_assoc_output {this};
 
     ParameterRef<std::vector<double>> m_energyResolutions {this, "energyResolutions", config().eRes};
     ParameterRef<double> m_timeResolution {this, "timeResolution", config().tRes};


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Add one-to-one relation with raw tracker/calorimeter hit for reconstructed tracker/calorimeter hit. Contingent on https://github.com/eic/EDM4eic/pull/86. 

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
