### PR TITLE
feat: fix compilation for Acts versions from v36 up to v39

### DIFF
--- a/src/algorithms/tracking/ActsGeometryProvider.h
+++ b/src/algorithms/tracking/ActsGeometryProvider.h
@@ -109,11 +109,19 @@ private:
     std::shared_ptr<spdlog::logger> m_init_log;
 
     /// Configuration for obj export
+#if Acts_VERSION_MAJOR >= 37
+    Acts::ViewConfig m_containerView{.color = {220, 220, 220}};
+    Acts::ViewConfig m_volumeView{.color = {220, 220, 0}};
+    Acts::ViewConfig m_sensitiveView{.color = {0, 180, 240}};
+    Acts::ViewConfig m_passiveView{.color = {240, 280, 0}};
+    Acts::ViewConfig m_gridView{.color = {220, 0, 0}};
+#else
     Acts::ViewConfig m_containerView{{220, 220, 220}};
     Acts::ViewConfig m_volumeView{{220, 220, 0}};
     Acts::ViewConfig m_sensitiveView{{0, 180, 240}};
     Acts::ViewConfig m_passiveView{{240, 280, 0}};
     Acts::ViewConfig m_gridView{{220, 0, 0}};
+#endif
     bool m_objWriteIt{false};
     bool m_plyWriteIt{false};
     std::string m_outputTag{""};

--- a/src/algorithms/tracking/ActsGeometryProvider.h
+++ b/src/algorithms/tracking/ActsGeometryProvider.h
@@ -138,15 +138,20 @@ public:
     void setOutputDir(std::string dir) { m_outputDir = dir; }
     std::string getOutputDir() const { return m_outputDir; }
 
-    void setContainerView(std::array<int,3> view) { m_containerView = Acts::ViewConfig{view}; }
+#if Acts_VERSION_MAJOR >= 37
+    using Color = Acts::Color;
+#else
+    using Color = Acts::ColorRGB;
+#endif
+    void setContainerView(std::array<int,3> c) { m_containerView.color = Color(c); }
     const Acts::ViewConfig& getContainerView() const { return m_containerView; }
-    void setVolumeView(std::array<int,3> view) { m_volumeView = Acts::ViewConfig{view}; }
+    void setVolumeView(std::array<int,3> c) { m_volumeView.color = Color(c); }
     const Acts::ViewConfig& getVolumeView() const { return m_volumeView; }
-    void setSensitiveView(std::array<int,3> view) { m_sensitiveView = Acts::ViewConfig{view}; }
+    void setSensitiveView(std::array<int,3> c) { m_sensitiveView.color = Color(c); }
     const Acts::ViewConfig& getSensitiveView() const { return m_sensitiveView; }
-    void setPassiveView(std::array<int,3> view) { m_passiveView = Acts::ViewConfig{view}; }
+    void setPassiveView(std::array<int,3> c) { m_passiveView.color = Color(c); }
     const Acts::ViewConfig& getPassiveView() const { return m_passiveView; }
-    void setGridView(std::array<int,3> view) { m_gridView = Acts::ViewConfig{view}; }
+    void setGridView(std::array<int,3> c) { m_gridView.color = Color(c); }
     const Acts::ViewConfig& getGridView() const { return m_gridView; }
 
 };

