### PR TITLE
fix: properly const_cast dynamic BField pointer

### DIFF
--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -141,8 +141,8 @@ std::unique_ptr<edm4eic::VertexCollection> eicrecon::IterativeVertexFinder::prod
   #if Acts_VERSION_MAJOR >= 36
   finderCfg.field = m_BField;
   #else
-  finderCfg.field = std::shared_ptr<Acts::MagneticFieldProvider>(
-    const_cast<eicrecon::BField::DD4hepBField*>(m_BField.get()));
+  finderCfg.field = std::dynamic_pointer_cast<Acts::MagneticFieldProvider>(
+    std::const_pointer_cast<eicrecon::BField::DD4hepBField>(m_BField));
   #endif
  #endif
   VertexFinder finder(std::move(finderCfg));


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes incorrect smart pointer handling that caused shared ownership semantics to be violated and objects to be deleted early.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: don't create shared_ptr from get)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.