### PR TITLE
Added deltaPhiMax parameter for Seed Finder

### DIFF
--- a/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
+++ b/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
@@ -38,6 +38,8 @@ namespace eicrecon {
     float rMinMiddle       = 20. * Acts::UnitConstants::mm; // Middle spacepoint must fall between these two radii
     float rMaxMiddle       = 400. * Acts::UnitConstants::mm;
 
+    float deltaPhiMax      = 0.085; // Max difference in phi between middle and either top or bottom sp 
+
     //////////////////////////////////////////////////////////////////////////
     /// SEED FILTER GENERAL PARAMETERS
     /// The parameters below control the process of filtering out seeds before

--- a/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
+++ b/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
@@ -38,7 +38,7 @@ namespace eicrecon {
     float rMinMiddle       = 20. * Acts::UnitConstants::mm; // Middle spacepoint must fall between these two radii
     float rMaxMiddle       = 400. * Acts::UnitConstants::mm;
 
-    float deltaPhiMax      = 0.085; // Max difference in phi between middle and either top or bottom sp 
+    float deltaPhiMax      = 0.085; // Max difference in phi between middle and either top or bottom sp
 
     //////////////////////////////////////////////////////////////////////////
     /// SEED FILTER GENERAL PARAMETERS

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -104,6 +104,7 @@ void eicrecon::TrackSeeding::configure() {
     m_seedFinderConfig.impactMax          = m_cfg.impactMax;
     m_seedFinderConfig.rMinMiddle         = m_cfg.rMinMiddle;
     m_seedFinderConfig.rMaxMiddle         = m_cfg.rMaxMiddle;
+    m_seedFinderConfig.deltaPhiMax        = m_cfg.deltaPhiMax;
 
     m_seedFinderOptions.beamPos   = Acts::Vector2(m_cfg.beamPosX, m_cfg.beamPosY);
     m_seedFinderOptions.bFieldInZ = m_cfg.bFieldInZ;

--- a/src/global/tracking/TrackSeeding_factory.h
+++ b/src/global/tracking/TrackSeeding_factory.h
@@ -50,6 +50,7 @@ private:
     ParameterRef<float> m_impactMax {this, "impactMax", config().impactMax, "maximum impact parameter allowed for seeds for Acts::OrthogonalSeedFinder. rMin should be larger than impactMax."};
     ParameterRef<float> m_rMinMiddle {this, "rMinMiddle", config().rMinMiddle, "min radius for middle space point for Acts::OrthogonalSeedFinder"};
     ParameterRef<float> m_rMaxMiddle {this, "rMaxMiddle", config().rMaxMiddle, "max radius for middle space point for Acts::OrthogonalSeedFinder"};
+    ParameterRef<float> m_deltaPhiMax {this, "deltaPhiMax", config().deltaPhiMax, "Max phi difference between middle and top/bottom space point"}; 
     ParameterRef<float> m_locaError {this, "loc_a_Error", config().locaError, "Error on Loc a for Acts::OrthogonalSeedFinder"};
     ParameterRef<float> m_locbError {this, "loc_b_Error", config().locbError, "Error on Loc b for Acts::OrthogonalSeedFinder"};
     ParameterRef<float> m_phiError {this, "phi_Error", config().phiError, "Error on phi for Acts::OrthogonalSeedFinder"};

--- a/src/global/tracking/TrackSeeding_factory.h
+++ b/src/global/tracking/TrackSeeding_factory.h
@@ -50,7 +50,7 @@ private:
     ParameterRef<float> m_impactMax {this, "impactMax", config().impactMax, "maximum impact parameter allowed for seeds for Acts::OrthogonalSeedFinder. rMin should be larger than impactMax."};
     ParameterRef<float> m_rMinMiddle {this, "rMinMiddle", config().rMinMiddle, "min radius for middle space point for Acts::OrthogonalSeedFinder"};
     ParameterRef<float> m_rMaxMiddle {this, "rMaxMiddle", config().rMaxMiddle, "max radius for middle space point for Acts::OrthogonalSeedFinder"};
-    ParameterRef<float> m_deltaPhiMax {this, "deltaPhiMax", config().deltaPhiMax, "Max phi difference between middle and top/bottom space point"}; 
+    ParameterRef<float> m_deltaPhiMax {this, "deltaPhiMax", config().deltaPhiMax, "Max phi difference between middle and top/bottom space point"};
     ParameterRef<float> m_locaError {this, "loc_a_Error", config().locaError, "Error on Loc a for Acts::OrthogonalSeedFinder"};
     ParameterRef<float> m_locbError {this, "loc_b_Error", config().locbError, "Error on Loc b for Acts::OrthogonalSeedFinder"};
     ParameterRef<float> m_phiError {this, "phi_Error", config().phiError, "Error on phi for Acts::OrthogonalSeedFinder"};


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Following up on the presentation yesterday ([here](https://indico.bnl.gov/event/25559/contributions/99383/attachments/58553/100546/tracking_111424.pdf)) on seeding inefficiencies at low momentum, I found that the Acts Orthogonal seeder does a comparison between the phi values of the middle/lower and middle/upper space points. By default, this parameter is set to 0.085 Rad:

https://github.com/acts-project/acts/blob/f6ed9013e76120137ae456583a04b554d88d9452/Core/include/Acts/Seeding/SeedFinderOrthogonalConfig.hpp#L79

This is checked, for example, here:

https://github.com/acts-project/acts/blob/f6ed9013e76120137ae456583a04b554d88d9452/Core/include/Acts/Seeding/SeedFinderOrthogonal.ipp#L82-L86

And this check is done prior to other doublet or triplet checks on the potential seed triplet.

This PR adds this deltaPhiMax parameter as an additional parameter in the seed finder. Right now, I keep the parameter at the default value in the configuration file. The parameter can be adjusted on the command line by doing this, for example:

`-Ptracking:CentralTrackSeedingResults:deltaPhiMax=0.25`

This will allow the parameter to be studied with single-particle and DIS events.


A quick test with negative muons with total momentum of 500 MeV/c and eta = [-4,4] shows the following. With the default parameter, we see this for 10 events:

```
root [1] events->Scan("CentralTrackSeedingResults.qOverP:CentralCKFTrackParametersUnfiltered.qOverP:CentralCKFTrackParameters.qOverP")
***********************************************************
*    Row   * Instance * CentralTr * CentralCK * CentralCK *
***********************************************************
*        0 *        0 * -2.017637 * -1.997553 * -1.997553 *
*        0 *        1 * -2.050001 * -1.997604 *           *
*        1 *        0 *           *           *           *
*        2 *        0 * -2.155712 * -2.155881 *           *
*        3 *        0 *           *           *           *
*        4 *        0 *           *           *           *
*        5 *        0 * -1.975466 * -1.992832 * -1.992857 *
*        5 *        1 *           * -1.992857 *           *
*        6 *        0 *           *           *           *
*        7 *        0 *           *           *           *
*        8 *        0 *           *           *           *
*        9 *        0 * -1.977929 * -1.975284 * -1.975284 *
***********************************************************
```

Seeds are formed in 4 events.

If we set deltaPhiMax=0.25, we get

```
root [4] events->Scan("CentralTrackSeedingResults.qOverP:CentralCKFTrackParametersUnfiltered.qOverP:CentralCKFTrackParameters.qOverP")
***********************************************************
*    Row   * Instance * CentralTr * CentralCK * CentralCK *
***********************************************************
*        0 *        0 * -2.017637 * -1.997553 * -1.997553 *
*        0 *        1 * -2.017606 * -1.997554 *           *
*        1 *        0 *           *           *           *
*        2 *        0 * -1.948913 * -1.945051 *           *
*        2 *        1 * -2.023722 * -2.024211 *           *
*        3 *        0 *           *           *           *
*        4 *        0 * -1.834852 * -2.038357 * -2.038357 *
*        5 *        0 * -1.985146 * -1.992834 * -1.992861 *
*        5 *        1 * -1.991421 * -1.992859 *           *
*        5 *        2 *           * -1.992836 *           *
*        5 *        3 *           * -1.992861 *           *
*        6 *        0 *           *           *           *
*        7 *        0 * -1.932271 * -1.938517 *           *
*        8 *        0 * -1.900319 * -1.974888 *           *
*        8 *        1 * -1.956748 * -1.954931 *           *
*        9 *        0 * -1.977929 * -1.975284 * -1.975284 *
***********************************************************
```

Seeds are formed in 7 events. Some of these events fail to produce tracks that survive the ambiguity solver, which needs to be studied.


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @Jeet-bhai 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No