### PR TITLE
feat: use spdlog mapped diagnostic context to store event number

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ set(CMAKE_INSTALL_RPATH
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 # Check and print what JANA2 is used
-find_package(JANA REQUIRED)
+find_package(JANA 2.2.0 REQUIRED)
 message(STATUS "${CMAKE_PROJECT_NAME}: JANA2 CMake   : ${JANA_DIR}")
 message(STATUS "${CMAKE_PROJECT_NAME}: JANA2 includes: ${JANA_INCLUDE_DIR}")
 message(STATUS "${CMAKE_PROJECT_NAME}: JANA2 library : ${JANA_LIBRARY}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,7 +165,7 @@ find_package(EDM4HEP 0.7.1 REQUIRED)
 find_package(EDM4EIC 5.0 REQUIRED)
 
 # spdlog
-find_package(spdlog 1.14 REQUIRED)
+find_package(spdlog REQUIRED)
 
 # fmt
 find_package(fmt 9.0.0 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,7 +165,7 @@ find_package(EDM4HEP 0.7.1 REQUIRED)
 find_package(EDM4EIC 5.0 REQUIRED)
 
 # spdlog
-find_package(spdlog REQUIRED)
+find_package(spdlog 1.14 REQUIRED)
 
 # fmt
 find_package(fmt 9.0.0 REQUIRED)

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -560,7 +560,6 @@ public:
                 output->Reset();
             }
 #if SPDLOG_VERSION >= 11400 && !SPDLOG_NO_TLS
-            spdlog::mdc::put("r", std::to_string(event->GetRunNumber()));
             spdlog::mdc::put("e", std::to_string(event->GetEventNumber()));
 #endif
             static_cast<AlgoT*>(this)->Process(event->GetRunNumber(), event->GetEventNumber());

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -13,8 +13,11 @@
 #include <JANA/CLI/JVersion.h>
 #include <JANA/JMultifactory.h>
 #include <JANA/JEvent.h>
-#include <spdlog/mdc.h>
 #include <spdlog/spdlog.h>
+#include <spdlog/version.h>
+#if SPDLOG_VERSION >= 11400
+#include <spdlog/mdc.h>
+#endif
 
 #include "services/io/podio/datamodel_glue.h"
 #include "services/log/Log_service.h"
@@ -556,8 +559,10 @@ public:
             for (auto* output : m_outputs) {
                 output->Reset();
             }
+#if SPDLOG_VERSION >= 11400 && !SPDLOG_NO_TLS
             spdlog::mdc::put("r", std::to_string(event->GetRunNumber()));
             spdlog::mdc::put("e", std::to_string(event->GetEventNumber()));
+#endif
             static_cast<AlgoT*>(this)->Process(event->GetRunNumber(), event->GetEventNumber());
             for (auto* output : m_outputs) {
                 output->SetCollection(*this);

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -13,6 +13,7 @@
 #include <JANA/CLI/JVersion.h>
 #include <JANA/JMultifactory.h>
 #include <JANA/JEvent.h>
+#include <spdlog/mdc.h>
 #include <spdlog/spdlog.h>
 
 #include "services/io/podio/datamodel_glue.h"
@@ -555,6 +556,8 @@ public:
             for (auto* output : m_outputs) {
                 output->Reset();
             }
+            spdlog::mdc::put("r", std::to_string(event->GetRunNumber()));
+            spdlog::mdc::put("e", std::to_string(event->GetEventNumber()));
             static_cast<AlgoT*>(this)->Process(event->GetRunNumber(), event->GetEventNumber());
             for (auto* output : m_outputs) {
                 output->SetCollection(*this);

--- a/src/services/log/Log_service.cc
+++ b/src/services/log/Log_service.cc
@@ -5,13 +5,19 @@
 #include "Log_service.h"
 
 #include <JANA/JException.h>
+#include <spdlog/details/log_msg.h>
+#include <spdlog/formatter.h>
 #include <spdlog/pattern_formatter.h>
 #include <spdlog/spdlog.h>
 #include <spdlog/version.h>
 #if SPDLOG_VERSION >= 11400 && !SPDLOG_NO_TLS
 #include <spdlog/mdc.h>
 #endif
+#include <ctime>
 #include <exception>
+#include <map>
+#include <string_view>
+#include <utility>
 
 #include "extensions/spdlog/SpdlogExtensions.h"
 

--- a/src/services/log/Log_service.cc
+++ b/src/services/log/Log_service.cc
@@ -6,6 +6,7 @@
 
 #include <JANA/JException.h>
 #include <spdlog/spdlog.h>
+#include <spdlog/version.h>
 #include <exception>
 
 #include "extensions/spdlog/SpdlogExtensions.h"
@@ -20,7 +21,11 @@ Log_service::Log_service(JApplication *app) {
     m_application->SetDefaultParameter("eicrecon:LogLevel", m_log_level_str, "log_level: trace, debug, info, warn, error, critical, off");
     spdlog::default_logger()->set_level(eicrecon::ParseLogLevel(m_log_level_str));
 
+#if SPDLOG_VERSION >= 11400 && !SPDLOG_NO_TLS
     m_log_format_str = "[%n] [%&] [%^%l%$] %v";
+#else
+    m_log_format_str = "[%n] [%^%l%$] %v";
+#endif
     m_application->SetDefaultParameter("eicrecon:LogFormat", m_log_level_str, "spdlog pattern string");
     spdlog::set_pattern(m_log_format_str);
 }

--- a/src/services/log/Log_service.cc
+++ b/src/services/log/Log_service.cc
@@ -5,11 +5,55 @@
 #include "Log_service.h"
 
 #include <JANA/JException.h>
+#include <spdlog/pattern_formatter.h>
 #include <spdlog/spdlog.h>
 #include <spdlog/version.h>
+#if SPDLOG_VERSION >= 11400 && !SPDLOG_NO_TLS
+#include <spdlog/mdc.h>
+#endif
 #include <exception>
 
 #include "extensions/spdlog/SpdlogExtensions.h"
+
+
+#if SPDLOG_VERSION >= 11400 && !SPDLOG_NO_TLS
+
+// Define our own MDC formatter since the one in libspdlog.so does not
+// function correctly under some compilers
+class mdc_formatter_flag : public spdlog::custom_flag_formatter {
+public:
+    void format(const spdlog::details::log_msg &,
+                const std::tm &,
+                spdlog::memory_buf_t &dest) override {
+        auto &mdc_map = spdlog::mdc::get_context();
+        if (mdc_map.empty()) {
+            return;
+        } else {
+            format_mdc(mdc_map, dest);
+        }
+    }
+
+    void format_mdc(const spdlog::mdc::mdc_map_t &mdc_map, spdlog::memory_buf_t &dest) {
+        auto last_element = --mdc_map.end();
+        for (auto it = mdc_map.begin(); it != mdc_map.end(); ++it) {
+            auto &pair = *it;
+            const auto &key = pair.first;
+            const auto &value = pair.second;
+            dest.append(std::string_view{key});
+            dest.append(std::string_view{":"});
+            dest.append(std::string_view{value});
+            if (it != last_element) {
+                dest.append(std::string_view{" "});
+            }
+        }
+    }
+
+    std::unique_ptr<custom_flag_formatter> clone() const override {
+        return spdlog::details::make_unique<mdc_formatter_flag>();
+    }
+};
+
+#endif
 
 
 Log_service::Log_service(JApplication *app) {
@@ -21,13 +65,14 @@ Log_service::Log_service(JApplication *app) {
     m_application->SetDefaultParameter("eicrecon:LogLevel", m_log_level_str, "log_level: trace, debug, info, warn, error, critical, off");
     spdlog::default_logger()->set_level(eicrecon::ParseLogLevel(m_log_level_str));
 
+    auto formatter = std::make_unique<spdlog::pattern_formatter>();
 #if SPDLOG_VERSION >= 11400 && !SPDLOG_NO_TLS
-    m_log_format_str = "[%n] [%&] [%^%l%$] %v";
+    formatter->add_flag<mdc_formatter_flag>('&').set_pattern("[%&] [%n] [%^%l%$] %v");
 #else
-    m_log_format_str = "[%n] [%^%l%$] %v";
+    formatter->set_pattern("[%n] [%^%l%$] %v");
 #endif
     m_application->SetDefaultParameter("eicrecon:LogFormat", m_log_level_str, "spdlog pattern string");
-    spdlog::set_pattern(m_log_format_str);
+    spdlog::set_formatter(std::move(formatter));
 }
 
 

--- a/src/services/log/Log_service.cc
+++ b/src/services/log/Log_service.cc
@@ -20,7 +20,7 @@ Log_service::Log_service(JApplication *app) {
     m_application->SetDefaultParameter("eicrecon:LogLevel", m_log_level_str, "log_level: trace, debug, info, warn, error, critical, off");
     spdlog::default_logger()->set_level(eicrecon::ParseLogLevel(m_log_level_str));
 
-    m_log_format_str = "[%n] [%^%l%$] %v";
+    m_log_format_str = "[%n] [%&] [%^%l%$] %v";
     m_application->SetDefaultParameter("eicrecon:LogFormat", m_log_level_str, "spdlog pattern string");
     spdlog::set_pattern(m_log_format_str);
 }

--- a/src/services/log/Log_service.h
+++ b/src/services/log/Log_service.h
@@ -2,7 +2,7 @@
 
 
 #include <JANA/JApplication.h>
-#include <JANA/Services/JServiceLocator.h>
+#include <JANA/JServiceFwd.h>
 #include <spdlog/common.h>
 #include <spdlog/logger.h>
 #include <memory>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds spdlog Mapped Diagnostic Context (MDC, https://github.com/gabime/spdlog/pull/2907) to store the run and event number in JOmniFactory, and print it on the logged line.

Needs:
- [x] spdlog-1.14 (https://eicweb.phy.anl.gov/containers/eic_container/-/merge_requests/1116)

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: print run and event number)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.