### PR TITLE
fix: revert back to HcalFarForwardZDCIslandProtoClusters

### DIFF
--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -185,7 +185,7 @@ extern "C" {
 
         app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
            "HcalFarForwardZDCClusters",
-          {"HcalFarForwardZDCImagingProtoClusters",  // edm4eic::ProtoClusterCollection
+          {"HcalFarForwardZDCIslandProtoClusters",  // edm4eic::ProtoClusterCollection
            "HcalFarForwardZDCHits"},                // edm4hep::SimCalorimeterHitCollection
           {"HcalFarForwardZDCClusters",             // edm4eic::Cluster
            "HcalFarForwardZDCClusterAssociations"}, // edm4eic::MCRecoClusterParticleAssociation


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Due to performance issues outlined in #1573, this PR reverts the ZDC reconstruction back from topological clustering to island clustering.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://eicweb.phy.anl.gov/EIC/benchmarks/physics_benchmarks/-/jobs/3651688#L4721)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators: @sebouh137 @veprbl 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, ZDC will use island clustering