### PR TITLE
separate OMD and RP algorithms and update matrices

### DIFF
--- a/src/algorithms/fardetectors/MatrixTransferStaticConfig_OMD.h
+++ b/src/algorithms/fardetectors/MatrixTransferStaticConfig_OMD.h
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2023, Simon Gardner
+
+#pragma once
+
+namespace eicrecon {
+
+  struct MatrixTransferStaticConfig_OMD {
+
+    float     partMass  {0.938272};
+    float     partCharge{1};
+    long long partPDG   {2212};
+
+    // Defaults here are for RPOTS
+    double local_x_offset      {0.0};
+    double local_y_offset      {0.0};
+    double local_x_slope_offset{-0.00622147};
+    double local_y_slope_offset{-0.0451035};
+    double crossingAngle       {0.025};
+    double nomMomentum         {100.0};
+
+    //std::vector<std::vector<double>> aX = {{2.102403743, 29.11067626},
+    //                                       {0.186640381, 0.192604619}};
+    //std::vector<std::vector<double>> aY = {{0.0000159900, 3.94082098},
+    //                                       {0.0000079946, -0.1402995}};
+
+
+    //x_offset       = 0.00979216;
+    //y_offset       = -0.00778646;
+    //x_slope_offset = 0.004526961;
+    //y_slope_offset = -0.003907849;
+
+    std::vector<std::vector<double>> aX = {{2.03459216, 22.85780784},
+                                           {0.179641961, -0.306626961}};
+    std::vector<std::vector<double>> aY = {{0.38879, 3.71612646},
+                                           {0.022685, -0.003907849}};
+
+    double hit1minZ{0};
+    double hit1maxZ{0};
+    double hit2minZ{0};
+    double hit2maxZ{0};
+
+    std::string readout{""};
+
+  };
+
+}

--- a/src/algorithms/fardetectors/MatrixTransferStatic_OMD.cc
+++ b/src/algorithms/fardetectors/MatrixTransferStatic_OMD.cc
@@ -3,7 +3,7 @@
 //
 // This converted from: https://eicweb.phy.anl.gov/EIC/juggler/-/blob/master/JugReco/src/components/FarForwardParticles.cpp
 
-#include "MatrixTransferStatic.h"
+#include "MatrixTransferStatic_OMD.h"
 
 #include <DD4hep/Alignments.h>
 #include <DD4hep/DetElement.h>
@@ -19,15 +19,15 @@
 #include <gsl/pointers>
 #include <vector>
 
-#include "algorithms/fardetectors/MatrixTransferStaticConfig.h"
+#include "algorithms/fardetectors/MatrixTransferStaticConfig_OMD.h"
 
