### PR TITLE
fix: IterativeVertexFinder Acts v33 compatibility

### DIFF
--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -225,8 +225,7 @@ std::unique_ptr<edm4eic::VertexCollection> eicrecon::IterativeVertexFinder::prod
 
     for (const auto& t : vtx.tracks()) {
 #if Acts_VERSION_MAJOR >= 33
-      const auto& trk = &t.originalParams;
-      const auto& par = finderCfg.extractParameters(trk);
+      const auto& par = finderCfg.extractParameters(t.originalParams);
 #else
       const auto& par = *t.originalParams;
 #endif


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes the IterativeVertexFinder when compiling for Acts v33. See e.g. https://github.com/acts-project/acts/blob/26b059f3af094df85f5826f4bde95b793f0106d0/Core/src/Vertexing/IterativeVertexFinder.cpp#L468.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/3746414)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.