### PR TITLE
Properly initialize time in FarDetectorMLReconstruction

### DIFF
--- a/src/algorithms/fardetectors/FarDetectorMLReconstruction.cc
+++ b/src/algorithms/fardetectors/FarDetectorMLReconstruction.cc
@@ -102,7 +102,7 @@ namespace eicrecon {
       float theta   = edm4eic::anglePolar(momentum);
       float phi     = edm4eic::angleAzimuthal(momentum);
       float qOverP  = charge/edm4eic::magnitude(momentum);
-      float time;
+      float time = 0;
       // PDG
       int32_t pdg = 11;
       // Point Error
@@ -115,12 +115,12 @@ namespace eicrecon {
 
       int32_t trackType = 0;
       edm4hep::Vector3f position = {0,0,0};
-      float timeError;
+      float timeError = 0;
       float charge    = -1;
       float chi2      = 0;
       uint32_t ndf    = 0;
 
-      auto outTrack      = outputFarDetectorMLTracks->create(trackType,position,momentum,error,time,timeError,charge,chi2,ndf);
+      auto outTrack      = outputFarDetectorMLTracks->create(trackType,position,momentum,error,time,timeError,charge,chi2,ndf,pdg);
       outTrack.setTrajectory(trajectory);
 
     }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Highlighted in https://github.com/eic/EICrecon/pull/1756, sometimes the value of time isn't properly set to 0. This should assure it it properly set.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No