### PR TITLE
Podio event source: Use new, exception-free Emit() callback

### DIFF
--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -57,6 +57,11 @@ macro(plugin_add _name)
       PROPERTIES PREFIX ""
                  OUTPUT_NAME "${_name}"
                  SUFFIX ".so")
+    target_compile_definitions(
+      ${PLUGIN_NAME}_plugin
+      PRIVATE "JANA_VERSION_MAJOR=${JANA_VERSION_MAJOR}"
+              "JANA_VERSION_MINOR=${JANA_VERSION_MINOR}"
+              "JANA_VERSION_PATCH=${JANA_VERSION_PATCH}")
     target_link_libraries(${_name}_plugin ${JANA_LIB} podio::podio
                           podio::podioRootIO spdlog::spdlog fmt::fmt)
     target_link_libraries(${_name}_plugin Microsoft.GSL::GSL)
@@ -82,6 +87,11 @@ macro(plugin_add _name)
       PROPERTIES PREFIX "lib"
                  OUTPUT_NAME "${_name}"
                  SUFFIX ${suffix})
+    target_compile_definitions(
+      ${PLUGIN_NAME}_library
+      PRIVATE "JANA_VERSION_MAJOR=${JANA_VERSION_MAJOR}"
+              "JANA_VERSION_MINOR=${JANA_VERSION_MINOR}"
+              "JANA_VERSION_PATCH=${JANA_VERSION_PATCH}")
 
     target_include_directories(
       ${_name}_library

--- a/src/services/io/podio/JEventSourcePODIO.cc
+++ b/src/services/io/podio/JEventSourcePODIO.cc
@@ -69,6 +69,7 @@ struct InsertingVisitor {
 //------------------------------------------------------------------------------
 JEventSourcePODIO::JEventSourcePODIO(std::string resource_name, JApplication* app) : JEventSource(resource_name, app) {
     SetTypeName(NAME_OF_THIS); // Provide JANA with class name
+    SetCallbackStyle(CallbackStyle::ExpertMode); // Use new, exception-free Emit() callback
 
     // Tell JANA that we want it to call the FinishEvent() method.
     // EnableFinishEvent();
@@ -185,7 +186,7 @@ void JEventSourcePODIO::Close() {
 ///
 /// \param event
 //------------------------------------------------------------------------------
-void JEventSourcePODIO::GetEvent(std::shared_ptr<JEvent> event) {
+JEventSourcePODIO::Result JEventSourcePODIO::Emit(JEvent& event) {
 
     /// Calls to GetEvent are synchronized with each other, which means they can
     /// read and write state on the JEventSource without causing race conditions.
@@ -194,10 +195,9 @@ void JEventSourcePODIO::GetEvent(std::shared_ptr<JEvent> event) {
     if( Nevents_read >= Nevents_in_file ) {
         if( m_run_forever ){
             Nevents_read = 0;
-        }else{
-            // m_reader.close();
-            // TODO:: ROOTReader does not appear to have a close() method.
-            throw RETURN_STATUS::kNO_MORE_EVENTS;
+        }
+        else{
+            return Result::FailureFinished;
         }
     }
 
@@ -208,19 +208,20 @@ void JEventSourcePODIO::GetEvent(std::shared_ptr<JEvent> event) {
     if (event_headers.size() != 1) {
         throw JException("Bad event headers: Entry %d contains %d items, but 1 expected.", Nevents_read, event_headers.size());
     }
-    event->SetEventNumber(event_headers[0].getEventNumber());
-    event->SetRunNumber(event_headers[0].getRunNumber());
+    event.SetEventNumber(event_headers[0].getEventNumber());
+    event.SetRunNumber(event_headers[0].getRunNumber());
 
     // Insert contents odf frame into JFactories
     VisitPodioCollection<InsertingVisitor> visit;
     for (const std::string& coll_name : frame->getAvailableCollections()) {
         const podio::CollectionBase* collection = frame->get(coll_name);
-        InsertingVisitor visitor(*event, coll_name);
+        InsertingVisitor visitor(event, coll_name);
         visit(visitor, *collection);
     }
 
-    event->Insert(frame.release()); // Transfer ownership from unique_ptr to JFactoryT<podio::Frame>
+    event.Insert(frame.release()); // Transfer ownership from unique_ptr to JFactoryT<podio::Frame>
     Nevents_read += 1;
+    return Result::Success;
 }
 
 //------------------------------------------------------------------------------

--- a/src/services/io/podio/JEventSourcePODIO.h
+++ b/src/services/io/podio/JEventSourcePODIO.h
@@ -30,7 +30,7 @@ public:
 
     void Close() override;
 
-    void GetEvent(std::shared_ptr<JEvent>) override;
+    Result Emit(JEvent& event) override;
 
     static std::string GetDescription();
 

--- a/src/services/io/podio/JEventSourcePODIO.h
+++ b/src/services/io/podio/JEventSourcePODIO.h
@@ -19,6 +19,12 @@
 #include <set>
 #include <string>
 
+#if ((JANA_VERSION_MAJOR == 2) && (JANA_VERSION_MINOR >= 3)) || (JANA_VERSION_MAJOR > 2)
+#define JANA_NEW_CALLBACK_STYLE 1
+#else
+#define JANA_NEW_CALLBACK_STYLE 0
+#endif
+
 class JEventSourcePODIO : public JEventSource {
 
 public:
@@ -30,7 +36,11 @@ public:
 
     void Close() override;
 
+#if JANA_NEW_CALLBACK_STYLE
     Result Emit(JEvent& event) override;
+#else
+    void GetEvent(std::shared_ptr<JEvent>) override;
+#endif
 
     static std::string GetDescription();
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Podio event source uses a new `Emit()` callback which doesn't use exceptions for control flow.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: Refactoring

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No