### PR TITLE
JEventProcessorPODIO: final deprecation of `-Ppodio:output_include_collections`

### DIFF
--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -395,8 +395,8 @@ void JEventProcessorPODIO::Init() {
     //       I definitely don't trust PODIO to do this for me.
 
     if (m_output_include_collections_set) {
-      m_log->error("The podio:output_include_collections was provided, but is deprecated. Use podio:output_collections instead. Address this to remove the 10 second delay.");
-      throw std::runtime_error("The podio:output_include_collections was provided, but is deprecated. Use podio:output_collections instead. Address this to remove the 10 second delay.");
+      m_log->error("The podio:output_include_collections was provided, but is deprecated. Use podio:output_collections instead.");
+      throw std::runtime_error("The podio:output_include_collections was provided, but is deprecated. Use podio:output_collections instead.");
     }
 
 }
@@ -558,8 +558,8 @@ void JEventProcessorPODIO::Process(const std::shared_ptr<const JEvent> &event) {
 
 void JEventProcessorPODIO::Finish() {
     if (m_output_include_collections_set) {
-      m_log->error("The podio:output_include_collections was provided, but is deprecated. Use podio:output_collections instead. Address this to remove the 10 second delay.");
-      throw std::runtime_error("The podio:output_include_collections was provided, but is deprecated. Use podio:output_collections instead. Address this to remove the 10 second delay.");
+      m_log->error("The podio:output_include_collections was provided, but is deprecated. Use podio:output_collections instead.");
+      throw std::runtime_error("The podio:output_include_collections was provided, but is deprecated. Use podio:output_collections instead.");
     }
 
     m_writer->finish();

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -16,7 +16,8 @@
 #include <podio/ROOTFrameWriter.h>
 #endif
 #include <exception>
-#include <thread>
+#include <ostream>
+#include <stdexcept>
 
 #include "services/log/Log_service.h"
 

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -15,7 +15,6 @@
 #else
 #include <podio/ROOTFrameWriter.h>
 #endif
-#include <chrono>
 #include <exception>
 #include <thread>
 
@@ -397,9 +396,7 @@ void JEventProcessorPODIO::Init() {
 
     if (m_output_include_collections_set) {
       m_log->error("The podio:output_include_collections was provided, but is deprecated. Use podio:output_collections instead. Address this to remove the 10 second delay.");
-      // Adding a delay to ensure users notice the deprecation warning.
-      using namespace std::chrono_literals;
-      std::this_thread::sleep_for(10s);
+      throw std::runtime_error("The podio:output_include_collections was provided, but is deprecated. Use podio:output_collections instead. Address this to remove the 10 second delay.");
     }
 
 }
@@ -562,9 +559,7 @@ void JEventProcessorPODIO::Process(const std::shared_ptr<const JEvent> &event) {
 void JEventProcessorPODIO::Finish() {
     if (m_output_include_collections_set) {
       m_log->error("The podio:output_include_collections was provided, but is deprecated. Use podio:output_collections instead. Address this to remove the 10 second delay.");
-      // Adding a delay to ensure users notice the deprecation warning.
-      using namespace std::chrono_literals;
-      std::this_thread::sleep_for(10s);
+      throw std::runtime_error("The podio:output_include_collections was provided, but is deprecated. Use podio:output_collections instead. Address this to remove the 10 second delay.");
     }
 
     m_writer->finish();


### PR DESCRIPTION
We had a soft deprecation before, now it's a hard failure. A message is provided to direct users to the new facility.

Follow up on https://github.com/eic/EICrecon/pull/1466 and https://github.com/eic/EICrecon/pull/1323

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
Yes

### Does this PR change default behavior?
No