### PR TITLE
updated RP 10x130 matrix to use with new beamline settings

### DIFF
--- a/src/algorithms/fardetectors/MatrixTransferStatic.cc
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.cc
@@ -91,15 +91,15 @@ void eicrecon::MatrixTransferStatic::process(
   }
   else if(abs(130.0 - nomMomentum)/130.0 < nomMomentumError){ //NOT TUNED -- just for testing purposes
 
-     aX[0][0] = 3.251116; //a
-     aX[0][1] = 30.285734; //b
-     aX[1][0] = 0.186036375; //c
-     aX[1][1] = 0.196439472; //d
+     aX[0][0] = 3.16912; //a
+     aX[0][1] = 22.4693; //b
+     aX[1][0] = 0.182402; //c
+     aX[1][1] = -0.218209; //d
 
-     aY[0][0] = 0.4730500000; //a
-     aY[0][1] = 3.062999454; //b
-     aY[1][0] = 0.0204108951; //c
-     aY[1][1] = -0.139318692; //d
+     aY[0][0] = 0.520743; //a
+     aY[0][1] = 3.17339; //b
+     aY[1][0] = 0.0222482; //c
+     aY[1][1] = -0.0923779; //d
 
      local_x_offset       = -1209.29;//-0.339334; these are the local coordinate values
      local_y_offset       = 0.00132511;//-0.000299454;

--- a/src/algorithms/fardetectors/MatrixTransferStatic.cc
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.cc
@@ -14,9 +14,8 @@
 #include <Math/GenVector/DisplacementVector3D.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <cmath>
 #include <fmt/core.h>
-#include <stdlib.h>
+#include <cmath>
 #include <gsl/pointers>
 #include <vector>
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Updates the 10x130 RP matrix to match the new beamline settings: https://github.com/eic/epic/pull/839

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ x] Other: updated to match magnet settings

### Please check if this PR fulfills the following:
- [x ] Tests for the changes have been added
- [x ] Documentation has been added / updated
- [x ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

Yes, it will make the 10x130 RP reco correct for this energy setting with above magnet setting change.

### Does this PR change default behavior?

Yes, see above.
[RP_and_B0_pt_resolution_comparison_10_100_and_interpol_10_130_3_7_2025.pdf](https://github.com/user-attachments/files/19130938/RP_and_B0_pt_resolution_comparison_10_100_and_interpol_10_130_3_7_2025.pdf)
[pt_squared_and_RP_hit_plot_comparison_10_100_and_interpol_10_130_3_7_2025.pdf](https://github.com/user-attachments/files/19130939/pt_squared_and_RP_hit_plot_comparison_10_100_and_interpol_10_130_3_7_2025.pdf)
