### PR TITLE
Added missing seed finder parameter

### DIFF
--- a/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
+++ b/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
@@ -35,7 +35,6 @@ namespace eicrecon {
     float beamPosX         = 0; // x offset for beam position
     float beamPosY         = 0; // y offset for beam position
     float impactMax        = 3. * Acts::UnitConstants::mm; // Maximum transverse PCA allowed
-    float bFieldMin        = 0.1 * Acts::UnitConstants::T; // T (in Acts units of GeV/[e*mm]) - Minimum Magnetic field strength
     float rMinMiddle       = 20. * Acts::UnitConstants::mm; // Middle spacepoint must fall between these two radii
     float rMaxMiddle       = 400. * Acts::UnitConstants::mm;
 

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -87,6 +87,7 @@ void eicrecon::TrackSeeding::configure() {
     // Finder parameters
     m_seedFinderConfig.seedFilter = std::make_unique<Acts::SeedFilter<eicrecon::SpacePoint>>(Acts::SeedFilter<eicrecon::SpacePoint>(m_seedFilterConfig));
     m_seedFinderConfig.rMax               = m_cfg.rMax;
+    m_seedFinderConfig.rMin               = m_cfg.rMin;
     m_seedFinderConfig.deltaRMinTopSP     = m_cfg.deltaRMinTopSP;
     m_seedFinderConfig.deltaRMaxTopSP     = m_cfg.deltaRMaxTopSP;
     m_seedFinderConfig.deltaRMinBottomSP  = m_cfg.deltaRMinBottomSP;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The _rMin_ parameter defined in the seeder configuration file was not being passed to the seed finder. This PR adds this. The parameter is currently set to the default value defined here:

https://github.com/acts-project/acts/blob/main/Core/include/Acts/Seeding/SeedFinderOrthogonalConfig.hpp#L39
https://github.com/acts-project/acts/blob/main/Core/include/Acts/Seeding/SeedFinderConfig.hpp#L43

So, there should be no change to the output. But it will be needed in the future if we ever want to search for seeds in an outer part of the tracking detector volume.

In addition, the _bFieldMin_ parameter defined in the seeder configuration file but not passed to the seed finder has been removed. This parameter does not seem to be a Acts seed finder parameter in any event. It seems to only be used if the _EstimateTrackParamsFromSeed_ class is called to fit the seed parameters (which we do not use):

https://github.com/acts-project/acts/blob/main/Core/include/Acts/Seeding/EstimateTrackParamsFromSeed.hpp#L148-L149


### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.