### PR TITLE
CalorimeterIslandCluster: fix incorrect distance parameter priorities

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -109,7 +109,7 @@ void CalorimeterIslandCluster::init() {
       return true;
     };
 
-    std::map<std::string, std::vector<double>> uprops{
+    std::vector<std::pair<std::string, std::vector<double>>> uprops{
             {"localDistXY", m_cfg.localDistXY},
             {"localDistXZ", m_cfg.localDistXZ},
             {"localDistYZ", m_cfg.localDistYZ},


### PR DESCRIPTION
### Briefly, what does this PR introduce?
A bug that was introduced when EICrecon code was produced from copy-pasting code from Juggler. A `uprops` variable that set option priority used to be an `std::vector`
https://eicweb.phy.anl.gov/EIC/juggler/-/blob/main/JugReco/src/components/CalorimeterIslandCluster.cpp#L213
but later became an `std::map`
https://github.com/eic/EICrecon/commit/de2f4896ff04af17dff7e2a96e0aee7485005e34#diff-57b413772a7a45d51cd383a3e763c8f739f1783ff05c234a7fdd130dd23d3045R88
hence the priority ordering became platform-dependent.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
Need to check

### Does this PR change default behavior?
Yes