### PR TITLE
CKFTracking: gracefully handle failures when extrapolating to perigee surface

### DIFF
--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -336,6 +336,15 @@ namespace eicrecon {
 
         std::optional<unsigned int> lastSeed;
         for (const auto& track : constTracks) {
+#if Acts_VERSION_MAJOR >= 34
+          // Some B0 tracks fail to extrapolate to the perigee surface. The
+          // Acts::extrapolateTrackToReferenceSurface will not set
+          // referenceSurface in that case, which is what we check here.
+          if (not track.hasReferenceSurface()) {
+            m_log->warn("Skipping a track not on perigee surface");
+            continue;
+          }
+#endif
           if (!lastSeed) {
             lastSeed = constSeedNumber(track);
           }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Starting with Acts 34.x the CKF fitting had been divorced from propagation to the target surface https://github.com/acts-project/acts/commit/d9f775f4155f1a13e316aa142e939ef7178ff665, so we now have to do it ourselves:
https://github.com/eic/EICrecon/blob/5e39885644bdf867aa2060ccc46da2500678c1da/src/algorithms/tracking/CKFTracking.cc#L278-L296
However the catch is that B0 CKF tracks may be affected by failures to extrapolate explicitly. The failure currently leads to a null pointer dereference. This PR changes that to a mere warning, the track is omitted from the output in the process. We would be able to upgrade to Acts 34 with this change.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No