### PR TITLE
jana_plugin.cmake: explicitly depend plugins on podio_datamodel_glue

### DIFF
--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -47,6 +47,11 @@ macro(plugin_add _name)
                           podio::podioRootIO spdlog::spdlog fmt::fmt)
     target_link_libraries(${_name}_plugin Microsoft.GSL::GSL)
 
+    # Ensure datamodel headers are available
+    if(TARGET podio_datamodel_glue)
+      add_dependencies(${_name}_plugin podio_datamodel_glue)
+    endif()
+
     # Install plugin
     install(
       TARGETS ${_name}_plugin
@@ -88,6 +93,11 @@ macro(plugin_add _name)
       spdlog::spdlog
       fmt::fmt
       Microsoft.GSL::GSL)
+
+    # Ensure datamodel headers are available
+    if(TARGET podio_datamodel_glue)
+      add_dependencies(${_name}_library podio_datamodel_glue)
+    endif()
 
     # Install library
     install(

--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -25,7 +25,7 @@ macro(plugin_add _name)
 
   # Define plugin
   if(${_name}_WITH_PLUGIN)
-    add_library(${_name}_plugin SHARED ${PLUGIN_SOURCES})
+    add_library(${_name}_plugin SHARED)
 
     target_include_directories(
       ${_name}_plugin

--- a/src/services/CMakeLists.txt
+++ b/src/services/CMakeLists.txt
@@ -1,9 +1,10 @@
+# io/podio exports podio_datamodel_glue target needed by plugin_add
+add_subdirectory(io/podio)
 add_subdirectory(algorithms_init)
 add_subdirectory(evaluator)
 add_subdirectory(geometry/dd4hep)
 add_subdirectory(geometry/acts)
 add_subdirectory(geometry/richgeo)
-add_subdirectory(io/podio)
 add_subdirectory(log)
 add_subdirectory(rootfile)
 add_subdirectory(pid_lut)

--- a/src/services/io/podio/CMakeLists.txt
+++ b/src/services/io/podio/CMakeLists.txt
@@ -37,11 +37,10 @@ add_custom_target(
     ${PROJECT_BINARY_DIR}/include/${DATAMODEL_RELATIVE_PATH}/datamodel_glue.h
   COMMENT "Create datamodel glue headers")
 
-# Install datamodel_glue headers
+# Install datamodel_glue header
 install(
   FILES
     ${PROJECT_BINARY_DIR}/include/${DATAMODEL_RELATIVE_PATH}/datamodel_glue.h
-    ${PROJECT_BINARY_DIR}/include/${DATAMODEL_RELATIVE_PATH}/datamodel_includes.h
   DESTINATION
     ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${DATAMODEL_RELATIVE_PATH})
 

--- a/src/services/io/podio/CMakeLists.txt
+++ b/src/services/io/podio/CMakeLists.txt
@@ -1,15 +1,3 @@
-# Automatically set plugin name the same as the directory name
-get_filename_component(PLUGIN_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
-
-# Function creates ${PLUGIN_NAME}_plugin and ${PLUGIN_NAME}_library targets
-# Setting default includes, libraries and installation paths
-plugin_add(${PLUGIN_NAME})
-
-# The macro grabs sources as *.cc *.cpp *.c and headers as *.h *.hh *.hpp Then
-# correctly sets sources for ${_name}_plugin and ${_name}_library targets Adds
-# headers to the correct installation directory
-plugin_glob_all(${PLUGIN_NAME})
-
 # Get properties at configuration evaluation time. The `$<TARGET_PROPERTY`
 # generator expression would include multiple additional paths from transitive
 # dependencies such as PODIO and ROOT.
@@ -56,6 +44,18 @@ install(
     ${PROJECT_BINARY_DIR}/include/${DATAMODEL_RELATIVE_PATH}/datamodel_includes.h
   DESTINATION
     ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${DATAMODEL_RELATIVE_PATH})
+
+# Automatically set plugin name the same as the directory name
+get_filename_component(PLUGIN_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
+
+# Function creates ${PLUGIN_NAME}_plugin and ${PLUGIN_NAME}_library targets
+# Setting default includes, libraries and installation paths
+plugin_add(${PLUGIN_NAME})
+
+# The macro grabs sources as *.cc *.cpp *.c and headers as *.h *.hh *.hpp Then
+# correctly sets sources for ${_name}_plugin and ${_name}_library targets Adds
+# headers to the correct installation directory
+plugin_glob_all(${PLUGIN_NAME})
 
 # Add include directories (works same as target_include_directories)
 plugin_include_directories(${PLUGIN_NAME} PRIVATE ${PROJECT_BINARY_DIR}/include)

--- a/src/services/io/podio/CMakeLists.txt
+++ b/src/services/io/podio/CMakeLists.txt
@@ -49,8 +49,6 @@ add_custom_target(
     ${PROJECT_BINARY_DIR}/include/${DATAMODEL_RELATIVE_PATH}/datamodel_glue.h
   COMMENT "Create datamodel glue headers")
 
-plugin_add_dependencies(${PLUGIN_NAME} podio_datamodel_glue)
-
 # Install datamodel_glue headers
 install(
   FILES


### PR DESCRIPTION
### Briefly, what does this PR introduce?

https://github.com/eic/EICrecon/pull/1704 broke multiprocess builds (e.g. `make -j10`). The issue is that cmake header scanner ignores rule that generates datamodel_glue.h, which leads to race conditions:
```
src/services/io/podio/JEventSourcePODIO.cc:30:10: fatal error: services/io/podio/datamodel_glue.h: No such file or directory
   30 | #include "services/io/podio/datamodel_glue.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This PR introduces a target-level dependency. The case of external plugin is handled by the fact that the headers are installed along with EICrecon.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No