### PR TITLE
remove OMD related matrices - will be put into a separate algorithm

### DIFF
--- a/src/algorithms/fardetectors/MatrixTransferStatic.cc
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.cc
@@ -143,42 +143,6 @@ void eicrecon::MatrixTransferStatic::process(
          local_y_slope_offset = 0.00498786;//-0.003212011;
 
   }
-  else if(abs(135.0 - nomMomentum)/135.0 < nomMomentumError){ //135 GeV deuterons
-
-      aX[0][0] = 1.6248;
-      aX[0][1] = 12.966293;
-      aX[1][0] = 0.1832;
-      aX[1][1] = -2.8636535;
-
-      aY[0][0] = 0.0001674; //a
-      aY[0][1] = -28.6003; //b
-      aY[1][0] = 0.0000837; //c
-      aY[1][1] = -2.87985; //d
-
-      local_x_offset       = -11.9872;
-      local_y_offset       = -0.0146;
-      local_x_slope_offset = -14.75315;
-      local_y_slope_offset = -0.0073;
-
-  }
-  else if(abs(130.0 - nomMomentum)/130.0 < nomMomentumError){ //130 GeV deuterons
-
-      aX[0][0] = 1.6248;
-      aX[0][1] = 12.966293;
-      aX[1][0] = 0.1832;
-      aX[1][1] = -2.8636535;
-
-      aY[0][0] = 0.0001674; //a
-      aY[0][1] = -28.6003; //b
-      aY[1][0] = 0.0000837; //c
-      aY[1][1] = -2.87985; //d
-
-      local_x_offset       = -11.9872;
-      local_y_offset       = -0.0146;
-      local_x_slope_offset = -14.75315;
-      local_y_slope_offset = -0.0073;
-
-  }
 
   else {
     error("MatrixTransferStatic:: No valid matrix found to match beam momentum!! Skipping!!");


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Fixes bug where you have conflicting matrices for 130 GeV. The problem would only have shown up if you ran deuterons. The solution will be to ultimately have a separate algorithm for the OMD. For now, the OMD matrices are removed entirely.

The reason for the full removal is the addition of the 130 GeV proton matrix. the default deuteron matrices are 130 and 135 GeV, which would both create a conflict for using the correct matrix.

This is because the MC level information doesn't contain any indication of a deuteron beam, so it's impossible to know at runtime which matrix to use with a single algorithm.

Ultimately, we will need to use a separate algorithm for the OMD which only uses the OMD hit collection, rather than sending the RP and OMD hit collections to the same algorithm.

Closes: #1751

### What kind of change does this PR introduce?
- [x ] Bug fix (issue # 1751)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

Yes, it fixes a bug, and now OMD will not have a reconstructed track (not a problem for the simulation campaign in the short term).

### Does this PR change default behavior?

Yes, OMD matrices are removed.