### PR TITLE
Fix naming of BTOF hits

### DIFF
--- a/src/benchmarks/reconstruction/tof_efficiency/TofEfficiency_processor.cc
+++ b/src/benchmarks/reconstruction/tof_efficiency/TofEfficiency_processor.cc
@@ -60,7 +60,7 @@ void TofEfficiency_processor::InitWithGlobalRootLock(){
 void TofEfficiency_processor::ProcessSequential(const std::shared_ptr<const JEvent>& event) {
     const auto &mcParticles   = *(event->GetCollection<edm4hep::MCParticle>("MCParticles"));
     const auto &trackSegments = *(event->GetCollection<edm4eic::TrackSegment>("CentralTrackSegments"));
-    const auto &barrelHits    = *(event->GetCollection<edm4eic::TrackerHit>("TOFBarrelRecHit"));
+    const auto &barrelHits    = *(event->GetCollection<edm4eic::TrackerHit>("TOFBarrelRecHits"));
     const auto &endcapHits    = *(event->GetCollection<edm4eic::TrackerHit>("TOFEndcapRecHits"));
 
     // List TOF Barrel hits from barrel

--- a/src/detectors/BTOF/BTOF.cc
+++ b/src/detectors/BTOF/BTOF.cc
@@ -29,12 +29,12 @@ void InitPlugin(JApplication *app) {
 
     // Digitization
     app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
-        "TOFBarrelRawHit",
+        "TOFBarrelRawHits",
         {
           "TOFBarrelHits"
         },
         {
-          "TOFBarrelRawHit",
+          "TOFBarrelRawHits",
           "TOFBarrelRawHitAssociations"
         },
         {
@@ -46,9 +46,9 @@ void InitPlugin(JApplication *app) {
 
     // Convert raw digitized hits into hits with geometry info (ready for tracking)
     app->Add(new JOmniFactoryGeneratorT<TrackerHitReconstruction_factory>(
-        "TOFBarrelRecHit",
-        {"TOFBarrelRawHit"},    // Input data collection tags
-        {"TOFBarrelRecHit"},     // Output data tag
+        "TOFBarrelRecHits",
+        {"TOFBarrelRawHits"},    // Input data collection tags
+        {"TOFBarrelRecHits"},     // Output data tag
         {
             .timeResolution = 10,
         },

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -50,7 +50,7 @@ void InitPlugin(JApplication *app) {
         {"SiBarrelHits", "SiBarrelRawHits", "SiBarrelRawHitAssociations", "SiBarrelTrackerRecHits"},
         {"VertexBarrelHits", "SiBarrelVertexRawHits", "SiBarrelVertexRawHitAssociations", "SiBarrelVertexRecHits"},
         {"TrackerEndcapHits", "SiEndcapTrackerRawHits", "SiEndcapTrackerRawHitAssociations", "SiEndcapTrackerRecHits"},
-        {"TOFBarrelHits", "TOFBarrelRawHits", "TOFBarrelRawHitAssociations", "TOFBarrelRecHit"},
+        {"TOFBarrelHits", "TOFBarrelRawHits", "TOFBarrelRawHitAssociations", "TOFBarrelRecHits"},
         {"TOFEndcapHits", "TOFEndcapRawHits", "TOFEndcapRawHitAssociations", "TOFEndcapRecHits"},
         {"MPGDBarrelHits", "MPGDBarrelRawHits", "MPGDBarrelRawHitAssociations", "MPGDBarrelRecHits"},
         {"OuterMPGDBarrelHits", "OuterMPGDBarrelRawHits", "OuterMPGDBarrelRawHitAssociations", "OuterMPGDBarrelRecHits"},

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -85,10 +85,10 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "SiEndcapTrackerRawHitAssociations",
 
             // TOF
-            "TOFBarrelRecHit",
+            "TOFBarrelRecHits",
             "TOFEndcapRecHits",
 
-            "TOFBarrelRawHit",
+            "TOFBarrelRawHits",
             "TOFEndcapRawHits",
 
             "TOFBarrelHits",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Changes the name of the BTOF hit collections to use Hits instead of Hit. This was inconsistent between the name output from the hit reconstruction and collection collector input.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #1659 probably some of the cause at least)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
Hopefully adds the BTOF into the tracking