-void eicrecon::MatrixTransferStatic::init() {
+void eicrecon::MatrixTransferStatic_OMD::init() {
 
 }
 
-void eicrecon::MatrixTransferStatic::process(
-    const MatrixTransferStatic::Input& input,
-    const MatrixTransferStatic::Output& output) const {
+void eicrecon::MatrixTransferStatic_OMD::process(
+    const MatrixTransferStatic_OMD::Input& input,
+    const MatrixTransferStatic_OMD::Output& output) const {
 
   const auto [mcparts, rechits] = input;
   auto [outputParticles] = output;
@@ -63,7 +63,6 @@ void eicrecon::MatrixTransferStatic::process(
                 runningMomentum += p.getMomentum().z;
                 numBeamProtons++;
         }
-
   }
 
   if(numBeamProtons == 0) {error("No beam protons to choose matrix!! Skipping!!"); return;}
@@ -75,88 +74,34 @@ void eicrecon::MatrixTransferStatic::process(
   //This is a temporary solution to get the beam energy information
   //needed to select the correct matrix
 
-  if(std::abs(275.0 - nomMomentum)/275.0 < nomMomentumError){
+  if(std::abs(130.0 - nomMomentum)/130.0 < nomMomentumError){
 
-     aX[0][0] = 3.251116; //a
-     aX[0][1] = 30.285734; //b
-     aX[1][0] = 0.186036375; //c
-     aX[1][1] = 0.196439472; //d
+     aX[0][0] = 1.61591; //a
+     aX[0][1] = 12.6786; //b
+     aX[1][0] = 0.184206; //c
+     aX[1][1] = -2.907; //d
 
-     aY[0][0] = 0.4730500000; //a
-     aY[0][1] = 3.062999454; //b
-     aY[1][0] = 0.0204108951; //c
-     aY[1][1] = -0.139318692; //d
+     aY[0][0] = -0.789385; //a
+     aY[0][1] = -28.5578; //b
+     aY[1][0] = -0.0721796; //c
+     aY[1][1] = -2.8763; //d
 
-     local_x_offset       = -1209.29;//-0.339334; these are the local coordinate values
-     local_y_offset       = 0.00132511;//-0.000299454;
-     local_x_slope_offset = -45.4772;//-0.219603248;
-     local_y_slope_offset = 0.000745498;//-0.000176128;
-
-  }
-  else if(std::abs(130.0 - nomMomentum)/130.0 < nomMomentumError){ //NOT TUNED -- just for testing purposes
-
-     aX[0][0] = 3.16912; //a
-     aX[0][1] = 22.4693; //b
-     aX[1][0] = 0.182402; //c
-     aX[1][1] = -0.218209; //d
-
-     aY[0][0] = 0.520743; //a
-     aY[0][1] = 3.17339; //b
-     aY[1][0] = 0.0222482; //c
-     aY[1][1] = -0.0923779; //d
-
-     local_x_offset       = -1209.29;//-0.339334; these are the local coordinate values
-     local_y_offset       = 0.00132511;//-0.000299454;
-     local_x_slope_offset = -45.4772;//-0.219603248;
-     local_y_slope_offset = 0.000745498;//-0.000176128;
-
-  }
-  else if(std::abs(100.0 - nomMomentum)/100.0 < nomMomentumError){
-
-     aX[0][0] = 3.152158; //a
-     aX[0][1] = 20.852072; //b
-     aX[1][0] = 0.181649517; //c
-     aX[1][1] = -0.303998487; //d
-
-     aY[0][0] = 0.5306100000; //a
-     aY[0][1] = 3.19623343; //b
-     aY[1][0] = 0.0226283320; //c
-     aY[1][1] = -0.082666019; //d
-
-     local_x_offset       = -1209.27;//-0.329072;
-     local_y_offset       = 0.00355218;//-0.00028343;
-     local_x_slope_offset = -45.4737;//-0.218525084;
-     local_y_slope_offset = 0.00204394;//-0.00015321;
-
-  }
-  else if(std::abs(41.0 - nomMomentum)/41.0 < nomMomentumError){
-
-         aX[0][0] = 3.135997; //a
-         aX[0][1] = 18.482273; //b
-         aX[1][0] = 0.176479921; //c
-         aX[1][1] = -0.497839483; //d
-
-         aY[0][0] = 0.4914400000; //a
-         aY[0][1] = 4.53857451; //b
-         aY[1][0] = 0.0179664765; //c
-         aY[1][1] = 0.004160679; //d
-
-         local_x_offset       = -1209.22;//-0.283273;
-         local_y_offset       = 0.00868737;//-0.00552451;
-         local_x_slope_offset = -45.4641;//-0.21174031;
-         local_y_slope_offset = 0.00498786;//-0.003212011;
+     local_x_offset       = -881.631;
+     local_y_offset       = -0.00552173;
+     local_x_slope_offset = -59.7386;
+     local_y_slope_offset = -0.00360656;
 
   }
 
   else {
-    error("MatrixTransferStatic:: No valid matrix found to match beam momentum!! Skipping!!");
+    error("MatrixTransferStatic_OMD:: No valid matrix found to match beam momentum!! Skipping!!");
     return;
   }
 
   double determinant = aX[0][0] * aX[1][1] - aX[0][1] * aX[1][0];
 
   if (determinant == 0) {
-    error("Reco matrix determinant = 0! Matrix cannot be inverted! Double-check matrix!");
+    error("OMD Reco matrix determinant = 0! Matrix cannot be inverted! Double-check matrix!");
     return;
   }
 
@@ -169,7 +114,7 @@ void eicrecon::MatrixTransferStatic::process(
   determinant = aY[0][0] * aY[1][1] - aY[0][1] * aY[1][0];
 
   if (determinant == 0) {
-    error("Reco matrix determinant = 0! Matrix cannot be inverted! Double-check matrix!");
+    error("OMD Reco matrix determinant = 0! Matrix cannot be inverted! Double-check matrix!");
     return;
   }
 
@@ -192,7 +137,7 @@ void eicrecon::MatrixTransferStatic::process(
   int numGoodHits1 = 0;
   int numGoodHits2 = 0;
 
-  trace("size of RP hit array = {}", rechits->size());
+  trace("size of OMD hit array = {}", rechits->size());
 
   for (const auto &h: *rechits) {
 
@@ -209,11 +154,11 @@ void eicrecon::MatrixTransferStatic::process(
     gpos = gpos/dd4hep::mm;
     pos0 = pos0/dd4hep::mm;
 
-   trace("gpos.z() = {}, pos0.z() = {}, E_dep = {}", gpos.z(), pos0.z(), h.getEdep());
+   trace("OMD --> gpos.z() = {}, pos0.z() = {}, E_dep = {}", gpos.z(), pos0.z(), h.getEdep());
 
     if(gpos.z() > m_cfg.hit2minZ && gpos.z() < m_cfg.hit2maxZ){
 
-      trace("[gpos.x(), gpos.y(), gpos.z()] = {}, {}, {};  E_dep = {} MeV", gpos.x(), gpos.y(), gpos.z(), h.getEdep()*1000);
+      trace("OMD --> [gpos.x(), gpos.y(), gpos.z()] = {}, {}, {};  E_dep = {} MeV", gpos.x(), gpos.y(), gpos.z(), h.getEdep()*1000);
       numGoodHits2++;
       goodHit[1].x = gpos.x(); //pos0.x() - pos0 is local coordinates, gpos is global
       goodHit[1].y = gpos.y(); //pos0.y() - temporarily changing to global to solve the local coordinate issue
@@ -224,7 +169,7 @@ void eicrecon::MatrixTransferStatic::process(
     }
     if(gpos.z() > m_cfg.hit1minZ && gpos.z() < m_cfg.hit1maxZ){
 
-      trace("[gpos.x(), gpos.y(), gpos.z()] = {}, {}, {};  E_dep = {} MeV", gpos.x(), gpos.y(), gpos.z(), h.getEdep()*1000);
+      trace("--> [gpos.x(), gpos.y(), gpos.z()] = {}, {}, {};  E_dep = {} MeV", gpos.x(), gpos.y(), gpos.z(), h.getEdep()*1000);
       numGoodHits1++;
       goodHit[0].x = gpos.x(); //pos0.x()
       goodHit[0].y = gpos.y(); //pos0.y()
@@ -250,7 +195,7 @@ void eicrecon::MatrixTransferStatic::process(
     double base = goodHit[1].z - goodHit[0].z;
 
     if (base == 0) {
-      info("Detector separation = 0! Cannot calculate slope!");
+      info("OMD --> Detector separation = 0! Cannot calculate slope!");
     }
     else{
 
@@ -259,7 +204,7 @@ void eicrecon::MatrixTransferStatic::process(
       double Yip[2] = {0.0, 0.0};
       double Yrp[2] = {YL[1], ((YL[1] - YL[0]) / (base))/dd4hep::mrad - local_y_slope_offset};
 
-      // use the hit information and calculated slope at the RP + the transfer matrix inverse to calculate the
+      // use the hit information and calculated slope at the OMD + the transfer matrix inverse to calculate the
       // Polar Angle and deltaP at the IP
 
       for (unsigned i0 = 0; i0 < 2; i0++) {
@@ -283,7 +228,7 @@ void eicrecon::MatrixTransferStatic::process(
                                 static_cast<float>(p / norm)};
       auto refPoint = goodHit[0];
 
-      trace("RP Reco Momentum ---> px = {},  py = {}, pz = {}", prec.x, prec.y, prec.z);
+      trace("OMD Reco Momentum ---> px = {},  py = {}, pz = {}", prec.x, prec.y, prec.z);
 
       //----- end reconstruction code ------
 

--- a/src/algorithms/fardetectors/MatrixTransferStatic_OMD.cc
+++ b/src/algorithms/fardetectors/MatrixTransferStatic_OMD.cc
@@ -51,18 +51,18 @@ void eicrecon::MatrixTransferStatic_OMD::process(
   double runningMomentum = 0.0;
 
   for (const auto& p: *mcparts) {
-        if(mcparts->size() == 1 && p.getPDG() == 2212){ //using particle gun for calibration or acceptance studies
-                runningMomentum = p.getMomentum().z;
-                numBeamProtons++;
-        }
-        if (p.getGeneratorStatus() == 4 && p.getPDG() == 2212) { //look for "beam" proton
-                runningMomentum += p.getMomentum().z;
-                numBeamProtons++;
-        }
-        else if (p.getGeneratorStatus() == 4 && p.getPDG() == 2112) { //look for "beam" neutron for e+D collisions with proton spectator
-                runningMomentum += p.getMomentum().z;
-                numBeamProtons++;
-        }
+      if(mcparts->size() == 1 && p.getPDG() == 2212){ //using particle gun for calibration or acceptance studies
+          runningMomentum = p.getMomentum().z;
+          numBeamProtons++;
+      }
+      if (p.getGeneratorStatus() == 4 && p.getPDG() == 2212) { //look for "beam" proton
+          runningMomentum += p.getMomentum().z;
+          numBeamProtons++;
+      }
+      if (p.getGeneratorStatus() == 4 && p.getPDG() == 2112) { //look for "beam" neutron for e+D collisions with proton spectator
+          runningMomentum += p.getMomentum().z;
+          numBeamProtons++;
+      }
   }
 
   if(numBeamProtons == 0) {error("No beam protons to choose matrix!! Skipping!!"); return;}

--- a/src/algorithms/fardetectors/MatrixTransferStatic_OMD.h
+++ b/src/algorithms/fardetectors/MatrixTransferStatic_OMD.h
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2022, 2023 Alex Jentsch, Wouter Deconinck, Sylvester Joosten, David Lawrence, Simon Gardner
+//
+// This converted from: https://eicweb.phy.anl.gov/EIC/juggler/-/blob/master/JugReco/src/components/FarForwardParticles.cpp
+
+#include <DD4hep/Detector.h>
+#include <DDRec/CellIDPositionConverter.h>
+#include <algorithms/algorithm.h>
+#include <algorithms/geo.h>
+#include <edm4eic/ReconstructedParticleCollection.h>
+#include <edm4eic/TrackerHitCollection.h>
+#include <edm4hep/MCParticleCollection.h>
+#include <gsl/pointers>
+#include <string>
+#include <string_view>
+
+#include "MatrixTransferStaticConfig_OMD.h"
+#include "algorithms/interfaces/WithPodConfig.h"
+
+namespace eicrecon {
+
+  using MatrixTransferStatic_OMDAlgorithm = algorithms::Algorithm<
+    algorithms::Input<
+      edm4hep::MCParticleCollection,
+      edm4eic::TrackerHitCollection
+    >,
+    algorithms::Output<
+      edm4eic::ReconstructedParticleCollection
+    >
+  >;
+
+  class MatrixTransferStatic_OMD
+  : public MatrixTransferStatic_OMDAlgorithm,
+    public WithPodConfig<MatrixTransferStaticConfig_OMD> {
+
+  public:
+    MatrixTransferStatic_OMD(std::string_view name)
+      : MatrixTransferStatic_OMDAlgorithm{name,
+                            {"mcParticles", "inputHitCollection"},
+                            {"outputParticleCollection"},
+                            "Apply OMD matrix method reconstruction to hits."} {}
+
+    void init() final;
+    void process(const Input&, const Output&) const final;
+
+  private:
+    const dd4hep::Detector* m_detector{algorithms::GeoSvc::instance().detector()};
+    const dd4hep::rec::CellIDPositionConverter* m_converter{algorithms::GeoSvc::instance().cellIDPositionConverter()};
+
+  };
+}

--- a/src/detectors/FOFFMTRK/FOFFMTRK.cc
+++ b/src/detectors/FOFFMTRK/FOFFMTRK.cc
@@ -7,10 +7,10 @@
 #include <JANA/JApplication.h>
 #include <vector>
 
-#include "algorithms/fardetectors/MatrixTransferStaticConfig.h"
+#include "algorithms/fardetectors/MatrixTransferStaticConfig_OMD.h"
 #include "extensions/jana/JOmniFactoryGeneratorT.h"
 #include "factories/digi/SiliconTrackerDigi_factory.h"
-#include "factories/fardetectors/MatrixTransferStatic_factory.h"
+#include "factories/fardetectors/MatrixTransferStatic_OMD_factory.h"
 #include "factories/tracking/TrackerHitReconstruction_factory.h"
 
 
@@ -19,7 +19,7 @@ void InitPlugin(JApplication *app) {
     InitJANAPlugin(app);
     using namespace eicrecon;
 
-    MatrixTransferStaticConfig recon_cfg;
+    MatrixTransferStaticConfig_OMD recon_cfg;
 
         //Digitized hits, especially for thresholds
         app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
@@ -60,14 +60,14 @@ void InitPlugin(JApplication *app) {
     recon_cfg.local_y_slope_offset = -0.0073;   // in mrad
     recon_cfg.nomMomentum          =  137.5;    // in GEV --> exactly half of the top energy momentum (for proton spectators from deuteron breakup)
 
-    recon_cfg.hit1minZ = 22499.0;
-    recon_cfg.hit1maxZ = 22522.0;
-    recon_cfg.hit2minZ = 24499.0;
-    recon_cfg.hit2maxZ = 24522.0;
+    recon_cfg.hit1minZ = 22490.0;
+    recon_cfg.hit1maxZ = 22512.0;
+    recon_cfg.hit2minZ = 24512.0;
+    recon_cfg.hit2maxZ = 24535.0;
 
     recon_cfg.readout              = "ForwardOffMTrackerRecHits";
 
-    app->Add(new JOmniFactoryGeneratorT<MatrixTransferStatic_factory>("ForwardOffMRecParticles",{"MCParticles","ForwardOffMTrackerRecHits"},{"ForwardOffMRecParticles"},recon_cfg,app));
+    app->Add(new JOmniFactoryGeneratorT<MatrixTransferStatic_OMD_factory>("ForwardOffMRecParticles",{"MCParticles","ForwardOffMTrackerRecHits"},{"ForwardOffMRecParticles"},recon_cfg,app));
 
 }
 }

--- a/src/factories/fardetectors/MatrixTransferStatic_OMD_factory.h
+++ b/src/factories/fardetectors/MatrixTransferStatic_OMD_factory.h
@@ -1,0 +1,75 @@
+// Created by Alex Jentsch
+// Subject to the terms in the LICENSE file found in the top-level directory.
+//
+
+#include <DDRec/CellIDPositionConverter.h>
+#include "services/algorithms_init/AlgorithmsInit_service.h"
+#include "algorithms/fardetectors/MatrixTransferStatic_OMD.h"
+#include "algorithms/fardetectors/MatrixTransferStaticConfig_OMD.h"
+
+// Event Model related classes
+#include <edm4eic/ReconstructedParticleCollection.h>
+#include <edm4eic/TrackerHitCollection.h>
+#include <edm4hep/SimTrackerHitCollection.h>
+#include <edm4hep/MCParticleCollection.h>
+
+#include "extensions/jana/JOmniFactory.h"
+
+namespace eicrecon {
+
+class MatrixTransferStatic_OMD_factory :
+    public JOmniFactory<MatrixTransferStatic_OMD_factory, MatrixTransferStaticConfig_OMD> {
+
+public:
+    using AlgoT = eicrecon::MatrixTransferStatic_OMD;
+private:
+    std::unique_ptr<AlgoT> m_algo;
+
+    PodioInput<edm4hep::MCParticle> m_mcparts_input {this};
+    PodioInput<edm4eic::TrackerHit> m_hits_input {this};
+    PodioOutput<edm4eic::ReconstructedParticle> m_tracks_output {this};
+
+    Service<DD4hep_service> m_geoSvc {this};
+
+    ParameterRef<float>     partMass  {this, "partMass", config().partMass};
+    ParameterRef<float>     partCharge{this, "partCharge", config().partCharge};
+    ParameterRef<long long> partPDG   {this, "partPDG", config().partPDG};
+
+    ParameterRef<double> local_x_offset      {this, "local_x_offset", config().local_x_offset};
+    ParameterRef<double> local_y_offset      {this, "local_y_offset", config().local_y_offset};
+    ParameterRef<double> local_x_slope_offset{this, "local_x_slope_offset", config().local_x_slope_offset};
+    ParameterRef<double> local_y_slope_offset{this, "local_y_slope_offset", config().local_y_slope_offset};
+    ParameterRef<double> crossingAngle       {this, "crossingAngle", config().crossingAngle};
+    ParameterRef<double> nomMomentum         {this, "nomMomentum", config().nomMomentum};
+
+    // FIXME JANA2 does not support vector of vector
+    //ParameterRef<std::vector<std::vector<double>>> aX {this, "aX", config().aX};
+    //ParameterRef<std::vector<std::vector<double>>> aY {this, "aY", config().aY};
+
+    ParameterRef<double> hit1minZ {this, "hit1minZ", config().hit1minZ};
+    ParameterRef<double> hit1maxZ {this, "hit1maxZ", config().hit1maxZ};
+    ParameterRef<double> hit2minZ {this, "hit2minZ", config().hit2minZ};
+    ParameterRef<double> hit2maxZ {this, "hit2maxZ", config().hit2maxZ};
+
+    ParameterRef<std::string> readout {this, "readout", config().readout};
+
+    Service<AlgorithmsInit_service> m_algorithmsInit {this};
+
+public:
+    void Configure() {
+        m_algo = std::make_unique<AlgoT>(GetPrefix());
+        m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
+        m_algo->applyConfig(config());
+        m_algo->init();
+    }
+
+    void ChangeRun(int64_t run_number) {
+    }
+
+    void Process(int64_t run_number, uint64_t event_number) {
+        m_algo->process({m_mcparts_input(), m_hits_input()}, {m_tracks_output().get()});
+    }
+
+};
+
+} // eicrecon


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This PR separates the OMD and RP reconstruction algorithms. Having them combined has already caused some clash with the early science beam energies between the detectors, and separating them now while things are simple will save larger headache in the future. It also enables flexibility to modify these algorithms to adapt to their specific needs.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x ] Tests for the changes have been added
- [ x] Documentation has been added / updated
- [x ] Changes have been communicated to collaborators

https://indico.bnl.gov/event/26528/contributions/105022/attachments/60787/104437/free_neutron_structure_ePIC_Jentsch_3_24_2025.pdf

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No, the changes should be transparent to users - the output branches have not changed, and it should improve the reconstruction for the OMD for the early science (10x130 GeV) deuteron energy. He3 will be added soon, but it requires a bit more of a complicate change.

### Does this PR change default behavior?

Not for an end user.