### PR TITLE
feat: support CartesianStripZ in CalorimeterHitReco

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitReco.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitReco.cc
@@ -264,6 +264,11 @@ void CalorimeterHitReco::process(
             cdim[0] = cell_dim[0];
             cdim[1] = cell_dim[1];
             debug("Using segmentation for cell dimensions: {}", fmt::join(cdim, ", "));
+        } else if (segmentation_type == "CartesianStripZ") {
+            auto cell_dim = m_converter->cellDimensions(cellID);
+            cdim.resize(3);
+            cdim[0] = cell_dim[0];
+            debug("Using segmentation for cell dimensions: {}", fmt::join(cdim, ", "));
         } else {
             if ((segmentation_type != "NoSegmentation") && (!warned_unsupported_segmentation)) {
                 warning("Unsupported segmentation type \"{}\"", segmentation_type);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds support for CartesianStripZ (EcalBarrelScFiHits) in CalorimeterHitReco writing of hit dimensions. This therefore resolves the warning that there is no support.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: CartesianStripZ suport in CalorimeterHitReco for EcalBarrelScFiHits)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.