### PR TITLE
Allow xrootd files as inputs to eicrecon

### DIFF
--- a/src/services/io/podio/JEventSourcePODIO.cc
+++ b/src/services/io/podio/JEventSourcePODIO.cc
@@ -131,17 +131,6 @@ void JEventSourcePODIO::Open() {
     // Open primary events file
     try {
 
-        // Verify file exists
-        // if( ! std::filesystem::exists(GetResourceName()) ){
-        //     // Here we go against the standard practice of throwing an error and print
-        //     // the message and exit immediately. This is because we want the last message
-        //     // on the screen to be that the file doesn't exist.
-        //     auto mess = fmt::format(fmt::emphasis::bold | fg(fmt::color::red),"ERROR: ");
-        //     mess += fmt::format(fmt::emphasis::bold, "file: {} does not exist!",  GetResourceName());
-        //     std::cerr << std::endl << std::endl << mess << std::endl << std::endl;
-        //     std::_Exit(EXIT_FAILURE);
-        // }
-
         m_reader.openFile( GetResourceName() );
 
         auto version = m_reader.currentFileVersion();

--- a/src/services/io/podio/JEventSourcePODIO.cc
+++ b/src/services/io/podio/JEventSourcePODIO.cc
@@ -14,16 +14,12 @@
 #include <JANA/Utils/JTypeInfo.h>
 #include <TFile.h>
 #include <TObject.h>
-#include <fmt/color.h>
 #include <fmt/core.h>
-#include <fmt/format.h>
 #include <podio/CollectionBase.h>
 #include <podio/Frame.h>
 #include <podio/podioVersion.h>
 #include <algorithm>
-#include <cstdlib>
 #include <exception>
-#include <filesystem>
 #include <iostream>
 #include <map>
 #include <utility>

--- a/src/services/io/podio/JEventSourcePODIO.cc
+++ b/src/services/io/podio/JEventSourcePODIO.cc
@@ -132,15 +132,15 @@ void JEventSourcePODIO::Open() {
     try {
 
         // Verify file exists
-        if( ! std::filesystem::exists(GetResourceName()) ){
-            // Here we go against the standard practice of throwing an error and print
-            // the message and exit immediately. This is because we want the last message
-            // on the screen to be that the file doesn't exist.
-            auto mess = fmt::format(fmt::emphasis::bold | fg(fmt::color::red),"ERROR: ");
-            mess += fmt::format(fmt::emphasis::bold, "file: {} does not exist!",  GetResourceName());
-            std::cerr << std::endl << std::endl << mess << std::endl << std::endl;
-            std::_Exit(EXIT_FAILURE);
-        }
+        // if( ! std::filesystem::exists(GetResourceName()) ){
+        //     // Here we go against the standard practice of throwing an error and print
+        //     // the message and exit immediately. This is because we want the last message
+        //     // on the screen to be that the file doesn't exist.
+        //     auto mess = fmt::format(fmt::emphasis::bold | fg(fmt::color::red),"ERROR: ");
+        //     mess += fmt::format(fmt::emphasis::bold, "file: {} does not exist!",  GetResourceName());
+        //     std::cerr << std::endl << std::endl << mess << std::endl << std::endl;
+        //     std::_Exit(EXIT_FAILURE);
+        // }
 
         m_reader.openFile( GetResourceName() );
 
@@ -267,7 +267,7 @@ double JEventSourceGeneratorT<JEventSourcePODIO>::CheckOpenable(std::string reso
 
     // PODIO FrameReader segfaults on legacy input files, so we use ROOT to validate beforehand. Of course,
     // we can't validate if ROOT can't read the file.
-    std::unique_ptr<TFile> file = std::make_unique<TFile>(resource_name.c_str());
+    std::unique_ptr<TFile> file = std::unique_ptr<TFile>{TFile::Open(resource_name.c_str())};
     if (!file || file->IsZombie()) return 0.0;
 
     // We test the format the same way that PODIO's python API does. See python/podio/reading.py


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Currently eicrecon has two checks for files existing, neither of which allow the file to be on a remote xrootd server. This PR adapts JEventSourcePODIO.cc so that the first check allows for remote files and (currently) removes the second check.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
tbd

### Does this PR change default behavior?
Allows remote files to be passed directly to eicrecon