### PR TITLE
fix: skip non-class  definition headers in make_datamodel_glue.py

### DIFF
--- a/src/services/io/podio/make_datamodel_glue.py
+++ b/src/services/io/podio/make_datamodel_glue.py
@@ -67,6 +67,11 @@ if not EDM4EIC_INCLUDE_DIR:
 
 def AddCollections(datamodelName, collectionfiles):
     for f in collectionfiles:
+        # require at least a class definition, not a using alias
+        with open(f, 'r') as file:
+            if not "class" in file.read():
+                continue
+
         header_fname = f.split('/'+datamodelName)[-1]
         basename = header_fname.split('/')[-1].split('Collection.h')[0]
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
In recent versions of EDM4hep, deprecated data types are defined as aliases to the recommended new data type: e.g.
```cpp
namespace edm4hep {
using MCRecoCaloParticleAssociation [[deprecated("use CaloHitMCParticleLink instead")]] =
    edm4hep::CaloHitMCParticleLink;
}
```
This leads to issues in the `datamodel_glue.h` header, which defines them as a class, e.g.
```
/opt/local/include/edm4hep/MCRecoCaloParticleAssociation.h:7:7: error: typedef redefinition with different types ('edm4hep::CaloHitMCParticleLink' vs 'edm4hep::MCRecoCaloParticleAssociation')
    7 | using MCRecoCaloParticleAssociation [[deprecated("use CaloHitMCParticleLink instead")]] =
      |       ^
/home/wdconinc/git/EICrecon/build/include/services/io/podio/datamodel_glue.h:326:11: note: previous definition is here
  326 |     class MCRecoCaloParticleAssociation;
      |           ^
```

This PR avoids listing `using` aliases in the `datamodel_glue.h` headers by only processing data type headers with an actual `class` definition.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (support for EDM4hep-0.99)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.