### PR TITLE
feat: print error when raw hit has amplitude > ADC capacity

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -171,7 +171,7 @@ void CalorimeterHitReco::process(
         if (rh.getAmplitude() < m_cfg.pedMeanADC + thresholdADC) {
             continue;
         }
- 
+
         if (rh.getAmplitude() > m_cfg.capADC) {
             error("Encountered hit with amplitude {} outside of ADC capacity {}", rh.getAmplitude(), m_cfg.capADC);
             continue;

--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -171,6 +171,11 @@ void CalorimeterHitReco::process(
         if (rh.getAmplitude() < m_cfg.pedMeanADC + thresholdADC) {
             continue;
         }
+ 
+        if (rh.getAmplitude() > m_cfg.capADC) {
+            error("Encountered hit with amplitude {} outside of ADC capacity {}", rh.getAmplitude(), m_cfg.capADC);
+            continue;
+        }
 
         // get layer and sector ID
         const int lid =


### PR DESCRIPTION
### Briefly, what does this PR introduce?
When a raw hit is encountered with an energy amplitude greater than the ADC capacity we think we are working with, then this almost certainly is an indication of a digitization configuration error. E.g. https://github.com/eic/EICrecon/actions/runs/10239218932/job/28324710737#step:9:6119.

This PR adds an error message for these raw hits in calorimetry.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/EICrecon/actions/runs/10239218932/job/28324710737#step:9:6119)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.