### PR TITLE
CalorimeterIslandCluster: avoid complaining about missing readouts

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -135,7 +135,9 @@ void CalorimeterIslandCluster::init() {
     };
 
     if (m_cfg.readout.empty()) {
-      error("readoutClass is not provided, it is needed to know the fields in readout ids");
+      if ((!m_cfg.adjacencyMatrix.empty()) || (!m_cfg.peakNeighbourhoodMatrix.empty())) {
+        throw std::runtime_error("readoutClass is not provided, it is needed to know the fields in readout ids");
+      }
     } else {
       m_idSpec = m_detector->readout(m_cfg.readout).idSpec();
     }
@@ -178,7 +180,7 @@ void CalorimeterIslandCluster::init() {
     }
 
     if (m_cfg.splitCluster) {
-      if (m_cfg.peakNeighbourhoodMatrix != "") {
+      if (!m_cfg.peakNeighbourhoodMatrix.empty()) {
         is_maximum_neighbourhood = serviceSvc.service<EvaluatorSvc>("EvaluatorSvc")->compile(m_cfg.peakNeighbourhoodMatrix, hit_pair_to_map);
       } else {
         is_maximum_neighbourhood = is_neighbour;

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -136,7 +136,7 @@ void CalorimeterIslandCluster::init() {
 
     if (m_cfg.readout.empty()) {
       if ((!m_cfg.adjacencyMatrix.empty()) || (!m_cfg.peakNeighbourhoodMatrix.empty())) {
-        throw std::runtime_error("readoutClass is not provided, it is needed to know the fields in readout ids");
+        throw std::runtime_error("'readout' is not provided, it is needed to know the fields in readout ids");
       }
     } else {
       m_idSpec = m_detector->readout(m_cfg.readout).idSpec();


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This fixes a small regression from https://github.com/eic/EICrecon/pull/1554 pointed out by @wdconinc. Some error messages would appear for detectors that are not using matrices and don't specify "readout" field. This allows the current status quo to continue, but removes the messages.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No