### PR TITLE
feat(ci): runs-on: ubuntu-22.04 -> ubuntu-24.04

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -49,7 +49,7 @@ jobs:
   env:
     # env cannot be used in matrix, but outputs can
     # so this job turns env into outputs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       platform_json: ${{ steps.define.outputs.platform_json }}
       release_json: ${{ steps.define.outputs.release_json }}
@@ -60,7 +60,7 @@ jobs:
         echo "release_json=[\"${{ env.release }}\"]" >> $GITHUB_OUTPUT
 
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: env
     strategy:
       # include multiple compilers for one release version,
@@ -175,7 +175,7 @@ jobs:
         if-no-files-found: error
 
   clang-tidy-iwyu:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: build
     steps:
     - uses: actions/checkout@v4
@@ -252,7 +252,7 @@ jobs:
       run: git diff --exit-code
 
   llvm-cov:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: build
     permissions:
       statuses: write
@@ -311,7 +311,7 @@ jobs:
         path: build/codecov_report/
 
   detector-info:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       hash: ${{ steps.detector-info.outputs.hash }}
     steps:
@@ -326,7 +326,7 @@ jobs:
         echo "hash=${hash%% *}" | tee $GITHUB_OUTPUT
 
   npsim-gun:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
     - detector-info
     strategy:
@@ -356,7 +356,7 @@ jobs:
         if-no-files-found: error
 
   npsim-gun-EcalLumiSpec:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
     - detector-info
     strategy:
@@ -390,7 +390,7 @@ jobs:
         if-no-files-found: error
 
   npsim-dis:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
     - detector-info
     strategy:
@@ -426,7 +426,7 @@ jobs:
         if-no-files-found: error
 
   npsim-minbias:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
     - detector-info
     strategy:
@@ -462,7 +462,7 @@ jobs:
         if-no-files-found: error
 
   eicrecon-two-stage-running:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
     - build
     - npsim-gun
@@ -526,7 +526,7 @@ jobs:
         if-no-files-found: error
 
   eicrecon-eicmkplugin:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
     - build
     - npsim-gun
@@ -569,7 +569,7 @@ jobs:
           $PWD/install/bin/eicrecon $JANA_OPTIONS -Pplugins=MyCustomPlugin -Ppodio:output_file=rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
 
   eicrecon-test-plugins:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
     - build
     - npsim-gun
@@ -618,7 +618,7 @@ jobs:
         if-no-files-found: error
 
   eicrecon-benchmarks-plugins:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
     - build
     - npsim-gun
@@ -671,7 +671,7 @@ jobs:
         if-no-files-found: error
 
   eicrecon-gun:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
     - build
     - npsim-gun
@@ -785,7 +785,7 @@ jobs:
         if-no-files-found: error
 
   eicrecon-gun-EcalLumiSpec:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
     - build
     - npsim-gun-EcalLumiSpec
@@ -852,7 +852,7 @@ jobs:
         if-no-files-found: error
 
   eicrecon-dis:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
     - build
     - npsim-dis
@@ -985,7 +985,7 @@ jobs:
         if-no-files-found: error
 
   trigger-container:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: ${{ github.event_name != 'merge_group' && github.event_name != 'schedule' && github.actor != 'dependabot[bot]' }}
     needs:
     - eicrecon-gun
@@ -1017,7 +1017,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-docs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - eicrecon-gun
       - eicrecon-dis
@@ -1055,7 +1055,7 @@ jobs:
           if-no-files-found: error
 
   list-open-prs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       json: ${{ steps.remap.outputs.json }}
     steps:
@@ -1074,7 +1074,7 @@ jobs:
           include.*.head_sha: ${{ toJSON(fromJSON(steps.query.outputs.data).*.head.sha) }}
 
   get-docs-from-open-prs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - build-docs
       - list-open-prs
@@ -1125,7 +1125,7 @@ jobs:
           if-no-files-found: ignore
 
   get-docs-from-main:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - build-docs
     steps:
@@ -1182,7 +1182,7 @@ jobs:
           if-no-files-found: error
 
   collect-docs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - get-docs-from-main
       - get-docs-from-open-prs
@@ -1241,7 +1241,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR updates the target operating system for CI jobs, from ubuntu-latest to a more explicit ubuntu-24.04. This is in part to test that the automatic update of implicit ubuntu-latest will not break anything (https://github.com/actions/runner-images/issues/10636), and in part because it makes sense to be explicit about the target operating system. 

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue https://github.com/actions/runner-images/issues/10636)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, for the next few days ubuntu-latest will still be ubuntu-22.04, and this will mean an upgrade to ubuntu-24.04.