### PR TITLE
feat: support EDM4hep v0.99, with TrackerHit as interface type

### DIFF
--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -6,7 +6,15 @@
 #include <edm4eic/TrackPoint.h>
 #include <edm4eic/TrackSegmentCollection.h>
 #include <edm4eic/vector_utils.h>
+#include <edm4hep/EDM4hepVersion.h>
+#if EDM4HEP_BUILD_VERSION < EDM4HEP_VERSION(0, 99, 0)
 #include <edm4hep/TrackerHitCollection.h>
+namespace edm4hep {
+  using TrackerHit3DCollection = TrackerHitCollection;
+}
+#else
+#include <edm4hep/TrackerHit3DCollection.h>
+#endif
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
@@ -71,7 +79,7 @@ namespace eicrecon {
 
     void FarDetectorLinearTracking::buildMatrixRecursive(int level,
                                                         Eigen::MatrixXd* hitMatrix,
-                                                        const std::vector<gsl::not_null<const edm4hep::TrackerHitCollection*>>& hits,
+                                                        const std::vector<gsl::not_null<const edm4hep::TrackerHit3DCollection*>>& hits,
                                                         gsl::not_null<edm4eic::TrackSegmentCollection*> outputTracks ) const {
 
       // Iterate over hits in this layer

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.h
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.h
@@ -26,7 +26,7 @@ namespace edm4hep {
 namespace eicrecon {
 
 using FarDetectorLinearTrackingAlgorithm =
-    algorithms::Algorithm<algorithms::Input<std::vector<edm4hep::TrackerHitCollection>>,
+    algorithms::Algorithm<algorithms::Input<std::vector<edm4hep::TrackerHit3DCollection>>,
                           algorithms::Output<edm4eic::TrackSegmentCollection>>;
 
 class FarDetectorLinearTracking : public FarDetectorLinearTrackingAlgorithm,
@@ -52,7 +52,7 @@ private:
 
   void
   buildMatrixRecursive(int level, Eigen::MatrixXd* hitMatrix,
-                       const std::vector<gsl::not_null<const edm4hep::TrackerHitCollection*>>& hits,
+                       const std::vector<gsl::not_null<const edm4hep::TrackerHit3DCollection*>>& hits,
                        gsl::not_null<edm4eic::TrackSegmentCollection*> outputTracks) const;
 
   void checkHitCombination(Eigen::MatrixXd* hitMatrix,

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.h
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.h
@@ -7,7 +7,15 @@
 #include <algorithms/algorithm.h>
 #include <algorithms/interfaces/WithPodConfig.h>
 #include <edm4eic/TrackSegmentCollection.h>
+#include <edm4hep/EDM4hepVersion.h>
+#if EDM4HEP_BUILD_VERSION < EDM4HEP_VERSION(0, 99, 0)
 #include <edm4hep/TrackerHitCollection.h>
+namespace edm4hep {
+  using TrackerHit3DCollection = TrackerHitCollection;
+}
+#else
+#include <edm4hep/TrackerHit3DCollection.h>
+#endif
 #include <gsl/pointers>
 #include <string>
 #include <string_view>

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
@@ -174,7 +174,7 @@ FarDetectorTrackerCluster::ClusterHits(const edm4eic::RawTrackerHitCollection& i
 // Convert to global coordinates and create TrackerHits
 void FarDetectorTrackerCluster::ConvertClusters(
     const std::vector<FDTrackerCluster>& clusters,
-    edm4hep::TrackerHitCollection& outputClusters) const {
+    edm4hep::TrackerHit3DCollection& outputClusters) const {
 
   // Get context of first hit
   const dd4hep::VolumeManagerContext* context = m_cellid_converter->findContext(clusters[0].cellID);

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.h
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.h
@@ -9,7 +9,15 @@
 #include <Parsers/Primitives.h>
 #include <algorithms/algorithm.h>
 #include <edm4eic/RawTrackerHitCollection.h>
+#include <edm4hep/EDM4hepVersion.h>
+#if EDM4HEP_BUILD_VERSION < EDM4HEP_VERSION(0, 99, 0)
 #include <edm4hep/TrackerHitCollection.h>
+namespace edm4hep {
+  using TrackerHit3DCollection = TrackerHitCollection;
+}
+#else
+#include <edm4hep/TrackerHit3DCollection.h>
+#endif
 #include <podio/ObjectID.h>
 #include <string>
 #include <string_view>
@@ -32,7 +40,7 @@ namespace eicrecon {
 
 using FarDetectorTrackerClusterAlgorithm =
     algorithms::Algorithm<algorithms::Input<std::vector<edm4eic::RawTrackerHitCollection>>,
-                          algorithms::Output<std::vector<edm4hep::TrackerHitCollection>>>;
+                          algorithms::Output<std::vector<edm4hep::TrackerHit3DCollection>>>;
 
 class FarDetectorTrackerCluster : public FarDetectorTrackerClusterAlgorithm,
                                   public WithPodConfig<FarDetectorTrackerClusterConfig> {
@@ -55,7 +63,7 @@ public:
   std::vector<FDTrackerCluster> ClusterHits(const edm4eic::RawTrackerHitCollection&) const;
 
   /** Convert clusters to TrackerHits **/
-  void ConvertClusters(const std::vector<FDTrackerCluster>&, edm4hep::TrackerHitCollection&) const;
+  void ConvertClusters(const std::vector<FDTrackerCluster>&, edm4hep::TrackerHit3DCollection&) const;
 
 private:
   const dd4hep::Detector* m_detector{nullptr};


### PR DESCRIPTION
### Briefly, what does this PR introduce?
EDM4hep v0.99 [introduced](https://github.com/key4hep/EDM4hep/pull/252) TrackerHit as an interface type, and the datatype that used to be called TrackerHit is now called TrackerHit3D. We use this in a few places, and this PR disambiguates the TrackerHit datatype. To minimize impact on the code and limit the annoying code effects to the preamble, this defines an alias of the new name.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue: https://github.com/key4hep/EDM4hep/pull/252)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.