### PR TITLE
Use Measurement2D for far detector clustering

### DIFF
--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -64,6 +64,10 @@ namespace eicrecon {
             info("Too many hits in layer");
             return;
           }
+          if((*layerHits).size()==0){
+            info("No hits in layer");
+            return;
+          }
           convertedHits.push_back(ConvertClusters(*layerHits));
         }
 
@@ -82,7 +86,7 @@ namespace eicrecon {
 
       // Iterate over hits in this layer
       for(auto hit : hits[level]){
-        
+
         hitMatrix->col(level) << hit;
 
         // Check the last two hits are within a certain angle of the optimum direction
@@ -169,7 +173,7 @@ namespace eicrecon {
       debug("Angle: {}, Tolerance {}",angle,m_cfg.step_angle_tolerance);
 
       if(angle>m_cfg.step_angle_tolerance) return false;
-
+      
       return true;
 
     }
@@ -185,7 +189,7 @@ namespace eicrecon {
       for (auto cluster : clusters) {
 
         auto globalPos = context->localToWorld({cluster.getLoc()[0], cluster.getLoc()[1], 0});
-        pointPositions.push_back(Eigen::Vector3d(globalPos.x(), globalPos.y(), globalPos.z()));
+        pointPositions.push_back(Eigen::Vector3d(globalPos.x()/ dd4hep::mm, globalPos.y()/ dd4hep::mm, globalPos.z()/ dd4hep::mm));
       
       }
 

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -173,7 +173,7 @@ namespace eicrecon {
       debug("Angle: {}, Tolerance {}",angle,m_cfg.step_angle_tolerance);
 
       if(angle>m_cfg.step_angle_tolerance) return false;
-      
+
       return true;
 
     }
@@ -190,7 +190,7 @@ namespace eicrecon {
 
         auto globalPos = context->localToWorld({cluster.getLoc()[0], cluster.getLoc()[1], 0});
         pointPositions.push_back(Eigen::Vector3d(globalPos.x()/ dd4hep::mm, globalPos.y()/ dd4hep::mm, globalPos.z()/ dd4hep::mm));
-      
+
       }
 
       return pointPositions;

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -1,23 +1,29 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2023, Simon Gardner
 
+#include <DD4hep/VolumeManager.h>
+#include <Evaluator/DD4hepUnits.h>
+#include <Math/GenVector/Cartesian3D.h>
+#include <Math/GenVector/DisplacementVector3D.h>
+#include <algorithms/geo.h>
 #include <edm4eic/Cov2f.h>
 #include <edm4eic/Cov3f.h>
+#include <edm4eic/Measurement2DCollection.h>
 #include <edm4eic/TrackPoint.h>
 #include <edm4eic/TrackSegmentCollection.h>
 #include <edm4eic/vector_utils.h>
-#include <edm4eic/Measurement2DCollection.h>
+#include <edm4hep/Vector2f.h>
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
 #include <stdint.h>
-#include <algorithms/geo.h>
 #include <Eigen/Geometry>
 #include <Eigen/Householder>
 #include <Eigen/Jacobi>
 #include <Eigen/QR>
 #include <Eigen/SVD>
+#include <algorithm>
 #include <cmath>
 #include <utility>
 

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2023, Simon Gardner
+// Copyright (C) 2023 - 2025, Simon Gardner
 
 #include <DD4hep/VolumeManager.h>
 #include <Evaluator/DD4hepUnits.h>

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.h
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.h
@@ -6,8 +6,9 @@
 #include <Eigen/Core>
 #include <algorithms/algorithm.h>
 #include <algorithms/interfaces/WithPodConfig.h>
+#include <DDRec/CellIDPositionConverter.h>
 #include <edm4eic/TrackSegmentCollection.h>
-#include <edm4hep/TrackerHitCollection.h>
+#include <edm4eic/Measurement2DCollection.h>
 #include <gsl/pointers>
 #include <string>
 #include <string_view>
@@ -18,7 +19,7 @@
 namespace eicrecon {
 
 using FarDetectorLinearTrackingAlgorithm =
-    algorithms::Algorithm<algorithms::Input<std::vector<edm4hep::TrackerHitCollection>>,
+    algorithms::Algorithm<algorithms::Input<std::vector<edm4eic::Measurement2DCollection>>,
                           algorithms::Output<edm4eic::TrackSegmentCollection>>;
 
 class FarDetectorLinearTracking : public FarDetectorLinearTrackingAlgorithm,
@@ -38,19 +39,24 @@ public:
   void process(const Input&, const Output&) const final;
 
 private:
+
+  const dd4hep::rec::CellIDPositionConverter* m_cellid_converter{nullptr};
   Eigen::VectorXd m_layerWeights;
 
   Eigen::Vector3d m_optimumDirection;
 
-  void
-  buildMatrixRecursive(int level, Eigen::MatrixXd* hitMatrix,
-                       const std::vector<gsl::not_null<const edm4hep::TrackerHitCollection*>>& hits,
+  void  buildMatrixRecursive(int level, Eigen::MatrixXd* hitMatrix,
+                       const std::vector<std::vector<Eigen::Vector3d>>& hits,
                        gsl::not_null<edm4eic::TrackSegmentCollection*> outputTracks) const;
 
   void checkHitCombination(Eigen::MatrixXd* hitMatrix,
                            gsl::not_null<edm4eic::TrackSegmentCollection*> outputTracks) const;
 
   bool checkHitPair(const Eigen::Vector3d& hit1, const Eigen::Vector3d& hit2) const;
+
+  /** Convert 2D clusters to 3D coordinates **/
+  std::vector<Eigen::Vector3d> ConvertClusters(const edm4eic::Measurement2DCollection& clusters ) const;
+
 };
 
 } // namespace eicrecon

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.h
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2024, Simon Gardner
+// Copyright (C) 2024 - 2025, Simon Gardner
 
 #pragma once
 

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2023 - 2024, Simon Gardner
+// Copyright (C) 2023 - 2025, Simon Gardner
 
 #include <DD4hep/Handle.h>
 #include <DD4hep/IDDescriptor.h>

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
@@ -5,19 +5,18 @@
 #include <DD4hep/IDDescriptor.h>
 #include <DD4hep/Objects.h>
 #include <DD4hep/Readout.h>
-#include <DD4hep/VolumeManager.h>
 #include <DD4hep/detail/SegmentationsInterna.h>
 #include <DDSegmentation/BitFieldCoder.h>
-#include <Evaluator/DD4hepUnits.h>
 #include <JANA/JException.h>
 #include <Math/GenVector/Cartesian3D.h>
 #include <Math/GenVector/DisplacementVector3D.h>
 #include <ROOT/RVec.hxx>
 #include <algorithms/geo.h>
-#include <edm4hep/Vector3d.h>
+#include <edm4eic/Cov3f.h>
+#include <edm4hep/Vector2f.h>
 #include <fmt/core.h>
-#include <gsl/pointers>
 #include <sys/types.h>
+#include <gsl/pointers>
 
 #include "algorithms/fardetectors/FarDetectorTrackerCluster.h"
 #include "algorithms/fardetectors/FarDetectorTrackerClusterConfig.h"

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
@@ -63,18 +63,13 @@ void FarDetectorTrackerCluster::process(const FarDetectorTrackerCluster::Input& 
     auto outputClusters = outputClustersCollection[i];
 
     // Make clusters
-    auto clusters = ClusterHits(*inputHits);
-
-    for(auto cluster: clusters){
-      clusters.push_back(cluster);
-    }
-
+    ClusterHits(*inputHits, *outputClusters);
 
   }
 }
 
 // Create vector of Measurement2D from list of hits
-std::vector<edm4eic::Measurement2D>  FarDetectorTrackerCluster::ClusterHits(const edm4eic::TrackerHitCollection& inputHits) const {
+void  FarDetectorTrackerCluster::ClusterHits(const edm4eic::TrackerHitCollection& inputHits, edm4eic::Measurement2DCollection& outputClusters) const {
 
 
   ROOT::VecOps::RVec<unsigned long> id;
@@ -96,8 +91,6 @@ std::vector<edm4eic::Measurement2D>  FarDetectorTrackerCluster::ClusterHits(cons
   // Set up clustering variables
   ROOT::VecOps::RVec<bool> available(id.size(), 1);
   auto indices = Enumerate(id);
-
-  std::vector<edm4eic::Measurement2D> clusters;
 
   // Loop while there are unclustered hits
   while (ROOT::VecOps::Any(available)) {
@@ -165,7 +158,7 @@ std::vector<edm4eic::Measurement2D>  FarDetectorTrackerCluster::ClusterHits(cons
     edm4eic::Cov3f    covariance;
 
     // Create cluster
-    edm4eic::MutableMeasurement2D cluster(id[maxIndex], xyPos, t0, covariance);
+    auto cluster = outputClusters->create(id[maxIndex], xyPos, t0, covariance);
 
     // Add hits to cluster
     for(auto hit : clusterHits){
@@ -173,10 +166,7 @@ std::vector<edm4eic::Measurement2D>  FarDetectorTrackerCluster::ClusterHits(cons
       cluster.addToHits(hit);
     }
 
-    clusters.push_back(cluster);
   }
-
-  return clusters;
 
 }
 

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
@@ -27,7 +27,6 @@ namespace eicrecon {
 void FarDetectorTrackerCluster::init() {
 
   m_detector         = algorithms::GeoSvc::instance().detector();
-  // m_cellid_converter = algorithms::GeoSvc::instance().cellIDPositionConverter();
 
   if (m_cfg.readout.empty()) {
     throw JException("Readout is empty");
@@ -180,32 +179,5 @@ std::vector<edm4eic::Measurement2D>  FarDetectorTrackerCluster::ClusterHits(cons
   return clusters;
 
 }
-
-// // Convert to global coordinates and create TrackerHits
-// void FarDetectorTrackerCluster::ConvertClusters(
-//     const std::vector<FDTrackerCluster>& clusters,
-//     edm4hep::TrackerHitCollection& outputClusters) const {
-
-//   // Get context of first hit
-//   const dd4hep::VolumeManagerContext* context = m_cellid_converter->findContext(clusters[0].cellID);
-
-//   for (auto cluster : clusters) {
-//     auto hitPos = outputClusters.create();
-
-//     auto globalPos = context->localToWorld({cluster.x, cluster.y, 0});
-
-//     // Set cluster members
-//     hitPos.setCellID(cluster.cellID);
-//     hitPos.setPosition(edm4hep::Vector3d(globalPos.x() / dd4hep::mm, globalPos.y() / dd4hep::mm,
-//                                          globalPos.z() / dd4hep::mm));
-//     hitPos.setEDep(cluster.energy);
-//     hitPos.setTime(cluster.time);
-
-//     // Add raw hits to cluster
-//     for (auto hit : cluster.rawHits) {
-//       hitPos.addToRawHits(hit);
-//     }
-//   }
-// }
 
 } // namespace eicrecon

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.h
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.h
@@ -53,13 +53,9 @@ public:
   /** Cluster hits **/
   std::vector<edm4eic::Measurement2D> ClusterHits(const edm4eic::TrackerHitCollection&) const;
 
-  /** Convert clusters to TrackerHits **/
-  // void ConvertClusters(const std::vector<FDTrackerCluster>&, edm4eic::TrackerHitCollection&) const;
-
 private:
   const dd4hep::Detector* m_detector{nullptr};
   const dd4hep::BitFieldCoder* m_id_dec{nullptr};
-  // const dd4hep::rec::CellIDPositionConverter* m_cellid_converter{nullptr};
   dd4hep::Segmentation m_seg;
 
   int m_x_idx{0};

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.h
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.h
@@ -8,9 +8,8 @@
 #include <DDRec/CellIDPositionConverter.h>
 #include <Parsers/Primitives.h>
 #include <algorithms/algorithm.h>
-#include <edm4eic/RawTrackerHitCollection.h>
-#include <edm4hep/TrackerHitCollection.h>
-#include <podio/ObjectID.h>
+#include <edm4eic/TrackerHitCollection.h>
+#include <edm4eic/Measurement2DCollection.h>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -31,8 +30,8 @@ struct FDTrackerCluster {
 namespace eicrecon {
 
 using FarDetectorTrackerClusterAlgorithm =
-    algorithms::Algorithm<algorithms::Input<std::vector<edm4eic::RawTrackerHitCollection>>,
-                          algorithms::Output<std::vector<edm4hep::TrackerHitCollection>>>;
+    algorithms::Algorithm<algorithms::Input<std::vector<edm4eic::TrackerHitCollection>>,
+                          algorithms::Output<std::vector<edm4eic::Measurement2DCollection>>>;
 
 class FarDetectorTrackerCluster : public FarDetectorTrackerClusterAlgorithm,
                                   public WithPodConfig<FarDetectorTrackerClusterConfig> {
@@ -52,15 +51,15 @@ public:
   void process(const Input&, const Output&) const final;
 
   /** Cluster hits **/
-  std::vector<FDTrackerCluster> ClusterHits(const edm4eic::RawTrackerHitCollection&) const;
+  std::vector<edm4eic::Measurement2D> ClusterHits(const edm4eic::TrackerHitCollection&) const;
 
   /** Convert clusters to TrackerHits **/
-  void ConvertClusters(const std::vector<FDTrackerCluster>&, edm4hep::TrackerHitCollection&) const;
+  // void ConvertClusters(const std::vector<FDTrackerCluster>&, edm4eic::TrackerHitCollection&) const;
 
 private:
   const dd4hep::Detector* m_detector{nullptr};
   const dd4hep::BitFieldCoder* m_id_dec{nullptr};
-  const dd4hep::rec::CellIDPositionConverter* m_cellid_converter{nullptr};
+  // const dd4hep::rec::CellIDPositionConverter* m_cellid_converter{nullptr};
   dd4hep::Segmentation m_seg;
 
   int m_x_idx{0};

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.h
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2023 - 2024, Simon Gardner
+// Copyright (C) 2023 - 2025, Simon Gardner
 
 #pragma once
 

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.h
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.h
@@ -5,11 +5,10 @@
 
 #include <DD4hep/Detector.h>
 #include <DD4hep/Segmentations.h>
-#include <DDRec/CellIDPositionConverter.h>
 #include <Parsers/Primitives.h>
 #include <algorithms/algorithm.h>
-#include <edm4eic/TrackerHitCollection.h>
 #include <edm4eic/Measurement2DCollection.h>
+#include <edm4eic/TrackerHitCollection.h>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.h
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.h
@@ -17,16 +17,6 @@
 #include "FarDetectorTrackerClusterConfig.h"
 #include "algorithms/interfaces/WithPodConfig.h"
 
-// Cluster struct
-struct FDTrackerCluster {
-  unsigned long cellID{0};
-  double x{0.0};
-  double y{0.0};
-  double energy{0.0};
-  double time{0.0};
-  double timeError{0.0};
-  std::vector<podio::ObjectID> rawHits;
-};
 namespace eicrecon {
 
 using FarDetectorTrackerClusterAlgorithm =
@@ -51,7 +41,7 @@ public:
   void process(const Input&, const Output&) const final;
 
   /** Cluster hits **/
-  std::vector<edm4eic::Measurement2D> ClusterHits(const edm4eic::TrackerHitCollection&) const;
+  void ClusterHits(const edm4eic::TrackerHitCollection&, edm4eic::Measurement2DCollection&) const;
 
 private:
   const dd4hep::Detector* m_detector{nullptr};

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -3,11 +3,11 @@
 //
 //
 
-#include <edm4eic/EDM4eicVersion.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
-#include <edm4eic/RawTrackerHit.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/TrackSegment.h>
+#include <edm4eic/TrackerHit.h>
 #include <edm4eic/unit_system.h>
 #include <fmt/core.h>
 #include <math.h>
@@ -20,12 +20,12 @@
 #include "algorithms/meta/SubDivideFunctors.h"
 #include "extensions/jana/JOmniFactoryGeneratorT.h"
 #include "factories/digi/SiliconTrackerDigi_factory.h"
-#include "factories/tracking/TrackerHitReconstruction_factory.h"
 #include "factories/fardetectors/FarDetectorLinearProjection_factory.h"
 #include "factories/fardetectors/FarDetectorLinearTracking_factory.h"
+#include "factories/tracking/TrackerHitReconstruction_factory.h"
 #if EDM4EIC_VERSION_MAJOR >= 8
-#include "factories/fardetectors/FarDetectorTransportationPreML_factory.h"
 #include "factories/fardetectors/FarDetectorTransportationPostML_factory.h"
+#include "factories/fardetectors/FarDetectorTransportationPreML_factory.h"
 #endif
 #include "factories/fardetectors/FarDetectorMLReconstruction_factory.h"
 #include "factories/fardetectors/FarDetectorTrackerCluster_factory.h"

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -1,7 +1,5 @@
-// Copyright 2023-2024, Simon Gardner
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
-//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2023 - 2025, Simon Gardner
 
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -20,6 +20,7 @@
 #include "algorithms/meta/SubDivideFunctors.h"
 #include "extensions/jana/JOmniFactoryGeneratorT.h"
 #include "factories/digi/SiliconTrackerDigi_factory.h"
+#include "factories/tracking/TrackerHitReconstruction_factory.h"
 #include "factories/fardetectors/FarDetectorLinearProjection_factory.h"
 #include "factories/fardetectors/FarDetectorLinearTracking_factory.h"
 #if EDM4EIC_VERSION_MAJOR >= 8
@@ -59,6 +60,17 @@ extern "C" {
          app
     ));
 
+    // Convert raw digitized hits into hits with geometry info (ready for tracking)
+    app->Add(new JOmniFactoryGeneratorT<TrackerHitReconstruction_factory>(
+      "TaggerTrackerRecHits",
+      {"TaggerTrackerRawHits"},
+      {"TaggerTrackerRecHits"},
+      {
+          .timeResolution = 2,
+      },
+      app
+    ));
+
     // Divide collection based on geometry segmentation labels
     // This should really be done before digitization as summing hits in the same cell couldn't even be mixed between layers. At the moment just prep for clustering.
     std::string readout = "TaggerTrackerHits";
@@ -76,15 +88,15 @@ extern "C" {
       moduleClusterTags.push_back({});
       for(int lay_id : layerIDs){
         geometryDivisions.push_back({mod_id,lay_id});
-        geometryDivisionCollectionNames.push_back(fmt::format("TaggerTrackerM{}L{}RawHits",mod_id,lay_id));
+        geometryDivisionCollectionNames.push_back(fmt::format("TaggerTrackerM{}L{}RecHits",mod_id,lay_id));
         outputClusterCollectionNames.push_back(fmt::format("TaggerTrackerM{}L{}ClusterPositions",mod_id,lay_id));
         moduleClusterTags.back().push_back(outputClusterCollectionNames.back());
       }
     }
 
-    app->Add(new JOmniFactoryGeneratorT<SubDivideCollection_factory<edm4eic::RawTrackerHit>>(
+    app->Add(new JOmniFactoryGeneratorT<SubDivideCollection_factory<edm4eic::TrackerHit>>(
          "TaggerTrackerSplitHits",
-         {"TaggerTrackerRawHits"},
+         {"TaggerTrackerRecHits"},
          geometryDivisionCollectionNames,
          {
           .function = GeometrySplit{geometryDivisions,readout,geometryLabels},

--- a/src/factories/fardetectors/FarDetectorLinearTracking_factory.h
+++ b/src/factories/fardetectors/FarDetectorLinearTracking_factory.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2024, Simon Gardner
+// Copyright (C) 2024 - 2025, Simon Gardner
 
 #include "services/geometry/dd4hep/DD4hep_service.h"
 

--- a/src/factories/fardetectors/FarDetectorLinearTracking_factory.h
+++ b/src/factories/fardetectors/FarDetectorLinearTracking_factory.h
@@ -21,7 +21,7 @@ public:
 private:
     std::unique_ptr<AlgoT> m_algo;
 
-    VariadicPodioInput<edm4hep::TrackerHit> m_hits_input    {this};
+    VariadicPodioInput<edm4eic::Measurement2D> m_hits_input    {this};
     PodioOutput<edm4eic::TrackSegment>      m_tracks_output {this};
 
     ParameterRef<int>   n_layer        {this, "numLayers",       config().n_layer         };
@@ -42,9 +42,9 @@ private:
     void Process(int64_t run_number, uint64_t event_number) {
 
         try {
-            std::vector<gsl::not_null<const edm4hep::TrackerHitCollection*>>  hits;
+            std::vector<gsl::not_null<const edm4eic::Measurement2DCollection*>>  hits;
             for( const auto& hit : m_hits_input() ) {
-                hits.push_back(gsl::not_null<const edm4hep::TrackerHitCollection*>{hit});
+                hits.push_back(gsl::not_null<const edm4eic::Measurement2DCollection*>{hit});
             }
 
             m_algo->process(hits, {m_tracks_output().get()});

--- a/src/factories/fardetectors/FarDetectorTrackerCluster_factory.h
+++ b/src/factories/fardetectors/FarDetectorTrackerCluster_factory.h
@@ -17,8 +17,8 @@ public:
 private:
   std::unique_ptr<AlgoT> m_algo;
 
-  VariadicPodioInput<edm4eic::RawTrackerHit> m_raw_hits_input {this};
-  VariadicPodioOutput<edm4hep::TrackerHit>   m_clustered_hits_output {this};
+  VariadicPodioInput<edm4eic::TrackerHit>     m_raw_hits_input {this};
+  VariadicPodioOutput<edm4eic::Measurement2D> m_clustered_hits_output {this};
 
   Service<AlgorithmsInit_service> m_algorithmsInit {this};
 
@@ -45,13 +45,13 @@ public:
   }
 
   void Process(int64_t run_number, uint64_t event_number) {
-    std::vector<gsl::not_null<edm4hep::TrackerHitCollection*>> clustered_collections;
+    std::vector<gsl::not_null<edm4eic::Measurement2DCollection*>> clustered_collections;
     for (const auto& clustered : m_clustered_hits_output()) {
-      clustered_collections.push_back(gsl::not_null<edm4hep::TrackerHitCollection*>(clustered.get()));
+      clustered_collections.push_back(gsl::not_null<edm4eic::Measurement2DCollection*>(clustered.get()));
     }
 
     auto in1 = m_raw_hits_input();
-    std::vector<gsl::not_null<const edm4eic::RawTrackerHitCollection*>> in2;
+    std::vector<gsl::not_null<const edm4eic::TrackerHitCollection*>> in2;
     std::copy(in1.cbegin(), in1.cend(), std::back_inserter(in2));
 
 

--- a/src/factories/fardetectors/FarDetectorTrackerCluster_factory.h
+++ b/src/factories/fardetectors/FarDetectorTrackerCluster_factory.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2023 - 2024, Simon Gardner
+// Copyright (C) 2023 - 2025, Simon Gardner
 
 #pragma once
 

--- a/src/tests/algorithms_test/tracking_SiliconSimpleCluster.cc
+++ b/src/tests/algorithms_test/tracking_SiliconSimpleCluster.cc
@@ -46,7 +46,8 @@ TEST_CASE("the clustering algorithm runs", "[FarDetectorTrackerCluster]") {
                      0.0                                                    // float edepError
     );
 
-    std::vector<edm4eic::Measurement2D> clusterPositions = algo.ClusterHits(hits_coll);
+    edm4eic::Measurement2DCollection clusterPositions;
+    algo.ClusterHits(hits_coll, clusterPositions);
 
     REQUIRE(clusterPositions.size() == 1);
     REQUIRE(clusterPositions[0].getHits().size() == 1);
@@ -76,7 +77,8 @@ TEST_CASE("the clustering algorithm runs", "[FarDetectorTrackerCluster]") {
         0.0                                                    // float edepError
     );
 
-    std::vector<edm4eic::Measurement2D> clusterPositions = algo.ClusterHits(hits_coll);
+    edm4eic::Measurement2DCollection clusterPositions;
+    algo.ClusterHits(hits_coll, clusterPositions);
 
     REQUIRE(clusterPositions.size() == 2);
     REQUIRE(clusterPositions[0].getHits().size() == 1);
@@ -104,7 +106,8 @@ TEST_CASE("the clustering algorithm runs", "[FarDetectorTrackerCluster]") {
         0.0                                                    // float edepError
     );
 
-    std::vector<edm4eic::Measurement2D> clusterPositions = algo.ClusterHits(hits_coll);
+    edm4eic::Measurement2DCollection clusterPositions;
+    algo.ClusterHits(hits_coll, clusterPositions);
 
     REQUIRE(clusterPositions.size() == 1);
     REQUIRE(clusterPositions[0].getHits().size() == 2);
@@ -132,7 +135,8 @@ TEST_CASE("the clustering algorithm runs", "[FarDetectorTrackerCluster]") {
         0.0                                                    // float edepError
     );
 
-    std::vector<edm4eic::Measurement2D> clusterPositions = algo.ClusterHits(hits_coll);
+    edm4eic::Measurement2DCollection clusterPositions;
+    algo.ClusterHits(hits_coll, clusterPositions);
 
     REQUIRE(clusterPositions.size() == 2);
     REQUIRE(clusterPositions[0].getHits().size() == 1);
@@ -175,8 +179,9 @@ TEST_CASE("the clustering algorithm runs", "[FarDetectorTrackerCluster]") {
         0.0                                                    // float edepError
     );
 
-    std::vector<edm4eic::Measurement2D> clusterPositions = algo.ClusterHits(hits_coll);
-
+    edm4eic::Measurement2DCollection clusterPositions;
+    algo.ClusterHits(hits_coll, clusterPositions);
+    
     if (pixel2Time < cfg.hit_time_limit) {
       REQUIRE(clusterPositions.size() == 1);
       REQUIRE(clusterPositions[0].getHits().size() == 3);

--- a/src/tests/algorithms_test/tracking_SiliconSimpleCluster.cc
+++ b/src/tests/algorithms_test/tracking_SiliconSimpleCluster.cc
@@ -31,7 +31,7 @@ TEST_CASE("the clustering algorithm runs", "[FarDetectorTrackerCluster]") {
   auto detector = algorithms::GeoSvc::instance().detector();
   auto id_desc  = detector->readout(cfg.readout).idSpec();
 
-  algo.applyConfig(cfg); 
+  algo.applyConfig(cfg);
   algo.level(algorithms::LogLevel::kTrace);
   algo.init();
 
@@ -181,7 +181,7 @@ TEST_CASE("the clustering algorithm runs", "[FarDetectorTrackerCluster]") {
 
     edm4eic::Measurement2DCollection clusterPositions;
     algo.ClusterHits(hits_coll, clusterPositions);
-    
+
     if (pixel2Time < cfg.hit_time_limit) {
       REQUIRE(clusterPositions.size() == 1);
       REQUIRE(clusterPositions[0].getHits().size() == 3);

--- a/src/tests/algorithms_test/tracking_SiliconSimpleCluster.cc
+++ b/src/tests/algorithms_test/tracking_SiliconSimpleCluster.cc
@@ -120,7 +120,7 @@ TEST_CASE("the clustering algorithm runs", "[FarDetectorTrackerCluster]") {
         id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
         edm4hep::Vector3f(0.0, 0.0, 0.0),                      // Vector3f position,
         edm4eic::CovDiag3f(),                                      // Cov3f cov,
-        5.0,                                                   // float time
+        0.0,                                                   // float time
         0.0,                                                   // float timeError,
         5.0,                                                   // float edep,
         0.0                                                    // float edepError

--- a/src/tests/algorithms_test/tracking_SiliconSimpleCluster.cc
+++ b/src/tests/algorithms_test/tracking_SiliconSimpleCluster.cc
@@ -8,11 +8,14 @@
 #include <algorithms/logger.h>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
-#include <edm4eic/TrackerHitCollection.h>
+#include <edm4eic/CovDiag3f.h>
 #include <edm4eic/Measurement2DCollection.h>
+#include <edm4eic/TrackerHitCollection.h>
 #include <edm4eic/unit_system.h>
+#include <edm4hep/Vector2f.h>
+#include <edm4hep/Vector3f.h>
+#include <podio/RelationRange.h>
 #include <gsl/pointers>
-#include <podio/ObjectID.h>
 #include <utility>
 #include <vector>
 

--- a/src/tests/algorithms_test/tracking_SiliconSimpleCluster.cc
+++ b/src/tests/algorithms_test/tracking_SiliconSimpleCluster.cc
@@ -8,7 +8,8 @@
 #include <algorithms/logger.h>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
-#include <edm4eic/RawTrackerHitCollection.h>
+#include <edm4eic/TrackerHitCollection.h>
+#include <edm4eic/Measurement2DCollection.h>
 #include <edm4eic/unit_system.h>
 #include <gsl/pointers>
 #include <podio/ObjectID.h>
@@ -30,81 +31,112 @@ TEST_CASE("the clustering algorithm runs", "[FarDetectorTrackerCluster]") {
   auto detector = algorithms::GeoSvc::instance().detector();
   auto id_desc  = detector->readout(cfg.readout).idSpec();
 
-  algo.applyConfig(cfg);
+  algo.applyConfig(cfg); 
   algo.level(algorithms::LogLevel::kTrace);
   algo.init();
 
   SECTION("on a single pixel") {
-    edm4eic::RawTrackerHitCollection hits_coll;
+    edm4eic::TrackerHitCollection hits_coll;
     hits_coll.create(id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
-                     5.0,                                                   // int32 charge,
-                     0.0                                                    // int32 timeStamp
+                     edm4hep::Vector3f(0.0, 0.0, 0.0),                      // Vector3f position,
+                     edm4eic::CovDiag3f(),                                      // Cov3f cov,
+                     0.0,                                                   // float time
+                     0.0,                                                   // float timeError,
+                     5.0,                                                   // float edep,
+                     0.0                                                    // float edepError
     );
 
-    std::vector<FDTrackerCluster> clusterPositions = algo.ClusterHits(hits_coll);
+    std::vector<edm4eic::Measurement2D> clusterPositions = algo.ClusterHits(hits_coll);
 
     REQUIRE(clusterPositions.size() == 1);
-    REQUIRE(clusterPositions[0].rawHits.size() == 1);
-    REQUIRE(clusterPositions[0].x == 0.0);
-    REQUIRE(clusterPositions[0].y == 0.0);
-    REQUIRE(clusterPositions[0].energy == 5.0);
-    REQUIRE(clusterPositions[0].time == 0.0);
+    REQUIRE(clusterPositions[0].getHits().size() == 1);
+    REQUIRE(clusterPositions[0].getLoc()[0] == 0.0);
+    REQUIRE(clusterPositions[0].getLoc()[1] == 0.0);
+    REQUIRE(clusterPositions[0].getTime() == 0.0);
   }
 
   SECTION("on two separated pixels") {
-    edm4eic::RawTrackerHitCollection hits_coll;
+    edm4eic::TrackerHitCollection hits_coll;
     hits_coll.create(
         id_desc.encode({{"system", 255}, {"x", 0}, {"y", 10}}), // std::uint64_t cellID,
-        5.0,                                                    // int32 charge,
-        5.0                                                     // int32 timeStamp
+        edm4hep::Vector3f(0.0, 0.0, 0.0),                      // Vector3f position,
+        edm4eic::CovDiag3f(),                                      // Cov3f cov,
+        5.0,                                                   // float time
+        0.0,                                                   // float timeError,
+        5.0,                                                   // float edep,
+        0.0                                                    // float edepError
     );
     hits_coll.create(
         id_desc.encode({{"system", 255}, {"x", 10}, {"y", 0}}), // std::uint64_t cellID,
-        5.0,                                                    // int32 charge,
-        5.0                                                     // int32 timeStamp
+        edm4hep::Vector3f(0.0, 0.0, 0.0),                      // Vector3f position,
+        edm4eic::CovDiag3f(),                                      // Cov3f cov,
+        5.0,                                                   // float time
+        0.0,                                                   // float timeError,
+        5.0,                                                   // float edep,
+        0.0                                                    // float edepError
     );
 
-    std::vector<FDTrackerCluster> clusterPositions = algo.ClusterHits(hits_coll);
+    std::vector<edm4eic::Measurement2D> clusterPositions = algo.ClusterHits(hits_coll);
 
     REQUIRE(clusterPositions.size() == 2);
-    REQUIRE(clusterPositions[0].rawHits.size() == 1);
-    REQUIRE(clusterPositions[1].rawHits.size() == 1);
+    REQUIRE(clusterPositions[0].getHits().size() == 1);
+    REQUIRE(clusterPositions[1].getHits().size() == 1);
   }
 
   SECTION("on two adjacent pixels") {
-    edm4eic::RawTrackerHitCollection hits_coll;
-    hits_coll.create(id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
-                     5.0,                                                   // int32 charge,
-                     5.0                                                    // int32 timeStamp
+    edm4eic::TrackerHitCollection hits_coll;
+    hits_coll.create(
+        id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
+        edm4hep::Vector3f(0.0, 0.0, 0.0),                      // Vector3f position,
+        edm4eic::CovDiag3f(),                                      // Cov3f cov,
+        5.0,                                                   // float time
+        0.0,                                                   // float timeError,
+        5.0,                                                   // float edep,
+        0.0                                                    // float edepError
     );
-    hits_coll.create(id_desc.encode({{"system", 255}, {"x", 1}, {"y", 0}}), // std::uint64_t cellID,
-                     5.0,                                                   // int32 charge,
-                     5.0                                                    // int32 timeStamp
+    hits_coll.create(
+        id_desc.encode({{"system", 255}, {"x", 1}, {"y", 0}}), // std::uint64_t cellID,
+        edm4hep::Vector3f(0.0, 0.0, 0.0),                      // Vector3f position,
+        edm4eic::CovDiag3f(),                                      // Cov3f cov,
+        5.0,                                                   // float time
+        0.0,                                                   // float timeError,
+        5.0,                                                   // float edep,
+        0.0                                                    // float edepError
     );
 
-    std::vector<FDTrackerCluster> clusterPositions = algo.ClusterHits(hits_coll);
+    std::vector<edm4eic::Measurement2D> clusterPositions = algo.ClusterHits(hits_coll);
 
     REQUIRE(clusterPositions.size() == 1);
-    REQUIRE(clusterPositions[0].rawHits.size() == 2);
-    REQUIRE(clusterPositions[0].x == 0.5);
+    REQUIRE(clusterPositions[0].getHits().size() == 2);
+    REQUIRE(clusterPositions[0].getLoc()[0]== 0.5);
   }
 
   SECTION("on two adjacent pixels outwith the time separation") {
-    edm4eic::RawTrackerHitCollection hits_coll;
-    hits_coll.create(id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
-                     5.0,                                                   // int32 charge,
-                     0.0                                                    // int32 timeStamp
+    edm4eic::TrackerHitCollection hits_coll;
+    hits_coll.create(
+        id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
+        edm4hep::Vector3f(0.0, 0.0, 0.0),                      // Vector3f position,
+        edm4eic::CovDiag3f(),                                      // Cov3f cov,
+        5.0,                                                   // float time
+        0.0,                                                   // float timeError,
+        5.0,                                                   // float edep,
+        0.0                                                    // float edepError
     );
-    hits_coll.create(id_desc.encode({{"system", 255}, {"x", 1}, {"y", 0}}), // std::uint64_t cellID,
-                     5.0,                                                   // int32 charge,
-                     1.1 * cfg.hit_time_limit                               // int32 timeStamp
+    hits_coll.create(id_desc.encode(
+        {{"system", 255}, {"x", 1}, {"y", 0}}), // std::uint64_t cellID,
+        edm4hep::Vector3f(0.0, 0.0, 0.0),                      // Vector3f position,
+        edm4eic::CovDiag3f(),                                      // Cov3f cov,
+        1.1 * cfg.hit_time_limit,                              // float time
+        0.0,                                                   // float timeError,
+        5.0,                                                   // float edep,
+        0.0                                                    // float edepError
     );
 
-    std::vector<FDTrackerCluster> clusterPositions = algo.ClusterHits(hits_coll);
+    std::vector<edm4eic::Measurement2D> clusterPositions = algo.ClusterHits(hits_coll);
 
     REQUIRE(clusterPositions.size() == 2);
-    REQUIRE(clusterPositions[0].rawHits.size() == 1);
-    REQUIRE(clusterPositions[1].rawHits.size() == 1);
+    REQUIRE(clusterPositions[0].getHits().size() == 1);
+    REQUIRE(clusterPositions[1].getHits().size() == 1);
   }
 
   SECTION("run on three adjacent pixels") {
@@ -114,32 +146,45 @@ TEST_CASE("the clustering algorithm runs", "[FarDetectorTrackerCluster]") {
     auto pixelCharges = GENERATE(std::vector<int>{5, 10, 5}, std::vector<int>{10, 5, 5});
     float pixel2Time  = GENERATE_COPY(0, 1.1 * cfg.hit_time_limit);
 
-    edm4eic::RawTrackerHitCollection hits_coll;
-    hits_coll.create(id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
-                     pixelCharges[0],                                       // int32 charge,
-                     0.0                                                    // int32 timeStamp
-    );
-    hits_coll.create(id_desc.encode({{"system", 255}, {"x", 1}, {"y", 0}}), // std::uint64_t cellID,
-                     pixelCharges[1],                                       // int32 charge,
-                     pixel2Time                                             // int32 timeStamp
+    edm4eic::TrackerHitCollection hits_coll;
+    hits_coll.create(
+        id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
+        edm4hep::Vector3f(0.0, 0.0, 0.0),                      // Vector3f position,
+        edm4eic::CovDiag3f(),                                  // Cov3f cov,
+        0.0,                                                   // float time
+        0.0,                                                   // float timeError,
+        pixelCharges[0],                                       // float edep,
+        0.0                                                    // float edepError
     );
     hits_coll.create(
-        id_desc.encode(
-            {{"system", 255}, {"x", pixel3[0]}, {"y", pixel3[1]}}), // std::uint64_t cellID,
-        pixelCharges[2],                                            // int32 charge,
-        0.0                                                         // int32 timeStamp
+        id_desc.encode({{"system", 255}, {"x", 1}, {"y", 0}}), // std::uint64_t cellID,
+        edm4hep::Vector3f(0.0, 0.0, 0.0),                      // Vector3f position,
+        edm4eic::CovDiag3f(),                                  // Cov3f cov,
+        pixel2Time,                                            // float time
+        0.0,                                                   // float timeError,
+        pixelCharges[1],                                       // float edep,
+        0.0                                                    // float edepError
+    );
+    hits_coll.create(
+        id_desc.encode({{"system", 255}, {"x", pixel3[0]}, {"y", pixel3[1]}}), // std::uint64_t cellID,
+        edm4hep::Vector3f(0.0, 0.0, 0.0),                      // Vector3f position,
+        edm4eic::CovDiag3f(),                                  // Cov3f cov,
+        0.0,                                                   // float time
+        0.0,                                                   // float timeError,
+        pixelCharges[2],                                       // float edep,
+        0.0                                                    // float edepError
     );
 
-    std::vector<FDTrackerCluster> clusterPositions = algo.ClusterHits(hits_coll);
+    std::vector<edm4eic::Measurement2D> clusterPositions = algo.ClusterHits(hits_coll);
 
     if (pixel2Time < cfg.hit_time_limit) {
       REQUIRE(clusterPositions.size() == 1);
-      REQUIRE(clusterPositions[0].rawHits.size() == 3);
+      REQUIRE(clusterPositions[0].getHits().size() == 3);
     } else if (pixel3[0] == 2) {
       REQUIRE(clusterPositions.size() == 3);
-      REQUIRE(clusterPositions[0].rawHits.size() == 1);
-      REQUIRE(clusterPositions[1].rawHits.size() == 1);
-      REQUIRE(clusterPositions[2].rawHits.size() == 1);
+      REQUIRE(clusterPositions[0].getHits().size() == 1);
+      REQUIRE(clusterPositions[1].getHits().size() == 1);
+      REQUIRE(clusterPositions[2].getHits().size() == 1);
     } else {
       REQUIRE(clusterPositions.size() == 2);
     }

--- a/src/tests/algorithms_test/tracking_SiliconSimpleCluster.cc
+++ b/src/tests/algorithms_test/tracking_SiliconSimpleCluster.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2024, Dmitry Kalinkin, Simon Gardner
+// Copyright (C) 2024 - 2025, Dmitry Kalinkin, Simon Gardner
 
 #include <DD4hep/Detector.h>
 #include <DD4hep/IDDescriptor.h>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Meant as a porential alternative to https://github.com/eic/EICrecon/pull/1765 and https://github.com/eic/EICrecon/pull/1676 and a step towards https://github.com/eic/EICrecon/issues/1657 without the need to change the data model.

This allows the edm4eic::TrackerHit to remain purely a calibrated sensor output defined by a single CellID and edm4eic::Measurement2D to be a clustered position on a surface.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
The type of TaggerTrackerM{}L{}ClusterPositions is changed to a Measurement2D so will not directly contain any 3D position information. Any downstream analysis using the collections will need to be changed.