### PR TITLE
fix: also add tracks that failed smoothing to failed_tracks

### DIFF
--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -291,6 +291,7 @@ namespace eicrecon {
                     ACTS_ERROR("Smoothing for seed "
                         << iseed << " and track " << track.index()
                         << " failed with error " << smoothingResult.error());
+                    failed_tracks.push_back(track.index());
                     continue;
                 }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Since #1677 we remove tracks that failed extrapolation. We don't do that with tracks that failed smoothing. This PR also applies the same treatment to tracks that failed smoothing.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.