### PR TITLE
feat: log error with algorithm exception before throwing to JANA

### DIFF
--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -553,6 +553,7 @@ public:
         output->SetCollection(*this);
       }
     } catch (std::exception& e) {
+      m_logger->error(e.what());
       throw JException(e.what());
     }
   }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds printing of exceptions from algorithms to the log stream as errors. Likely to be useful with #1789 since it would otherwise be overwhelming. This will help avoid issues like https://github.com/eic/EICrecon/pull/1762#issuecomment-2798888885, https://github.com/eic/EICrecon/pull/1788, and https://github.com/eic/EICrecon/pull/1795.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: exceptions are silently ignored)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, prints exceptions. Likely a lot for simulation input that does not contain default collections.