### PR TITLE
CKFTracking: remove Acts tracks that failed to extrapolate, not just the trajectories

### DIFF
--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -7,7 +7,9 @@
 #include <Acts/Definitions/TrackParametrization.hpp>
 #include <Acts/Definitions/Units.hpp>
 #include <Acts/EventData/GenericBoundTrackParameters.hpp>
+#if Acts_VERSION_MAJOR >= 32
 #include <Acts/EventData/TrackStateProxy.hpp>
+#endif
 #include <Acts/EventData/Types.hpp>
 #if Acts_VERSION_MAJOR < 36
 #include <Acts/EventData/Measurement.hpp>

--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -7,6 +7,8 @@
 #include <Acts/Definitions/TrackParametrization.hpp>
 #include <Acts/Definitions/Units.hpp>
 #include <Acts/EventData/GenericBoundTrackParameters.hpp>
+#include <Acts/EventData/TrackStateProxy.hpp>
+#include <Acts/EventData/Types.hpp>
 #if Acts_VERSION_MAJOR < 36
 #include <Acts/EventData/Measurement.hpp>
 #endif


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This is re-implements #1663 in such a way that downstream algorithms, such as the AmbiguitySolver, that operate on Acts EDM do not see the failed tracks.
Resolves: #1672

### What kind of change does this PR introduce?
- [x] Bug fix (issue #1672)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No