### PR TITLE
fix: if no hadronic final state, return instead of throw

### DIFF
--- a/src/algorithms/reco/InclusiveKinematicsDA.cc
+++ b/src/algorithms/reco/InclusiveKinematicsDA.cc
@@ -70,6 +70,10 @@ namespace eicrecon {
     auto theta_e = e_boosted.Theta();
 
     // Get hadronic final state variables
+    if (hfs->size() == 0) {
+      debug("No hadronic final state found");
+      return;
+    }
     auto sigma_h = hfs->at(0).getSigma();
     auto ptsum = hfs->at(0).getPT();
     auto gamma_h = hfs->at(0).getGamma();

--- a/src/algorithms/reco/InclusiveKinematicsESigma.cc
+++ b/src/algorithms/reco/InclusiveKinematicsESigma.cc
@@ -71,6 +71,10 @@ namespace eicrecon {
     auto sigma_e = e_boosted.E() - e_boosted.Pz();
 
     // Get hadronic final state variables
+    if (hfs->size() == 0) {
+      debug("No hadronic final state found");
+      return;
+    }
     auto sigma_h = hfs->at(0).getSigma();
     auto ptsum = hfs->at(0).getPT();
     auto gamma_h = hfs->at(0).getGamma();

--- a/src/algorithms/reco/InclusiveKinematicsJB.cc
+++ b/src/algorithms/reco/InclusiveKinematicsJB.cc
@@ -58,6 +58,10 @@ namespace eicrecon {
       );
 
     // Get hadronic final state variables
+    if (hfs->size() == 0) {
+      debug("No hadronic final state found");
+      return;
+    }
     auto sigma_h = hfs->at(0).getSigma();
     auto ptsum = hfs->at(0).getPT();
     auto gamma_h = hfs->at(0).getGamma();

--- a/src/algorithms/reco/InclusiveKinematicsSigma.cc
+++ b/src/algorithms/reco/InclusiveKinematicsSigma.cc
@@ -70,6 +70,10 @@ namespace eicrecon {
     auto sigma_e = e_boosted.E() - e_boosted.Pz();
 
     // Get hadronic final state variables
+    if (hfs->size() == 0) {
+      debug("No hadronic final state found");
+      return;
+    }
     auto sigma_h = hfs->at(0).getSigma();
     auto ptsum = hfs->at(0).getPT();
     auto gamma_h = hfs->at(0).getGamma();


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes the inclusive kinematics algorithms that need the hadronic final state. Until now these algorithms would assume that `at(0)` returns a valid entry without testing the size first. Now the size is tested and the algorithm returns before throwing an exception in `at(0)`.

See e.g. https://github.com/eic/EICrecon/actions/runs/14424316365/job/40450940599?pr=1790#step:7:1090.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: inclusive kinematics algorithms throw exceptions)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No. Return without action is equivalent to silently ignored exception right now.