### PR TITLE
Update to SiPM-on-Tile ZDC digitization parameters

### DIFF
--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -134,10 +134,10 @@ extern "C" {
 #endif
           {
             .tRes = 0.0 * dd4hep::ns,
-            .capADC = 32768,
-            .dyRangeADC = 800 * dd4hep::MeV,
+            .capADC = 65536,
+            .dyRangeADC = 1000. * dd4hep::MeV,
             .pedMeanADC = 400,
-            .pedSigmaADC = 10,
+            .pedSigmaADC = 2,
             .resolutionTDC = 10 * dd4hep::picosecond,
             .corrMeanScale = "1.0",
             .readout = "HcalFarForwardZDCHits",
@@ -148,12 +148,12 @@ extern "C" {
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitReco_factory>(
           "HcalFarForwardZDCRecHits", {"HcalFarForwardZDCRawHits"}, {"HcalFarForwardZDCRecHits"},
           {
-            .capADC = 32678,
-            .dyRangeADC = 800. * dd4hep::MeV,
+            .capADC = 65536,
+            .dyRangeADC = 1000. * dd4hep::MeV,
             .pedMeanADC = 400,
-            .pedSigmaADC = 10,
+            .pedSigmaADC = 2,
             .resolutionTDC = 10 * dd4hep::picosecond,
-            .thresholdFactor = 4.0,
+            .thresholdFactor = 3.0,
             .thresholdValue = 0.0,
             .sampFrac = "1.0",
             .readout = "HcalFarForwardZDCHits",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR updates the digitization parameters for the SiPM-on-Tile ZDC. The current default parameters place a zero-suppression threshold at 40 ADC channels. With a 15-bit ADC with dynamic range of 800 MeV, this is a cut at 0.98 MeV (~ 2 MIPs). We see that this has an impact on the energy reconstruction for single-particle simulations.

This PR changes following values:

```
ADC Capacity = 16-bit (65536 channels)
DynamicRange = 1000 MeV (0.015 MeV per ADC channel)
pedSigmaADC = 2
thresholdFactor = 3.0
```

These parameters are realistic. The HGROC ASIC can have a capacity of 16-bits; a high-energy photon shower can leave up to 800-1000 MeV in a single channel; and a zero-suppression cut of 6 ADC channels (0.2 MIPs) will allow studies of threshold cuts in the 0.2-0.5 MIP range.

The above changes have been discussed with the SiPM-on-Tile DSC lead, Miguel Arratia.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: Digitization parameters update

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators Discussed with @sebouh137 and M. Arratia

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, for SiPM-on-Tile ZDC

Closes: #1541