### PR TITLE
feat: hide JANA2 implementation detail into JOmniFactory

### DIFF
--- a/src/algorithms/tracking/AmbiguitySolver.h
+++ b/src/algorithms/tracking/AmbiguitySolver.h
@@ -24,11 +24,11 @@ public:
 
   void init(std::shared_ptr<spdlog::logger> log);
 
-std::tuple<
-      std::vector<ActsExamples::ConstTrackContainer *>,
-      std::vector<ActsExamples::Trajectories *>
+  std::tuple<
+      ActsExamples::ConstTrackContainer,
+      std::vector<ActsExamples::Trajectories*>
       >
-  process(std::vector<const ActsExamples::ConstTrackContainer*> input_container,const edm4eic::Measurement2DCollection& meas2Ds);
+  process(const ActsExamples::ConstTrackContainer& input_container, const edm4eic::Measurement2DCollection& meas2Ds);
 
 private:
   std::shared_ptr<spdlog::logger> m_log;

--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -112,7 +112,7 @@ namespace eicrecon {
 
     std::tuple<
         std::vector<ActsExamples::Trajectories*>,
-        std::vector<ActsExamples::ConstTrackContainer*>
+        ActsExamples::ConstTrackContainer
     >
     CKFTracking::process(const edm4eic::TrackParametersCollection& init_trk_params,
                          const edm4eic::Measurement2DCollection& meas2Ds) {
@@ -320,24 +320,13 @@ namespace eicrecon {
         }
 
         // Move track states and track container to const containers
-        // NOTE Using the non-const containers leads to references to
-        // implicitly converted temporaries inside the Trajectories.
         auto constTrackStateContainer =
             std::make_shared<Acts::ConstVectorMultiTrajectory>(
                 std::move(*trackStateContainer));
-
         auto constTrackContainer =
             std::make_shared<Acts::ConstVectorTrackContainer>(
                 std::move(*trackContainer));
-
-        // FIXME JANA2 std::vector<T*> requires wrapping ConstTrackContainer, instead of:
-        //ConstTrackContainer constTracks(constTrackContainer, constTrackStateContainer);
-        std::vector<ActsExamples::ConstTrackContainer*> constTracks_v;
-        constTracks_v.push_back(
-          new ActsExamples::ConstTrackContainer(
-            constTrackContainer,
-            constTrackStateContainer));
-        auto& constTracks = *(constTracks_v.front());
+        ActsExamples::ConstTrackContainer constTracks(constTrackContainer, constTrackStateContainer);
 
         // Seed number column accessor
 #if Acts_VERSION_MAJOR >= 32
@@ -388,7 +377,7 @@ namespace eicrecon {
           constTracks.trackStateContainer(),
           std::move(tips), std::move(parameters)));
 
-        return std::make_tuple(std::move(acts_trajectories), std::move(constTracks_v));
+        return std::make_tuple(std::move(acts_trajectories), std::move(constTracks));
     }
 
 } // namespace eicrecon

