### PR TITLE
fix: static_cast<float>(sqrt(...)) to avoid c++-narrowing warning/error (again)

### DIFF
--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -295,7 +295,7 @@ void TrackPropagation::propagateToSurfaceList(
 
         // time
         const float time{static_cast<float>(parameter(Acts::eBoundTime))};
-        const float timeError{sqrt(static_cast<float>(covariance(Acts::eBoundTime, Acts::eBoundTime)))};
+        const float timeError{static_cast<float>(sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)))};
 
         // Direction
         const float theta(parameter[Acts::eBoundTheta]);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
#1675 again see there.
