### PR TITLE
TrackProjector: fill relation from segment to track

### DIFF
--- a/src/algorithms/tracking/TrackProjector.cc
+++ b/src/algorithms/tracking/TrackProjector.cc
@@ -20,7 +20,7 @@
 #include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
 #include <fmt/ostream.h>
-#include <stdint.h>
+#include <cstdint>
 #include <cmath>
 #include <gsl/pointers>
 #include <iterator>
@@ -48,7 +48,7 @@ namespace eicrecon {
         debug("Track projector event process. Num of input trajectories: {}", std::size(acts_trajectories));
 
         // Loop over the trajectories
-        for (size_t i = 0; const auto &traj: acts_trajectories) {
+        for (std::size_t i = 0; const auto &traj: acts_trajectories) {
             // Get the entry index for the single trajectory
             // The trajectory entry indices and the multiTrajectory
             const auto &mj = traj->multiTrajectory();

--- a/src/algorithms/tracking/TrackProjector.cc
+++ b/src/algorithms/tracking/TrackProjector.cc
@@ -3,7 +3,6 @@
 
 #include <Acts/Definitions/TrackParametrization.hpp>
 #include <Acts/EventData/MultiTrajectoryHelpers.hpp>
-#include <stddef.h>
 #if Acts_VERSION_MAJOR >= 34
 #include <Acts/EventData/TransformationHelpers.hpp>
 #endif
@@ -20,8 +19,9 @@
 #include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
 #include <fmt/ostream.h>
-#include <cstdint>
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
 #include <gsl/pointers>
 #include <iterator>
 

--- a/src/algorithms/tracking/TrackProjector.cc
+++ b/src/algorithms/tracking/TrackProjector.cc
@@ -3,6 +3,7 @@
 
 #include <Acts/Definitions/TrackParametrization.hpp>
 #include <Acts/EventData/MultiTrajectoryHelpers.hpp>
+#include <stddef.h>
 #if Acts_VERSION_MAJOR >= 34
 #include <Acts/EventData/TransformationHelpers.hpp>
 #endif

--- a/src/algorithms/tracking/TrackProjector.cc
+++ b/src/algorithms/tracking/TrackProjector.cc
@@ -41,13 +41,13 @@ namespace eicrecon {
 
 
     void TrackProjector::process(const Input& input, const Output& output) const {
-        const auto [trajectories] = input;
+        const auto [acts_trajectories, tracks] = input;
         auto [track_segments] = output;
 
-        debug("Track projector event process. Num of input trajectories: {}", std::size(trajectories));
+        debug("Track projector event process. Num of input trajectories: {}", std::size(acts_trajectories));
 
         // Loop over the trajectories
-        for (const auto &traj: trajectories) {
+        for (size_t i = 0; const auto &traj: acts_trajectories) {
             // Get the entry index for the single trajectory
             // The trajectory entry indices and the multiTrajectory
             const auto &mj = traj->multiTrajectory();
@@ -71,6 +71,13 @@ namespace eicrecon {
             debug("  Num state in trajectory {}", m_nStates);
 
             auto track_segment = track_segments->create();
+
+            // corresponding track
+            if (tracks->size() == acts_trajectories.size()) {
+              trace("track segment connected to track {}", i);
+              track_segment.setTrack((*tracks)[i]);
+              ++i;
+            }
 
             // visit the track points
             mj.visitBackwards(trackTip, [&](auto &&trackstate) {

--- a/src/algorithms/tracking/TrackProjector.h
+++ b/src/algorithms/tracking/TrackProjector.h
@@ -5,6 +5,7 @@
 
 #include <ActsExamples/EventData/Trajectories.hpp>
 #include <algorithms/algorithm.h>
+#include <edm4eic/TrackCollection.h>
 #include <edm4eic/TrackSegmentCollection.h>
 #include <memory>
 #include <string>
@@ -15,9 +16,9 @@
 
 namespace eicrecon {
 
-using TrackProjectorAlgorithm =
-    algorithms::Algorithm<algorithms::Input<std::vector<ActsExamples::Trajectories>>,
-                          algorithms::Output<edm4eic::TrackSegmentCollection>>;
+using TrackProjectorAlgorithm = algorithms::Algorithm<
+    algorithms::Input<std::vector<ActsExamples::Trajectories>, edm4eic::TrackCollection>,
+    algorithms::Output<edm4eic::TrackSegmentCollection>>;
 
 class TrackProjector : public TrackProjectorAlgorithm {
 public:

--- a/src/global/tracking/TrackProjector_factory.h
+++ b/src/global/tracking/TrackProjector_factory.h
@@ -24,6 +24,7 @@ private:
   std::unique_ptr<AlgoT> m_algo;
 
   Input<ActsExamples::Trajectories> m_acts_trajectories_input{this};
+  PodioInput<edm4eic::Track> m_tracks_input{this};
   PodioOutput<edm4eic::TrackSegment> m_segments_output{this};
 
   Service<AlgorithmsInit_service> m_algorithmsInit {this};
@@ -45,6 +46,7 @@ public:
     m_algo->process(
         {
             acts_trajectories_input,
+            m_tracks_input(),
         },
         {
             m_segments_output().get(),

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -6,6 +6,7 @@
 #include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
 #include <edm4eic/TrackCollection.h>
 #include <edm4eic/TrackerHitCollection.h>
+#include <fmt/core.h>
 #include <algorithm>
 #include <gsl/pointers>
 #include <map>

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -217,11 +217,16 @@ void InitPlugin(JApplication *app) {
     ));
 
     app->Add(new JOmniFactoryGeneratorT<TrackProjector_factory>(
+        "CentralTrackSegments",
+        {
+            "CentralCKFActsTrajectories",
+            "CentralCKFTracks",
+        },
+        {
             "CentralTrackSegments",
-            {"CentralCKFActsTrajectories"},
-            {"CentralTrackSegments"},
-            app
-            ));
+        },
+        app
+    ));
 
     app->Add(new JOmniFactoryGeneratorT<IterativeVertexFinder_factory>(
             "CentralTrackVertices",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The `TrackProjector` records Acts TrackStates as `edm4eic::TrackSegment`s to be saved as "CentralTrackSegments" collection. The current implementation is lacking associations from those segments to the full tracks. This PR implements the same logic as in https://github.com/eic/EICrecon/blob/d072a3ea944b7e4f171b03237de95ba5176c24c5/src/algorithms/tracking/TrackPropagation.cc#L143 to provide this information.

Fixes: #1730

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
Yes