### PR TITLE
fix: CMake only needs CXX compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ cmake_minimum_required(VERSION 3.24)
 # 3.27: find_package() uses upper-case <PACKAGENAME>_ROOT variables
 cmake_policy(SET CMP0144 NEW)
 
-project(EICrecon)
+project(EICrecon LANGUAGES CXX)
 
 # CMake includes
 include(CheckCXXCompilerFlag)

--- a/src/utilities/eicrecon/CMakeLists.txt
+++ b/src/utilities/eicrecon/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(eicrecon_project)
+project(eicrecon_project LANGUAGES CXX)
 
 # Find dependencies
 find_package(JANA REQUIRED)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR updates the CMake projects (eicrecon should not be one, but that's for another day) so they don't search for the default C and C++ compilers, since only a C++ compiler is needed.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: CMake expectes CC and CXX)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.