### PR TITLE
fix: use podio::ObjectID::index in CalorimeterHitDigi

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -22,6 +22,7 @@
 #include <algorithms/service.h>
 #include <edm4hep/CaloHitContributionCollection.h>
 #include <fmt/core.h>
+#include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
 #include <algorithm>
 #include <cmath>

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -130,16 +130,13 @@ void CalorimeterHitDigi::process(
 
     // find the hits that belong to the same group (for merging)
     std::unordered_map<uint64_t, std::vector<std::size_t>> merge_map;
-    std::size_t ix = 0;
     for (const auto &ahit : *simhits) {
         uint64_t hid = ahit.getCellID() & id_mask;
 
         trace("org cell ID in {:s}: {:#064b}", m_cfg.readout, ahit.getCellID());
         trace("new cell ID in {:s}: {:#064b}", m_cfg.readout, hid);
 
-        merge_map[hid].push_back(ix);
-
-        ix++;
+        merge_map[hid].push_back(ahit.getObjectID().index);
     }
 
     // signal sum


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Instead of using our own counting index in the loop, we should use the `podio::ObjectID` index, which is semantically defined as the order in the collection. Reduces locals, but otherwise pedantic.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: pedanticism, is that even a word?

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.