### PR TITLE
Generic silicon pulse generation

### DIFF
--- a/src/algorithms/digi/PulseShapeFunctors.h
+++ b/src/algorithms/digi/PulseShapeFunctors.h
@@ -7,39 +7,41 @@
 
 namespace eicrecon {
 
+class SignalPulse {
+
+public:
+    virtual double operator()(double time) const = 0;
+
+    void setHitCharge(double charge) {
+        m_charge = charge;
+    }
+
+    void setHitTime(double hit_time) {
+        m_hit_time = hit_time;
+    }
+
+protected:
+    double m_charge;
+    double m_hit_time;
+
+};
+
 // ----------------------------------------------------------------------------
 // Landau Pulse Shape Functor
 // ----------------------------------------------------------------------------
-class LandauPulse {
+class LandauPulse: public SignalPulse {
 public:
 
-LandauPulse(double gain, double Vm, double sigma_analog, double adc_range) : m_gain(ranges), m_sigma_analog(sigma_analog) {
-    // calculation of the extreme values for Landau distribution can be found on lin 514-520 of
-    // https://root.cern.ch/root/html524/src/TMath.cxx.html#fsokrB Landau reaches minimum for mpv =
-    // 0 and sigma = 1 at x = -0.22278
-    const double x_when_landau_min = -0.22278;
-    const double landau_min    = -gain * TMath::Landau(x_when_landau_min, 0, 1, kTRUE) / m_sigma_analog;
-    m_scalingFactor = 1. / Vm / landau_min * adc_range;
-};
+LandauPulse(double gain, double sigma_analog, double risetime) : m_gain(gain), m_sigma_analog(sigma_analog), m_risetime(risetime) {};
 
 double operator()(double time) const {
-    return m_charge * m_gain * TMath::Landau(time, m_hit_time, m_sigma_analog, kTRUE) * m_scalingFactor;
-}
-
-void SetCharge(double charge) {
-    m_charge = charge;
-}
-
-void SetHitTime(double hit_time) {
-    m_hit_time = hit_time;
+    return m_charge * m_gain * TMath::Landau(time, m_hit_time-m_risetime, m_sigma_analog, kTRUE);
 }
 
 private:
-    double m_charge;
-    double m_hit_time;
     const double m_gain;
     const double m_sigma_analog;
-    double m_scalingFactor;
+    const double m_risetime;
 };
 
 } // eicrecon

--- a/src/algorithms/digi/PulseShapeFunctors.h
+++ b/src/algorithms/digi/PulseShapeFunctors.h
@@ -37,11 +37,11 @@ public:
 LandauPulse(double gain, double sigma_analog) : m_gain(gain), m_sigma_analog(sigma_analog) {};
 
 double operator()(double time) const {
-    return m_charge * m_gain * TMath::Landau(time, m_hit_time+3*m_sigma_analog, m_sigma_analog, kTRUE);
+    return m_charge * m_gain * TMath::Landau(time, m_hit_time+3.5*m_sigma_analog, m_sigma_analog, kTRUE);
 }
 
 float getMaximumTime() const {
-    return m_hit_time+3*m_sigma_analog;
+    return m_hit_time+3.5*m_sigma_analog;
 }
 
 private:

--- a/src/algorithms/digi/PulseShapeFunctors.h
+++ b/src/algorithms/digi/PulseShapeFunctors.h
@@ -20,6 +20,8 @@ public:
         m_hit_time = hit_time;
     }
 
+    virtual float getMaximumTime() const = 0;
+
 protected:
     double m_charge;
     double m_hit_time;
@@ -32,16 +34,19 @@ protected:
 class LandauPulse: public SignalPulse {
 public:
 
-LandauPulse(double gain, double sigma_analog, double risetime) : m_gain(gain), m_sigma_analog(sigma_analog), m_risetime(risetime) {};
+LandauPulse(double gain, double sigma_analog) : m_gain(gain), m_sigma_analog(sigma_analog) {};
 
 double operator()(double time) const {
-    return m_charge * m_gain * TMath::Landau(time, m_hit_time-m_risetime, m_sigma_analog, kTRUE);
+    return m_charge * m_gain * TMath::Landau(time, m_hit_time+3*m_sigma_analog, m_sigma_analog, kTRUE);
+}
+
+float getMaximumTime() const {
+    return m_hit_time+3*m_sigma_analog;
 }
 
 private:
     const double m_gain;
     const double m_sigma_analog;
-    const double m_risetime;
 };
 
 } // eicrecon

