### PR TITLE
fix: add rule to ubsan.supp to avoid spurious UB warning

### DIFF
--- a/.github/ubsan.supp
+++ b/.github/ubsan.supp
@@ -3,4 +3,5 @@ implicit-integer-sign-change:/opt/local/include/eigen3/Eigen/src/Core/arch/SSE/P
 implicit-integer-sign-change:TObject
 implicit-signed-integer-truncation:/opt/local/include/boost/iostreams/filter/gzip.hpp
 implicit-integer-sign-change:/opt/local/include/eigen3/Eigen/src/Core/arch/SSE/Complex.h
+implicit-integer-sign-change:/opt/local/include/root/TStorage.h
 implicit-unsigned-integer-truncation:/opt/local/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR hides the spurious warning at https://github.com/eic/EICrecon/actions/runs/10441671950/job/28913100131#step:10:81

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/EICrecon/actions/runs/10441671950/job/28913100131#step:10:81)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.