### PR TITLE
src/detectors: remove unused dimScaledLocalDistXY settings

### DIFF
--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -85,8 +85,6 @@ extern "C" {
             .adjacencyMatrix = HcalBarrel_adjacencyMatrix,
             .readout = "HcalBarrelHits",
             .sectorDist = 5.0 * dd4hep::cm,
-            .localDistXY = {15*dd4hep::mm, 15*dd4hep::mm},
-            .dimScaledLocalDistXY = {50.0*dd4hep::mm, 50.0*dd4hep::mm},
             .splitCluster = false,
             .minClusterHitEdep = 5.0 * dd4hep::MeV,
             .minClusterCenterEdep = 30.0 * dd4hep::MeV,

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -70,7 +70,6 @@ extern "C" {
           {
             .sectorDist = 5.0 * dd4hep::cm,
             .localDistXY = {10.0 * dd4hep::cm, 10.0 * dd4hep::cm},
-            .dimScaledLocalDistXY = {1.5, 1.5},
             .splitCluster = true,
             .minClusterHitEdep = 0.0 * dd4hep::MeV,
             .minClusterCenterEdep = 10.0 * dd4hep::MeV,

--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -64,7 +64,6 @@ extern "C" {
           {
             .sectorDist = 5.0 * dd4hep::cm,
             .localDistXY = {50 * dd4hep::cm, 50 * dd4hep::cm},
-            .dimScaledLocalDistXY = {50.0*dd4hep::mm, 50.0*dd4hep::mm},
             .splitCluster = true,
             .minClusterHitEdep = 0.1 * dd4hep::MeV,
             .minClusterCenterEdep = 3.0 * dd4hep::MeV,
@@ -211,7 +210,6 @@ extern "C" {
           {
             .sectorDist = 5.0 * dd4hep::cm,
             .localDistXY = {50 * dd4hep::cm, 50 * dd4hep::cm},
-            .dimScaledLocalDistXY = {50.0*dd4hep::mm, 50.0*dd4hep::mm},
             .splitCluster = true,
             .minClusterHitEdep = 0.1 * dd4hep::MeV,
             .minClusterCenterEdep = 3.0 * dd4hep::MeV,


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The priority of values is given by https://github.com/eic/EICrecon/blob/0d5b8d8d156099a5b1e585e277b394ff3cd61109/src/algorithms/calorimetry/CalorimeterIslandCluster.cc#L112-L120 in descending order. Hence dimScaledLocalDistXY is taken in precedence by all others. adjacencyMatrix trumps localDistXY. Hence, those values can be removed, especially given that they are often incorrect and misleading.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No