### PR TITLE
Correct PID LUT for protons

### DIFF
--- a/src/algorithms/pid_lut/PIDLookup.cc
+++ b/src/algorithms/pid_lut/PIDLookup.cc
@@ -85,7 +85,7 @@ void PIDLookup::process(const Input& input, const Output& output) const {
 
     int identified_pdg = 0; // unknown
 
-    if ((entry != nullptr) && ((entry->prob_electron != 0.) || (entry->prob_pion != 0.) || (entry->prob_kaon != 0.) || (entry->prob_electron != 0.))) {
+    if ((entry != nullptr) && ((entry->prob_electron != 0.) || (entry->prob_pion != 0.) || (entry->prob_kaon != 0.) || (entry->prob_proton != 0.))) {
       double random_unit_interval = m_dist(m_gen);
 
       trace("entry with e:pi:K:P={}:{}:{}:{}", entry->prob_electron, entry->prob_pion, entry->prob_kaon, entry->prob_proton);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The electron is checked for twice rather than including the proton probability for an entry. Meaning anything with 100% chance of being a proton is ignored.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
Will set particles which have 100% chance of being identified as a proton to have a proton PDG value where currently they will be set to 0.