### PR TITLE
updated MIP value in insert; also adjusted parameters of the topo clustering

### DIFF
--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -88,7 +88,7 @@ extern "C" {
       app->Add(new JOmniFactoryGeneratorT<HEXPLIT_factory>(
         "HcalEndcapPInsertSubcellHits", {"HcalEndcapPInsertRecHits"}, {"HcalEndcapPInsertSubcellHits"},
         {
-          .MIP = 800. * dd4hep::keV,
+          .MIP = 480. * dd4hep::keV,
           .Emin_in_MIPs=0.5,
           .tmax=162 * dd4hep::ns, //150 ns + (z at front face)/(speed of light)
         },
@@ -112,7 +112,7 @@ extern "C" {
               .layerMode = eicrecon::ImagingTopoClusterConfig::ELayerMode::xy,
               .sectorDist = 10.0 * dd4hep::cm,
               .minClusterHitEdep = 5.0 * dd4hep::keV,
-              .minClusterCenterEdep = 5.0 * dd4hep::MeV,
+              .minClusterCenterEdep = 3.0 * dd4hep::MeV,
               .minClusterEdep = 11.0 * dd4hep::MeV,
               .minClusterNhits = 100,
           },


### PR DESCRIPTION

### Briefly, what does this PR introduce?
Updates the MIP value used in the HEXPLIT algorithm in the calorimeter insert.  Also lowers the threshold for the center hit in a cluster.  Doing this fixes issues in the benchmark for neutron reconstruction ( see https://github.com/eic/physics_benchmarks/issues/32 ).

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [X] Other: Parameter update

### Please check if this PR fulfills the following:
- [X] Tests for the changes have been added
- [X] Documentation has been added / updated
- [X] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no

### Does this PR change default behavior?
yes.  Changes the parameters of the topo clustering.  