### PR TITLE
fix: avoid DD4hep printout for missing Barrel Hcal sector field

### DIFF
--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -39,13 +39,9 @@ extern "C" {
         }
 
         // check if sector field is present
-        bool useSectorIndex = false;
-        try {
-          auto sector = descriptor.field("sector");
-          return true;
-        } catch(const std::runtime_error &e) {
-          return false;
-        }
+        auto fields = descriptor.fields();
+        auto is_sector = [](auto& field){ return field.first == "sector"; };
+        return std::ranges::find_if(fields, is_sector) != fields.end();
 
     }  // end 'UseSectorIndexedBHCalReadout(JApplication*)'
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
For every run, the BHcal tries to find whether a `sector` field is in the id specification, and every time DD4hep prints out an error because it doesn't exist (e.g. https://github.com/eic/EICrecon/actions/runs/10237639088/job/28321546930#step:8:178).

This PR changes our strategy to looking in the field list, and avoiding the error message from DD4hep.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: error message for correct operation)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @ruse-traveler 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.