--- a/src/algorithms/tracking/AmbiguitySolver.cc
+++ b/src/algorithms/tracking/AmbiguitySolver.cc
@@ -102,6 +102,11 @@ AmbiguitySolver::process(std::vector<const ActsExamples::ConstTrackContainer*> i
         tips.clear();
         parameters.clear();
 
+        if (!track.hasReferenceSurface()) {
+           ACTS_WARNING("Track has no reference surface.");
+           continue;
+        }
+
         tips.push_back(track.tipIndex());
         parameters.emplace(
            std::pair{track.tipIndex(),

--- a/src/algorithms/tracking/AmbiguitySolver.cc
+++ b/src/algorithms/tracking/AmbiguitySolver.cc
@@ -102,11 +102,6 @@ AmbiguitySolver::process(std::vector<const ActsExamples::ConstTrackContainer*> i
         tips.clear();
         parameters.clear();
 
-        if (!track.hasReferenceSurface()) {
-           ACTS_WARNING("Track has no reference surface.");
-           continue;
-        }
-
         tips.push_back(track.tipIndex());
         parameters.emplace(
            std::pair{track.tipIndex(),

--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -76,7 +76,7 @@
 #include <list>
 #include <optional>
 #include <ostream>
-#include <ranges>
+#include <set>
 #include <system_error>
 #include <utility>
 

--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -291,7 +291,12 @@ namespace eicrecon {
                 &Acts::GainMatrixSmoother::operator()<Acts::VectorMultiTrajectory>>(
                 &kfSmoother);
 #endif
-#if Acts_VERSION_MAJOR < 39
+#if (Acts_VERSION_MAJOR >= 36) && (Acts_VERSION_MAJOR < 39)
+        extensions.measurementSelector.connect<
+                &Acts::MeasurementSelector::select<
+                typename ActsExamples::TrackContainer::TrackStateContainerBackend>>(
+                &measSel);
+#elif Acts_VERSION_MAJOR < 39
         extensions.measurementSelector.connect<
                 &Acts::MeasurementSelector::select<Acts::VectorMultiTrajectory>>(
                 &measSel);

--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -421,7 +421,7 @@ namespace eicrecon {
             }
         }
 
-        for (ssize_t track_index = acts_tracks.size() - 1; track_index >= 0; track_index--) {
+        for (ssize_t track_index = static_cast<ssize_t>(acts_tracks.size()) - 1; track_index >= 0; track_index--) {
             if (not passed_tracks.count(track_index)) {
                 // NOTE This does not remove track states corresponding to the
                 // removed tracks. Doing so would require implementing some garbage

--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -148,12 +148,13 @@ namespace eicrecon {
             src_links.insert(src_links.end(), sourceLink);
             // ---
             // Create ACTS measurements
-            Acts::Vector2 loc = Acts::Vector2::Zero();
+            std::array<Acts::BoundIndices, 2> indices{Acts::eBoundLoc0, Acts::eBoundLoc1};
+
+            Acts::ActsVector<2> loc = Acts::Vector2::Zero();
             loc[Acts::eBoundLoc0] = meas2D.getLoc().a;
             loc[Acts::eBoundLoc1] = meas2D.getLoc().b;
 
-
-            Acts::SquareMatrix2 cov = Acts::SquareMatrix2::Zero();
+            Acts::ActsSquareMatrix<2> cov = Acts::ActsSquareMatrix<2>::Zero();
             cov(0, 0) = meas2D.getCovariance().xx;
             cov(1, 1) = meas2D.getCovariance().yy;
             cov(0, 1) = meas2D.getCovariance().xy;

--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -173,13 +173,9 @@ namespace eicrecon {
             Acts::visit_measurement(
               indices.size(), [&](auto dim) -> ActsExamples::VariableBoundMeasurementProxy {
                 if constexpr (dim == indices.size()) {
-                  ActsExamples::FixedBoundMeasurementProxy<dim> measurement =
-                    measurements->makeMeasurement<dim>();
-                  measurement.setSourceLink(sourceLink);
-                  measurement.setSubspaceIndices(indices);
-                  measurement.parameters() = loc;
-                  measurement.covariance() = cov;
-                  return measurement;
+                  return ActsExamples::VariableBoundMeasurementProxy{
+                    measurements->emplaceMeasurement<dim>(Acts::SourceLink{sourceLink}, indices, loc, cov)
+                  };
                 } else {
                   throw std::runtime_error("Dimension not supported in measurement creation");
                 }

--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -299,6 +299,7 @@ namespace eicrecon {
                 auto extrapolationResult = Acts::extrapolateTrackToReferenceSurface(
                     track, *pSurface, extrapolator, extrapolationOptions,
                     Acts::TrackExtrapolationStrategy::firstOrLast, logger());
+
                 if (!extrapolationResult.ok()) {
                     ACTS_ERROR("Extrapolation for seed "
                         << iseed << " and track " << track.index()
@@ -372,6 +373,11 @@ namespace eicrecon {
           }
 
           lastSeed = constSeedNumber(track);
+
+          if (!track.hasReferenceSurface()) {
+            ACTS_WARNING("Track has no reference surface.");
+            continue;
+          }
 
           tips.push_back(track.tipIndex());
           parameters.emplace(

--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -479,11 +479,6 @@ namespace eicrecon {
 
           lastSeed = constSeedNumber(track);
 
-          if (!track.hasReferenceSurface()) {
-            ACTS_WARNING("Track has no reference surface.");
-            continue;
-          }
-
           tips.push_back(track.tipIndex());
           parameters.emplace(
               std::pair{track.tipIndex(),

--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -160,14 +160,19 @@ namespace eicrecon {
             cov(0, 1) = meas2D.getCovariance().xy;
             cov(1, 0) = meas2D.getCovariance().xy;
 
-#if Acts_VERSION_MAJOR >= 36
+#if Acts_VERSION_MAJOR > 36 || (Acts_VERSION_MAJOR == 36 && Acts_VERSION_MINOR >= 1)
+            auto measurement = ActsExamples::makeVariableSizeMeasurement(
+              Acts::SourceLink{sourceLink}, loc, cov, Acts::eBoundLoc0, Acts::eBoundLoc1);
+            measurements->emplace_back(std::move(measurement));
+#elif Acts_VERSION_MAJOR == 36 && Acts_VERSION_MINOR == 0
             auto measurement = ActsExamples::makeFixedSizeMeasurement(
               Acts::SourceLink{sourceLink}, loc, cov, Acts::eBoundLoc0, Acts::eBoundLoc1);
+            measurements->emplace_back(std::move(measurement));
 #else
             auto measurement = Acts::makeMeasurement(
               Acts::SourceLink{sourceLink}, loc, cov, Acts::eBoundLoc0, Acts::eBoundLoc1);
-#endif
             measurements->emplace_back(std::move(measurement));
+#endif
 
             hit_index++;
         }

--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -10,39 +10,36 @@
 #include <Acts/EventData/GenericBoundTrackParameters.hpp>
 #include <Acts/EventData/TrackStateProxy.hpp>
 #include <Acts/EventData/Types.hpp>
-#include <Acts/Geometry/Layer.hpp>
-#include <boost/container/vector.hpp>
-#include <boost/move/utility_core.hpp>
 #if Acts_VERSION_MAJOR < 36
 #include <Acts/EventData/Measurement.hpp>
 #endif
 #include <Acts/EventData/MultiTrajectory.hpp>
 #include <Acts/EventData/ParticleHypothesis.hpp>
+#include <Acts/EventData/ProxyAccessor.hpp>
 #include <Acts/EventData/SourceLink.hpp>
 #include <Acts/EventData/TrackContainer.hpp>
 #include <Acts/EventData/TrackProxy.hpp>
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
 #include <Acts/EventData/VectorTrackContainer.hpp>
 #include <Acts/Geometry/GeometryIdentifier.hpp>
-
-#include "Acts/EventData/ProxyAccessor.hpp"
+#include <Acts/Geometry/Layer.hpp>
 #if Acts_VERSION_MAJOR >= 34
 #if Acts_VERSION_MAJOR >= 37
-#include "Acts/Propagator/ActorList.hpp"
+#include <Acts/Propagator/ActorList.hpp>
 #else
-#include "Acts/Propagator/AbortList.hpp"
+#include <Acts/Propagator/AbortList.hpp>
 #include <Acts/Propagator/ActionList.hpp>
 #endif
-#include "Acts/Propagator/EigenStepper.hpp"
-#include "Acts/Propagator/MaterialInteractor.hpp"
-#include "Acts/Propagator/Navigator.hpp"
+#include <Acts/Propagator/EigenStepper.hpp>
+#include <Acts/Propagator/MaterialInteractor.hpp>
+#include <Acts/Propagator/Navigator.hpp>
 #endif
 #include <Acts/Propagator/Propagator.hpp>
 #if Acts_VERSION_MAJOR >= 36
-#include "Acts/Propagator/PropagatorOptions.hpp"
+#include <Acts/Propagator/PropagatorOptions.hpp>
 #endif
 #if Acts_VERSION_MAJOR >= 34
-#include "Acts/Propagator/StandardAborters.hpp"
+#include <Acts/Propagator/StandardAborters.hpp>
 #endif
 #include <Acts/Surfaces/PerigeeSurface.hpp>
 #include <Acts/Surfaces/Surface.hpp>
@@ -55,12 +52,14 @@
 #include <Acts/TrackFitting/GainMatrixUpdater.hpp>
 #include <Acts/Utilities/Logger.hpp>
 #if Acts_VERSION_MAJOR >= 34
-#include "Acts/Utilities/TrackHelpers.hpp"
+#include <Acts/Utilities/TrackHelpers.hpp>
 #endif
 #include <ActsExamples/EventData/IndexSourceLink.hpp>
 #include <ActsExamples/EventData/Measurement.hpp>
 #include <ActsExamples/EventData/MeasurementCalibration.hpp>
 #include <ActsExamples/EventData/Track.hpp>
+#include <boost/container/vector.hpp>
+#include <boost/move/utility_core.hpp>
 #include <edm4eic/Cov3f.h>
 #include <edm4eic/Cov6f.h>
 #include <edm4eic/Measurement2DCollection.h>

--- a/src/algorithms/tracking/CKFTracking.h
+++ b/src/algorithms/tracking/CKFTracking.h
@@ -41,9 +41,15 @@ namespace eicrecon {
     public:
         /// Track finder function that takes input measurements, initial trackstate
         /// and track finder options and returns some track-finder-specific result.
+#if Acts_VERSION_MAJOR >= 36
+        using TrackFinderOptions =
+            Acts::CombinatorialKalmanFilterOptions<ActsExamples::IndexSourceLinkAccessor::Iterator,
+                                                   ActsExamples::TrackContainer>;
+#else
         using TrackFinderOptions =
             Acts::CombinatorialKalmanFilterOptions<ActsExamples::IndexSourceLinkAccessor::Iterator,
                                                    Acts::VectorMultiTrajectory>;
+#endif
         using TrackFinderResult =
             Acts::Result<std::vector<ActsExamples::TrackContainer::TrackProxy>>;
 

--- a/src/algorithms/tracking/CKFTracking.h
+++ b/src/algorithms/tracking/CKFTracking.h
@@ -41,7 +41,10 @@ namespace eicrecon {
     public:
         /// Track finder function that takes input measurements, initial trackstate
         /// and track finder options and returns some track-finder-specific result.
-#if Acts_VERSION_MAJOR >= 36
+#if Acts_VERSION_MAJOR >= 39
+        using TrackFinderOptions =
+            Acts::CombinatorialKalmanFilterOptions<ActsExamples::TrackContainer>;
+#elif Acts_VERSION_MAJOR >= 36
         using TrackFinderOptions =
             Acts::CombinatorialKalmanFilterOptions<ActsExamples::IndexSourceLinkAccessor::Iterator,
                                                    ActsExamples::TrackContainer>;

--- a/src/algorithms/tracking/CKFTrackingFunction.cc
+++ b/src/algorithms/tracking/CKFTrackingFunction.cc
@@ -12,7 +12,6 @@
 #endif
 #include <Acts/Geometry/Layer.hpp>
 #include <Acts/Geometry/TrackingGeometry.hpp>
-#include <Acts/Geometry/TrackingVolume.hpp>
 #include <Acts/MagneticField/MagneticFieldProvider.hpp>
 #include <Acts/Propagator/EigenStepper.hpp>
 #include <Acts/Propagator/Navigator.hpp>

--- a/src/algorithms/tracking/CKFTrackingFunction.cc
+++ b/src/algorithms/tracking/CKFTrackingFunction.cc
@@ -18,8 +18,6 @@
 #include <Acts/Propagator/Navigator.hpp>
 #include <Acts/Propagator/Propagator.hpp>
 #include <Acts/TrackFinding/CombinatorialKalmanFilter.hpp>
-#include <Acts/TrackFitting/GainMatrixSmoother.hpp>
-#include <Acts/TrackFitting/GainMatrixUpdater.hpp>
 #include <Acts/Utilities/Logger.hpp>
 #include <ActsExamples/EventData/IndexSourceLink.hpp>
 #include <boost/container/vector.hpp>
@@ -31,10 +29,7 @@
 #include "ActsExamples/EventData/Track.hpp"
 #include "CKFTracking.h"
 
-namespace eicrecon{
-
-  using Updater  = Acts::GainMatrixUpdater;
-  using Smoother = Acts::GainMatrixSmoother;
+namespace eicrecon {
 
   using Stepper    = Acts::EigenStepper<>;
   using Navigator  = Acts::Navigator;

--- a/src/algorithms/tracking/CKFTrackingFunction.cc
+++ b/src/algorithms/tracking/CKFTrackingFunction.cc
@@ -6,8 +6,10 @@
 #include <Acts/EventData/ParticleHypothesis.hpp>
 #include <Acts/EventData/TrackContainer.hpp>
 #include <Acts/EventData/TrackStatePropMask.hpp>
+#if Acts_VERSION_MAJOR < 36
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
 #include <Acts/EventData/VectorTrackContainer.hpp>
+#endif
 #include <Acts/Geometry/Layer.hpp>
 #include <Acts/Geometry/TrackingGeometry.hpp>
 #include <Acts/Geometry/TrackingVolume.hpp>
@@ -38,12 +40,17 @@ namespace eicrecon{
   using Navigator  = Acts::Navigator;
   using Propagator = Acts::Propagator<Stepper, Navigator>;
 
+#if Acts_VERSION_MAJOR >= 36
+  using CKF =
+      Acts::CombinatorialKalmanFilter<Propagator, ActsExamples::TrackContainer>;
+#else
   using CKF =
       Acts::CombinatorialKalmanFilter<Propagator, Acts::VectorMultiTrajectory>;
 
   using TrackContainer =
       Acts::TrackContainer<Acts::VectorTrackContainer,
                            Acts::VectorMultiTrajectory, std::shared_ptr>;
+#endif
 
   /** Finder implementation .
    *
@@ -58,7 +65,11 @@ namespace eicrecon{
     eicrecon::CKFTracking::TrackFinderResult operator()(
         const ActsExamples::TrackParameters& initialParameters,
         const eicrecon::CKFTracking::TrackFinderOptions& options,
+#if Acts_VERSION_MAJOR >= 36
+        ActsExamples::TrackContainer& tracks) const override {
+#else
         TrackContainer& tracks) const override {
+#endif
       return trackFinder.findTracks(initialParameters, options, tracks);
     };
   };

--- a/src/algorithms/tracking/DD4hepBField.cc
+++ b/src/algorithms/tracking/DD4hepBField.cc
@@ -11,6 +11,7 @@
 #include <Math/GenVector/Cartesian3D.h>
 #include <Math/GenVector/DisplacementVector3D.h>
 #include <Eigen/Core>
+#include <cmath>
 #include <limits>
 
 namespace eicrecon::BField {

--- a/src/algorithms/tracking/DD4hepBField.cc
+++ b/src/algorithms/tracking/DD4hepBField.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2022 Whitney Armstrong, Wouter Deconinck
+// Copyright (C) 2022 - 2025 Whitney Armstrong, Wouter Deconinck, Dmitry Kalinkin
 
 #include "DD4hepBField.h"
 
@@ -22,6 +22,12 @@ namespace eicrecon::BField {
       position[0] * (dd4hep::mm / Acts::UnitConstants::mm),
       position[1] * (dd4hep::mm / Acts::UnitConstants::mm),
       position[2] * (dd4hep::mm / Acts::UnitConstants::mm));
+
+    // Avoid crash during lookup.
+    // Infinite values are possible due to https://github.com/acts-project/acts/issues/4166.
+    if ((!std::isfinite(position[0])) && (!std::isfinite(position[1])) && (!std::isfinite(position[2]))) {
+      return Acts::Result<Acts::Vector3>::success({0., 0., 0.});
+    }
 
     auto fieldObj = m_det->field();
     auto field = fieldObj.magneticField(pos) * (Acts::UnitConstants::T / dd4hep::tesla);

--- a/src/algorithms/tracking/DD4hepBField.cc
+++ b/src/algorithms/tracking/DD4hepBField.cc
@@ -39,11 +39,13 @@ namespace eicrecon::BField {
     return Acts::Result<Acts::Vector3>::success({field.x(), field.y(), field.z()});
   }
 
+#if Acts_VERSION_MAJOR < 39
   Acts::Result<Acts::Vector3> DD4hepBField::getFieldGradient(const Acts::Vector3& position,
                                                              Acts::ActsMatrix<3, 3>& /*derivative*/,
                                                              Acts::MagneticFieldProvider::Cache& cache) const
   {
     return this->getField(position, cache);
   }
+#endif
 
 } // namespace eicrecon::BField

--- a/src/algorithms/tracking/DD4hepBField.h
+++ b/src/algorithms/tracking/DD4hepBField.h
@@ -43,7 +43,11 @@ namespace eicrecon::BField {
 
     Acts::MagneticFieldProvider::Cache makeCache(const Acts::MagneticFieldContext& mctx) const override
     {
+#if Acts_VERSION_MAJOR >= 32
       return Acts::MagneticFieldProvider::Cache(std::in_place_type<Cache>, mctx);
+#else
+      return Acts::MagneticFieldProvider::Cache::make<Cache>(mctx);
+#endif
     }
 
     /** construct constant magnetic field from field vector.
@@ -63,6 +67,7 @@ namespace eicrecon::BField {
      */
     Acts::Result<Acts::Vector3> getField(const Acts::Vector3& position, Acts::MagneticFieldProvider::Cache& cache) const override;
 
+#if Acts_VERSION_MAJOR < 39
     /** @brief retrieve magnetic field value & its gradient
      *
      * @param [in]  position   global position
@@ -78,6 +83,8 @@ namespace eicrecon::BField {
      */
     Acts::Result<Acts::Vector3> getFieldGradient(const Acts::Vector3& position, Acts::ActsMatrix<3, 3>& /*derivative*/,
                                                  Acts::MagneticFieldProvider::Cache& cache) const override;
+#endif
+
   };
 
   using BFieldVariant = std::variant<std::shared_ptr<const DD4hepBField>>;

--- a/src/algorithms/tracking/DD4hepBField.h
+++ b/src/algorithms/tracking/DD4hepBField.h
@@ -15,6 +15,7 @@
 #include <DD4hep/Detector.h>
 #include <gsl/pointers>
 #include <memory>
+#include <utility>
 #include <variant>
 
 

--- a/src/algorithms/tracking/SpacePoint.h
+++ b/src/algorithms/tracking/SpacePoint.h
@@ -1,7 +1,11 @@
 #pragma once
 
-#include <Acts/Geometry/GeometryIdentifier.hpp>
+#if Acts_VERSION_MAJOR >= 37
+#include <Acts/EventData/Seed.hpp>
+#else
 #include <Acts/Seeding/Seed.hpp>
+#endif
+#include <Acts/Geometry/GeometryIdentifier.hpp>
 #include <Acts/Surfaces/Surface.hpp>
 #include "ActsGeometryProvider.h"
 namespace eicrecon {

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -245,7 +245,11 @@ void TrackPropagation::propagateToSurfaceList(
 
         ACTS_LOCAL_LOGGER(eicrecon::getSpdlogLogger("PROP", m_log));
 
+#if Acts_VERSION_MAJOR >= 36
+        Propagator::template Options<> options(m_geoContext, m_fieldContext);
+#else
         Acts::PropagatorOptions<> options(m_geoContext, m_fieldContext);
+#endif
 
         auto result = propagator.propagate(initial_bound_parameters, *targetSurf, options);
 

--- a/src/algorithms/tracking/TrackSeeding.h
+++ b/src/algorithms/tracking/TrackSeeding.h
@@ -4,10 +4,16 @@
 
 #pragma once
 
+#if Acts_VERSION_MAJOR >= 37
+#include <Acts/EventData/SpacePointContainer.hpp>
+#endif
 #include <Acts/MagneticField/MagneticFieldContext.hpp>
 #include <Acts/Seeding/SeedFilterConfig.hpp>
 #include <Acts/Seeding/SeedFinderConfig.hpp>
 #include <Acts/Seeding/SeedFinderOrthogonalConfig.hpp>
+#if Acts_VERSION_MAJOR >= 37
+#include <ActsExamples/EventData/SpacePointContainer.hpp>
+#endif
 #include <edm4eic/TrackParametersCollection.h>
 #include <edm4eic/TrackerHitCollection.h>
 #include <spdlog/logger.h>
@@ -28,6 +34,13 @@ namespace eicrecon {
     class TrackSeeding:
             public eicrecon::WithPodConfig<eicrecon::OrthogonalTrackSeedingConfig> {
     public:
+
+#if Acts_VERSION_MAJOR >= 37
+        using proxy_type = typename Acts::SpacePointContainer<
+            ActsExamples::SpacePointContainer<std::vector<const SpacePoint*>>,
+            Acts::detail::RefHolder>::SpacePointProxyType;
+#endif
+
         void init(std::shared_ptr<const ActsGeometryProvider> geo_svc, std::shared_ptr<spdlog::logger> log);
         std::unique_ptr<edm4eic::TrackParametersCollection> produce(const edm4eic::TrackerHitCollection& trk_hits);
 
@@ -42,7 +55,11 @@ namespace eicrecon {
 
         Acts::SeedFilterConfig m_seedFilterConfig;
         Acts::SeedFinderOptions m_seedFinderOptions;
+#if Acts_VERSION_MAJOR >= 37
+        Acts::SeedFinderOrthogonalConfig<proxy_type> m_seedFinderConfig;
+#else
         Acts::SeedFinderOrthogonalConfig<SpacePoint> m_seedFinderConfig;
+#endif
 
         int determineCharge(std::vector<std::pair<float,float>>& positions, const std::pair<float,float>& PCA, std::tuple<float,float,float>& RX0Y0) const;
         std::pair<float,float> findPCA(std::tuple<float,float,float>& circleParams) const;

--- a/src/services/geometry/acts/ACTSGeo_service.cc
+++ b/src/services/geometry/acts/ACTSGeo_service.cc
@@ -70,11 +70,19 @@ std::shared_ptr<const ActsGeometryProvider> ACTSGeo_service::actsGeoProvider() {
             m_acts_provider->setOutputTag(outputTag);
             m_acts_provider->setOutputDir(outputDir);
 
+#if Acts_VERSION_MAJOR >= 37
+            std::array<int,3> containerView = m_acts_provider->getContainerView().color.rgb;
+            std::array<int,3> volumeView = m_acts_provider->getVolumeView().color.rgb;
+            std::array<int,3> sensitiveView = m_acts_provider->getSensitiveView().color.rgb;
+            std::array<int,3> passiveView = m_acts_provider->getPassiveView().color.rgb;
+            std::array<int,3> gridView = m_acts_provider->getGridView().color.rgb;
+#else
             std::array<int,3> containerView = m_acts_provider->getContainerView().color;
             std::array<int,3> volumeView = m_acts_provider->getVolumeView().color;
             std::array<int,3> sensitiveView = m_acts_provider->getSensitiveView().color;
             std::array<int,3> passiveView = m_acts_provider->getPassiveView().color;
             std::array<int,3> gridView = m_acts_provider->getGridView().color;
+#endif
             m_app->SetDefaultParameter("acts:ContainerView", containerView, "RGB for container views");
             m_app->SetDefaultParameter("acts:VolumeView", volumeView, "RGB for volume views");
             m_app->SetDefaultParameter("acts:SensitiveView", sensitiveView, "RGB for sensitive views");

--- a/src/services/geometry/acts/ACTSGeo_service.h
+++ b/src/services/geometry/acts/ACTSGeo_service.h
@@ -5,6 +5,7 @@
 
 #include <DD4hep/Detector.h>
 #include <JANA/JApplication.h>
+#include <JANA/JServiceFwd.h>
 #include <JANA/Services/JServiceLocator.h>
 #include <spdlog/logger.h>
 #include <memory>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This adapts our tracking algorithms to any Acts version between v36 and v38.

The commits in this branch are topologically ordered with reference to the commit message title, Acts PR number, and version validity. All commits compile individually, but no event-for-event validation has been performed. See also https://github.com/eic/EICrecon/pull/1525.

The support for mulitple versions is done by somewhat extensive use of preprocessor directives based on `Acts_VERSION_MAJOR` and `Acts_VERSION_MINOR`.

Builds with: 35.2.0 36.0.0 36.1.0 36.2.0 36.3.2 37.4.0 38.2.0 39.1.0

Needs:
- [x] #1711 
- [x] #1712

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: Acts versions are released faster than we can keep up with)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.