### PR TITLE
fix(ci): avoid python3.10 reference; don't install bokeh, pygithub

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -769,7 +769,6 @@ jobs:
         platform-release: "${{ env.platform }}:${{ env.release }}"
         setup: "/opt/detector/epic-${{ env.detector-version }}/bin/thisepic.sh"
         run: |
-          export PYTHONPATH=$HOME/.local/lib/python3.10/site-packages:$PYTHONPATH
           mkdir capybara-reports
           mkdir new
           ln -sf ../rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root new/
@@ -970,8 +969,6 @@ jobs:
         platform-release: "${{ env.platform }}:${{ env.release }}"
         setup: "/opt/detector/epic-${{ env.detector-version }}/bin/thisepic.sh"
         run: |
-          pip install 'pygithub>=2' 'bokeh>=3'
-          export PYTHONPATH=$HOME/.local/lib/python3.10/site-packages:$PYTHONPATH
           mkdir capybara-reports
           mkdir new
           ln -sf ../rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root new/


### PR DESCRIPTION
### Briefly, what does this PR introduce?
We are using python3.11 now, so the `pip install` would install to `~/.local/lib/python3.11/site-packages` if it did anything, and the hardcoded `PYTHONPATH` prepend would then fail to find the module. That this continued to work demonstrates that we don't need to install anything locally, and can get rid of the `PYTHONPATH` modifications too.

This PR removes the `PYTHONPATH` additions and the custom `pip install`. If an update to the bokeh and pygithub packages are needed, then this is better handled by updating what is in the container, now that we have reached a more stable capybara stage of development.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: hardcoded reference to python3.10)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.