### PR TITLE
fix(ci): suppress memory leaks in libJANA.so and DD4hep

### DIFF
--- a/.github/lsan.supp
+++ b/.github/lsan.supp
@@ -5,3 +5,4 @@ leak:edm4hep::*::createBuffers
 leak:libActsCore.so
 leak:libCling.so
 leak:libCore.so
+leak:libJANA.so

--- a/.github/lsan.supp
+++ b/.github/lsan.supp
@@ -1,5 +1,6 @@
 leak:CherenkovPID::AddMassHypothesis
 leak:dd4hep::DetElement::DetElement
+leak:dd4hep::detail::VolumeManager_Populator::scanPhysicalVolume
 leak:dd4hep::Header::Header
 leak:edm4hep::*::createBuffers
 leak:libActsCore.so


### PR DESCRIPTION
# Description
Backport of #1628 to `v1.18`.