### PR TITLE
fix: allow both Vector3f or Vector3d in Beam.h

### DIFF
--- a/src/algorithms/reco/Beam.h
+++ b/src/algorithms/reco/Beam.h
@@ -60,7 +60,6 @@ namespace eicrecon {
     return find_first_with_pdg(rcparts, {11});
   }
 
-  inline
   template<Vector3>
   PxPyPzEVector
   round_beam_four_momentum(

--- a/src/algorithms/reco/Beam.h
+++ b/src/algorithms/reco/Beam.h
@@ -61,9 +61,10 @@ namespace eicrecon {
   }
 
   inline
+  template<Vector3>
   PxPyPzEVector
   round_beam_four_momentum(
-      const edm4hep::Vector3f& p_in,
+      const Vector3& p_in,
       const float mass,
       const std::vector<float>& pz_set,
       const float crossing_angle = 0.0) {

--- a/src/algorithms/reco/Beam.h
+++ b/src/algorithms/reco/Beam.h
@@ -60,7 +60,7 @@ namespace eicrecon {
     return find_first_with_pdg(rcparts, {11});
   }
 
-  template<Vector3>
+  template<typename Vector3>
   PxPyPzEVector
   round_beam_four_momentum(
       const Vector3& p_in,


### PR DESCRIPTION
### Briefly, what does this PR introduce?
EDM4hep-0.99 changed the type of momentum in particles from float to double, which requires more flexibility in our `round_beam_four_momentum` function.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (support EDM4hep-0.99)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.