### PR TITLE
Charge sharing no longer checks segmentation class as BTOF segmentati…

### DIFF
--- a/src/algorithms/digi/LGADChargeSharing.cc
+++ b/src/algorithms/digi/LGADChargeSharing.cc
@@ -39,9 +39,6 @@ void LGADChargeSharing::init() {
 
   auto seg  = m_detector->readout(m_cfg.readout).segmentation();
   auto type = seg.type();
-  if (type != "CartesianGridXY")
-    throw std::runtime_error("Unsupported segmentation type: " + type +
-                             ". BarrelTOF must use CartesianGridXY.");
   // retrieve meaning of cellID bits
   m_decoder = seg.decoder();
   m_idSpec = m_detector->readout(m_cfg.readout).idSpec();


### PR DESCRIPTION
…on changes.

### Briefly, what does this PR introduce?

The segmentation class of BTOF changes from CartesianGridXY to MultiSegmentation since https://github.com/eic/epic/pull/834. Therefore, we need to remove the segmentation class restriction on LGADChargeSharing class. 

### What kind of change does this PR introduce?
- [x ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No.

### Does this PR change default behavior?

No.