### PR TITLE
fix: write local position in mm in CalorimeterHitsMerger

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitsMerger.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitsMerger.cc
@@ -121,7 +121,7 @@ void CalorimeterHitsMerger::process(
                 gpos.x() / dd4hep::mm, gpos.y() / dd4hep::mm, gpos.z() / dd4hep::mm
         );
         const decltype(edm4eic::CalorimeterHitData::local) local(
-                pos.x(), pos.y(), pos.z()
+                pos.x() / dd4hep::mm, pos.y() / dd4hep::mm, pos.z() / dd4hep::mm
         );
 
         out_hits->create(


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes an issue where the `local` position of merged hits is written in DD4hep units instead of EDM4eic units. The subsequent clustering expects the `local` position to be in EDM4eic units of course.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: no clustering in backward HCal, https://chat.epic-eic.org/main/pl/pg6fwpimetgf8esmz4zfotwc3c)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @lkosarz 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Fixes backward HCal clusters (should have changing number of clusters, distributed over 10x larger area).