--- a/src/algorithms/tracking/CKFTracking.h
+++ b/src/algorithms/tracking/CKFTracking.h
@@ -72,7 +72,7 @@ namespace eicrecon {
 
         std::tuple<
             std::vector<ActsExamples::Trajectories*>,
-            std::vector<ActsExamples::ConstTrackContainer*>
+            ActsExamples::ConstTrackContainer
         >
         process(const edm4eic::TrackParametersCollection& init_trk_params,
                 const edm4eic::Measurement2DCollection& meas2Ds);

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -107,7 +107,7 @@ void TrackPropagation::init(const dd4hep::Detector* detector,
 
 
 void TrackPropagation::propagateToSurfaceList(
-          const std::tuple<const edm4eic::TrackCollection&, const std::vector<const ActsExamples::Trajectories*>, const std::vector<const ActsExamples::ConstTrackContainer*>> input,
+          const std::tuple<const edm4eic::TrackCollection&, const std::vector<const ActsExamples::Trajectories*>, const ActsExamples::ConstTrackContainer&> input,
           const std::tuple<edm4eic::TrackSegmentCollection*> output) const
 {
     const auto [tracks, acts_trajectories, acts_tracks] = input;

--- a/src/algorithms/tracking/TrackPropagation.h
+++ b/src/algorithms/tracking/TrackPropagation.h
@@ -43,7 +43,7 @@ namespace eicrecon {
         void init(const dd4hep::Detector* detector, std::shared_ptr<const ActsGeometryProvider> geo_svc, std::shared_ptr<spdlog::logger> logger);
 
         void process(
-                const std::tuple<const edm4eic::TrackCollection&, const std::vector<const ActsExamples::Trajectories*>, const std::vector<const ActsExamples::ConstTrackContainer*>> input,
+                const std::tuple<const edm4eic::TrackCollection&, const std::vector<const ActsExamples::Trajectories*>, const ActsExamples::ConstTrackContainer&> input,
                 const std::tuple<edm4eic::TrackSegmentCollection*> output) const {
 
             const auto [tracks, acts_trajectories, acts_tracks] = input;

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -62,6 +62,29 @@ public:
     };
 
 
+    template <typename T>
+    class ContainerInput : public InputBase {
+
+        const T m_data;
+
+    public:
+        ContainerInput(JOmniFactory* owner, std::string default_tag="") {
+            owner->RegisterInput(this);
+            this->collection_names.push_back(default_tag);
+            this->type_name = JTypeInfo::demangle<T>();
+        }
+
+        const T& operator()() { return m_data; }
+
+    private:
+        friend class JOmniFactory;
+
+        void GetCollection(const JEvent& event) {
+            m_data = event.Get<std::vector<T>>(this->collection_names[0]).front();
+        }
+    };
+
+
     template <typename PodioT>
     class PodioInput : public InputBase {
 
@@ -158,6 +181,34 @@ public:
 
         void SetCollection(JOmniFactory& fac) override {
             fac.SetData<T>(this->collection_names[0], this->m_data);
+        }
+
+        void Reset() override { }
+    };
+
+
+    template <typename T>
+    class ContainerOutput : public OutputBase {
+        T m_data;
+
+    public:
+        ContainerOutput(JOmniFactory* owner, std::string default_tag_name="") {
+            owner->RegisterOutput(this);
+            this->collection_names.push_back(default_tag_name);
+            this->type_name = JTypeInfo::demangle<T>();
+        }
+
+        T& operator()() { return m_data; }
+
+    private:
+        friend class JOmniFactory;
+
+        void CreateHelperFactory(JOmniFactory& fac) override {
+            fac.DeclareOutput<T>(this->collection_names[0]);
+        }
+
+        void SetCollection(JOmniFactory& fac) override {
+            fac.SetData<T>(this->collection_names[0], std::vector<T>{this->m_data});
         }
 
         void Reset() override { }

--- a/src/global/tracking/AmbiguitySolver_factory.h
+++ b/src/global/tracking/AmbiguitySolver_factory.h
@@ -22,9 +22,9 @@ private:
   using AlgoT = eicrecon::AmbiguitySolver;
   std::unique_ptr<AlgoT> m_algo;
 
-  Input<ActsExamples::ConstTrackContainer> m_acts_tracks_input {this};
+  ContainerInput<ActsExamples::ConstTrackContainer> m_acts_tracks_input {this};
   PodioInput<edm4eic::Measurement2D> m_measurements_input {this};
-  Output<ActsExamples::ConstTrackContainer> m_acts_tracks_output {this};
+  ContainerOutput<ActsExamples::ConstTrackContainer> m_acts_tracks_output {this};
   Output<ActsExamples::Trajectories> m_acts_trajectories_output {this};
 
   ParameterRef<std::uint32_t> m_maximumSharedHits{this, "maximumSharedHits", config().maximum_shared_hits,

--- a/src/global/tracking/CKFTracking_factory.h
+++ b/src/global/tracking/CKFTracking_factory.h
@@ -31,7 +31,7 @@ private:
     PodioInput<edm4eic::TrackParameters> m_parameters_input {this};
     PodioInput<edm4eic::Measurement2D> m_measurements_input {this};
     Output<ActsExamples::Trajectories> m_acts_trajectories_output {this};
-    Output<ActsExamples::ConstTrackContainer> m_acts_tracks_output {this};
+    ContainerOutput<ActsExamples::ConstTrackContainer> m_acts_tracks_output {this};
 
     ParameterRef<std::vector<double>> m_etaBins {this, "EtaBins", config().etaBins, "Eta Bins for ACTS CKF tracking reco"};
     ParameterRef<std::vector<double>> m_chi2CutOff {this, "Chi2CutOff", config().chi2CutOff, "Chi2 Cut Off for ACTS CKF tracking"};

--- a/src/global/tracking/TrackPropagation_factory.h
+++ b/src/global/tracking/TrackPropagation_factory.h
@@ -29,7 +29,7 @@ private:
 
     PodioInput<edm4eic::Track> m_tracks_input {this};
     Input<ActsExamples::Trajectories> m_acts_trajectories_input {this};
-    Input<ActsExamples::ConstTrackContainer> m_acts_tracks_input {this};
+    ContainerInput<ActsExamples::ConstTrackContainer> m_acts_tracks_input {this};
     PodioOutput<edm4eic::TrackSegment> m_track_segments_output {this};
 
     Service<DD4hep_service> m_GeoSvc {this};


### PR DESCRIPTION
### Briefly, what does this PR introduce?
JOmniFactory supports either `std::vector<T*>` (with JANA2's `SetData<T>`) or podio containers (where `T` is now a container), but not the `ActsExamples::TrackContainer` container type which CKFTracking produces. This has resulted in CKFTracking creating a `std::vector<ActsExamples::TrackContainer*>`, but that implementation detail imposed by JOmniFactory has now propagated (no pun intended) to multiple other algorithms.

This change aims to remove the implementation detail from the algorithms and into the JOmniFactory through a new `ContainerInput` and `ContainerOutput` that takes care of the wrapping.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.