### PR TITLE
BHCAL: drop support for legacy sectors

### DIFF
--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -1,15 +1,9 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022 - 2024 David Lawrence, Derek Anderson, Wouter Deconinck
 
-#include <DD4hep/Detector.h>
-#include <DD4hep/IDDescriptor.h>
-#include <DD4hep/Readout.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
-#include <algorithm>
-#include <gsl/pointers>
 #include <memory>
-#include <stdexcept>
 
 #include "algorithms/calorimetry/CalorimeterHitDigiConfig.h"
 #include "algorithms/calorimetry/CalorimeterIslandClusterConfig.h"
@@ -19,7 +13,6 @@
 #include "factories/calorimetry/CalorimeterHitReco_factory.h"
 #include "factories/calorimetry/CalorimeterIslandCluster_factory.h"
 #include "factories/calorimetry/CalorimeterTruthClustering_factory.h"
-#include "services/geometry/dd4hep/DD4hep_service.h"
 
 extern "C" {
 

--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -23,32 +23,6 @@
 
 extern "C" {
 
-    bool UseSectorIndexedBHCalReadout(JApplication *app) {
-
-        using namespace eicrecon;
-
-        // grab detector & segmentation descriptor
-        auto detector   = app->GetService<DD4hep_service>()->detector();
-        dd4hep::IDDescriptor descriptor;
-        try {
-          descriptor = detector->readout("HcalBarrelHits").idSpec();
-        } catch(const std::runtime_error &e) {
-          // detector not found in the geometry, result should not matter -
-          // default to non-deprecated behavior
-          return true;
-        }
-
-        // check if sector field is present
-        bool useSectorIndex = false;
-        try {
-          auto sector = descriptor.field("sector");
-          return true;
-        } catch(const std::runtime_error &e) {
-          return false;
-        }
-
-    }  // end 'UseSectorIndexedBHCalReadout(JApplication*)'
-
     void InitPlugin(JApplication *app) {
 
         using namespace eicrecon;
@@ -73,19 +47,6 @@ extern "C" {
           // check for horizontally adjacent tiles at wraparound
           "  ( (abs(eta_1 - eta_2) == 0) && (abs(phi_1 - phi_2) == (320 - 1)) )"
           ") == 1";
-
-        // If using readout structure with sector segmentation,
-        // ensure adjacency matrix uses sector indices
-        if ( UseSectorIndexedBHCalReadout(app) ) {
-          HcalBarrel_adjacencyMatrix =
-            "("
-            "  abs(fmod(tower_1, 24) - fmod(tower_2, 24))"
-            "  + min("
-            "      abs((sector_1 - sector_2) * (2 * 5) + (floor(tower_1 / 24) - floor(tower_2 / 24)) * 5 + fmod(tile_1, 5) - fmod(tile_2, 5)),"
-            "      (32 * 2 * 5) - abs((sector_1 - sector_2) * (2 * 5) + (floor(tower_1 / 24) - floor(tower_2 / 24)) * 5 + fmod(tile_1, 5) - fmod(tile_2, 5))"
-            "    )"
-            ") == 1";
-        }
 
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
           "HcalBarrelRawHits", {"HcalBarrelHits"}, {"HcalBarrelRawHits"},


### PR DESCRIPTION
This readout field was removed in 24.03.0. We don't need to support it.

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No