### PR TITLE
Swap the order of the CKF algorithm arguments

### DIFF
--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -109,8 +109,8 @@ namespace eicrecon {
         std::vector<ActsExamples::Trajectories*>,
         std::vector<ActsExamples::ConstTrackContainer*>
     >
-    CKFTracking::process(const edm4eic::Measurement2DCollection& meas2Ds,
-                         const edm4eic::TrackParametersCollection &init_trk_params) {
+    CKFTracking::process(const edm4eic::TrackParametersCollection& init_trk_params,
+                         const edm4eic::Measurement2DCollection& meas2Ds) {
 
 
         // create sourcelink and measurement containers

--- a/src/algorithms/tracking/CKFTracking.h
+++ b/src/algorithms/tracking/CKFTracking.h
@@ -74,8 +74,8 @@ namespace eicrecon {
             std::vector<ActsExamples::Trajectories*>,
             std::vector<ActsExamples::ConstTrackContainer*>
         >
-        process(const edm4eic::Measurement2DCollection& meas2Ds,
-                const edm4eic::TrackParametersCollection &init_trk_params);
+        process(const edm4eic::TrackParametersCollection& init_trk_params,
+                const edm4eic::Measurement2DCollection& meas2Ds);
 
     private:
         std::shared_ptr<spdlog::logger> m_log;

--- a/src/global/tracking/CKFTracking_factory.h
+++ b/src/global/tracking/CKFTracking_factory.h
@@ -54,8 +54,8 @@ public:
             m_acts_trajectories_output(),
             m_acts_tracks_output()
         ) = m_algo->process(
-            *m_measurements_input(),
-            *m_parameters_input()
+            *m_parameters_input(),
+            *m_measurements_input()
         );
     }
 };


### PR DESCRIPTION
Minor code clean up.

The order of the CKF algorithm arguments has been swapped around to match the order provided to the factory generator making it slightly easier to follow the code.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No