### PR TITLE
fix: no more JANA2 banner, since now JANA2 itself prints one for us

### DIFF
--- a/src/utilities/eicrecon/eicrecon_cli.cpp
+++ b/src/utilities/eicrecon/eicrecon_cli.cpp
@@ -409,7 +409,6 @@ int Execute(JApplication* app, UserOptions& options) {
   } else {
     // Run JANA in normal mode
     try {
-      printJANAHeaderIMG();
       JSignalHandler::register_handlers(app);
       app->Run();
     } catch (JException& e) {

--- a/src/utilities/eicrecon/print_info.h
+++ b/src/utilities/eicrecon/print_info.h
@@ -33,17 +33,3 @@ void printPluginNames(std::vector<std::string> const& plugin_names) {
     plugin_table.Render(ss);
     std::cout << ss.str() << std::endl;
 }
-
-void printJANAHeaderIMG() {
-    std::cout << "     ____      _     ___      ___       _               \n"
-                 "     `MM'     dM.    `MM\\     `M'      dM.              \n"
-                 "      MM     ,MMb     MMM\\     M      ,MMb              \n"
-                 "      MM     d'YM.    M\\MM\\    M      d'YM.      ____   \n"
-                 "      MM    ,P `Mb    M \\MM\\   M     ,P `Mb     6MMMMb  \n"
-                 "      MM    d'  YM.   M  \\MM\\  M     d'  YM.   MM'  `Mb \n"
-                 "      MM   ,P   `Mb   M   \\MM\\ M    ,P   `Mb        ,MM \n"
-                 "      MM   d'    YM.  M    \\MM\\M    d'    YM.      ,MM' \n"
-                 "(8)   MM  ,MMMMMMMMb  M     \\MMM   ,MMMMMMMMb    ,M'    \n"
-                 "((   ,M9  d'      YM. M      \\MM   d'      YM. ,M'      \n"
-                 " YMMMM9 _dM_     _dMM_M_      \\M _dM_     _dMM_MMMMMMMM " << std::endl << std::endl;
-}


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Two banners is a bit much:
```console
     ____      _     ___      ___       _               
     `MM'     dM.    `MM\     `M'      dM.              
      MM     ,MMb     MMM\     M      ,MMb              
      MM     d'YM.    M\MM\    M      d'YM.      ____   
      MM    ,P `Mb    M \MM\   M     ,P `Mb     6MMMMb  
      MM    d'  YM.   M  \MM\  M     d'  YM.   MM'  `Mb 
      MM   ,P   `Mb   M   \MM\ M    ,P   `Mb        ,MM 
      MM   d'    YM.  M    \MM\M    d'    YM.      ,MM' 
(8)   MM  ,MMMMMMMMb  M     \MMM   ,MMMMMMMMb    ,M'    
((   ,M9  d'      YM. M      \MM   d'      YM. ,M'      
 YMMMM9 _dM_     _dMM_M_      \M _dM_     _dMM_MMMMMMMM 

[INFO] Creating pipe named "/tmp/jana_status" for status info.
[INFO] Setting signal handler USR1. Use to write status info to the named pipe.
[INFO] Setting signal handler SIGINT (Ctrl-C). Use a single SIGINT to enter the Inspector, or multiple SIGINTs for an immediate shutdown.
[INFO] Initializing...

       |    \      \  |     \    ___ \   
       |   _ \      \ |    _ \      ) |
   \   |  ___ \   |\  |   ___ \    __/
  \___/ _/    _\ _| \_| _/    _\ _____|

JANA2 version:   2.3.1  (unknown git status)
Install prefix:  /opt/software/linux-debian12-x86_64_v2/gcc-12.2.0/jana2-2.3.1-dpa4z6hu4nohqa6jw2337zvpwgw2pamp
Optional deps:   Podio ROOT 
```
This PR removes the larger one that we print as part of EICrecon. This now ends up with e.g.
```console
$ eicrecon ../../sim_dis_18x275_minQ2\=1000_craterlake.edm4hep.root 

[INFO] Creating pipe named "/tmp/jana_status" for status info.
[INFO] Setting signal handler USR1. Use to write status info to the named pipe.
[INFO] Setting signal handler SIGINT (Ctrl-C). Use a single SIGINT to enter the Inspector, or multiple SIGINTs for an immediate shutdown.
[INFO] Initializing...

       |    \      \  |     \    ___ \   
       |   _ \      \ |    _ \      ) |
   \   |  ___ \   |\  |   ___ \    __/
  \___/ _/    _\ _| \_| _/    _\ _____|

JANA2 version:   2.3.1  (unknown git status)
Install prefix:  /opt/software/linux-debian12-x86_64_v2/gcc-12.2.0/jana2-2.3.1-dpa4z6hu4nohqa6jw2337zvpwgw2pamp
Optional deps:   Podio ROOT 

[INFO] Initializing plugin "/home/wdconinc/git/EICrecon/.worktree/rm-jana2-double-banner/lib/EICrecon/plugins/log.so"
[INFO] Initializing plugin "/home/wdconinc/git/EICrecon/.worktree/rm-jana2-double-banner/lib/EICrecon/plugins/dd4hep.so"
[INFO] Initializing plugin "/home/wdconinc/git/EICrecon/.worktree/rm-jana2-double-banner/lib/EICrecon/plugins/acts.so"
[INFO] Initializing plugin "/home/wdconinc/git/EICrecon/.worktree/rm-jana2-double-banner/lib/EICrecon/plugins/algorithms_init.so"
```

### What kind of change does this PR introduce?
- [x] Bug fix (issue: double banner, all the way)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.