### PR TITLE
Add early science rp omd matrices

### DIFF
--- a/src/algorithms/fardetectors/MatrixTransferStatic.cc
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.cc
@@ -159,6 +159,25 @@ void eicrecon::MatrixTransferStatic::process(
       local_y_slope_offset = -0.0073;
 
   }
+  else if(abs(130.0 - nomMomentum)/130.0 < nomMomentumError){ //130 GeV deuterons
+
+      aX[0][0] = 1.6248;
+      aX[0][1] = 12.966293;
+      aX[1][0] = 0.1832;
+      aX[1][1] = -2.8636535;
+
+      aY[0][0] = 0.0001674; //a
+      aY[0][1] = -28.6003; //b
+      aY[1][0] = 0.0000837; //c
+      aY[1][1] = -2.87985; //d
+
+      local_x_offset       = -11.9872;
+      local_y_offset       = -0.0146;
+      local_x_slope_offset = -14.75315;
+      local_y_slope_offset = -0.0073;
+
+  }
+
   else {
     error("MatrixTransferStatic:: No valid matrix found to match beam momentum!! Skipping!!");
     return;
@@ -200,7 +219,10 @@ void eicrecon::MatrixTransferStatic::process(
   bool goodHit1 = false;
   bool goodHit2 = false;
 
-  std::cout << "size of RP hit array = " << rechits.size() << std::endl;
+  int numGoodHits1 = 0;
+  int numGoodHits2 = 0;
+
+  //std::cout << "size of RP hit array = " << rechits->size() << std::endl;
 
   for (const auto &h: *rechits) {
 
@@ -217,23 +239,29 @@ void eicrecon::MatrixTransferStatic::process(
     gpos = gpos/dd4hep::mm;
     pos0 = pos0/dd4hep::mm;
 
-    //std::cout << "gpos.z() = " << gpos.z() << " pos0.z() = " << pos0.z() << std::endl;
-    //std::cout << "[gpos.x(), gpos.y()] = " << gpos.x() <<", "<< gpos.y() << "  and [pos0.x(), pos0.y()] = "<< pos0.x()<< ", " << pos0.y() << std::endl;
+    //std::cout << "gpos.z() = " << gpos.z() << " pos0.z() = " << pos0.z() << "  E_dep = " << h.getEdep() << std::endl;
 
-    if(!goodHit2 && gpos.z() > m_cfg.hit2minZ && gpos.z() < m_cfg.hit2maxZ){
+    if(gpos.z() > m_cfg.hit2minZ && gpos.z() < m_cfg.hit2maxZ){
 
+      //std::cout << "[gpos.x(), gpos.y(), gpos.z()] = " << gpos.x() <<", "<< gpos.y() << ", " << gpos.z() << "  E_dep = " << h.getEdep()*1000 << " MeV " << std::endl;
+      numGoodHits2++;
       goodHit[1].x = gpos.x(); //pos0.x() - pos0 is local coordinates, gpos is global
       goodHit[1].y = gpos.y(); //pos0.y() - temporarily changing to global to solve the local coordinate issue
       goodHit[1].z = gpos.z(); //         - which is unique to the Roman pots situation
-      goodHit2 = true;
+      if(numGoodHits2 == 1){goodHit2 = true;}
+      else goodHit2 = false; 
+      //std::cout << "goodHit2 = " << goodHit2 << std::endl;
 
     }
-    if(!goodHit1 && gpos.z() > m_cfg.hit1minZ && gpos.z() < m_cfg.hit1maxZ){
+    if(gpos.z() > m_cfg.hit1minZ && gpos.z() < m_cfg.hit1maxZ){
 
+      //std::cout << "[gpos.x(), gpos.y(), gpos.z()] = " << gpos.x() <<", "<< gpos.y() << ", " << gpos.z() << "  E_dep = " << h.getEdep()*1000 << " MeV " << std::endl;
+      numGoodHits1++;
       goodHit[0].x = gpos.x(); //pos0.x()
       goodHit[0].y = gpos.y(); //pos0.y()
       goodHit[0].z = gpos.z();
-      goodHit1 = true;
+      if(numGoodHits1 == 1){goodHit1 = true;}
+      else goodHit1 = false;
 
     }
 
@@ -285,6 +313,8 @@ void eicrecon::MatrixTransferStatic::process(
       edm4hep::Vector3f prec = {static_cast<float>(p * rsx / norm), static_cast<float>(p * rsy / norm),
                                 static_cast<float>(p / norm)};
       auto refPoint = goodHit[0];
+
+	  //std::cout << "RP Reco Momentum ---> px = " << prec.x << "  py = " << prec.y << "  pz = " << prec.z << std::endl;
 
       //----- end reconstruction code ------
 

--- a/src/algorithms/fardetectors/MatrixTransferStatic.cc
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.cc
@@ -255,7 +255,7 @@ void eicrecon::MatrixTransferStatic::process(
     }
     if(gpos.z() > m_cfg.hit1minZ && gpos.z() < m_cfg.hit1maxZ){
 
-      //std::cout << "[gpos.x(), gpos.y(), gpos.z()] = " << gpos.x() <<", "<< gpos.y() << ", " << gpos.z() << "  E_dep = " << h.getEdep()*1000 << " MeV " << std::endl;
+      trace("[gpos.x(), gpos.y(), gpos.z()] = {}, {}, {};  E_dep = {} MeV", gpos.x(), gpos.y(), gpos.z(), h.getEdep()*1000);
       numGoodHits1++;
       goodHit[0].x = gpos.x(); //pos0.x()
       goodHit[0].y = gpos.y(); //pos0.y()

--- a/src/algorithms/fardetectors/MatrixTransferStatic.cc
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.cc
@@ -222,7 +222,7 @@ void eicrecon::MatrixTransferStatic::process(
   int numGoodHits1 = 0;
   int numGoodHits2 = 0;
 
-  //std::cout << "size of RP hit array = " << rechits->size() << std::endl;
+  trace("size of RP hit array = {}", rechits->size());
 
   for (const auto &h: *rechits) {
 

--- a/src/algorithms/fardetectors/MatrixTransferStatic.cc
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.cc
@@ -250,7 +250,6 @@ void eicrecon::MatrixTransferStatic::process(
       goodHit[1].z = gpos.z(); //         - which is unique to the Roman pots situation
       if(numGoodHits2 == 1){goodHit2 = true;}
       else goodHit2 = false;
-      //std::cout << "goodHit2 = " << goodHit2 << std::endl;
 
     }
     if(gpos.z() > m_cfg.hit1minZ && gpos.z() < m_cfg.hit1maxZ){

--- a/src/algorithms/fardetectors/MatrixTransferStatic.cc
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.cc
@@ -87,6 +87,24 @@ void eicrecon::MatrixTransferStatic::process(
      local_y_slope_offset = 0.000745498;//-0.000176128;
 
   }
+  else if(abs(130.0 - nomMomentum)/130.0 < nomMomentumError){ //NOT TUNED -- just for testing purposes
+
+     aX[0][0] = 3.251116; //a
+     aX[0][1] = 30.285734; //b
+     aX[1][0] = 0.186036375; //c
+     aX[1][1] = 0.196439472; //d
+
+     aY[0][0] = 0.4730500000; //a
+     aY[0][1] = 3.062999454; //b
+     aY[1][0] = 0.0204108951; //c
+     aY[1][1] = -0.139318692; //d
+
+     local_x_offset       = -1209.29;//-0.339334; these are the local coordinate values
+     local_y_offset       = 0.00132511;//-0.000299454;
+     local_x_slope_offset = -45.4772;//-0.219603248;
+     local_y_slope_offset = 0.000745498;//-0.000176128;
+
+  }
   else if(abs(100.0 - nomMomentum)/100.0 < nomMomentumError){
 
      aX[0][0] = 3.152158; //a
@@ -181,6 +199,8 @@ void eicrecon::MatrixTransferStatic::process(
 
   bool goodHit1 = false;
   bool goodHit2 = false;
+
+  std::cout << "size of RP hit array = " << rechits.size() << std::endl;
 
   for (const auto &h: *rechits) {
 

--- a/src/algorithms/fardetectors/MatrixTransferStatic.cc
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.cc
@@ -314,7 +314,7 @@ void eicrecon::MatrixTransferStatic::process(
                                 static_cast<float>(p / norm)};
       auto refPoint = goodHit[0];
 
-          //std::cout << "RP Reco Momentum ---> px = " << prec.x << "  py = " << prec.y << "  pz = " << prec.z << std::endl;
+      trace("RP Reco Momentum ---> px = {},  py = {}, pz = {}", prec.x, prec.y, prec.z);
 
       //----- end reconstruction code ------
 

--- a/src/algorithms/fardetectors/MatrixTransferStatic.cc
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.cc
@@ -249,7 +249,7 @@ void eicrecon::MatrixTransferStatic::process(
       goodHit[1].y = gpos.y(); //pos0.y() - temporarily changing to global to solve the local coordinate issue
       goodHit[1].z = gpos.z(); //         - which is unique to the Roman pots situation
       if(numGoodHits2 == 1){goodHit2 = true;}
-      else goodHit2 = false; 
+      else goodHit2 = false;
       //std::cout << "goodHit2 = " << goodHit2 << std::endl;
 
     }
@@ -314,7 +314,7 @@ void eicrecon::MatrixTransferStatic::process(
                                 static_cast<float>(p / norm)};
       auto refPoint = goodHit[0];
 
-	  //std::cout << "RP Reco Momentum ---> px = " << prec.x << "  py = " << prec.y << "  pz = " << prec.z << std::endl;
+          //std::cout << "RP Reco Momentum ---> px = " << prec.x << "  py = " << prec.y << "  pz = " << prec.z << std::endl;
 
       //----- end reconstruction code ------
 

--- a/src/algorithms/fardetectors/MatrixTransferStatic.cc
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.cc
@@ -243,7 +243,7 @@ void eicrecon::MatrixTransferStatic::process(
 
     if(gpos.z() > m_cfg.hit2minZ && gpos.z() < m_cfg.hit2maxZ){
 
-      //std::cout << "[gpos.x(), gpos.y(), gpos.z()] = " << gpos.x() <<", "<< gpos.y() << ", " << gpos.z() << "  E_dep = " << h.getEdep()*1000 << " MeV " << std::endl;
+      trace("[gpos.x(), gpos.y(), gpos.z()] = {}, {}, {};  E_dep = {} MeV", gpos.x(), gpos.y(), gpos.z(), h.getEdep()*1000);
       numGoodHits2++;
       goodHit[1].x = gpos.x(); //pos0.x() - pos0 is local coordinates, gpos is global
       goodHit[1].y = gpos.y(); //pos0.y() - temporarily changing to global to solve the local coordinate issue

--- a/src/algorithms/fardetectors/MatrixTransferStatic.cc
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2022, 2023 Alex Jentsch, Wouter Deconinck, Sylvester Joosten, David Lawrence, Simon Gardner
+// Copyright (C) 2022 - 2025 Alex Jentsch, Wouter Deconinck, Sylvester Joosten, David Lawrence, Simon Gardner
 //
 // This converted from: https://eicweb.phy.anl.gov/EIC/juggler/-/blob/master/JugReco/src/components/FarForwardParticles.cpp
 
@@ -15,6 +15,8 @@
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <cmath>
+#include <fmt/core.h>
+#include <stdlib.h>
 #include <gsl/pointers>
 #include <vector>
 

--- a/src/algorithms/fardetectors/MatrixTransferStatic.cc
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.cc
@@ -239,7 +239,7 @@ void eicrecon::MatrixTransferStatic::process(
     gpos = gpos/dd4hep::mm;
     pos0 = pos0/dd4hep::mm;
 
-    //std::cout << "gpos.z() = " << gpos.z() << " pos0.z() = " << pos0.z() << "  E_dep = " << h.getEdep() << std::endl;
+   trace("gpos.z() = {}, pos0.z() = {}, E_dep = {}", gpos.z(), pos0.z(), h.getEdep());
 
     if(gpos.z() > m_cfg.hit2minZ && gpos.z() < m_cfg.hit2maxZ){
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This PR introduces two things:

1) early-science 130 GeV RP and OMD matrices, although the OMD one is only for testing right now (won't be used for tracks in March campaign).

2) Very mediocre protection against tracks which are truly unphysical.

These tracks come from events where the number of RP hits > 4, and one (or more) of the hits is in one detector layer. The algorithm is not yet able to properly sort hits to pick the "best" one. 

This protection works well for events where you have a truly insane number of hits from spallation on metal components in the RP layers, but it also kills some "good" events with, say, 5 or 6 hits where some simple sorting could easily through away an essentially duplicate hit in the same layer. 

The old approach did this by default for the 5-6 hit cases because it took the first hit it found in the outer two layers. 

An issue has been created to re-address this on a very short timescale (1-2 weeks).

https://github.com/eic/EICrecon/issues/1747

### What kind of change does this PR introduce?
- [x ] Bug fix (issue #__)
- [x ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No, it adds functionality.

### Does this PR change default behavior?

Yes, the overall RP tracking efficiency will drop by about 5%-10%, in the short-term, but will no longer produce unphysical tracks.

130 GeV proton beams can now also be used with RP reconstruction for EIC early-science.
