### PR TITLE
PIDLookup: avoid complaining about ambiguous associations

### DIFF
--- a/src/algorithms/pid_lut/PIDLookup.cc
+++ b/src/algorithms/pid_lut/PIDLookup.cc
@@ -8,7 +8,6 @@
 #include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
 #include <podio/podioVersion.h>
-#include <podio/ObjectID.h>
 #include <cmath>
 #include <gsl/pointers>
 #include <stdexcept>

--- a/src/algorithms/pid_lut/PIDLookup.cc
+++ b/src/algorithms/pid_lut/PIDLookup.cc
@@ -44,28 +44,26 @@ void PIDLookup::process(const Input& input, const Output& output) const {
   auto [recoparts_out, partassocs_out, partids_out] = output;
 
   for (const auto& recopart_without_pid : *recoparts_in) {
-    edm4hep::MCParticle mcpart;
     auto recopart = recopart_without_pid.clone();
 
     // Find MCParticle from associations and propagate the relevant ones further
-    bool assoc_found = false;
+    auto best_assoc = edm4eic::MCRecoParticleAssociation::makeEmpty();
     for (auto assoc_in : *partassocs_in) {
       if (assoc_in.getRec() == recopart_without_pid) {
-        if (assoc_found) {
-          warning("Found a duplicate association for ReconstructedParticle at index {}", recopart_without_pid.getObjectID().index);
-          warning("The previous MCParticle was at {} and the duplicate is at {}", mcpart.getObjectID().index, assoc_in.getSim().getObjectID().index);
+        if ((not best_assoc.isAvailable()) || (best_assoc.getWeight() < assoc_in.getWeight())) {
+          best_assoc = assoc_in;
         }
-        assoc_found    = true;
-        mcpart         = assoc_in.getSim();
         auto assoc_out = assoc_in.clone();
         assoc_out.setRec(recopart);
         partassocs_out->push_back(assoc_out);
       }
     }
-    if (not assoc_found) {
+    if (not best_assoc.isAvailable()) {
       recoparts_out->push_back(recopart);
       continue;
     }
+
+    edm4hep::MCParticle mcpart = best_assoc.getSim();
 
     int true_pdg    = mcpart.getPDG();
     int true_charge = mcpart.getCharge();

--- a/src/algorithms/pid_lut/PIDLookup.cc
+++ b/src/algorithms/pid_lut/PIDLookup.cc
@@ -7,6 +7,7 @@
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
+#include <podio/podioVersion.h>
 #include <podio/ObjectID.h>
 #include <cmath>
 #include <gsl/pointers>
@@ -47,7 +48,13 @@ void PIDLookup::process(const Input& input, const Output& output) const {
     auto recopart = recopart_without_pid.clone();
 
     // Find MCParticle from associations and propagate the relevant ones further
+#if podio_VERSION >= PODIO_VERSION(0, 17, 4)
     auto best_assoc = edm4eic::MCRecoParticleAssociation::makeEmpty();
+#else
+    edm4eic::MCRecoParticleAssociationCollection _best_assoc_coll;
+    edm4eic::MCRecoParticleAssociation best_assoc = _best_assoc_coll.create();
+    best_assoc.unlink();
+#endif
     for (auto assoc_in : *partassocs_in) {
       if (assoc_in.getRec() == recopart_without_pid) {
         if ((not best_assoc.isAvailable()) || (best_assoc.getWeight() < assoc_in.getWeight())) {


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This disambiguates associations by selecting one with the largest contribution. As the result, no more need to output pesky warnings:
```
[PFRICH:RICHEndcapNLUTPID] [warning] Found a duplicate association for ReconstructedParticle at index 0
[PFRICH:RICHEndcapNLUTPID] [warning] The previous MCParticle was at 2 and the duplicate is at 0
```

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No