--- a/src/algorithms/digi/PulseShapeFunctors.h
+++ b/src/algorithms/digi/PulseShapeFunctors.h
@@ -1,0 +1,45 @@
+// Copyright 2025, Simon Gardner
+// Subject to the terms in the LICENSE file found in the top-level directory.
+//
+#pragma once
+
+#include <TMath.h>
+
+namespace eicrecon {
+
+// ----------------------------------------------------------------------------
+// Landau Pulse Shape Functor
+// ----------------------------------------------------------------------------
+class LandauPulse {
+public:
+
+LandauPulse(double gain, double Vm, double sigma_analog, double adc_range) : m_gain(ranges), m_sigma_analog(sigma_analog) {
+    // calculation of the extreme values for Landau distribution can be found on lin 514-520 of
+    // https://root.cern.ch/root/html524/src/TMath.cxx.html#fsokrB Landau reaches minimum for mpv =
+    // 0 and sigma = 1 at x = -0.22278
+    const double x_when_landau_min = -0.22278;
+    const double landau_min    = -gain * TMath::Landau(x_when_landau_min, 0, 1, kTRUE) / m_sigma_analog;
+    m_scalingFactor = 1. / Vm / landau_min * adc_range;
+};
+
+double operator()(double time) const {
+    return m_charge * m_gain * TMath::Landau(time, m_hit_time, m_sigma_analog, kTRUE) * m_scalingFactor;
+}
+
+void SetCharge(double charge) {
+    m_charge = charge;
+}
+
+void SetHitTime(double hit_time) {
+    m_hit_time = hit_time;
+}
+
+private:
+    double m_charge;
+    double m_hit_time;
+    const double m_gain;
+    const double m_sigma_analog;
+    double m_scalingFactor;
+};
+
+} // eicrecon

--- a/src/algorithms/digi/SiliconPulseGeneration.cc
+++ b/src/algorithms/digi/SiliconPulseGeneration.cc
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2024 Souvik Paul, Chun Yuen Tsang, Prithwish Tribedy
-// Special Acknowledgement: Kolja Kauder
+// Copyright (C) 2025 Simon Gardner
 //
 // Convert energy deposition into ADC pulses
 // ADC pulses are assumed to follow the shape of landau function

--- a/src/algorithms/digi/SiliconPulseGeneration.cc
+++ b/src/algorithms/digi/SiliconPulseGeneration.cc
@@ -37,7 +37,6 @@ void SiliconPulseGeneration::process(const SiliconPulseGeneration::Input& input,
     auto time_series = rawADCs->create();
     time_series.setCellID(cellID);
     time_series.setTime(signal_time);
-    time_series.setCharge(charge);
     time_series.setInterval(m_cfg.timestep);
     
     m_pulse->setHitCharge(charge);
@@ -48,7 +47,7 @@ void SiliconPulseGeneration::process(const SiliconPulseGeneration::Input& input,
       auto signal = (*m_pulse)(t);
       // std::cout << "Signal: " << signal << std::endl;
       if (signal < m_cfg.ignore_thres) break;
-      time_series.addToAdcCounts(signal);
+      time_series.addToAmplitude(signal);
     }
   }
 

--- a/src/algorithms/digi/SiliconPulseGeneration.cc
+++ b/src/algorithms/digi/SiliconPulseGeneration.cc
@@ -5,12 +5,7 @@
 // Convert energy deposition into ADC pulses
 // ADC pulses are assumed to follow the shape of landau function
 
-#include <DDRec/CellIDPositionConverter.h>
 #include <Evaluator/DD4hepUnits.h>
-#include <cmath>
-#include <gsl/pointers>
-#include <unordered_map>
-#include <vector>
 
 #include "SiliconPulseGeneration.h"
 

