### PR TITLE
fix: rm repeated information logging line in CalorimeterIslandClustering

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -167,7 +167,6 @@ void CalorimeterIslandCluster::init() {
             }
           };
 
-          info("Using clustering method: {}", uprop.first);
           break;
         }
       }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The CalorimeterIslandClustering algorithm prints upon initialization:
```
[ZDC:EcalFarForwardZDCIslandProtoClusters] [info] Clustering uses dimScaledLocalDistXY with distances <= [5,5]
[ZDC:EcalFarForwardZDCIslandProtoClusters] [info] Using clustering method: dimScaledLocalDistXY
```
The second line contains no information that is not already in the previous line. Code inspection indicates that the second line is only every printed when the first line has already been printed.

This PR removes the second line.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: redundant output)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No. (Unless you're parsing output, per Hyrum's Law.)

### Does this PR change default behavior?
No.