### PR TITLE
fix: rm find_package outside jana_plugin.cmake

### DIFF
--- a/src/benchmarks/reconstruction/TRACKINGcheck/CMakeLists.txt
+++ b/src/benchmarks/reconstruction/TRACKINGcheck/CMakeLists.txt
@@ -19,4 +19,4 @@ plugin_add_eigen3(${PLUGIN_NAME})
 plugin_add_event_model(${PLUGIN_NAME})
 
 # Add libraries (works same as target_include_directories)
-plugin_link_libraries(${PLUGIN_NAME} Eigen3::Eigen)
+plugin_link_libraries(${PLUGIN_NAME})

--- a/src/benchmarks/reconstruction/femc_studies/CMakeLists.txt
+++ b/src/benchmarks/reconstruction/femc_studies/CMakeLists.txt
@@ -8,7 +8,6 @@ get_filename_component(PLUGIN_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
 plugin_add(${PLUGIN_NAME})
 
 # Find dependencies
-find_package(ROOT REQUIRED COMPONENTS Core Tree Hist RIO EG)
 plugin_add_event_model(${PLUGIN_NAME})
 plugin_add_dd4hep(${PLUGIN_NAME})
 plugin_add_acts(${PLUGIN_NAME})

--- a/src/benchmarks/reconstruction/lfhcal_studies/CMakeLists.txt
+++ b/src/benchmarks/reconstruction/lfhcal_studies/CMakeLists.txt
@@ -8,7 +8,6 @@ get_filename_component(PLUGIN_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
 plugin_add(${PLUGIN_NAME})
 
 # Find dependencies
-find_package(ROOT REQUIRED COMPONENTS Core Tree Hist RIO EG)
 plugin_add_event_model(${PLUGIN_NAME})
 plugin_add_dd4hep(${PLUGIN_NAME})
 plugin_add_acts(${PLUGIN_NAME})

--- a/src/benchmarks/reconstruction/tof_efficiency/CMakeLists.txt
+++ b/src/benchmarks/reconstruction/tof_efficiency/CMakeLists.txt
@@ -9,8 +9,8 @@ plugin_add(${PLUGIN_NAME})
 
 # Find dependencies
 plugin_add_dd4hep(${PLUGIN_NAME})
-find_package(ROOT REQUIRED COMPONENTS Core Tree Hist RIO EG)
 plugin_add_acts(${PLUGIN_NAME})
+plugin_add_cern_root(${PLUGIN_NAME})
 plugin_add_event_model(${PLUGIN_NAME})
 
 # The macro grabs sources as *.cc *.cpp *.c and headers as *.h *.hh *.hpp Then
@@ -20,12 +20,4 @@ plugin_glob_all(${PLUGIN_NAME})
 
 # Add libraries (same as target_include_directories but for both plugin and
 # library)
-plugin_link_libraries(
-  ${PLUGIN_NAME}
-  ROOT::Core
-  ROOT::Tree
-  ROOT::Hist
-  ROOT::RIO
-  ROOT::EG
-  ActsCore
-  EDM4EIC::edm4eic)
+plugin_link_libraries(${PLUGIN_NAME})

--- a/src/benchmarks/reconstruction/tracking_efficiency/CMakeLists.txt
+++ b/src/benchmarks/reconstruction/tracking_efficiency/CMakeLists.txt
@@ -9,8 +9,8 @@ plugin_add(${PLUGIN_NAME})
 
 # Find dependencies
 plugin_add_dd4hep(${PLUGIN_NAME})
-find_package(ROOT REQUIRED COMPONENTS Core Tree Hist RIO EG)
 plugin_add_acts(${PLUGIN_NAME})
+plugin_add_cern_root(${PLUGIN_NAME})
 plugin_add_event_model(${PLUGIN_NAME})
 
 # The macro grabs sources as *.cc *.cpp *.c and headers as *.h *.hh *.hpp Then
@@ -20,12 +20,4 @@ plugin_glob_all(${PLUGIN_NAME})
 
 # Add libraries (same as target_include_directories but for both plugin and
 # library)
-plugin_link_libraries(
-  ${PLUGIN_NAME}
-  ROOT::Core
-  ROOT::Tree
-  ROOT::Hist
-  ROOT::RIO
-  ROOT::EG
-  ActsCore
-  EDM4EIC::edm4eic)
+plugin_link_libraries(${PLUGIN_NAME})

--- a/src/benchmarks/reconstruction/tracking_occupancy/CMakeLists.txt
+++ b/src/benchmarks/reconstruction/tracking_occupancy/CMakeLists.txt
@@ -8,7 +8,6 @@ get_filename_component(PLUGIN_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
 plugin_add(${PLUGIN_NAME})
 
 # Find dependencies
-find_package(ROOT REQUIRED COMPONENTS Core Tree Hist RIO EG)
 plugin_add_event_model(${PLUGIN_NAME})
 plugin_add_dd4hep(${PLUGIN_NAME})
 plugin_add_acts(${PLUGIN_NAME})


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes the find_package use in benchmarks, outside of jana_plugin.cmake. Finding packages is better done centralized, to reduce duplication, to ensure the same components are found, and to ensure we keep track of minimum version requirements.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: code duplication)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.