### PR TITLE
feat: determine detector checksum on geometry read (if supported)

### DIFF
--- a/.github/lsan.supp
+++ b/.github/lsan.supp
@@ -9,3 +9,4 @@ leak:libActsCore.so
 leak:libCling.so
 leak:libCore.so
 leak:libJANA.so
+leak:libDDCorePlugins.so

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ endif()
 # Minimal dependency versions
 set(Acts_VERSION_MIN 33.0.0)
 set(algorithms_VERSION_MIN 1.0.0)
-set(DD4hep_VERSION_MIN 1.21)
+set(DD4hep_VERSION_MIN 1.26)
 set(EDM4EIC_VERSION_MIN 7.0)
 set(EDM4HEP_VERSION_MIN 0.7.1)
 set(Eigen3_VERSION_MIN 3.3)

--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -266,7 +266,7 @@ macro(plugin_add_dd4hep _name)
     find_package(DD4hep ${DD4hep_VERSION_MIN} REQUIRED)
   endif()
 
-  plugin_link_libraries(${_name} DD4hep::DDCore DD4hep::DDRec ${ARGN})
+  plugin_link_libraries(${_name} DD4hep::DDCore DD4hep::DDRec)
 
 endmacro()
 

--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -266,7 +266,7 @@ macro(plugin_add_dd4hep _name)
     find_package(DD4hep ${DD4hep_VERSION_MIN} REQUIRED)
   endif()
 
-  plugin_link_libraries(${_name} DD4hep::DDCore DD4hep::DDRec)
+  plugin_link_libraries(${_name} DD4hep::DDCore DD4hep::DDRec ${ARGN})
 
 endmacro()
 

--- a/src/services/geometry/dd4hep/CMakeLists.txt
+++ b/src/services/geometry/dd4hep/CMakeLists.txt
@@ -16,4 +16,4 @@ plugin_glob_all(${PLUGIN_NAME})
 
 # Find dependencies
 plugin_add_event_model(${PLUGIN_NAME})
-plugin_add_dd4hep(${PLUGIN_NAME})
+plugin_add_dd4hep(${PLUGIN_NAME} DD4hep::DDCorePlugins)

--- a/src/services/geometry/dd4hep/DD4hep_service.cc
+++ b/src/services/geometry/dd4hep/DD4hep_service.cc
@@ -5,6 +5,8 @@
 #include <JANA/JApplication.h>
 #include <JANA/JException.h>
 #include <JANA/Services/JServiceLocator.h>
+#include <DD4hep/DetElement.h>
+#include <Parsers/Primitives.h>
 #include <Parsers/Printout.h>
 #include <TGeoManager.h>
 #include <fmt/color.h>
@@ -14,6 +16,7 @@
 #include <exception>
 #include <filesystem>
 #include <iostream>
+#include <set>
 #include <stdexcept>
 #include <utility>
 #include <vector>

--- a/src/services/geometry/dd4hep/DD4hep_service.h
+++ b/src/services/geometry/dd4hep/DD4hep_service.h
@@ -15,6 +15,10 @@
 #include <string>
 #include <vector>
 
+#if __has_include(<DD4hep/plugins/DetectorChecksum.h>)
+#include <DD4hep/plugins/DetectorChecksum.h>
+#endif
+
 class DD4hep_service : public JService {
 public:
   DD4hep_service(JApplication* app) : m_app(app) {}
@@ -22,6 +26,11 @@ public:
 
   virtual gsl::not_null<const dd4hep::Detector*> detector();
   virtual gsl::not_null<const dd4hep::rec::CellIDPositionConverter*> converter();
+
+  const std::map<std::string, dd4hep::detail::DetectorChecksum::hash_t>&
+  GetDetectorChecksums() const {
+    return m_detector_checksums;
+  };
 
 protected:
   void Initialize();
@@ -35,6 +44,9 @@ private:
   std::unique_ptr<const dd4hep::Detector> m_dd4hepGeo                            = nullptr;
   std::unique_ptr<const dd4hep::rec::CellIDPositionConverter> m_cellid_converter = nullptr;
   std::vector<std::string> m_xml_files;
+
+  // Checksum map from name to hash
+  std::map<std::string, dd4hep::detail::DetectorChecksum::hash_t> m_detector_checksums;
 
   /// Ensures there is a geometry file that should be opened
   static std::string resolveFileName(const std::string& filename, char* detector_path_env);

--- a/src/services/io/podio/CMakeLists.txt
+++ b/src/services/io/podio/CMakeLists.txt
@@ -62,6 +62,7 @@ plugin_include_directories(${PLUGIN_NAME} PRIVATE ${PROJECT_BINARY_DIR}/include)
 # Add libraries (works same as target_include_directories)
 plugin_link_libraries(
   ${PLUGIN_NAME}
+  dd4hep_plugin
   fmt::fmt
   EDM4HEP::edm4hep
   EDM4HEP::edm4hepDict

--- a/src/services/io/podio/JEventSourcePODIO.h
+++ b/src/services/io/podio/JEventSourcePODIO.h
@@ -13,6 +13,8 @@
 #include <memory>
 #include <string>
 
+#include "services/geometry/dd4hep/DD4hep_service.h"
+
 #if ((JANA_VERSION_MAJOR == 2) && (JANA_VERSION_MINOR >= 3)) || (JANA_VERSION_MAJOR > 2)
 #define JANA_NEW_CALLBACK_STYLE 1
 #else
@@ -42,6 +44,8 @@ public:
 
 protected:
   podio::ROOTReader m_reader;
+
+  std::shared_ptr<DD4hep_service> m_dd4hep_service;
 
   std::size_t Nevents_in_file = 0;
   std::size_t Nevents_read    = 0;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds geometry checksum determination on geometry read. At this point there is no comparison to the detector checksum used on simulation input determination, but it's a start and a proof of concept.

Needs:
- [x] https://eicweb.phy.anl.gov/containers/eic_container/-/merge_requests/1118 to get the right header

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @veprbl 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.