### PR TITLE
Fix: Correctly fill track parameters covariance error matrix

### DIFF
--- a/src/algorithms/tracking/ActsToTracks.cc
+++ b/src/algorithms/tracking/ActsToTracks.cc
@@ -120,7 +120,9 @@ void ActsToTracks::process(const Input& input, const Output& output) const {
         for (size_t j = 0; const auto& [b, y] : edm4eic_indexed_units) {
           // FIXME why not pars.getCovariance()(i,j) = covariance(a,b) / x / y;
           cov(i,j) = covariance(a,b) / x / y;
+	  ++j;
         }
+	++i;
       }
       pars.setCovariance(cov);
 

--- a/src/algorithms/tracking/ActsToTracks.cc
+++ b/src/algorithms/tracking/ActsToTracks.cc
@@ -120,9 +120,9 @@ void ActsToTracks::process(const Input& input, const Output& output) const {
         for (size_t j = 0; const auto& [b, y] : edm4eic_indexed_units) {
           // FIXME why not pars.getCovariance()(i,j) = covariance(a,b) / x / y;
           cov(i,j) = covariance(a,b) / x / y;
-	  ++j;
+          ++j;
         }
-	++i;
+        ++i;
       }
       pars.setCovariance(cov);
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
In the loop that writes the covariance matrix for the track parameters to the edm4eic output, the indices were not being incremented.

This lead to this output:

```
root [1] events->Scan("CentralCKFTrackParameters.covariance.covariance")
***********************************
*    Row   * Instance * CentralCK *
***********************************
*        0 *        0 * 0.0003341 *
*        0 *        1 *         0 *
*        0 *        2 *         0 *
*        0 *        3 *         0 *
*        0 *        4 *         0 *
*        0 *        5 *         0 *
*        0 *        6 *         0 *
*        0 *        7 *         0 *
*        0 *        8 *         0 *
*        0 *        9 *         0 *
*        0 *       10 *         0 *
*        0 *       11 *         0 *
*        0 *       12 *         0 *
*        0 *       13 *         0 *
*        0 *       14 *         0 *
*        0 *       15 *         0 *
*        0 *       16 *         0 *
*        0 *       17 *         0 *
*        0 *       18 *         0 *
*        0 *       19 *         0 *
*        0 *       20 *         0 *
*        1 *        0 * 0.0005269 *
*        1 *        1 *         0 *
*        1 *        2 *         0 *
*        1 *        3 *         0 *
```

With the fix applied here, the correct covariance matrix is written out:

```
root [1] events->Scan("CentralCKFTrackParameters.covariance.covariance")
***********************************
*    Row   * Instance * CentralCK *
***********************************
*        0 *        0 * 0.0013565 *
*        0 *        1 * -1.27e-05 *
*        0 *        2 * 0.0514564 *
*        0 *        3 * -3.36e-05 *
*        0 *        4 * -7.13e-07 *
*        0 *        5 * 8.446e-07 *
*        0 *        6 * 2.282e-08 *
*        0 *        7 * 3.088e-05 *
*        0 *        8 * -1.17e-09 *
*        0 *        9 * 1.880e-08 *
*        0 *       10 * 7.277e-06 *
*        0 *       11 * -6.51e-07 *
*        0 *       12 * -1.60e-07 *
*        0 *       13 * -5.63e-11 *
*        0 *       14 * 4.297e-07 *
*        0 *       15 * -1.14e-07 *
*        0 *       16 * 0.0001654 *
*        0 *       17 * -9.91e-10 *
*        0 *       18 * 1.011e-07 *
*        0 *       19 * -4.97e-09 *
*        0 *       20 * 0.0003341 *
*        1 *        0 * 0.2452857 *
*        1 *        1 * -0.024439 *
*        1 *        2 * 16.420986 *
*        1 *        3 * -0.004535 *
Type <CR> to continue or q to quit ==>
*        1 *        4 * 0.0026367 *
*        1 *        5 * 8.454e-05 *
*        1 *        6 * -3.22e-05 *
*        1 *        7 * 0.0043999 *
*        1 *        8 * 1.179e-06 *
*        1 *        9 * 1.181e-06 *
*        1 *       10 * 0.0003995 *
*        1 *       11 * 0.0001339 *
*        1 *       12 * -1.09e-05 *
*        1 *       13 * 6.757e-09 *
*        1 *       14 * 3.378e-05 *
*        1 *       15 * 7.834e-05 *
*        1 *       16 * -0.054508 *
*        1 *       17 * -8.71e-06 *
*        1 *       18 * -1.46e-05 *
*        1 *       19 * -2.89e-07 *
*        1 *       20 * 0.0005269 *

```

This can be needed when propagating the track in an analysis script (e.g. https://github.com/eic/snippets/tree/main/Tracking/ImpactPointEstimator).

### What kind of change does this PR introduce?
- [x ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No. A user will only see a change if they use covariance matrix written out to the ROOT file in their analysis.

### Does this PR change default behavior?
No
