### PR TITLE
More deprecation-related fixes

### DIFF
--- a/src/tests/algorithms_test/calorimetry_HEXPLIT.cc
+++ b/src/tests/algorithms_test/calorimetry_HEXPLIT.cc
@@ -88,7 +88,7 @@ TEST_CASE( "the subcell-splitting algorithm runs", "[HEXPLIT]" ) {
     Esum+=subcell.getEnergy();
     i++;
     if (i%12==0){
-      REQUIRE(abs(Esum-E[i/12-1])/E[i/12-1]<tol);
+      REQUIRE(fabs(Esum-E[i/12-1])/E[i/12-1]<tol);
       Esum=0;
     }
   }

--- a/src/utilities/dump_flags/DumpFlags_processor.cc
+++ b/src/utilities/dump_flags/DumpFlags_processor.cc
@@ -10,6 +10,7 @@
 #include <spdlog/spdlog.h>
 #include <string.h>
 #include <exception>
+#include <fstream>
 #include <map>
 #include <ostream>
 

--- a/src/utilities/eicrecon/eicrecon_cli.cpp
+++ b/src/utilities/eicrecon/eicrecon_cli.cpp
@@ -320,8 +320,9 @@ void PrintPodioCollections(JApplication* app) {
       for (auto* event_source : event_sources) {
         //                    std::cout << event_source->GetPluginName() << std::endl;  // podio.so
         //                    std::cout << event_source->GetResourceName() << std::endl;
-        if (event_source->GetPluginName().find("podio") != std::string::npos)
-          event_source->DoInitialize();
+        if (event_source->GetPluginName().find("podio") != std::string::npos) {
+          event_source->DoOpen();
+        }
       }
     }
   }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
- Fixes deprecation warning inside JANA2
- Fixes an include file which was coming from JANA2
- Fixes a warning relating to using abs() instead of fabs() inside a test case

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no

### Does this PR change default behavior?
no
