### PR TITLE
Change EventHeader check to be non fatal

### DIFF
--- a/src/services/io/podio/JEventSourcePODIO.cc
+++ b/src/services/io/podio/JEventSourcePODIO.cc
@@ -199,12 +199,17 @@ void JEventSourcePODIO::GetEvent(std::shared_ptr<JEvent> _event) {
     auto frame_data = m_reader.readEntry("events", Nevents_read);
     auto frame = std::make_unique<podio::Frame>(std::move(frame_data));
 
-    const auto& event_headers = frame->get<edm4hep::EventHeaderCollection>("EventHeader"); // TODO: What is the collection name?
-    if (event_headers.size() != 1) {
-        throw JException("Bad event headers: Entry %d contains %d items, but 1 expected.", Nevents_read, event_headers.size());
+    if(m_use_event_headers){
+        const auto& event_headers = frame->get<edm4hep::EventHeaderCollection>("EventHeader");
+        if (event_headers.size() != 1) {
+            LOG_WARN(default_cerr_logger) << "Missing or bad event headers: Entry " << Nevents_read << " contains " << event_headers.size() << " items, but 1 expected. Will not use event and run numbers from header" << LOG_END;
+            m_use_event_headers = false;
+        }
+        else {
+            event.SetEventNumber(event_headers[0].getEventNumber());
+            event.SetRunNumber(event_headers[0].getRunNumber());
+        }
     }
-    event.SetEventNumber(event_headers[0].getEventNumber());
-    event.SetRunNumber(event_headers[0].getRunNumber());
 
     // Insert contents odf frame into JFactories
     VisitPodioCollection<InsertingVisitor> visit;

--- a/src/services/io/podio/JEventSourcePODIO.cc
+++ b/src/services/io/podio/JEventSourcePODIO.cc
@@ -22,6 +22,7 @@
 #include <exception>
 #include <iostream>
 #include <map>
+#include <memory>
 #include <utility>
 #include <vector>
 

--- a/src/services/io/podio/JEventSourcePODIO.h
+++ b/src/services/io/podio/JEventSourcePODIO.h
@@ -56,11 +56,8 @@ protected:
     size_t Nevents_in_file = 0;
     size_t Nevents_read = 0;
 
-    std::string m_include_collections_str;
-    std::string m_exclude_collections_str;
-    std::set<std::string> m_INPUT_INCLUDE_COLLECTIONS;
-    std::set<std::string> m_INPUT_EXCLUDE_COLLECTIONS;
     bool m_run_forever=false;
+    bool m_use_event_headers=true;
 
 };
 

--- a/src/services/io/podio/JEventSourcePODIO.h
+++ b/src/services/io/podio/JEventSourcePODIO.h
@@ -15,8 +15,6 @@
 #include <podio/ROOTFrameReader.h>
 #endif
 #include <stddef.h>
-#include <memory>
-#include <set>
 #include <string>
 
 #if ((JANA_VERSION_MAJOR == 2) && (JANA_VERSION_MINOR >= 3)) || (JANA_VERSION_MAJOR > 2)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Allows running of EICrecon on files without an EventHeader collection. Files with a single/small subset of output collections can have analysis continued without needing to manually persist EventHeader.

A warning has been added.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #1696)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No