### PR TITLE
Remove MCParticlesHeadOnFrameNoBeamFX from default output collections list

### DIFF
--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -59,7 +59,6 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "MCBeamProtons",
             "MCScatteredElectrons",
             "MCScatteredProtons",
-            "MCParticlesHeadOnFrameNoBeamFX",
 
             // All tracking hits combined
             "CentralTrackingRecHits",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Remove MCParticlesHeadOnFrameNoBeamFX from default output collections list to prevent file size explosion. See issue#812 on epic. 

### What kind of change does this PR introduce?
- [ ] Bug fix (issue # __)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: https://github.com/eic/epic/issues/812

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
