### PR TITLE
Weight hit relation by energy in FarDetectorTrackerCluster

### DIFF
--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
@@ -106,7 +106,7 @@ void  FarDetectorTrackerCluster::ClusterHits(const edm4eic::TrackerHitCollection
 
     ROOT::VecOps::RVec<unsigned long> clusterList = {maxIndex};
     ROOT::VecOps::RVec<float> clusterT;
-    
+
     // Create cluster
     auto cluster = outputClusters->create();
 
@@ -139,7 +139,7 @@ void  FarDetectorTrackerCluster::ClusterHits(const edm4eic::TrackerHitCollection
 
       // Time
       clusterT.push_back(t[index]);
-      
+
       // Adds hit and weight to Measurement2D contribution
       cluster.addToHits(inputHits[index]);
       cluster.addToWeights(weight);

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
@@ -106,7 +106,9 @@ void  FarDetectorTrackerCluster::ClusterHits(const edm4eic::TrackerHitCollection
 
     ROOT::VecOps::RVec<unsigned long> clusterList = {maxIndex};
     ROOT::VecOps::RVec<float> clusterT;
-    std::vector<edm4eic::TrackerHit> clusterHits;
+    
+    // Create cluster
+    auto cluster = outputClusters->create();
 
     // Loop over hits, adding neighbouring hits as relevant
     while (clusterList.size()) {
@@ -127,22 +129,20 @@ void  FarDetectorTrackerCluster::ClusterHits(const edm4eic::TrackerHitCollection
       // Removes current hit from remaining found cluster hits
       clusterList.erase(clusterList.begin());
 
-      // Adds raw hit to TrackerHit contribution
-      clusterHits.push_back(inputHits[index]);
-
-      // Energy
-      auto hitE = e[index];
-      esum += hitE;
       // TODO - See if now a single detector element is expected a better function is available.
       auto pos = m_seg->position(id[index]);
 
       // Weighted position
-      float weight = hitE; // TODO - Calculate appropriate weighting based on sensor charge sharing
+      float weight = e[index]; // TODO - Calculate appropriate weighting based on sensor charge sharing
       weightSum += weight;
       localPos += pos * weight;
 
       // Time
       clusterT.push_back(t[index]);
+      
+      // Adds hit and weight to Measurement2D contribution
+      cluster.addToHits(inputHits[index]);
+      cluster.addToWeights(weight);
     }
 
     // Finalise position
@@ -152,18 +152,13 @@ void  FarDetectorTrackerCluster::ClusterHits(const edm4eic::TrackerHitCollection
 
     // Finalise time
     t0     = Mean(clusterT);
-    tError = StdDev(clusterT); // TODO fold detector timing resolution into error
 
     edm4eic::Cov3f    covariance;
 
-    // Create cluster
-    auto cluster = outputClusters->create(id[maxIndex], xyPos, t0, covariance);
-
-    // Add hits to cluster
-    for(auto hit : clusterHits){
-      cluster.addToWeights(1);
-      cluster.addToHits(hit);
-    }
+    cluster.setSurface(id[maxIndex]);
+    cluster.setLoc(xyPos);
+    cluster.setTime(t0);
+    cluster.setCovariance(covariance);
 
   }
 

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
@@ -106,6 +106,7 @@ void  FarDetectorTrackerCluster::ClusterHits(const edm4eic::TrackerHitCollection
 
     ROOT::VecOps::RVec<unsigned long> clusterList = {maxIndex};
     ROOT::VecOps::RVec<float> clusterT;
+    ROOT::VecOps::RVec<float> clusterW;
 
     // Create cluster
     auto cluster = outputClusters->create();
@@ -140,9 +141,11 @@ void  FarDetectorTrackerCluster::ClusterHits(const edm4eic::TrackerHitCollection
       // Time
       clusterT.push_back(t[index]);
 
+
       // Adds hit and weight to Measurement2D contribution
       cluster.addToHits(inputHits[index]);
-      cluster.addToWeights(weight);
+      clusterW.push_back(e[index]);
+
     }
 
     // Finalise position
@@ -152,6 +155,13 @@ void  FarDetectorTrackerCluster::ClusterHits(const edm4eic::TrackerHitCollection
 
     // Finalise time
     t0     = Mean(clusterT);
+
+    // Normalize weights then add to cluster
+    clusterW /= weightSum;
+
+    for(auto& w : clusterW) {
+      cluster.addToWeights(w);
+    }
 
     edm4eic::Cov3f    covariance;
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Changes the hit relation weight from 1 to the energy of the hit. A step towards addressing https://github.com/eic/EICrecon/issues/1657

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
Outputs energy based weights for clusters.