### PR TITLE
feat: support EDM4hep-0.99 relations to MCParticle

### DIFF
--- a/src/algorithms/digi/SiliconTrackerDigi.cc
+++ b/src/algorithms/digi/SiliconTrackerDigi.cc
@@ -5,6 +5,7 @@
 
 #include <Evaluator/DD4hepUnits.h>
 #include <edm4eic/EDM4eicVersion.h>
+#include <edm4hep/EDM4hepVersion.h>
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
@@ -54,7 +55,11 @@ void SiliconTrackerDigi::process(
         debug("   momentum  = ({:.2f}, {:.2f}, {:.2f})", sim_hit.getMomentum().x, sim_hit.getMomentum().y, sim_hit.getMomentum().z);
         debug("   edep = {:.2f}", sim_hit.getEDep());
         debug("   time = {:.4f}[ns]", sim_hit.getTime());
+#if EDM4HEP_BUILD_VERSION >= EDM4HEP_VERSION(0, 99, 0)
+        debug("   particle time = {}[ns]", sim_hit.getParticle().getTime());
+#else 
         debug("   particle time = {}[ns]", sim_hit.getMCParticle().getTime());
+#endif
         debug("   time smearing: {:.4f}, resulting time = {:.4f} [ns]", time_smearing, result_time);
         debug("   hit_time_stamp: {} [~ps]", hit_time_stamp);
 

--- a/src/algorithms/digi/SiliconTrackerDigi.cc
+++ b/src/algorithms/digi/SiliconTrackerDigi.cc
@@ -57,7 +57,7 @@ void SiliconTrackerDigi::process(
         debug("   time = {:.4f}[ns]", sim_hit.getTime());
 #if EDM4HEP_BUILD_VERSION >= EDM4HEP_VERSION(0, 99, 0)
         debug("   particle time = {}[ns]", sim_hit.getParticle().getTime());
-#else 
+#else
         debug("   particle time = {}[ns]", sim_hit.getMCParticle().getTime());
 #endif
         debug("   time smearing: {:.4f}, resulting time = {:.4f} [ns]", time_smearing, result_time);

--- a/src/algorithms/pid/IrtCherenkovParticleID.cc
+++ b/src/algorithms/pid/IrtCherenkovParticleID.cc
@@ -13,6 +13,7 @@
 #include <edm4eic/CherenkovParticleIDHypothesis.h>
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/TrackPoint.h>
+#include <edm4hep/EDM4hepVersion.h>
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/SimTrackerHitCollection.h>
 #include <edm4hep/Vector2f.h>
@@ -218,7 +219,11 @@ void IrtCherenkovParticleID::process(
             if(hit_assoc.getRawHit().isAvailable()) {
               if(hit_assoc.getRawHit().id() == raw_hit.id()) {
 #if EDM4EIC_VERSION_MAJOR >= 6
+# if EDM4HEP_BUILD_VERSION >= EDM4HEP_VERSION(0, 99, 0)
+                mc_photon = hit_assoc.getSimHit().getParticle();
+# else
                 mc_photon = hit_assoc.getSimHit().getMCParticle();
+# endif
 #else
                 // hit association found, get the MC photon and break the loop
                 if(hit_assoc.simHits_size() > 0) {

--- a/src/algorithms/tracking/ActsToTracks.cc
+++ b/src/algorithms/tracking/ActsToTracks.cc
@@ -11,6 +11,7 @@
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/RawTrackerHit.h>
 #include <edm4eic/TrackerHit.h>
+#include <edm4hep/EDM4hepVersion.h>
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/SimTrackerHit.h>
 #include <edm4hep/Vector2f.h>
@@ -196,7 +197,11 @@ void ActsToTracks::process(const Input& input, const Output& output) const {
                         for (const auto raw_hit_assoc : *raw_hit_assocs) {
                           if (raw_hit_assoc.getRawHit() == raw_hit) {
                             auto sim_hit = raw_hit_assoc.getSimHit();
+#if EDM4HEP_BUILD_VERSION >= EDM4HEP_VERSION(0, 99, 0)
+                            auto mc_particle = sim_hit.getParticle();
+#else
                             auto mc_particle = sim_hit.getMCParticle();
+#endif
                             mcparticle_weight_by_hit_count[mc_particle]++;
                           }
                         }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
In EDM4hep v0.99, https://github.com/key4hep/EDM4hep/commit/cb738b0e2a5a8d4c922aa2a0d49974caf4adcd2e, the names of relations to `edm4hep::MCParticle` types were renamed from `MCParticle` to `particle`. This is more consistent in capitalization, and it avoids reusing type names as field names. It also is necessary for julia ports, it seems.

This PR adapts to the new names and avoids deprecation warnings during compilation of EICrecon..

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: EDM4hep 0.99 support without warnings)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.