### PR TITLE
[Backport v1.24] fix: correct CalorimeterClusterRecoCoG inputs by EDM4eic version

### DIFF
--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -215,7 +215,11 @@ extern "C" {
           new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
              "HcalBarrelSplitMergeClustersWithoutShapes",
             {"HcalBarrelSplitMergeProtoClusters", // edm4eic::ProtoClusterCollection
-             "HcalBarrelHits"},                          // edm4hep::SimCalorimeterHitCollection
+#if EDM4EIC_VERSION_MAJOR >= 7
+             "HcalBarrelRawHitAssociations"}, // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#else
+             "HcalBarrelHits"}, // edm4hep::SimCalorimeterHitCollection
+#endif
             {"HcalBarrelSplitMergeClustersWithoutShapes", // edm4eic::Cluster
              "HcalBarrelSplitMergeClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
             {

--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -251,7 +251,11 @@ extern "C" {
           new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
              "EcalEndcapNSplitMergeClustersWithoutShapes",
             {"EcalEndcapNSplitMergeProtoClusters", // edm4eic::ProtoClusterCollection
+#if EDM4EIC_VERSION_MAJOR >= 7
+             "EcalEndcapNRawHitAssociations"}, // edm4hep::MCRecoCalorimeterHitAssociationCollection
+#else
              "EcalEndcapNHits"}, // edm4hep::SimCalorimeterHitCollection
+#endif
             {"EcalEndcapNSplitMergeClustersWithoutShapes", // edm4eic::Cluster
              "EcalEndcapNSplitMergeClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
             {

--- a/src/detectors/EHCAL/EHCAL.cc
+++ b/src/detectors/EHCAL/EHCAL.cc
@@ -183,7 +183,11 @@ extern "C" {
           new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
              "HcalEndcapNSplitMergeClustersWithoutShapes",
             {"HcalEndcapNSplitMergeProtoClusters", // edm4eic::ProtoClusterCollection
+#if EDM4EIC_VERSION_MAJOR >= 7
+             "HcalEndcapNRawHitAssociations"}, // edm4hep::MCRecoCalorimeterHitAssociationCollection
+#else
              "HcalEndcapNHits"}, // edm4hep::SimCalorimeterHitCollection
+#endif
             {"HcalEndcapNSplitMergeClustersWithoutShapes", // edm4eic::Cluster
              "HcalEndcapNSplitMergeClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
             {

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -181,7 +181,11 @@ extern "C" {
           new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
              "EcalEndcapPSplitMergeClustersWithoutShapes",
             {"EcalEndcapPSplitMergeProtoClusters", // edm4eic::ProtoClusterCollection
-             "EcalEndcapPHits"},                          // edm4hep::SimCalorimeterHitCollection
+#if EDM4EIC_VERSION_MAJOR >= 7
+             "EcalEndcapPRawHitAssociations"}, // edm4hep::MCRecoCalorimeterHitAssociationCollection
+#else
+             "EcalEndcapPHits"}, // edm4hep::SimCalorimeterHitCollection
+#endif
             {"EcalEndcapPSplitMergeClustersWithoutShapes", // edm4eic::Cluster
              "EcalEndcapPSplitMergeClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
             {

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -384,7 +384,11 @@ extern "C" {
           new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
              "LFHCALSplitMergeClustersWithoutShapes",
             {"LFHCALSplitMergeProtoClusters", // edm4eic::ProtoClusterCollection
+#if EDM4EIC_VERSION_MAJOR >= 7
+             "LFHCALRawHitAssociations"}, // edm4hep::MCRecoCalorimeterHitAssociationCollection
+#else
              "LFHCALHits"}, // edm4hep::SimCalorimeterHitCollection
+#endif
             {"LFHCALSplitMergeClustersWithoutShapes", // edm4eic::Cluster
              "LFHCALSplitMergeClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
             {


### PR DESCRIPTION
# Description
Backport of #1788 to `v1.24`.