### PR TITLE
BIC sampling fraction update

### DIFF
--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -68,7 +68,7 @@ extern "C" {
             .resolutionTDC = EcalBarrelScFi_resolutionTDC,
             .thresholdFactor = 0.0, // use only thresholdValue
             .thresholdValue = 5.0, // 16384 ADC counts/1500 MeV * 0.5 MeV (desired threshold) = 5.46
-            .sampFrac = "0.10200085",
+            .sampFrac = "0.09320426",
             .readout = "EcalBarrelScFiHits",
             .layerField = "layer",
             .sectorField = "sector",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Sampling fraction of the BIC ScFi layer has been updated using 5 GeV photons generated at eta = 0.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue EICrecon #1638)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
