### PR TITLE
fix(ci): suppress more UB false positives out of our scope

### DIFF
--- a/.github/ubsan.supp
+++ b/.github/ubsan.supp
@@ -1,3 +1,6 @@
 implicit-integer-sign-change:JsonMaterialDecorator
-implicit-integer-sign-change:/usr/local/include/eigen3/Eigen/src/Core/arch/SSE/PacketMath.h
+implicit-integer-sign-change:/opt/local/include/eigen3/Eigen/src/Core/arch/SSE/PacketMath.h
 implicit-integer-sign-change:TObject
+implicit-signed-integer-truncation:/opt/local/include/boost/iostreams/filter/gzip.hpp
+implicit-integer-sign-change:/opt/local/include/eigen3/Eigen/src/Core/arch/SSE/Complex.h
+implicit-unsigned-integer-truncation:/opt/local/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -43,7 +43,7 @@ env:
   JANA_OPTIONS: "-Pjana:ticker_interval=60000 -Pjana:extended_report=1 -Pjana:warmup_timeout=0 -Pjana:timeout=0"
   ASAN_OPTIONS: suppressions=${{ github.workspace }}/.github/asan.supp:malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:detect_stack_use_after_return=1:detect_odr_violation=1:new_delete_type_mismatch=0:intercept_tls_get_addr=0
   LSAN_OPTIONS: suppressions=${{ github.workspace }}/.github/lsan.supp
-  UBSAN_OPTIONS: suppressions=${{ github.workspace }}/.github/ubsan.supp:print_stacktrace=1:silence_unsigned_overflow=1
+  UBSAN_OPTIONS: suppressions=${{ github.workspace }}/.github/ubsan.supp:print_stacktrace=1:silence_unsigned_overflow=1,report_error_type=1
 
 jobs:
   env:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
We're at 71 warnings (https://github.com/eic/EICrecon/actions/runs/10238130891), most outside of our control in boost iostream, eigen3, and acts. This PR causes UBSan to print the actual error name to use in the suppression file, and then uses that to suppress the false positives (well, out of our scope errors). This bring us down to 34 errors.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.