--- a/src/algorithms/digi/SiliconPulseGeneration.cc
+++ b/src/algorithms/digi/SiliconPulseGeneration.cc
@@ -23,7 +23,7 @@ void SiliconPulseGeneration::init() {
 void SiliconPulseGeneration::process(const SiliconPulseGeneration::Input& input,
                                      const SiliconPulseGeneration::Output& output) const {
   const auto [simhits] = input;
-  auto [rawADCs]       = output;
+  auto [rawPulses]     = output;
 
   for (const auto& hit : *simhits) {
 
@@ -34,21 +34,31 @@ void SiliconPulseGeneration::process(const SiliconPulseGeneration::Input& input,
     // Calculate nearest timestep to the hit time rounded down (assume clocks aligned with time 0)
     double signal_time = m_cfg.timestep*static_cast<int>(time / m_cfg.timestep);
     
-    auto time_series = rawADCs->create();
+    auto time_series = rawPulses->create();
     time_series.setCellID(cellID);
-    time_series.setTime(signal_time);
     time_series.setInterval(m_cfg.timestep);
     
     m_pulse->setHitCharge(charge);
     m_pulse->setHitTime(time);
 
-    for(int i = signal_time; i < m_max_time_bins; i ++) {
+    float maxSignalTime = m_pulse->getMaximumTime();
+
+    for(int i = 0; i < m_max_time_bins; i ++) {
       double t = signal_time + i*m_cfg.timestep;
       auto signal = (*m_pulse)(t);
-      // std::cout << "Signal: " << signal << std::endl;
-      if (signal < m_cfg.ignore_thres) break;
+      if (signal < m_cfg.ignore_thres) {
+        if (t > maxSignalTime) {
+          break;
+        } else {
+          signal_time = t;
+          continue;
+        }
+      }
       time_series.addToAmplitude(signal);
     }
+
+    time_series.setTime(signal_time);
+
   }
 
 } // SiliconPulseGeneration:process

--- a/src/algorithms/digi/SiliconPulseGeneration.cc
+++ b/src/algorithms/digi/SiliconPulseGeneration.cc
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2024 Souvik Paul, Chun Yuen Tsang, Prithwish Tribedy
+// Special Acknowledgement: Kolja Kauder
+//
+// Convert energy deposition into ADC pulses
+// ADC pulses are assumed to follow the shape of landau function
+
+#include <DDRec/CellIDPositionConverter.h>
+#include <Evaluator/DD4hepUnits.h>
+#include <cmath>
+#include <gsl/pointers>
+#include <unordered_map>
+#include <vector>
+
+#include "SiliconPulseGeneration.h"
+#include "algorithms/digi/SiliconPulseGenerationConfig.h"
+
+namespace eicrecon {
+
+void SiliconPulseGeneration::init() {
+    m_pulse = m_cfg.pulse_shape_function;
+}
+
+void SiliconPulseGeneration::process(const SiliconPulseGeneration::Input& input,
+                                     const SiliconPulseGeneration::Output& output) const {
+  const auto [simhits] = input;
+  auto [rawADCs]       = output;
+
+  for (const auto& hit : *simhits) {
+
+    auto   cellID = hit.getCellID();
+    double time   = hit.getTime();
+    double charge = hit.getEDep();
+
+    // Calculate nearest timestep to the hit time rounded down (assume clocks aligned with time 0)
+    int signal_time = m_cfg.timestep*static_cast<int>(time / m_cfg.timestep);
+    
+    auto time_series = rawADCs->create();
+    time_series.setCellID(cellID);
+    time_series.setTime(signal_time);
+    time_series.setCharge(charge);
+    
+    double mpv_analog = time + m_cfg.risetime;
+
+    m_pulse -> setCharge(charge);
+    m_pulse -> setTime(time);
+
+    for(int i = signal_time; i < m_max_bins; i ++) {
+      t = signal_time + i*m_cfg.timestep;
+      auto signal = m_pulse(t);
+      if (signal < m_cfg.ignore_thres) break;
+      time_series.addToAdcCounts(signal);
+    }
+  }
+
+  }
+} // SiliconPulseGeneration:process
+} // namespace eicrecon

--- a/src/algorithms/digi/SiliconPulseGeneration.cc
+++ b/src/algorithms/digi/SiliconPulseGeneration.cc
@@ -28,11 +28,11 @@ void SiliconPulseGeneration::process(const SiliconPulseGeneration::Input& input,
 
     // Calculate nearest timestep to the hit time rounded down (assume clocks aligned with time 0)
     double signal_time = m_cfg.timestep*static_cast<int>(time / m_cfg.timestep);
-    
+
     auto time_series = rawPulses->create();
     time_series.setCellID(cellID);
     time_series.setInterval(m_cfg.timestep);
-    
+
     m_pulse->setHitCharge(charge);
     m_pulse->setHitTime(time);
 

--- a/src/algorithms/digi/SiliconPulseGeneration.h
+++ b/src/algorithms/digi/SiliconPulseGeneration.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2025
+// Copyright (C) 2025 Simon Gardner
 //
 // Convert energy deposition into analog pulses
 

--- a/src/algorithms/digi/SiliconPulseGeneration.h
+++ b/src/algorithms/digi/SiliconPulseGeneration.h
@@ -29,7 +29,7 @@ using SiliconPulseGenerationAlgorithm =
                           algorithms::Output<edm4hep::RawTimeSeriesCollection>>;
 
 class SiliconPulseGeneration : public SiliconPulseGenerationAlgorithm,
-                            public WithPodConfig<SiliconPulseGenerationConfig> {
+                               public WithPodConfig<SiliconPulseGenerationConfig> {
 
 public:
   SiliconPulseGeneration(std::string_view name)
@@ -39,7 +39,7 @@ public:
 
 private:
 
-  std::function<double(const double)> m_pulse;
+  std::shared_ptr<SignalPulse> m_pulse;
   int m_max_time_bins = 10000;
 
 };

--- a/src/algorithms/digi/SiliconPulseGeneration.h
+++ b/src/algorithms/digi/SiliconPulseGeneration.h
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2024 Souvik Paul, Chun Yuen Tsang, Prithwish Tribedy
+// Special Acknowledgement: Kolja Kauder
+//
+// Convert energy deposition into ADC pulses
+// ADC pulses are assumed to follow the shape of landau function
+
+#pragma once
+
+#include <DDRec/CellIDPositionConverter.h>
+#include <RtypesCore.h>
+#include <TMath.h>
+#include <algorithms/algorithm.h>
+#include <edm4hep/RawTimeSeriesCollection.h>
+#include <edm4hep/SimTrackerHitCollection.h>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include "algorithms/digi/SiliconPulseGenerationConfig.h"
+#include "algorithms/interfaces/WithPodConfig.h"
+
+namespace eicrecon {
+
+using SiliconPulseGenerationAlgorithm =
+    algorithms::Algorithm<algorithms::Input<edm4hep::SimTrackerHitCollection>,
+                          algorithms::Output<edm4hep::RawTimeSeriesCollection>>;
+
+class SiliconPulseGeneration : public SiliconPulseGenerationAlgorithm,
+                            public WithPodConfig<SiliconPulseGenerationConfig> {
+
+public:
+  SiliconPulseGeneration(std::string_view name)
+      : SiliconPulseGenerationAlgorithm{name, {"RawHits"}, {"OutputPulses"}, {}} {}
+  virtual void init() final;
+  void process(const Input&, const Output&) const final;
+
+private:
+
+  std::function<double(const double)> m_pulse;
+  int m_max_time_bins = 10000;
+
+};
+
+} // namespace eicrecon

--- a/src/algorithms/digi/SiliconPulseGeneration.h
+++ b/src/algorithms/digi/SiliconPulseGeneration.h
@@ -11,7 +11,7 @@
 #include <RtypesCore.h>
 #include <TMath.h>
 #include <algorithms/algorithm.h>
-#include <edm4hep/RawTimeSeriesCollection.h>
+#include <edm4hep/TimeSeriesCollection.h>
 #include <edm4hep/SimTrackerHitCollection.h>
 #include <memory>
 #include <string>
@@ -26,7 +26,7 @@ namespace eicrecon {
 
 using SiliconPulseGenerationAlgorithm =
     algorithms::Algorithm<algorithms::Input<edm4hep::SimTrackerHitCollection>,
-                          algorithms::Output<edm4hep::RawTimeSeriesCollection>>;
+                          algorithms::Output<edm4hep::TimeSeriesCollection>>;
 
 class SiliconPulseGeneration : public SiliconPulseGenerationAlgorithm,
                                public WithPodConfig<SiliconPulseGenerationConfig> {

--- a/src/algorithms/digi/SiliconPulseGeneration.h
+++ b/src/algorithms/digi/SiliconPulseGeneration.h
@@ -1,23 +1,16 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2024 Souvik Paul, Chun Yuen Tsang, Prithwish Tribedy
-// Special Acknowledgement: Kolja Kauder
+// Copyright (C) 2025 
 //
-// Convert energy deposition into ADC pulses
-// ADC pulses are assumed to follow the shape of landau function
+// Convert energy deposition into analog pulses
 
 #pragma once
 
-#include <DDRec/CellIDPositionConverter.h>
-#include <RtypesCore.h>
-#include <TMath.h>
 #include <algorithms/algorithm.h>
 #include <edm4hep/TimeSeriesCollection.h>
 #include <edm4hep/SimTrackerHitCollection.h>
 #include <memory>
 #include <string>
 #include <string_view>
-#include <unordered_map>
-#include <vector>
 
 #include "algorithms/digi/SiliconPulseGenerationConfig.h"
 #include "algorithms/interfaces/WithPodConfig.h"

--- a/src/algorithms/digi/SiliconPulseGeneration.h
+++ b/src/algorithms/digi/SiliconPulseGeneration.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2025 
+// Copyright (C) 2025
 //
 // Convert energy deposition into analog pulses
 

--- a/src/algorithms/digi/SiliconPulseGenerationConfig.h
+++ b/src/algorithms/digi/SiliconPulseGenerationConfig.h
@@ -4,14 +4,14 @@
 #pragma once
 
 #include <DD4hep/DD4hepUnits.h>
+#include "PulseShapeFunctors.h"
 
 namespace eicrecon {
 
 struct SiliconPulseGenerationConfig {
   // Parameters of Silicon signal generation
-  std::function<double(const double)> pulse_shape_function;
-  double risetime       = 1.5 * dd4hep::ns;
-  double ignore_thres   = 0.001 * Vm; // When EDep drops below this value pulse stops
+  std::shared_ptr<SignalPulse> pulse_shape_function;
+  double ignore_thres   = 10; // When EDep drops below this value pulse stops
   double timestep       = 0.2 * dd4hep::ns; // Minimum digitization time step
 
 };

--- a/src/algorithms/digi/SiliconPulseGenerationConfig.h
+++ b/src/algorithms/digi/SiliconPulseGenerationConfig.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2024 Souvik Paul
+// Copyright (C) 2025 Simon Gardner
 
 #pragma once
 

--- a/src/algorithms/digi/SiliconPulseGenerationConfig.h
+++ b/src/algorithms/digi/SiliconPulseGenerationConfig.h
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2024 Souvik Paul
+
+#pragma once
+
+#include <DD4hep/DD4hepUnits.h>
+
+namespace eicrecon {
+
+struct SiliconPulseGenerationConfig {
+  // Parameters of Silicon signal generation
+  std::function<double(const double)> pulse_shape_function;
+  double risetime       = 1.5 * dd4hep::ns;
+  double ignore_thres   = 0.001 * Vm; // When EDep drops below this value pulse stops
+  double timestep       = 0.2 * dd4hep::ns; // Minimum digitization time step
+
+};
+
+} // namespace eicrecon

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -48,8 +48,8 @@ extern "C" {
       {"TaggerTrackerHits"},
       {"TaggerTrackerHitPulses"},
       {
-          .pulse_shape_function = std::make_shared<LandauPulse>(113.755, 1 * dd4hep::ns),
-          .ignore_thres = 10000.0,
+          .pulse_shape_function = std::make_shared<LandauPulse>(1, 2 * dd4hep::ns),
+          .ignore_thres = 150.0,
           .timestep = 0.2 * dd4hep::ns,
       },
       app

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -48,8 +48,8 @@ extern "C" {
       {"TaggerTrackerHits"},
       {"TaggerTrackerHitPulses"},
       {
-          .pulse_shape_function = std::make_shared<LandauPulse>(113.755, 1.0 * dd4hep::ns, 0.1 * dd4hep::ns),
-          .ignore_thres = 50.0,
+          .pulse_shape_function = std::make_shared<LandauPulse>(113.755, 1 * dd4hep::ns),
+          .ignore_thres = 2000.0,
           .timestep = 0.2 * dd4hep::ns,
       },
       app

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -49,7 +49,7 @@ extern "C" {
       {"TaggerTrackerHitPulses"},
       {
           .pulse_shape_function = std::make_shared<LandauPulse>(113.755, 1 * dd4hep::ns),
-          .ignore_thres = 2000.0,
+          .ignore_thres = 10000.0,
           .timestep = 0.2 * dd4hep::ns,
       },
       app

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -18,7 +18,7 @@
 
 #include "algorithms/interfaces/WithPodConfig.h"
 #include "algorithms/meta/SubDivideFunctors.h"
-#incluse "algorithms/meta/PulseShapeFunctors.h"
+#include "algorithms/digi/PulseShapeFunctors.h"
 #include "extensions/jana/JOmniFactoryGeneratorT.h"
 #include "factories/digi/SiliconTrackerDigi_factory.h"
 #include "factories/digi/LGADChargeSharing_factory.h"
@@ -43,41 +43,23 @@ extern "C" {
 
     using namespace eicrecon;
 
-    std::string tracker_readout = "TaggerTrackerHits";
-
-    app->Add(new JOmniFactoryGeneratorT<LGADChargeSharing_factory>(
-      "TaggerTrackerChargeSharing",
-      {"TaggerTrackerHits"},
-      {"TaggerTrackerSharedHits"},
-      {
-          .sigma_sharingx = 10 * dd4hep::um,
-          .sigma_sharingy = 10 * dd4hep::um,
-          .readout = tracker_readout,
-          .same_sensor_condition = "layer_1 == layer_2",
-          .neighbor_fields = {"x", "y"}
-      },
-      app
-    ));
-
     app->Add(new JOmniFactoryGeneratorT<SiliconPulseGeneration_factory>(
       "TaggerTrackerPulseGeneration",
-      {"TaggerTrackerSharedHits"},
+      {"TaggerTrackerHits"},
       {"TaggerTrackerHitPulses"},
       {
-          .pulse_shape_function = LandauPulse{113.755, 1.0 * dd4hep::Vm, 5.0 * dd4hep::ns, 1000},
-          .ignore_thres = 0.001 * dd4hep::Vm,
+          .pulse_shape_function = std::make_shared<LandauPulse>(113.755, 1.0 * dd4hep::ns, 0.1 * dd4hep::ns),
+          .ignore_thres = 50.0,
           .timestep = 0.2 * dd4hep::ns,
       },
       app
     ));
 
-
-
     // Digitization of silicon hits
     app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
          "TaggerTrackerRawHits",
          {
-           "TaggerTrackerSharedHits"
+           "TaggerTrackerHits"
          },
          {
            "TaggerTrackerRawHits",

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -21,7 +21,6 @@
 #include "algorithms/digi/PulseShapeFunctors.h"
 #include "extensions/jana/JOmniFactoryGeneratorT.h"
 #include "factories/digi/SiliconTrackerDigi_factory.h"
-#include "factories/digi/LGADChargeSharing_factory.h"
 #include "factories/digi/SiliconPulseGeneration_factory.h"
 #include "factories/fardetectors/FarDetectorLinearProjection_factory.h"
 #include "factories/fardetectors/FarDetectorLinearTracking_factory.h"

--- a/src/factories/digi/SiliconPulseGeneration_factory.h
+++ b/src/factories/digi/SiliconPulseGeneration_factory.h
@@ -20,7 +20,7 @@ private:
 
   PodioInput<edm4hep::SimTrackerHit> m_in_sim_track{this};
 
-  PodioOutput<edm4hep::RawTimeSeries> m_out_reco_particles{this};
+  PodioOutput<edm4hep::TimeSeries> m_out_reco_particles{this};
 
   ParameterRef<double> m_timestep{this, "timestep", config().timestep};
   ParameterRef<double> m_ignore_thres{this, "ignoreThreshold", config().ignore_thres};

--- a/src/factories/digi/SiliconPulseGeneration_factory.h
+++ b/src/factories/digi/SiliconPulseGeneration_factory.h
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2024 Chun Yuen Tsang
+
+#pragma once
+
+#include "extensions/jana/JOmniFactory.h"
+
+#include "algorithms/digi/SiliconPulseGeneration.h"
+#include <iostream>
+
+namespace eicrecon {
+
+class SiliconPulseGeneration_factory
+    : public JOmniFactory<SiliconPulseGeneration_factory, SiliconPulseGenerationConfig> {
+public:
+  using AlgoT = eicrecon::SiliconPulseGeneration;
+
+private:
+  std::unique_ptr<AlgoT> m_algo;
+
+  PodioInput<edm4hep::SimTrackerHit> m_in_sim_track{this};
+
+  PodioOutput<edm4hep::RawTimeSeries> m_out_reco_particles{this};
+
+  ParameterRef<double> m_Vm{this, "Vm", config().Vm};
+  ParameterRef<double> m_tMax{this, "tMax", config().tMax};
+  ParameterRef<int> m_adc_range{this, "adcRange", config().adc_range};
+  ParameterRef<double> m_ignore_thres{this, "ignoreThreshold", config().ignore_thres};
+
+  Service<AlgorithmsInit_service> m_algorithmsInit{this};
+
+public:
+  void Configure() {
+    m_algo = std::make_unique<eicrecon::SiliconPulseGeneration>(GetPrefix());
+    m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
+    m_algo->applyConfig(config());
+    m_algo->init();
+  }
+
+  void ChangeRun(int64_t run_number) {}
+
+  void Process(int64_t run_number, uint64_t event_number) {
+    m_algo->process({m_in_sim_track()}, {m_out_reco_particles().get()});
+  }
+};
+
+} // namespace eicrecon

--- a/src/factories/digi/SiliconPulseGeneration_factory.h
+++ b/src/factories/digi/SiliconPulseGeneration_factory.h
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2024 Chun Yuen Tsang
+// Copyright (C) 2025 Simon Gardner
+//
 
 #pragma once
 

--- a/src/factories/digi/SiliconPulseGeneration_factory.h
+++ b/src/factories/digi/SiliconPulseGeneration_factory.h
@@ -22,9 +22,7 @@ private:
 
   PodioOutput<edm4hep::RawTimeSeries> m_out_reco_particles{this};
 
-  ParameterRef<double> m_Vm{this, "Vm", config().Vm};
-  ParameterRef<double> m_tMax{this, "tMax", config().tMax};
-  ParameterRef<int> m_adc_range{this, "adcRange", config().adc_range};
+  ParameterRef<double> m_timestep{this, "timestep", config().timestep};
   ParameterRef<double> m_ignore_thres{this, "ignoreThreshold", config().ignore_thres};
 
   Service<AlgorithmsInit_service> m_algorithmsInit{this};

--- a/src/factories/digi/SiliconPulseGeneration_factory.h
+++ b/src/factories/digi/SiliconPulseGeneration_factory.h
@@ -18,9 +18,9 @@ public:
 private:
   std::unique_ptr<AlgoT> m_algo;
 
-  PodioInput<edm4hep::SimTrackerHit> m_in_sim_track{this};
+  PodioInput<edm4hep::SimTrackerHit> m_in_sim_hits{this};
 
-  PodioOutput<edm4hep::TimeSeries> m_out_reco_particles{this};
+  PodioOutput<edm4hep::TimeSeries> m_out_pulses{this};
 
   ParameterRef<double> m_timestep{this, "timestep", config().timestep};
   ParameterRef<double> m_ignore_thres{this, "ignoreThreshold", config().ignore_thres};
@@ -38,7 +38,7 @@ public:
   void ChangeRun(int64_t run_number) {}
 
   void Process(int64_t run_number, uint64_t event_number) {
-    m_algo->process({m_in_sim_track()}, {m_out_reco_particles().get()});
+    m_algo->process({m_in_sim_hits()}, {m_out_pulses().get()});
   }
 };
 

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -140,6 +140,9 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
             "ForwardMPGDEndcapRawHitAssociations",
 
             // LOWQ2 hits
+            "TaggerTrackerHits",
+            "TaggerTrackerSharedHits",
+            "TaggerTrackerHitPulses",
             "TaggerTrackerRawHits",
             "TaggerTrackerRawHitAssociations",
             "TaggerTrackerM1L0ClusterPositions",

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -141,7 +141,6 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
 
             // LOWQ2 hits
             "TaggerTrackerHits",
-            "TaggerTrackerSharedHits",
             "TaggerTrackerHitPulses",
             "TaggerTrackerRawHits",
             "TaggerTrackerRawHitAssociations",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Introduces a generic algorithm which will output a edm4hep::TimeSeries based on a function provided through the config. The interval of the time series needs to be equal to or below the fastest sampling to be used in digitization.

Built off the ToF implementation and using the Low-Q2 tagger as a demonstration.

Example plots of hits at different times and energies, red dot is the hit time:
![image](https://github.com/user-attachments/assets/e57618b3-395b-4eb2-b5c7-5c6d0fb31da6)
![image](https://github.com/user-attachments/assets/98615b1c-0baa-43f9-ac4a-bf9fa0cd7137)

To be followed by pulse combining and noise injection.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
Outputs new collection containing a time series TaggerTrackerPulses for every hit in TaggerTrackerHits