### PR TITLE
treewide: fix codespell issues

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = *.drawio,*.svg
+skip = *.drawio,*.svg,.github/iwyu.imp
 ignore-words = .codespell-ignore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ There are many coding guidelines which could be selected by the whole community,
 - member functions: camelCase
 - members:  m_snake_case
 - local variables: snake_case
-- constands, definitions: SCREAMING_SNAKE_CASE
+- constants, definitions: SCREAMING_SNAKE_CASE
 - base namespace: eicrecon
 - indent: 4 spaces
 

--- a/src/algorithms/pid/MatchToRICHPID.cc
+++ b/src/algorithms/pid/MatchToRICHPID.cc
@@ -105,7 +105,7 @@ namespace eicrecon {
                 return false;
             }
 
-            // get averge momentum direction of the track's TrackPoints
+            // get average momentum direction of the track's TrackPoints
             decltype(edm4eic::TrackPoint::momentum) in_track_p{0.0, 0.0, 0.0};
             for (const auto& in_track_point : in_track.getPoints())
                 in_track_p = in_track_p + ( in_track_point.momentum / in_track.points_size() );


### PR DESCRIPTION
Fixes codespell: https://results.pre-commit.ci/run/github/512187504/1738308139.YIrmyPXzSpaFmHjIt5yjgA