### PR TITLE
fix: decltype on MCParticle::momentum in UndoAfterBurner

### DIFF
--- a/src/algorithms/reco/UndoAfterBurner.cc
+++ b/src/algorithms/reco/UndoAfterBurner.cc
@@ -126,7 +126,7 @@ void eicrecon::UndoAfterBurner::process(
         mc = rotationAboutX(mc);
         mc = headOnBoostVector(mc);
 
-        edm4hep::Vector3f mcMom(mc.Px(), mc.Py(), mc.Pz());
+        decltype(edm4hep::MCParticleData::momentum) mcMom(mc.Px(), mc.Py(), mc.Pz());
         edm4hep::MutableMCParticle MCTrack(p.clone());
         MCTrack.setMomentum(mcMom);
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
In EDM4hep-0.99, `MCParticle::momentum` is now `Vector3f` instead of `Vector3d`, which causes warnings in UndoAfterBurner. This PR adds a decltype to get around this.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (support EDM4hep-0.99)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.