### PR TITLE
fix: static_cast<float>(sqrt(...)) to avoid c++-narrowing warning/error

### DIFF
--- a/src/algorithms/tracking/TrackProjector.cc
+++ b/src/algorithms/tracking/TrackProjector.cc
@@ -153,7 +153,7 @@ namespace eicrecon {
                         static_cast<float>(boundCov(Acts::eBoundPhi, Acts::eBoundQOverP))
                 };
                 const float time{static_cast<float>(boundParams(Acts::eBoundTime))};
-                const float timeError{sqrt(static_cast<float>(boundCov(Acts::eBoundTime, Acts::eBoundTime)))};
+                const float timeError{static_cast<float>(sqrt(static_cast<float>(boundCov(Acts::eBoundTime, Acts::eBoundTime))))};
                 const float theta(boundParams[Acts::eBoundTheta]);
                 const float phi(boundParams[Acts::eBoundPhi]);
                 const decltype(edm4eic::TrackPoint::directionError) directionError{

--- a/src/algorithms/tracking/TrackProjector.cc
+++ b/src/algorithms/tracking/TrackProjector.cc
@@ -153,7 +153,7 @@ namespace eicrecon {
                         static_cast<float>(boundCov(Acts::eBoundPhi, Acts::eBoundQOverP))
                 };
                 const float time{static_cast<float>(boundParams(Acts::eBoundTime))};
-                const float timeError{static_cast<float>(sqrt(static_cast<float>(boundCov(Acts::eBoundTime, Acts::eBoundTime))))};
+                const float timeError{static_cast<float>(sqrt(boundCov(Acts::eBoundTime, Acts::eBoundTime)))};
                 const float theta(boundParams[Acts::eBoundTheta]);
                 const float phi(boundParams[Acts::eBoundPhi]);
                 const decltype(edm4eic::TrackPoint::directionError) directionError{


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR should fix the eicrecon build error in https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/4175065/raw (root-6.32.06 upgrade).

### What kind of change does this PR introduce?
- [x] Bug fix (issue https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/4175065/raw)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.