### PR TITLE
Moved exceptions from init and added debug statements to process

### DIFF
--- a/src/algorithms/fardetectors/FarDetectorMLReconstruction.cc
+++ b/src/algorithms/fardetectors/FarDetectorMLReconstruction.cc
@@ -59,7 +59,7 @@ namespace eicrecon {
     if(!m_initialized){
       debug("Initialization did not complete");
       return;
-    }    
+    }
 
     //Set beam energy from first MCBeamElectron, using std::call_once
     std::call_once(m_initBeamE,[&](){

--- a/src/algorithms/fardetectors/FarDetectorMLReconstruction.cc
+++ b/src/algorithms/fardetectors/FarDetectorMLReconstruction.cc
@@ -32,10 +32,10 @@ namespace eicrecon {
 
     // Locate and load the weight file
     // TODO - Add functionality to select passed by configuration
-    bool methodFound = false;
     if(!m_cfg.modelPath.empty()){
       try{
         m_method = dynamic_cast<TMVA::MethodBase*>(m_reader->BookMVA( m_cfg.methodName, m_cfg.modelPath ));
+        m_initialized = true;
       }
       catch(std::exception &e){
         error(fmt::format("Failed to load method {} from file {}: {}", m_cfg.methodName, m_cfg.modelPath, e.what()));
@@ -54,6 +54,12 @@ namespace eicrecon {
 
     const auto [inputTracks,beamElectrons] = input;
     auto [outputFarDetectorMLTrajectories, outputFarDetectorMLTrackParameters, outputFarDetectorMLTracks] = output;
+
+    // Check if the algorithm has been initialized properly
+    if(!m_initialized){
+      debug("Initialization did not complete");
+      return;
+    }    
 
     //Set beam energy from first MCBeamElectron, using std::call_once
     std::call_once(m_initBeamE,[&](){

--- a/src/algorithms/fardetectors/FarDetectorMLReconstruction.h
+++ b/src/algorithms/fardetectors/FarDetectorMLReconstruction.h
@@ -61,6 +61,7 @@ namespace eicrecon {
       float m_beamE{10.0};
       std::once_flag m_initBeamE;
       float nnInput[4]  = {0.0,0.0,0.0,0.0};
+      bool m_initialized{false};
 
   };
 

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
@@ -30,7 +30,7 @@ void FarDetectorTrackerCluster::init() {
   m_cellid_converter = algorithms::GeoSvc::instance().cellIDPositionConverter();
 
   if (m_cfg.readout.empty()) {
-    throw JException("Readout is empty");
+    error("Config readout field is empty");
   }
   try {
     m_seg    = m_detector->readout(m_cfg.readout).segmentation();
@@ -43,9 +43,9 @@ void FarDetectorTrackerCluster::init() {
       m_y_idx = m_id_dec->index(m_cfg.y_field);
       debug("Find layer field {}, index = {}", m_cfg.y_field, m_y_idx);
     }
+    m_initialized = true;
   } catch (...) {
     error("Failed to load ID decoder for {}", m_cfg.readout);
-    throw JException("Failed to load ID decoder");
   }
 }
 
@@ -54,6 +54,12 @@ void FarDetectorTrackerCluster::process(const FarDetectorTrackerCluster::Input& 
 
   const auto [inputHitsCollections] = input;
   auto [outputClustersCollection]   = output;
+
+  // Return if configurations are not set properly
+  if (!m_initialized) {
+    debug("Initialization did not complete");
+    return;
+  }
 
   // Loop over input and output collections - Any collection should only contain hits from a single
   // surface

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.h
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.h
@@ -62,6 +62,7 @@ private:
   const dd4hep::BitFieldCoder* m_id_dec{nullptr};
   const dd4hep::rec::CellIDPositionConverter* m_cellid_converter{nullptr};
   dd4hep::Segmentation m_seg;
+  bool m_initialized{false};
 
   int m_x_idx{0};
   int m_y_idx{0};


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Highlighted by @ShujieL and @wdconinc [https://chat.epic-eic.org/main/pl/uiei8z865tbdjn4mpou19o4tuo](https://chat.epic-eic.org/main/pl/uiei8z865tbdjn4mpou19o4tuo). Failing to initialise the FarDetectorTrackerCluster algorithm, due to missing detectors in the geometry, calls an exception meaning JANA tries to init it again on the next event resulting in errors printed for each event.

This PR tries to tidy up the output by removing the exception so that the initialisation error is only printed once. A check is instead moved to the start of process() where repeated warning messages can still be accessed by setting the logger to debug.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
NA
### Does this PR change default behavior?
Fewer repeated error statements should be printed. Otherwise no.