### PR TITLE
feat: produce *RawHitAssociations in CalorimeterHitDigi

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -150,15 +150,16 @@ void CalorimeterHitDigi::process(
         ix++;
     }
 
-    // create hit and association in advance
-    edm4hep::MutableRawCalorimeterHit rawhit;
-#if EDM4EIC_VERSION_MAJOR >= 7
-    std::vector<edm4eic::MutableMCRecoCalorimeterHitAssociation> rawassocs_;
-#endif
-
     // signal sum
     // NOTE: we take the cellID of the most energetic hit in this group so it is a real cellID from an MC hit
     for (const auto &[id, ixs] : merge_map) {
+
+        // create hit and association in advance
+        edm4hep::MutableRawCalorimeterHit rawhit;
+#if EDM4EIC_VERSION_MAJOR >= 7
+        std::vector<edm4eic::MutableMCRecoCalorimeterHitAssociation> rawassocs_;
+#endif
+
         double edep     = 0;
         double time     = std::numeric_limits<double>::max();
         double max_edep = 0;

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -157,7 +157,7 @@ void CalorimeterHitDigi::process(
         // create hit and association in advance
         edm4hep::MutableRawCalorimeterHit rawhit;
 #if EDM4EIC_VERSION_MAJOR >= 7
-        std::vector<edm4eic::MutableMCRecoCalorimeterHitAssociation> rawassocs_;
+        std::vector<edm4eic::MutableMCRecoCalorimeterHitAssociation> rawassocs_staging;
 #endif
 
         double edep     = 0;
@@ -192,7 +192,7 @@ void CalorimeterHitDigi::process(
             assoc.setRawHit(rawhit);
             assoc.setSimHit(hit);
             assoc.setWeight(hit.getEnergy());
-            rawassocs_.push_back(assoc);
+            rawassocs_staging.push_back(assoc);
 #endif
         }
         if (time > m_cfg.capTime) continue;
@@ -221,7 +221,7 @@ void CalorimeterHitDigi::process(
         rawhits->push_back(rawhit);
 
 #if EDM4EIC_VERSION_MAJOR >= 7
-        for (auto& assoc : rawassocs_) {
+        for (auto& assoc : rawassocs_staging) {
             assoc.setWeight(assoc.getWeight() / edep);
             rawassocs->push_back(assoc);
         }

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.h
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.h
@@ -16,6 +16,10 @@
 #include <algorithms/algorithm.h>
 #include <algorithms/geo.h>
 #include <DD4hep/IDDescriptor.h>
+#include <edm4eic/EDM4eicVersion.h>
+#if EDM4EIC_VERSION_MAJOR >= 7
+#include <edm4eic/MCRecoCalorimeterHitAssociationCollection.h>
+#endif
 #include <edm4hep/RawCalorimeterHitCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
 #include <random>
@@ -34,7 +38,12 @@ namespace eicrecon {
       edm4hep::SimCalorimeterHitCollection
     >,
     algorithms::Output<
+#if EDM4EIC_VERSION_MAJOR >= 7
+      edm4hep::RawCalorimeterHitCollection,
+      edm4eic::MCRecoCalorimeterHitAssociationCollection
+#else
       edm4hep::RawCalorimeterHitCollection
+#endif
     >
   >;
 
@@ -46,7 +55,11 @@ namespace eicrecon {
     CalorimeterHitDigi(std::string_view name)
       : CalorimeterHitDigiAlgorithm{name,
                             {"inputHitCollection"},
+#if EDM4EIC_VERSION_MAJOR >= 7
+                            {"outputRawHitCollection", "outputRawHitAssociationCollection"},
+#else
                             {"outputRawHitCollection"},
+#endif
                             "Smear energy deposit, digitize within ADC range, add pedestal, "
                             "convert time with smearing resolution, and sum signals."} {}
 

--- a/src/detectors/B0ECAL/B0ECAL.cc
+++ b/src/detectors/B0ECAL/B0ECAL.cc
@@ -24,7 +24,7 @@ extern "C" {
         InitJANAPlugin(app);
 
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-          "B0ECalRawHits", {"B0ECalHits"}, {"B0ECalRawHits"},
+          "B0ECalRawHits", {"B0ECalHits"}, {"B0ECalRawHits", "B0ECalRawHitAssociations"},
           {
             .eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV},
             .tRes = 0.0 * dd4hep::ns,

--- a/src/detectors/B0ECAL/B0ECAL.cc
+++ b/src/detectors/B0ECAL/B0ECAL.cc
@@ -3,6 +3,7 @@
 //
 //
 
+#include <edm4eic/EDM4eicVersion.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
 #include <math.h>
@@ -24,7 +25,13 @@ extern "C" {
         InitJANAPlugin(app);
 
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-          "B0ECalRawHits", {"B0ECalHits"}, {"B0ECalRawHits", "B0ECalRawHitAssociations"},
+          "B0ECalRawHits",
+          {"B0ECalHits"},
+#if EDM4EIC_VERSION_MAJOR >= 7
+          {"B0ECalRawHits", "B0ECalRawHitAssociations"},
+#else
+          {"B0ECalRawHits"},
+#endif
           {
             .eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV},
             .tRes = 0.0 * dd4hep::ns,

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -3,6 +3,7 @@
 //
 //
 
+#include <edm4eic/EDM4eicVersion.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
 #include <math.h>
@@ -37,7 +38,11 @@ extern "C" {
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
            "EcalBarrelScFiRawHits",
            {"EcalBarrelScFiHits"},
+#if EDM4EIC_VERSION_MAJOR >= 7
            {"EcalBarrelScFiRawHits", "EcalBarrelScFiRawHitAssociations"},
+#else
+           {"EcalBarrelScFiRawHits"},
+#endif
            {
              .eRes = {0.0 * sqrt(dd4hep::GeV), 0.0, 0.0 * dd4hep::GeV},
              .tRes = 0.0 * dd4hep::ns,
@@ -113,7 +118,11 @@ extern "C" {
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
            "EcalBarrelImagingRawHits",
           {"EcalBarrelImagingHits"},
+#if EDM4EIC_VERSION_MAJOR >= 7
           {"EcalBarrelImagingRawHits", "EcalBarrelImagingRawHitAssociations"},
+#else
+          {"EcalBarrelImagingRawHits"},
+#endif
           {
              .eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV},
              .tRes = 0.0 * dd4hep::ns,

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -37,7 +37,7 @@ extern "C" {
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
            "EcalBarrelScFiRawHits",
            {"EcalBarrelScFiHits"},
-           {"EcalBarrelScFiRawHits"},
+           {"EcalBarrelScFiRawHits", "EcalBarrelScFiRawHitAssociations"},
            {
              .eRes = {0.0 * sqrt(dd4hep::GeV), 0.0, 0.0 * dd4hep::GeV},
              .tRes = 0.0 * dd4hep::ns,
@@ -113,7 +113,7 @@ extern "C" {
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
            "EcalBarrelImagingRawHits",
           {"EcalBarrelImagingHits"},
-          {"EcalBarrelImagingRawHits"},
+          {"EcalBarrelImagingRawHits", "EcalBarrelImagingRawHitAssociations"},
           {
              .eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV},
              .tRes = 0.0 * dd4hep::ns,

--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022 - 2024 David Lawrence, Derek Anderson, Wouter Deconinck
 
+#include <edm4eic/EDM4eicVersion.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
 #include <memory>
@@ -42,7 +43,13 @@ extern "C" {
           ") == 1";
 
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-          "HcalBarrelRawHits", {"HcalBarrelHits"}, {"HcalBarrelRawHits", "HcalBarrelRawHitAssociations"},
+          "HcalBarrelRawHits",
+          {"HcalBarrelHits"},
+#if EDM4EIC_VERSION_MAJOR >= 7
+          {"HcalBarrelRawHits", "HcalBarrelRawHitAssociations"},
+#else
+          {"HcalBarrelRawHits"},
+#endif
           {
             .eRes = {},
             .tRes = 0.0 * dd4hep::ns,

--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -42,7 +42,7 @@ extern "C" {
           ") == 1";
 
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-          "HcalBarrelRawHits", {"HcalBarrelHits"}, {"HcalBarrelRawHits"},
+          "HcalBarrelRawHits", {"HcalBarrelHits"}, {"HcalBarrelRawHits", "HcalBarrelRawHitAssociations"},
           {
             .eRes = {},
             .tRes = 0.0 * dd4hep::ns,

--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -30,7 +30,7 @@ extern "C" {
         decltype(CalorimeterHitDigiConfig::pedSigmaADC)   EcalEndcapN_pedSigmaADC = 1;
         decltype(CalorimeterHitDigiConfig::resolutionTDC) EcalEndcapN_resolutionTDC = 10 * dd4hep::picosecond;
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-          "EcalEndcapNRawHits", {"EcalEndcapNHits"}, {"EcalEndcapNRawHits"},
+          "EcalEndcapNRawHits", {"EcalEndcapNHits"}, {"EcalEndcapNRawHits", "EcalEndcapNRawHitAssociations"},
           {
             .eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV},
             .tRes = 0.0 * dd4hep::ns,

--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -3,6 +3,7 @@
 //
 //
 
+#include <edm4eic/EDM4eicVersion.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
 #include <math.h>
@@ -30,7 +31,13 @@ extern "C" {
         decltype(CalorimeterHitDigiConfig::pedSigmaADC)   EcalEndcapN_pedSigmaADC = 1;
         decltype(CalorimeterHitDigiConfig::resolutionTDC) EcalEndcapN_resolutionTDC = 10 * dd4hep::picosecond;
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-          "EcalEndcapNRawHits", {"EcalEndcapNHits"}, {"EcalEndcapNRawHits", "EcalEndcapNRawHitAssociations"},
+          "EcalEndcapNRawHits",
+          {"EcalEndcapNHits"},
+#if EDM4EIC_VERSION_MAJOR >= 7
+          {"EcalEndcapNRawHits", "EcalEndcapNRawHitAssociations"},
+#else
+          {"EcalEndcapNRawHits"},
+#endif
           {
             .eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV},
             .tRes = 0.0 * dd4hep::ns,

--- a/src/detectors/EHCAL/EHCAL.cc
+++ b/src/detectors/EHCAL/EHCAL.cc
@@ -3,6 +3,7 @@
 //
 //
 
+#include <edm4eic/EDM4eicVersion.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
 #include <string>
@@ -30,7 +31,13 @@ extern "C" {
         decltype(CalorimeterHitDigiConfig::resolutionTDC) HcalEndcapN_resolutionTDC = 10 * dd4hep::picosecond;
 
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-          "HcalEndcapNRawHits", {"HcalEndcapNHits"}, {"HcalEndcapNRawHits", "HcalEndcapNRawHitAssociations"},
+          "HcalEndcapNRawHits",
+          {"HcalEndcapNHits"},
+#if EDM4EIC_VERSION_MAJOR >= 7
+          {"HcalEndcapNRawHits", "HcalEndcapNRawHitAssociations"},
+#else
+          {"HcalEndcapNRawHits"},
+#endif
           {
             .tRes = 0.0 * dd4hep::ns,
             .capADC = HcalEndcapN_capADC,

--- a/src/detectors/EHCAL/EHCAL.cc
+++ b/src/detectors/EHCAL/EHCAL.cc
@@ -30,7 +30,7 @@ extern "C" {
         decltype(CalorimeterHitDigiConfig::resolutionTDC) HcalEndcapN_resolutionTDC = 10 * dd4hep::picosecond;
 
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-          "HcalEndcapNRawHits", {"HcalEndcapNHits"}, {"HcalEndcapNRawHits"},
+          "HcalEndcapNRawHits", {"HcalEndcapNHits"}, {"HcalEndcapNRawHits", "HcalEndcapNRawHitAssociations"},
           {
             .tRes = 0.0 * dd4hep::ns,
             .capADC = HcalEndcapN_capADC,

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -29,7 +29,7 @@ extern "C" {
         decltype(CalorimeterHitDigiConfig::pedSigmaADC)   EcalEndcapP_pedSigmaADC = 2.4576;
         decltype(CalorimeterHitDigiConfig::resolutionTDC) EcalEndcapP_resolutionTDC = 10 * dd4hep::picosecond;
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-          "EcalEndcapPRawHits", {"EcalEndcapPHits"}, {"EcalEndcapPRawHits"},
+          "EcalEndcapPRawHits", {"EcalEndcapPHits"}, {"EcalEndcapPRawHits", "EcalEndcapPRawHitAssociations"},
           {
             .eRes = {0.11333 * sqrt(dd4hep::GeV), 0.03, 0.0 * dd4hep::GeV}, // (11.333% / sqrt(E)) \oplus 3%
             .tRes = 0.0,
@@ -115,7 +115,7 @@ extern "C" {
 
         // Insert is identical to regular Ecal
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-          "EcalEndcapPInsertRawHits", {"EcalEndcapPInsertHits"}, {"EcalEndcapPInsertRawHits"},
+          "EcalEndcapPInsertRawHits", {"EcalEndcapPInsertHits"}, {"EcalEndcapPInsertRawHits", "EcalEndcapPInsertRawHitAssociations"},
           {
             .eRes = {0.11333 * sqrt(dd4hep::GeV), 0.03, 0.0 * dd4hep::GeV}, // (11.333% / sqrt(E)) \oplus 3%
             .tRes = 0.0,

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -3,6 +3,7 @@
 //
 //
 
+#include <edm4eic/EDM4eicVersion.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
 #include <math.h>
@@ -29,7 +30,13 @@ extern "C" {
         decltype(CalorimeterHitDigiConfig::pedSigmaADC)   EcalEndcapP_pedSigmaADC = 2.4576;
         decltype(CalorimeterHitDigiConfig::resolutionTDC) EcalEndcapP_resolutionTDC = 10 * dd4hep::picosecond;
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-          "EcalEndcapPRawHits", {"EcalEndcapPHits"}, {"EcalEndcapPRawHits", "EcalEndcapPRawHitAssociations"},
+          "EcalEndcapPRawHits",
+          {"EcalEndcapPHits"},
+#if EDM4EIC_VERSION_MAJOR >= 7
+          {"EcalEndcapPRawHits", "EcalEndcapPRawHitAssociations"},
+#else
+          {"EcalEndcapPRawHits"},
+#endif
           {
             .eRes = {0.11333 * sqrt(dd4hep::GeV), 0.03, 0.0 * dd4hep::GeV}, // (11.333% / sqrt(E)) \oplus 3%
             .tRes = 0.0,
@@ -115,7 +122,13 @@ extern "C" {
 
         // Insert is identical to regular Ecal
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-          "EcalEndcapPInsertRawHits", {"EcalEndcapPInsertHits"}, {"EcalEndcapPInsertRawHits", "EcalEndcapPInsertRawHitAssociations"},
+          "EcalEndcapPInsertRawHits",
+          {"EcalEndcapPInsertHits"},
+#if EDM4EIC_VERSION_MAJOR >= 7
+          {"EcalEndcapPInsertRawHits", "EcalEndcapPInsertRawHitAssociations"},
+#else
+          {"EcalEndcapPInsertRawHits"},
+#endif
           {
             .eRes = {0.11333 * sqrt(dd4hep::GeV), 0.03, 0.0 * dd4hep::GeV}, // (11.333% / sqrt(E)) \oplus 3%
             .tRes = 0.0,

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -40,7 +40,7 @@ extern "C" {
         decltype(CalorimeterHitDigiConfig::resolutionTDC) HcalEndcapPInsert_resolutionTDC = 10 * dd4hep::picosecond;
 
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-           "HcalEndcapPInsertRawHits", {"HcalEndcapPInsertHits"}, {"HcalEndcapPInsertRawHits"},
+           "HcalEndcapPInsertRawHits", {"HcalEndcapPInsertHits"}, {"HcalEndcapPInsertRawHits", "HcalEndcapPInsertRawHitAssociations"},
            {
              .eRes = {},
              .tRes = 0.0 * dd4hep::ns,
@@ -163,7 +163,7 @@ extern "C" {
         decltype(CalorimeterHitDigiConfig::resolutionTDC) LFHCAL_resolutionTDC = 10 * dd4hep::picosecond;
 
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-          "LFHCALRawHits", {"LFHCALHits"}, {"LFHCALRawHits"},
+          "LFHCALRawHits", {"LFHCALHits"}, {"LFHCALRawHits", "LFHCALRawHitAssociations"},
           {
             .eRes = {},
             .tRes = 0.0 * dd4hep::ns,

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -2,6 +2,7 @@
 // Copyright (C) 2023 Friederike Bock, Wouter Deconinck
 
 #include <DD4hep/Detector.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
 #include <TString.h>
@@ -40,7 +41,13 @@ extern "C" {
         decltype(CalorimeterHitDigiConfig::resolutionTDC) HcalEndcapPInsert_resolutionTDC = 10 * dd4hep::picosecond;
 
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-           "HcalEndcapPInsertRawHits", {"HcalEndcapPInsertHits"}, {"HcalEndcapPInsertRawHits", "HcalEndcapPInsertRawHitAssociations"},
+           "HcalEndcapPInsertRawHits",
+           {"HcalEndcapPInsertHits"},
+#if EDM4EIC_VERSION_MAJOR >= 7
+           {"HcalEndcapPInsertRawHits", "HcalEndcapPInsertRawHitAssociations"},
+#else
+           {"HcalEndcapPInsertRawHits"},
+#endif
            {
              .eRes = {},
              .tRes = 0.0 * dd4hep::ns,
@@ -163,7 +170,13 @@ extern "C" {
         decltype(CalorimeterHitDigiConfig::resolutionTDC) LFHCAL_resolutionTDC = 10 * dd4hep::picosecond;
 
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-          "LFHCALRawHits", {"LFHCALHits"}, {"LFHCALRawHits", "LFHCALRawHitAssociations"},
+          "LFHCALRawHits",
+          {"LFHCALHits"},
+#if EDM4EIC_VERSION_MAJOR >= 7
+          {"LFHCALRawHits", "LFHCALRawHitAssociations"},
+#else
+          {"LFHCALRawHits"},
+#endif
           {
             .eRes = {},
             .tRes = 0.0 * dd4hep::ns,

--- a/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
+++ b/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
@@ -24,7 +24,7 @@ extern "C" {
         InitJANAPlugin(app);
 
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-          "EcalLumiSpecRawHits", {"EcalLumiSpecHits"}, {"EcalLumiSpecRawHits"},
+          "EcalLumiSpecRawHits", {"EcalLumiSpecHits"}, {"EcalLumiSpecRawHits", "EcalLumiSpecRawHitAssociations"},
           {
             .eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV}, // flat 2%
             .tRes = 0.0 * dd4hep::ns,

--- a/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
+++ b/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
@@ -3,6 +3,7 @@
 //
 //
 
+#include <edm4eic/EDM4eicVersion.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
 #include <math.h>
@@ -24,7 +25,13 @@ extern "C" {
         InitJANAPlugin(app);
 
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-          "EcalLumiSpecRawHits", {"EcalLumiSpecHits"}, {"EcalLumiSpecRawHits", "EcalLumiSpecRawHitAssociations"},
+          "EcalLumiSpecRawHits",
+          {"EcalLumiSpecHits"},
+#if EDM4EIC_VERSION_MAJOR >= 7
+          {"EcalLumiSpecRawHits", "EcalLumiSpecRawHitAssociations"},
+#else
+          {"EcalLumiSpecRawHits"},
+#endif
           {
             .eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV}, // flat 2%
             .tRes = 0.0 * dd4hep::ns,

--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -3,6 +3,7 @@
 //
 //
 
+#include <edm4eic/EDM4eicVersion.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
 #include <math.h>
@@ -27,7 +28,13 @@ extern "C" {
 
         // LYSO part of the ZDC
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-          "EcalFarForwardZDCRawHits", {"EcalFarForwardZDCHits"}, {"EcalFarForwardZDCRawHits", "EcalFarForwardZDCRawHitAssociations"},
+          "EcalFarForwardZDCRawHits",
+          {"EcalFarForwardZDCHits"},
+#if EDM4EIC_VERSION_MAJOR >= 7
+          {"EcalFarForwardZDCRawHits", "EcalFarForwardZDCRawHitAssociations"},
+#else
+          {"EcalFarForwardZDCRawHits"},
+#endif
           {
             .tRes = 0.0 * dd4hep::ns,
             .capADC = 32768,
@@ -110,7 +117,13 @@ extern "C" {
         );
 
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-          "HcalFarForwardZDCRawHits", {"HcalFarForwardZDCHits"}, {"HcalFarForwardZDCRawHits", "HcalFarForwardZDCRawHitAssociations"},
+          "HcalFarForwardZDCRawHits",
+          {"HcalFarForwardZDCHits"},
+#if EDM4EIC_VERSION_MAJOR >= 7
+          {"HcalFarForwardZDCRawHits", "HcalFarForwardZDCRawHitAssociations"},
+#else
+          {"HcalFarForwardZDCRawHits"},
+#endif
           {
             .tRes = 0.0 * dd4hep::ns,
             .capADC = 32768,

--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -27,7 +27,7 @@ extern "C" {
 
         // LYSO part of the ZDC
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-          "EcalFarForwardZDCRawHits", {"EcalFarForwardZDCHits"}, {"EcalFarForwardZDCRawHits"},
+          "EcalFarForwardZDCRawHits", {"EcalFarForwardZDCHits"}, {"EcalFarForwardZDCRawHits", "EcalFarForwardZDCRawHitAssociations"},
           {
             .tRes = 0.0 * dd4hep::ns,
             .capADC = 32768,
@@ -110,7 +110,7 @@ extern "C" {
         );
 
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-          "HcalFarForwardZDCRawHits", {"HcalFarForwardZDCHits"}, {"HcalFarForwardZDCRawHits"},
+          "HcalFarForwardZDCRawHits", {"HcalFarForwardZDCHits"}, {"HcalFarForwardZDCRawHits", "HcalFarForwardZDCRawHitAssociations"},
           {
             .tRes = 0.0 * dd4hep::ns,
             .capADC = 32768,

--- a/src/factories/calorimetry/CalorimeterHitDigi_factory.h
+++ b/src/factories/calorimetry/CalorimeterHitDigi_factory.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <edm4eic/EDM4eicVersion.h>
+
 #include "algorithms/calorimetry/CalorimeterHitDigi.h"
 #include "services/algorithms_init/AlgorithmsInit_service.h"
 #include "extensions/jana/JOmniFactory.h"
@@ -18,7 +20,9 @@ private:
 
     PodioInput<edm4hep::SimCalorimeterHit> m_hits_input {this};
     PodioOutput<edm4hep::RawCalorimeterHit> m_hits_output {this};
+#if EDM4EIC_VERSION_MAJOR >= 7
     PodioOutput<edm4eic::MCRecoCalorimeterHitAssociation> m_hit_assocs_output {this};
+#endif
 
     ParameterRef<std::vector<double>> m_energyResolutions {this, "energyResolutions", config().eRes};
     ParameterRef<double> m_timeResolution {this, "timeResolution", config().tRes};
@@ -45,7 +49,11 @@ public:
     }
 
     void Process(int64_t run_nr, uint64_t event_nr) {
+#if EDM4EIC_VERSION_MAJOR >= 7
         m_algo->process({m_hits_input()}, {m_hits_output().get(), m_hit_assocs_output().get()});
+#else
+        m_algo->process({m_hits_input()}, {m_hits_output().get()});
+#endif
     }
 };
 

--- a/src/factories/calorimetry/CalorimeterHitDigi_factory.h
+++ b/src/factories/calorimetry/CalorimeterHitDigi_factory.h
@@ -18,6 +18,7 @@ private:
 
     PodioInput<edm4hep::SimCalorimeterHit> m_hits_input {this};
     PodioOutput<edm4hep::RawCalorimeterHit> m_hits_output {this};
+    PodioOutput<edm4eic::MCRecoCalorimeterHitAssociation> m_hit_assocs_output {this};
 
     ParameterRef<std::vector<double>> m_energyResolutions {this, "energyResolutions", config().eRes};
     ParameterRef<double> m_timeResolution {this, "timeResolution", config().tRes};
@@ -44,7 +45,7 @@ public:
     }
 
     void Process(int64_t run_nr, uint64_t event_nr) {
-        m_algo->process({m_hits_input()}, {m_hits_output().get()});
+        m_algo->process({m_hits_input()}, {m_hits_output().get(), m_hit_assocs_output().get()});
     }
 };
 

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -320,6 +320,22 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "DIRCPID",
             "DIRCParticleIDs",
             "DIRCSeededParticleIDs",
+
+#if EDM4EIC_VERSION_MAJOR >= 7
+            "B0ECalRawHitAssociations",
+            "EcalBarrelScFiRawHitAssociations",
+            "EcalBarrelImagingRawHitAssociations",
+            "HcalBarrelRawHitAssociations",
+            "EcalEndcapNRawHitAssociations",
+            "HcalEndcapNRawHitAssociations",
+            "EcalEndcapPRawHitAssociations",
+            "EcalEndcapPInsertRawHitAssociations",
+            "HcalEndcapPInsertRawHitAssociations",
+            "LFHCALRawHitAssociations",
+            "EcalLumiSpecRawHitAssociations",
+            "EcalFarForwardZDCRawHitAssociations",
+            "HcalFarForwardZDCRawHitAssociations",
+#endif
     };
     std::vector<std::string> output_exclude_collections;  // need to get as vector, then convert to set
     std::string output_include_collections = "DEPRECATED";

--- a/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
@@ -9,6 +9,7 @@
 #include <algorithms/logger.h>
 #include <catch2/catch_test_macros.hpp>
 #include <edm4eic/EDM4eicVersion.h>
+#include <edm4eic/MCRecoCalorimeterHitAssociationCollection.h>
 #include <edm4hep/CaloHitContributionCollection.h>
 #include <edm4hep/RawCalorimeterHitCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>

--- a/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
@@ -94,8 +94,8 @@ TEST_CASE( "the clustering algorithm runs", "[CalorimeterHitDigi]" ) {
 
 #if EDM4EIC_VERSION_MAJOR >= 7
     REQUIRE( (*rawassocs).size() == 1 );
-    REQUIRE( (*rawassocs)[0].getRec() == (*simhits)[0] );
-    REQUIRE( (*rawassocs)[0].getSim() == (*rawhits)[0] );
+    REQUIRE( (*rawassocs)[0].getSim() == (*simhits)[0] );
+    REQUIRE( (*rawassocs)[0].getRaw() == (*rawhits)[0] );
 #endif
   }
 }

--- a/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
@@ -94,8 +94,8 @@ TEST_CASE( "the clustering algorithm runs", "[CalorimeterHitDigi]" ) {
 
 #if EDM4EIC_VERSION_MAJOR >= 7
     REQUIRE( (*rawassocs).size() == 1 );
-    REQUIRE( (*rawassocs)[0].getSim() == (*simhits)[0] );
-    REQUIRE( (*rawassocs)[0].getRaw() == (*rawhits)[0] );
+    REQUIRE( (*rawassocs)[0].getSimHit() == (*simhits)[0] );
+    REQUIRE( (*rawassocs)[0].getRawHit() == (*rawhits)[0] );
 #endif
   }
 }

--- a/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
@@ -91,5 +91,11 @@ TEST_CASE( "the clustering algorithm runs", "[CalorimeterHitDigi]" ) {
     REQUIRE( (*rawhits)[0].getCellID() == id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}));
     REQUIRE( (*rawhits)[0].getAmplitude() == 123 + 111 );
     REQUIRE( (*rawhits)[0].getTimeStamp() == 7 ); // currently, earliest contribution is returned
+
+#if EDM4EIC_VERSION_MAJOR >= 7
+    REQUIRE( (*rawassocs).size() == 1 );
+    REQUIRE( (*rawassocs)[0].getRec() == (*simhits)[0] );
+    REQUIRE( (*rawassocs)[0].getSim() == (*rawhits)[0] );
+#endif
   }
 }

--- a/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
@@ -76,7 +76,8 @@ TEST_CASE( "the clustering algorithm runs", "[CalorimeterHitDigi]" ) {
     ));
 
     auto rawhits = std::make_unique<edm4hep::RawCalorimeterHitCollection>();
-    algo.process({simhits.get()}, {rawhits.get()});
+    auto rawassocs = std::make_unique<edm4eic::MCRecoCalorimeterHitAssociationCollection>();
+    algo.process({simhits.get()}, {rawhits.get(), rawassocs.get()});
 
     REQUIRE( (*rawhits).size() == 1 );
     REQUIRE( (*rawhits)[0].getCellID() == id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}));

--- a/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
@@ -9,7 +9,9 @@
 #include <algorithms/logger.h>
 #include <catch2/catch_test_macros.hpp>
 #include <edm4eic/EDM4eicVersion.h>
+#if EDM4EIC_VERSION_MAJOR >= 7
 #include <edm4eic/MCRecoCalorimeterHitAssociationCollection.h>
+#endif
 #include <edm4hep/CaloHitContributionCollection.h>
 #include <edm4hep/RawCalorimeterHitCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>

--- a/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
@@ -8,6 +8,7 @@
 #include <algorithms/geo.h>
 #include <algorithms/logger.h>
 #include <catch2/catch_test_macros.hpp>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4hep/CaloHitContributionCollection.h>
 #include <edm4hep/RawCalorimeterHitCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
@@ -76,8 +77,12 @@ TEST_CASE( "the clustering algorithm runs", "[CalorimeterHitDigi]" ) {
     ));
 
     auto rawhits = std::make_unique<edm4hep::RawCalorimeterHitCollection>();
+#if EDM4EIC_VERSION_MAJOR >= 7
     auto rawassocs = std::make_unique<edm4eic::MCRecoCalorimeterHitAssociationCollection>();
     algo.process({simhits.get()}, {rawhits.get(), rawassocs.get()});
+#else
+    algo.process({simhits.get()}, {rawhits.get()});
+#endif
 
     REQUIRE( (*rawhits).size() == 1 );
     REQUIRE( (*rawhits)[0].getCellID() == id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}));


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR modifies CalorimeterHitDigi to produce raw hit associations (i.e. assocations from raw hits back to sim hits, and then from there MCParticles). The weighting is done based on total energy, and only non-trivial when merging hits.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: raw calorimeter hit associations)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.