### PR TITLE
fix(ci): ubsan.supp: implicit-integer-sign-change in edm4hep::ObjectID

### DIFF
--- a/.github/ubsan.supp
+++ b/.github/ubsan.supp
@@ -4,4 +4,5 @@ implicit-integer-sign-change:TObject
 implicit-signed-integer-truncation:/opt/local/include/boost/iostreams/filter/gzip.hpp
 implicit-integer-sign-change:/opt/local/include/eigen3/Eigen/src/Core/arch/SSE/Complex.h
 implicit-integer-sign-change:/opt/local/include/root/TStorage.h
+implicit-integer-sign-change:/opt/local/include/edm4hep/ObjectID.h
 implicit-unsigned-integer-truncation:/opt/local/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes an UBSan error external to our code, showing up e.g. https://github.com/eic/EICrecon/actions/runs/12128923399/job/33816533286?pr=1635#step:8:880

EDM4hep defines CollectionID as signed int32_t, https://github.com/key4hep/EDM4hep/blob/v00-10-05/edm4hep.yaml#L111, but podio defines it as unsigned uint32_t, https://github.com/AIDASoft/podio/blob/v01-01/include/podio/ObjectID.h#L25. This is an issue as of podio-0.17.1, https://github.com/AIDASoft/podio/commit/ac086e004bdb6f7d8972a1f62276504bb21370e0, and disappears with EDM4hep-0.99 which removed the edm4hep::ObjectID component.

### What kind of change does this PR introduce?
- [x] Bug fix (issue https://github.com/eic/EICrecon/actions/runs/12128923399/job/33816533286?pr=1635#step:8:880)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.