### PR TITLE
BUGFIX: PIDLookup: fix proton sampling threshold

### DIFF
--- a/src/algorithms/pid_lut/PIDLookup.cc
+++ b/src/algorithms/pid_lut/PIDLookup.cc
@@ -126,7 +126,7 @@ void PIDLookup::process(const Input& input, const Output& output) const {
         identified_pdg = 321; // kaon
         recopart.setParticleIDUsed((*partids_out)[partids_out->size() - 2]);
       } else if (random_unit_interval < (entry->prob_electron + entry->prob_pion +
-                                         entry->prob_kaon + entry->prob_electron)) {
+                                         entry->prob_kaon + entry->prob_proton)) {
         identified_pdg = 2212; // proton
         recopart.setParticleIDUsed((*partids_out)[partids_out->size() - 1]);
       }


### PR DESCRIPTION
Electron threshold was used for sampling protons due to what looks like some copy-paste error. The threshold reported in ParticleID for 2212 is correct, however. Basically, this is only issue for `ReconstructedParticles.PDG`.

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
Yes