### PR TITLE
fix: do not override log level to debug for JEventProcessorPODIO

### DIFF
--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -15,7 +15,6 @@
 #else
 #include <podio/ROOTFrameWriter.h>
 #endif
-#include <spdlog/common.h>
 #include <chrono>
 #include <exception>
 #include <thread>

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -356,7 +356,6 @@ void JEventProcessorPODIO::Init() {
 
     auto *app = GetApplication();
     m_log = app->GetService<Log_service>()->logger("JEventProcessorPODIO");
-    m_log->set_level(spdlog::level::debug);
 #if podio_VERSION >= PODIO_VERSION(0, 99, 0)
     m_writer = std::make_unique<podio::ROOTWriter>(m_output_file);
 #else


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The JEventProcessorPODIO overrides the log level to `debug` instead of the default `info` (set by the logging service).

This PR changes that behavior and the log level is now determined by the usual mechanisms. 

### What kind of change does this PR introduce?
- [x] Bug fix (issue: hardcoded log level is debug)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.