### PR TITLE
TrackParamTruthInitConfig: maxEtaForward=10 for B0 coverage

### DIFF
--- a/src/algorithms/tracking/TrackParamTruthInitConfig.h
+++ b/src/algorithms/tracking/TrackParamTruthInitConfig.h
@@ -12,7 +12,7 @@ struct TrackParamTruthInitConfig {
     double maxVertexY       = 80  * dd4hep::mm;
     double maxVertexZ       = 200 * dd4hep::mm;
     double minMomentum      = 100 * dd4hep::MeV;
-    double maxEtaForward    = 6.0;
+    double maxEtaForward    = 10.0;
     double maxEtaBackward   = 4.1;
     double momentumSmear    = 0.1;
 


### PR DESCRIPTION
We should cover down to 5.5 mrad.
The new value eta=10 covers that:
```
>>> import numpy as np
>>> np.rad2deg(2*np.arctan(np.exp(-10)))
0.005202448727587163
```

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No