### PR TITLE
tracking: use Seeded tracks by default, rename previous default to TruthSeeded

### DIFF
--- a/src/detectors/BTOF/BTOF.cc
+++ b/src/detectors/BTOF/BTOF.cc
@@ -75,6 +75,21 @@ void InitPlugin(JApplication *app) {
     };
 
     app->Add(new JOmniFactoryGeneratorT<PIDLookup_factory>(
+          "CombinedTOFTruthSeededLUTPID",
+          {
+          "ReconstructedTruthSeededChargedWithPFRICHPIDParticles",
+          "ReconstructedTruthSeededChargedWithPFRICHPIDParticleAssociations",
+          },
+          {
+          "ReconstructedTruthSeededChargedWithPFRICHTOFPIDParticles",
+          "ReconstructedTruthSeededChargedWithPFRICHTOFPIDParticleAssociations",
+          "CombinedTOFTruthSeededParticleIDs",
+          },
+          pid_cfg,
+          app
+          ));
+
+    app->Add(new JOmniFactoryGeneratorT<PIDLookup_factory>(
           "CombinedTOFLUTPID",
           {
           "ReconstructedChargedWithPFRICHPIDParticles",
@@ -84,21 +99,6 @@ void InitPlugin(JApplication *app) {
           "ReconstructedChargedWithPFRICHTOFPIDParticles",
           "ReconstructedChargedWithPFRICHTOFPIDParticleAssociations",
           "CombinedTOFParticleIDs",
-          },
-          pid_cfg,
-          app
-          ));
-
-    app->Add(new JOmniFactoryGeneratorT<PIDLookup_factory>(
-          "CombinedTOFSeededLUTPID",
-          {
-          "ReconstructedSeededChargedWithPFRICHPIDParticles",
-          "ReconstructedSeededChargedWithPFRICHPIDParticleAssociations",
-          },
-          {
-          "ReconstructedSeededChargedWithPFRICHTOFPIDParticles",
-          "ReconstructedSeededChargedWithPFRICHTOFPIDParticleAssociations",
-          "CombinedTOFSeededParticleIDs",
           },
           pid_cfg,
           app

--- a/src/detectors/DIRC/DIRC.cc
+++ b/src/detectors/DIRC/DIRC.cc
@@ -101,6 +101,21 @@ extern "C" {
     };
 
     app->Add(new JOmniFactoryGeneratorT<PIDLookup_factory>(
+          "DIRCTruthSeededLUTPID",
+          {
+          "ReconstructedTruthSeededChargedWithPFRICHTOFPIDParticles",
+          "ReconstructedTruthSeededChargedWithPFRICHTOFPIDParticleAssociations",
+          },
+          {
+          "ReconstructedTruthSeededChargedWithPFRICHTOFDIRCPIDParticles",
+          "ReconstructedTruthSeededChargedWithPFRICHTOFDIRCPIDParticleAssociations",
+          "DIRCTruthSeededParticleIDs",
+          },
+          pid_cfg,
+          app
+          ));
+
+    app->Add(new JOmniFactoryGeneratorT<PIDLookup_factory>(
           "DIRCLUTPID",
           {
           "ReconstructedChargedWithPFRICHTOFPIDParticles",
@@ -110,21 +125,6 @@ extern "C" {
           "ReconstructedChargedWithPFRICHTOFDIRCPIDParticles",
           "ReconstructedChargedWithPFRICHTOFDIRCPIDParticleAssociations",
           "DIRCParticleIDs",
-          },
-          pid_cfg,
-          app
-          ));
-
-    app->Add(new JOmniFactoryGeneratorT<PIDLookup_factory>(
-          "DIRCSeededLUTPID",
-          {
-          "ReconstructedSeededChargedWithPFRICHTOFPIDParticles",
-          "ReconstructedSeededChargedWithPFRICHTOFPIDParticleAssociations",
-          },
-          {
-          "ReconstructedSeededChargedWithPFRICHTOFDIRCPIDParticles",
-          "ReconstructedSeededChargedWithPFRICHTOFDIRCPIDParticleAssociations",
-          "DIRCSeededParticleIDs",
           },
           pid_cfg,
           app

--- a/src/detectors/DRICH/DRICH.cc
+++ b/src/detectors/DRICH/DRICH.cc
@@ -209,6 +209,21 @@ extern "C" {
     };
 
     app->Add(new JOmniFactoryGeneratorT<PIDLookup_factory>(
+          "DRICHTruthSeededLUTPID",
+          {
+          "ReconstructedTruthSeededChargedWithPFRICHTOFDIRCPIDParticles",
+          "ReconstructedTruthSeededChargedWithPFRICHTOFDIRCPIDParticleAssociations",
+          },
+          {
+          "ReconstructedTruthSeededChargedParticles",
+          "ReconstructedTruthSeededChargedParticleAssociations",
+          "DRICHTruthSeededParticleIDs",
+          },
+          pid_cfg,
+          app
+          ));
+
+    app->Add(new JOmniFactoryGeneratorT<PIDLookup_factory>(
           "DRICHLUTPID",
           {
           "ReconstructedChargedWithPFRICHTOFDIRCPIDParticles",
@@ -218,21 +233,6 @@ extern "C" {
           "ReconstructedChargedParticles",
           "ReconstructedChargedParticleAssociations",
           "DRICHParticleIDs",
-          },
-          pid_cfg,
-          app
-          ));
-
-    app->Add(new JOmniFactoryGeneratorT<PIDLookup_factory>(
-          "DRICHSeededLUTPID",
-          {
-          "ReconstructedSeededChargedWithPFRICHTOFDIRCPIDParticles",
-          "ReconstructedSeededChargedWithPFRICHTOFDIRCPIDParticleAssociations",
-          },
-          {
-          "ReconstructedSeededChargedParticles",
-          "ReconstructedSeededChargedParticleAssociations",
-          "DRICHSeededParticleIDs",
           },
           pid_cfg,
           app

--- a/src/detectors/PFRICH/PFRICH.cc
+++ b/src/detectors/PFRICH/PFRICH.cc
@@ -99,6 +99,21 @@ extern "C" {
     };
 
     app->Add(new JOmniFactoryGeneratorT<PIDLookup_factory>(
+          "RICHEndcapNTruthSeededLUTPID",
+          {
+          "ReconstructedTruthSeededChargedWithoutPIDParticles",
+          "ReconstructedTruthSeededChargedWithoutPIDParticleAssociations",
+          },
+          {
+          "ReconstructedTruthSeededChargedWithPFRICHPIDParticles",
+          "ReconstructedTruthSeededChargedWithPFRICHPIDParticleAssociations",
+          "RICHEndcapNTruthSeededParticleIDs",
+          },
+          pid_cfg,
+          app
+          ));
+
+    app->Add(new JOmniFactoryGeneratorT<PIDLookup_factory>(
           "RICHEndcapNLUTPID",
           {
           "ReconstructedChargedWithoutPIDParticles",
@@ -108,21 +123,6 @@ extern "C" {
           "ReconstructedChargedWithPFRICHPIDParticles",
           "ReconstructedChargedWithPFRICHPIDParticleAssociations",
           "RICHEndcapNParticleIDs",
-          },
-          pid_cfg,
-          app
-          ));
-
-    app->Add(new JOmniFactoryGeneratorT<PIDLookup_factory>(
-          "RICHEndcapNSeededLUTPID",
-          {
-          "ReconstructedSeededChargedWithoutPIDParticles",
-          "ReconstructedSeededChargedWithoutPIDParticleAssociations",
-          },
-          {
-          "ReconstructedSeededChargedWithPFRICHPIDParticles",
-          "ReconstructedSeededChargedWithPFRICHPIDParticleAssociations",
-          "RICHEndcapNSeededParticleIDs",
           },
           pid_cfg,
           app

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -93,9 +93,75 @@ void InitPlugin(JApplication *app) {
             ));
 
     app->Add(new JOmniFactoryGeneratorT<CKFTracking_factory>(
-        "CentralCKFTrajectories",
+        "CentralCKFTruthSeededTrajectories",
         {
             "InitTrackParams",
+            "CentralTrackerMeasurements"
+        },
+        {
+            "CentralCKFTruthSeededActsTrajectoriesUnfiltered",
+            "CentralCKFTruthSeededActsTracksUnfiltered",
+        },
+        app
+    ));
+
+    app->Add(new JOmniFactoryGeneratorT<ActsToTracks_factory>(
+        "CentralCKFTruthSeededTracksUnfiltered",
+        {
+            "CentralTrackerMeasurements",
+            "CentralCKFTruthSeededActsTrajectoriesUnfiltered",
+            "CentralTrackingRawHitAssociations",
+        },
+        {
+            "CentralCKFTruthSeededTrajectoriesUnfiltered",
+            "CentralCKFTruthSeededTrackParametersUnfiltered",
+            "CentralCKFTruthSeededTracksUnfiltered",
+            "CentralCKFTruthSeededTrackUnfilteredAssociations",
+        },
+        app
+    ));
+
+    app->Add(new JOmniFactoryGeneratorT<AmbiguitySolver_factory>(
+        "TruthSeededAmbiguityResolutionSolver",
+        {
+             "CentralCKFTruthSeededActsTracksUnfiltered",
+             "CentralTrackerMeasurements"
+        },
+        {
+             "CentralCKFTruthSeededActsTracks",
+             "CentralCKFTruthSeededActsTrajectories",
+        },
+        app
+    ));
+
+    app->Add(new JOmniFactoryGeneratorT<ActsToTracks_factory>(
+        "CentralCKFTruthSeededTracks",
+        {
+            "CentralTrackerMeasurements",
+            "CentralCKFTruthSeededActsTrajectories",
+            "CentralTrackingRawHitAssociations",
+        },
+        {
+            "CentralCKFTruthSeededTrajectories",
+            "CentralCKFTruthSeededTrackParameters",
+            "CentralCKFTruthSeededTracks",
+            "CentralCKFTruthSeededTrackAssociations",
+        },
+        app
+    ));
+
+    app->Add(new JOmniFactoryGeneratorT<TrackSeeding_factory>(
+        "CentralTrackSeedingResults",
+        {"CentralTrackingRecHits"},
+        {"CentralTrackSeedingResults"},
+        {},
+        app
+        ));
+
+    app->Add(new JOmniFactoryGeneratorT<CKFTracking_factory>(
+        "CentralCKFTrajectories",
+        {
+            "CentralTrackSeedingResults",
             "CentralTrackerMeasurements"
         },
         {
@@ -146,72 +212,6 @@ void InitPlugin(JApplication *app) {
             "CentralCKFTrackParameters",
             "CentralCKFTracks",
             "CentralCKFTrackAssociations",
-        },
-        app
-    ));
-
-    app->Add(new JOmniFactoryGeneratorT<TrackSeeding_factory>(
-        "CentralTrackSeedingResults",
-        {"CentralTrackingRecHits"},
-        {"CentralTrackSeedingResults"},
-        {},
-        app
-        ));
-
-    app->Add(new JOmniFactoryGeneratorT<CKFTracking_factory>(
-        "CentralCKFSeededTrajectories",
-        {
-            "CentralTrackSeedingResults",
-            "CentralTrackerMeasurements"
-        },
-        {
-            "CentralCKFSeededActsTrajectoriesUnfiltered",
-            "CentralCKFSeededActsTracksUnfiltered",
-        },
-        app
-    ));
-
-    app->Add(new JOmniFactoryGeneratorT<ActsToTracks_factory>(
-        "CentralCKFSeededTracksUnfiltered",
-        {
-            "CentralTrackerMeasurements",
-            "CentralCKFSeededActsTrajectoriesUnfiltered",
-            "CentralTrackingRawHitAssociations",
-        },
-        {
-            "CentralCKFSeededTrajectoriesUnfiltered",
-            "CentralCKFSeededTrackParametersUnfiltered",
-            "CentralCKFSeededTracksUnfiltered",
-            "CentralCKFSeededTrackUnfilteredAssociations",
-        },
-        app
-    ));
-
-    app->Add(new JOmniFactoryGeneratorT<AmbiguitySolver_factory>(
-        "SeededAmbiguityResolutionSolver",
-        {
-             "CentralCKFSeededActsTracksUnfiltered",
-             "CentralTrackerMeasurements"
-        },
-        {
-             "CentralCKFSeededActsTracks",
-             "CentralCKFSeededActsTrajectories",
-        },
-        app
-    ));
-
-    app->Add(new JOmniFactoryGeneratorT<ActsToTracks_factory>(
-        "CentralCKFSeededTracks",
-        {
-            "CentralTrackerMeasurements",
-            "CentralCKFSeededActsTrajectories",
-            "CentralTrackingRawHitAssociations",
-        },
-        {
-            "CentralCKFSeededTrajectories",
-            "CentralCKFSeededTrackParameters",
-            "CentralCKFSeededTracks",
-            "CentralCKFSeededTrackAssociations",
         },
         app
     ));
@@ -289,27 +289,27 @@ void InitPlugin(JApplication *app) {
             ));
 
     app->Add(new JOmniFactoryGeneratorT<TracksToParticles_factory>(
-            "ChargedParticlesWithAssociations",
+            "ChargedTruthSeededParticlesWithAssociations",
             {
-              "CombinedTracks",
-              "CentralCKFTrackAssociations",
+              "CentralCKFTruthSeededTracks",
+              "CentralCKFTruthSeededTrackAssociations",
             },
-            {"ReconstructedChargedWithoutPIDParticles",
-             "ReconstructedChargedWithoutPIDParticleAssociations"
+            {"ReconstructedTruthSeededChargedWithoutPIDParticles",
+             "ReconstructedTruthSeededChargedWithoutPIDParticleAssociations"
             },
             {},
             app
             ));
 
     app->Add(new JOmniFactoryGeneratorT<TracksToParticles_factory>(
-            "ChargedSeededParticlesWithAssociations",
+            "ChargedParticlesWithAssociations",
             {
-              "CentralCKFSeededTracks",
-              "CentralCKFSeededTrackAssociations",
+              "CombinedTracks",
+              "CentralCKFTrackAssociations",
             },
             {
-              "ReconstructedSeededChargedWithoutPIDParticles",
-              "ReconstructedSeededChargedWithoutPIDParticleAssociations"
+              "ReconstructedChargedWithoutPIDParticles",
+              "ReconstructedChargedWithoutPIDParticleAssociations"
             },
             {},
             app

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -97,8 +97,8 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "TOFBarrelRawHitAssociations",
             "TOFEndcapRawHitAssociations",
 
+            "CombinedTOFTruthSeededParticleIDs",
             "CombinedTOFParticleIDs",
-            "CombinedTOFSeededParticleIDs",
 
             // DRICH
             "DRICHRawHits",
@@ -107,14 +107,14 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "DRICHGasTracks",
             "DRICHAerogelIrtCherenkovParticleID",
             "DRICHGasIrtCherenkovParticleID",
+            "DRICHTruthSeededParticleIDs",
             "DRICHParticleIDs",
-            "DRICHSeededParticleIDs",
 
             // PFRICH
             "RICHEndcapNRawHits",
             "RICHEndcapNRawHitsAssociations",
+            "RICHEndcapNTruthSeededParticleIDs",
             "RICHEndcapNParticleIDs",
-            "RICHEndcapNSeededParticleIDs",
 
             // MPGD
             "MPGDBarrelRecHits",
@@ -175,35 +175,35 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "GeneratedBreitFrameParticles",
             "ReconstructedParticles",
             "ReconstructedParticleAssociations",
+            "ReconstructedTruthSeededChargedParticles",
+            "ReconstructedTruthSeededChargedParticleAssociations",
+            "ReconstructedChargedRealPIDParticles",
             "ReconstructedChargedParticles",
             "ReconstructedChargedParticleAssociations",
-            "ReconstructedChargedRealPIDParticles",
-            "ReconstructedSeededChargedParticles",
-            "ReconstructedSeededChargedParticleAssociations",
             "MCScatteredElectronAssociations", // Remove if/when used internally
             "MCNonScatteredElectronAssociations", // Remove if/when used internally
             "ReconstructedChargedParticleIDs",
             "ReconstructedBreitFrameParticles",
             "CentralTrackSegments",
             "CentralTrackVertices",
+            "CentralCKFTruthSeededTrajectories",
+            "CentralCKFTruthSeededTracks",
+            "CentralCKFTruthSeededTrackAssociations",
+            "CentralCKFTruthSeededTrackParameters",
             "CentralCKFTrajectories",
             "CentralCKFTracks",
             "CentralCKFTrackAssociations",
             "CentralCKFTrackParameters",
-            "CentralCKFSeededTrajectories",
-            "CentralCKFSeededTracks",
-            "CentralCKFSeededTrackAssociations",
-            "CentralCKFSeededTrackParameters",
             //tracking properties - true seeding
+            "CentralCKFTruthSeededTrajectoriesUnfiltered",
+            "CentralCKFTruthSeededTracksUnfiltered",
+            "CentralCKFTruthSeededTrackUnfilteredAssociations",
+            "CentralCKFTruthSeededTrackParametersUnfiltered",
+             //tracking properties - realistic seeding
             "CentralCKFTrajectoriesUnfiltered",
             "CentralCKFTracksUnfiltered",
             "CentralCKFTrackUnfilteredAssociations",
             "CentralCKFTrackParametersUnfiltered",
-             //tracking properties - realistic seeding
-            "CentralCKFSeededTrajectoriesUnfiltered",
-            "CentralCKFSeededTracksUnfiltered",
-            "CentralCKFSeededTrackUnfilteredAssociations",
-            "CentralCKFSeededTrackParametersUnfiltered",
             "InclusiveKinematicsDA",
             "InclusiveKinematicsJB",
             "InclusiveKinematicsML",
@@ -318,8 +318,8 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             // DIRC
             "DIRCRawHits",
             "DIRCPID",
+            "DIRCTruthSeededParticleIDs",
             "DIRCParticleIDs",
-            "DIRCSeededParticleIDs",
     };
     std::vector<std::string> output_exclude_collections;  // need to get as vector, then convert to set
     std::string output_include_collections = "DEPRECATED";


### PR DESCRIPTION
### Briefly, what does this PR introduce?

As we agreed during the collaboration meeting, the real seeding workflow is mature and should become the default. This changes Seeded collections to not include that prefix, and prefixless collections are moved to TruthSeeding (name is long but not supposed to be used by general users). As a side effect, Jet finding and ReconstructedParticles and DRICH IRT-based PID will use real seeding.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
Yes