### PR TITLE
eicrecon_cli: disable parameter tables for JANA2 2.3.x

### DIFF
--- a/src/utilities/eicrecon/eicrecon_cli.cpp
+++ b/src/utilities/eicrecon/eicrecon_cli.cpp
@@ -6,7 +6,6 @@
 
 #include <JANA/CLI/JBenchmarker.h>
 #include <JANA/CLI/JSignalHandler.h>
-#include <JANA/CLI/JVersion.h>
 #include <JANA/Services/JComponentManager.h>
 #include <algorithm>
 #include <cstdlib>
@@ -22,6 +21,7 @@
 #include "JANA/JApplication.h"
 #include "JANA/JEventSource.h"
 #include "JANA/JException.h"
+#include "JANA/JVersion.h"
 #include "JANA/Services/JParameterManager.h"
 #include "print_info.h"
 
@@ -377,9 +377,6 @@ int Execute(JApplication* app, UserOptions& options) {
 
   std::cout << std::endl;
 
-  // std::cout << "JANA " << JVersion::GetVersion() << " [" << JVersion::GetRevision() << "]" <<
-  // std::endl;
-
   if (options.flags[ShowConfigs]) {
     // Load all plugins, collect all parameters, exit without running anything
     app->Initialize();
@@ -407,6 +404,12 @@ int Execute(JApplication* app, UserOptions& options) {
     // TODO: more elegant processing here
     PrintPodioCollections(app);
   } else {
+    if ((JVersion::GetMajorNumber() == 2) && (JVersion::GetMinorNumber() == 3) && (JVersion::GetPatchNumber() <= 1)) {
+      // JANA2 2.3.x has a bug with not filtering default-state parameters, which causes enormous printouts
+      if (not app->GetJParameterManager()->Exists("jana:parameter_verbosity")) {
+        app->GetJParameterManager()->SetParameter("jana:parameter_verbosity", 0);
+      }
+    }
     // Run JANA in normal mode
     try {
       JSignalHandler::register_handlers(app);

--- a/src/utilities/eicrecon/eicrecon_cli.cpp
+++ b/src/utilities/eicrecon/eicrecon_cli.cpp
@@ -6,6 +6,7 @@
 
 #include <JANA/CLI/JBenchmarker.h>
 #include <JANA/CLI/JSignalHandler.h>
+#include <JANA/CLI/JVersion.h>
 #include <JANA/Services/JComponentManager.h>
 #include <algorithm>
 #include <cstdlib>
@@ -21,7 +22,6 @@
 #include "JANA/JApplication.h"
 #include "JANA/JEventSource.h"
 #include "JANA/JException.h"
-#include "JANA/JVersion.h"
 #include "JANA/Services/JParameterManager.h"
 #include "print_info.h"
 


### PR DESCRIPTION
Users will be notified about a way to re-enable the parameter table: https://github.com/JeffersonLab/JANA2/blob/a439a5682586bf4ba951a9723aa0d4cf55015e35/src/libraries/JANA/Services/JParameterManager.cc#L127

### Briefly, what does this PR introduce?
Reduce amount of output

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
Yes