### PR TITLE
Update of the BIC sampling fractions

### DIFF
--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -68,7 +68,7 @@ extern "C" {
             .resolutionTDC = EcalBarrelScFi_resolutionTDC,
             .thresholdFactor = 0.0, // use only thresholdValue
             .thresholdValue = 5.0, // 16384 ADC counts/1500 MeV * 0.5 MeV (desired threshold) = 5.46
-            .sampFrac = "0.09320426",
+            .sampFrac = "0.09285755",
             .readout = "EcalBarrelScFiHits",
             .layerField = "layer",
             .sectorField = "sector",
@@ -150,7 +150,7 @@ extern "C" {
             .resolutionTDC = EcalBarrelImaging_resolutionTDC,
             .thresholdFactor = 0.0, // use only thresholdValue
             .thresholdValue = 41, // 8192 ADC counts/3 MeV * 0.015 MeV (desired threshold) = 41
-            .sampFrac = "0.00619766",
+            .sampFrac = "0.00429453",
             .readout = "EcalBarrelImagingHits",
             .layerField = "layer",
             .sectorField = "sector",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Sampling fractions of the BIC ScFi and imaging layers have been updated using 5 GeV electrons generated at eta = 0. Only the constant sampling fractions are provided this time. The energy- and eta-dependent ones will be provided next time referring to the comments on the last BIC sampling fraction PR.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No