### PR TITLE
CalorimeterIslandCluster: peakNeighbourhoodMatrix to control how far peaks need to be to split

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -80,6 +80,7 @@ static edm4hep::Vector2f globalDistEtaPhi(const CaloHit &h1, const CaloHit &h2) 
 // AlgorithmInit
 //------------------------
 void CalorimeterIslandCluster::init() {
+
     static std::map<std::string,
                 std::tuple<std::function<edm4hep::Vector2f(const CaloHit&, const CaloHit&)>, std::vector<double>>>
     distMethods{

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -80,7 +80,6 @@ static edm4hep::Vector2f globalDistEtaPhi(const CaloHit &h1, const CaloHit &h2) 
 // AlgorithmInit
 //------------------------
 void CalorimeterIslandCluster::init() {
-
     static std::map<std::string,
                 std::tuple<std::function<edm4hep::Vector2f(const CaloHit&, const CaloHit&)>, std::vector<double>>>
     distMethods{
@@ -119,30 +118,31 @@ void CalorimeterIslandCluster::init() {
             {"dimScaledLocalDistXY", m_cfg.dimScaledLocalDistXY}
     };
 
+    auto& serviceSvc = algorithms::ServiceSvc::instance();
+
+    std::function hit_pair_to_map = [this](const edm4eic::CalorimeterHit &h1, const edm4eic::CalorimeterHit &h2) {
+      std::unordered_map<std::string, double> params;
+      for(const auto &p : m_idSpec.fields()) {
+        const std::string &name = p.first;
+        const dd4hep::IDDescriptor::Field* field = p.second;
+        params.emplace(name + "_1", field->value(h1.getCellID()));
+        params.emplace(name + "_2", field->value(h2.getCellID()));
+        trace("{}_1 = {}", name, field->value(h1.getCellID()));
+        trace("{}_2 = {}", name, field->value(h2.getCellID()));
+      }
+      return params;
+    };
+
+    if (m_cfg.readout.empty()) {
+      error("readoutClass is not provided, it is needed to know the fields in readout ids");
+    } else {
+      m_idSpec = m_detector->readout(m_cfg.readout).idSpec();
+    }
+
     bool method_found = false;
 
     // Adjacency matrix methods
     if (!m_cfg.adjacencyMatrix.empty()) {
-      // sanity checks
-      if (m_cfg.readout.empty()) {
-        error("readoutClass is not provided, it is needed to know the fields in readout ids");
-      }
-      m_idSpec = m_detector->readout(m_cfg.readout).idSpec();
-
-      std::function hit_pair_to_map = [this](const edm4eic::CalorimeterHit &h1, const edm4eic::CalorimeterHit &h2) {
-        std::unordered_map<std::string, double> params;
-        for(const auto &p : m_idSpec.fields()) {
-          const std::string &name = p.first;
-          const dd4hep::IDDescriptor::Field* field = p.second;
-          params.emplace(name + "_1", field->value(h1.getCellID()));
-          params.emplace(name + "_2", field->value(h2.getCellID()));
-          trace("{}_1 = {}", name, field->value(h1.getCellID()));
-          trace("{}_2 = {}", name, field->value(h2.getCellID()));
-        }
-        return params;
-      };
-
-      auto& serviceSvc = algorithms::ServiceSvc::instance();
       is_neighbour = serviceSvc.service<EvaluatorSvc>("EvaluatorSvc")->compile(m_cfg.adjacencyMatrix, hit_pair_to_map);
       method_found = true;
     }
@@ -177,6 +177,12 @@ void CalorimeterIslandCluster::init() {
     }
 
     if (m_cfg.splitCluster) {
+      if (m_cfg.peakNeighbourhoodMatrix != "") {
+        is_maximum_neighbourhood = serviceSvc.service<EvaluatorSvc>("EvaluatorSvc")->compile(m_cfg.peakNeighbourhoodMatrix, hit_pair_to_map);
+      } else {
+        is_maximum_neighbourhood = is_neighbour;
+      }
+
       auto transverseEnergyProfileMetric_it = std::find_if(distMethods.begin(), distMethods.end(), [&](auto &p) { return m_cfg.transverseEnergyProfileMetric == p.first; });
       if (transverseEnergyProfileMetric_it == distMethods.end()) {
           throw std::runtime_error(fmt::format("Unsupported value \"{}\" for \"transverseEnergyProfileMetric\"", m_cfg.transverseEnergyProfileMetric));

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.h
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.h
@@ -67,6 +67,9 @@ namespace eicrecon {
     // helper function to group hits
     std::function<bool(const CaloHit &h1, const CaloHit &h2)> is_neighbour;
 
+    // helper function to define hit maximum
+    std::function<bool(const CaloHit &maximum, const CaloHit &other)> is_maximum_neighbourhood;
+
     // unitless counterparts of the input parameters
     std::array<double, 2> neighbourDist;
 
@@ -138,7 +141,7 @@ namespace eicrecon {
           continue;
         }
 
-        if (is_neighbour(hits[idx1], hits[idx2]) && (hits[idx2].getEnergy() > hits[idx1].getEnergy())) {
+        if (is_maximum_neighbourhood(hits[idx1], hits[idx2]) && (hits[idx2].getEnergy() > hits[idx1].getEnergy())) {
           maximum = false;
           break;
         }

--- a/src/algorithms/calorimetry/CalorimeterIslandClusterConfig.h
+++ b/src/algorithms/calorimetry/CalorimeterIslandClusterConfig.h
@@ -10,6 +10,7 @@ namespace eicrecon {
     struct CalorimeterIslandClusterConfig {
 
         std::string adjacencyMatrix;
+        std::string peakNeighbourhoodMatrix;
         std::string readout;
 
         // neighbour checking distances

--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -69,6 +69,7 @@ extern "C" {
           "EcalEndcapNIslandProtoClusters", {"EcalEndcapNRecHits"}, {"EcalEndcapNIslandProtoClusters"},
           {
             .adjacencyMatrix = "(abs(row_1 - row_2) + abs(column_1 - column_2)) == 1",
+            .peakNeighbourhoodMatrix = "max(abs(row_1 - row_2), abs(column_1 - column_2)) == 1",
             .readout = "EcalEndcapNHits",
             .sectorDist = 5.0 * dd4hep::cm,
             .splitCluster = true,

--- a/src/tests/algorithms_test/calorimetry_CalorimeterIslandCluster.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterIslandCluster.cc
@@ -151,10 +151,16 @@ TEST_CASE( "the clustering algorithm runs", "[CalorimeterIslandCluster]" ) {
     bool use_adjacencyMatrix = GENERATE(false, true);
     if (use_adjacencyMatrix) {
       cfg.adjacencyMatrix = "abs(x_1 - x_2) + abs(y_1 - y_2) == 1";
-      cfg.readout = "MockCalorimeterHits";
     } else {
       cfg.localDistXY = {1 * dd4hep::mm, 1 * dd4hep::mm};
     }
+    bool disalow_diagonal_peaks = GENERATE(false, true);
+    if (disalow_diagonal_peaks) {
+      cfg.peakNeighbourhoodMatrix = "max(abs(x_1 - x_2), abs(y_1 - y_2)) == 1";
+    } else {
+      cfg.peakNeighbourhoodMatrix = "abs(x_1 - x_2) + abs(y_1 - y_2) == 1";
+    }
+    cfg.readout = "MockCalorimeterHits";
 
     cfg.splitCluster = GENERATE(false, true);
     if (cfg.splitCluster) {
@@ -190,8 +196,17 @@ TEST_CASE( "the clustering algorithm runs", "[CalorimeterIslandCluster]" ) {
       0, // std::int32_t layer,
       edm4hep::Vector3f(0.9 /* mm */, 0.9 /* mm */, 0.0) // edm4hep::Vector3f local
     );
+
+    bool test_diagonal_cluster = GENERATE(false, true);
+    // If false, test a cluster with two maxima:
+    //  XxX
+    // If true, test a diagonal cluster:
+    //  Xx
+    //   X
+    // The idea is to test whether peakNeighbourhoodMatrix allowes increasing
+    // peak resolution threshold while keeping the Island algorithm the same.
     hits_coll.create(
-      id_desc.encode({{"system", 255}, {"x", 2}, {"y", 0}}), // std::uint64_t cellID,
+      id_desc.encode({{"system", 255}, {"x", test_diagonal_cluster ? 1 : 2}, {"y", test_diagonal_cluster ? 1 : 0}}), // std::uint64_t cellID,
       6.0, // float energy,
       0.0, // float energyError,
       0.0, // float time,
@@ -205,7 +220,11 @@ TEST_CASE( "the clustering algorithm runs", "[CalorimeterIslandCluster]" ) {
     auto protoclust_coll = std::make_unique<edm4eic::ProtoClusterCollection>();
     algo.process({&hits_coll}, {protoclust_coll.get()});
 
-    if (cfg.splitCluster) {
+    bool expect_two_peaks = cfg.splitCluster;
+    if (cfg.splitCluster && disalow_diagonal_peaks) {
+      expect_two_peaks = not test_diagonal_cluster;
+    }
+    if (expect_two_peaks) {
       REQUIRE( (*protoclust_coll).size() == 2 );
       REQUIRE( (*protoclust_coll)[0].hits_size() == 3 );
       REQUIRE( (*protoclust_coll)[0].weights_size() == 3 );

--- a/src/tests/algorithms_test/calorimetry_CalorimeterIslandCluster.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterIslandCluster.cc
@@ -203,7 +203,7 @@ TEST_CASE( "the clustering algorithm runs", "[CalorimeterIslandCluster]" ) {
     // If true, test a diagonal cluster:
     //  Xx
     //   X
-    // The idea is to test whether peakNeighbourhoodMatrix allowes increasing
+    // The idea is to test whether peakNeighbourhoodMatrix allows increasing
     // peak resolution threshold while keeping the Island algorithm the same.
     hits_coll.create(
       id_desc.encode({{"system", 255}, {"x", test_diagonal_cluster ? 1 : 2}, {"y", test_diagonal_cluster ? 1 : 0}}), // std::uint64_t cellID,


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This reduces excessive splitting observed in EEEMCal. The issue is observed by looking at E/p in log scale. The splitting causes an extended tail towards lower E/p, which reduces electron efficiency.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
Yes