### PR TITLE
Update in IterativeVertexFinder

### DIFF
--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -64,7 +64,7 @@ std::unique_ptr<edm4eic::VertexCollection> eicrecon::IterativeVertexFinder::prod
     std::vector<const edm4eic::ReconstructedParticle*> reconParticles) {
 
   auto outputVertices = std::make_unique<edm4eic::VertexCollection>();
-  
+
   using Propagator        = Acts::Propagator<Acts::EigenStepper<>>;
   using PropagatorOptions = Acts::PropagatorOptions<>;
 #if Acts_VERSION_MAJOR >= 33
@@ -177,18 +177,18 @@ std::unique_ptr<edm4eic::VertexCollection> eicrecon::IterativeVertexFinder::prod
     }
     /// CKF can provide multiple track trajectories for a single input seed
     for (auto& tip : tips) {
-      ActsExamples::TrackParameters par = trajectory->trackParameters(tip); 
-    
+      ActsExamples::TrackParameters par = trajectory->trackParameters(tip);
+
 #if Acts_VERSION_MAJOR >= 33
       inputTracks.emplace_back(&(trajectory->trackParameters(tip)));
 #else
       inputTrackPointers.push_back(&(trajectory->trackParameters(tip)));
 #endif
-      m_log->debug(" --- track local position at input = {}, {}", par.localPosition().x(), par.localPosition().y());      
-      
+      m_log->debug(" --- track local position at input = {}, {}", par.localPosition().x(), par.localPosition().y());
+
     }
   }
-  
+
 #if Acts_VERSION_MAJOR >= 33
   std::vector<Acts::Vertex> vertices;
   auto result = finder.find(inputTracks, finderOpts, state);
@@ -204,7 +204,7 @@ std::unique_ptr<edm4eic::VertexCollection> eicrecon::IterativeVertexFinder::prod
     edm4eic::Cov4f cov(vtx.fullCovariance()(0,0), vtx.fullCovariance()(1,1), vtx.fullCovariance()(2,2), vtx.fullCovariance()(3,3),
                        vtx.fullCovariance()(0,1), vtx.fullCovariance()(0,2), vtx.fullCovariance()(0,3),
                        vtx.fullCovariance()(1,2), vtx.fullCovariance()(1,3),
-                       vtx.fullCovariance()(2,3)); 
+                       vtx.fullCovariance()(2,3));
     auto eicvertex = outputVertices->create();
     eicvertex.setType(1);                                  // boolean flag if vertex is primary vertex of event
     eicvertex.setChi2((float)vtx.fitQuality().first);      // chi2
@@ -216,7 +216,7 @@ std::unique_ptr<edm4eic::VertexCollection> eicrecon::IterativeVertexFinder::prod
          (float)vtx.time(),
     }); // vtxposition
     eicvertex.setPositionError(cov);                          // covariance
-    
+
     for (const auto& t : vtx.tracks()) {
 #if Acts_VERSION_MAJOR >= 33
       const auto& trk = &t.originalParams;
@@ -227,7 +227,7 @@ std::unique_ptr<edm4eic::VertexCollection> eicrecon::IterativeVertexFinder::prod
       m_log->debug(" === track local position from vertex = {}, {}", par.localPosition().x(), par.localPosition().y());
       float loc_a = par.localPosition().x();
       float loc_b = par.localPosition().y();
-      
+
       for (const auto part : reconParticles) {
         const auto& tracks = part->getTracks();
         for (const auto trk : tracks) {

--- a/src/algorithms/tracking/IterativeVertexFinder.h
+++ b/src/algorithms/tracking/IterativeVertexFinder.h
@@ -7,6 +7,7 @@
 #include <Acts/Geometry/GeometryContext.hpp>
 #include <Acts/MagneticField/MagneticFieldContext.hpp>
 #include <edm4eic/VertexCollection.h>
+#include <edm4eic/ReconstructedParticle.h>
 #include <spdlog/logger.h>
 #include <memory>
 #include <vector>
@@ -24,7 +25,7 @@ public:
   void init(std::shared_ptr<const ActsGeometryProvider> geo_svc,
             std::shared_ptr<spdlog::logger> log);
   std::unique_ptr<edm4eic::VertexCollection>
-  produce(std::vector<const ActsExamples::Trajectories*> trajectories);
+  produce(std::vector<const ActsExamples::Trajectories*> trajectories, std::vector<const edm4eic::ReconstructedParticle*> reconParticles);
 
 private:
   std::shared_ptr<spdlog::logger> m_log;

--- a/src/global/tracking/IterativeVertexFinder_factory.h
+++ b/src/global/tracking/IterativeVertexFinder_factory.h
@@ -7,6 +7,7 @@
 #include <ActsExamples/EventData/Trajectories.hpp>
 #include <JANA/JEvent.h>
 #include <edm4eic/VertexCollection.h>
+#include <edm4eic/ReconstructedParticle.h>
 #include <memory>
 #include <string>
 #include <utility>
@@ -26,6 +27,7 @@ private:
     std::unique_ptr<AlgoT> m_algo;
 
     Input<ActsExamples::Trajectories> m_acts_trajectories_input {this};
+    Input<edm4eic::ReconstructedParticle> m_edm4eic_reconParticles_input {this, "ReconstructedParticles"};
     PodioOutput<edm4eic::Vertex> m_vertices_output {this};
 
     ParameterRef<int> m_maxVertices {this, "maxVertices", config().maxVertices,
@@ -47,7 +49,7 @@ public:
     }
 
     void Process(int64_t run_number, uint64_t event_number) {
-        m_vertices_output() = m_algo->produce(m_acts_trajectories_input());
+        m_vertices_output() = m_algo->produce(m_acts_trajectories_input(), m_edm4eic_reconParticles_input());
     }
 };
 

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -226,7 +226,7 @@ void InitPlugin(JApplication *app) {
 
     app->Add(new JOmniFactoryGeneratorT<IterativeVertexFinder_factory>(
             "CentralTrackVertices",
-            {"CentralCKFActsTrajectories"},
+            {"CentralCKFSeededActsTrajectories","ReconstructedSeededChargedParticles"},
             {"CentralTrackVertices"},
             {},
             app


### PR DESCRIPTION
### Briefly, what does this PR introduce?
  - input chosen to use SeededTrajectories
  - added association for ReconstructionParticles to output vertices

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [X] Tests for the changes have been added
- [X] Documentation has been added / updated
- [X] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
- Default input to vertexing changed to CKFSeededActsTrajectories
- ReconstructedParticle association added to the default output CKFCentralVertices