### PR TITLE
fix: rm unused options in IterativeVertexFinder.cc

### DIFF
--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -4,16 +4,18 @@
 
 #include "IterativeVertexFinder.h"
 
+#include <Acts/Definitions/Common.hpp>
+#include <Acts/Definitions/Direction.hpp>
 #include <Acts/Definitions/TrackParametrization.hpp>
 #include <Acts/Definitions/Units.hpp>
 #include <Acts/EventData/GenericBoundTrackParameters.hpp>
-#include <Acts/MagneticField/MagneticFieldProvider.hpp>
+#include <Acts/EventData/GenericParticleHypothesis.hpp>
+#include <Acts/EventData/ParticleHypothesis.hpp>
+#include <Acts/EventData/TrackParameters.hpp>
 #include <Acts/Propagator/EigenStepper.hpp>
 #include <Acts/Propagator/Propagator.hpp>
-#include <Acts/Utilities/Delegate.hpp>
-#include <Acts/Vertexing/IVertexFinder.hpp>
-#include <Acts/Vertexing/LinearizedTrack.hpp>
 #include <ActsExamples/EventData/Track.hpp>
+#include <boost/move/utility_core.hpp>
 #include <edm4eic/Track.h>
 #include <fmt/core.h>
 #include <podio/RelationRange.h>
@@ -24,6 +26,7 @@
 #endif
 #include <Acts/Utilities/Logger.hpp>
 #include <Acts/Utilities/Result.hpp>
+#include <Acts/Utilities/VectorHelpers.hpp>
 #include <Acts/Vertexing/FullBilloirVertexFitter.hpp>
 #include <Acts/Vertexing/HelicalTrackLinearizer.hpp>
 #include <Acts/Vertexing/ImpactPointEstimator.hpp>
@@ -33,6 +36,7 @@
 #include <Acts/Vertexing/VertexingOptions.hpp>
 #include <Acts/Vertexing/ZScanVertexFinder.hpp>
 #include <ActsExamples/EventData/Trajectories.hpp>
+#include <boost/container/vector.hpp>
 #include <edm4eic/Cov4f.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4eic/TrackParameters.h>
@@ -40,7 +44,12 @@
 #include <edm4eic/unit_system.h>
 #include <edm4hep/Vector2f.h>
 #include <Eigen/Core>
+#include <Eigen/Geometry>
+#include <Eigen/LU>
+#include <algorithm>
 #include <cmath>
+#include <optional>
+#include <tuple>
 #include <utility>
 
 #include "extensions/spdlog/SpdlogToActs.h"

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -73,7 +73,6 @@ std::unique_ptr<edm4eic::VertexCollection> eicrecon::IterativeVertexFinder::prod
   auto outputVertices = std::make_unique<edm4eic::VertexCollection>();
 
   using Propagator        = Acts::Propagator<Acts::EigenStepper<>>;
-  using PropagatorOptions = Acts::PropagatorOptions<>;
 #if Acts_VERSION_MAJOR >= 33
   using Linearizer        = Acts::HelicalTrackLinearizer;
   using VertexFitter      = Acts::FullBilloirVertexFitter;
@@ -102,7 +101,6 @@ std::unique_ptr<edm4eic::VertexCollection> eicrecon::IterativeVertexFinder::prod
   auto propagator = std::make_shared<Propagator>(
     stepper, Acts::detail::VoidNavigator{}, logger().cloneWithSuffix("Prop"));
 #endif
-  Acts::PropagatorOptions opts(m_geoctx, m_fieldctx);
 
   // Setup the track linearizer
 #if Acts_VERSION_MAJOR >= 33

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -4,18 +4,16 @@
 
 #include "IterativeVertexFinder.h"
 
-#include <Acts/Definitions/Common.hpp>
-#include <Acts/Definitions/Direction.hpp>
 #include <Acts/Definitions/TrackParametrization.hpp>
 #include <Acts/Definitions/Units.hpp>
 #include <Acts/EventData/GenericBoundTrackParameters.hpp>
-#include <Acts/EventData/GenericParticleHypothesis.hpp>
-#include <Acts/EventData/ParticleHypothesis.hpp>
-#include <Acts/EventData/TrackParameters.hpp>
+#include <Acts/MagneticField/MagneticFieldProvider.hpp>
 #include <Acts/Propagator/EigenStepper.hpp>
 #include <Acts/Propagator/Propagator.hpp>
+#include <Acts/Utilities/Delegate.hpp>
+#include <Acts/Vertexing/IVertexFinder.hpp>
+#include <Acts/Vertexing/LinearizedTrack.hpp>
 #include <ActsExamples/EventData/Track.hpp>
-#include <boost/move/utility_core.hpp>
 #include <edm4eic/Track.h>
 #include <fmt/core.h>
 #include <podio/RelationRange.h>
@@ -26,7 +24,6 @@
 #endif
 #include <Acts/Utilities/Logger.hpp>
 #include <Acts/Utilities/Result.hpp>
-#include <Acts/Utilities/VectorHelpers.hpp>
 #include <Acts/Vertexing/FullBilloirVertexFitter.hpp>
 #include <Acts/Vertexing/HelicalTrackLinearizer.hpp>
 #include <Acts/Vertexing/ImpactPointEstimator.hpp>
@@ -36,7 +33,6 @@
 #include <Acts/Vertexing/VertexingOptions.hpp>
 #include <Acts/Vertexing/ZScanVertexFinder.hpp>
 #include <ActsExamples/EventData/Trajectories.hpp>
-#include <boost/container/vector.hpp>
 #include <edm4eic/Cov4f.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4eic/TrackParameters.h>
@@ -44,12 +40,7 @@
 #include <edm4eic/unit_system.h>
 #include <edm4hep/Vector2f.h>
 #include <Eigen/Core>
-#include <Eigen/Geometry>
-#include <Eigen/LU>
-#include <algorithm>
 #include <cmath>
-#include <optional>
-#include <tuple>
 #include <utility>
 
 #include "extensions/spdlog/SpdlogToActs.h"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes an entirely unused options variable (and type alias) in IterativeVertexFinder.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: unused code)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.