### PR TITLE
EEEMCal: remove 2% smearing

### DIFF
--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -40,7 +40,7 @@ extern "C" {
           {"EcalEndcapNRawHits"},
 #endif
           {
-            .eRes = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV},
+            .eRes = {0.0 * sqrt(dd4hep::GeV), 0.0, 0.0 * dd4hep::GeV},
             .tRes = 0.0 * dd4hep::ns,
             .threshold =  0.0 * dd4hep::MeV,  // Use ADC cut instead
             .capADC = EcalEndcapN_capADC,


### PR DESCRIPTION
This comes from Athena times where all calorimeters were smeared by 2%. We don't expect this term, we want to have something more motivated like #1064, instead. Submitting separately to confirm the effect.