### PR TITLE
fix: workaround m_particleHypothesis in CKFTracking for acts-36.0.0 too

### DIFF
--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -428,7 +428,7 @@ namespace eicrecon {
                 // collection. We'll just assume no algorithm will access them
                 // directly.
                 acts_tracks.removeTrack(track_index);
-#if Acts_VERSION_MAJOR < 36
+#if Acts_VERSION_MAJOR < 36 || (Acts_VERSION_MAJOR == 36 && Acts_VERSION_MINOR < 1)
                // Workaround an upstream bug in Acts::VectorTrackContainer::removeTrack_impl()
                // https://github.com/acts-project/acts/commit/94cf81f3f1109210b963977e0904516b949b1154
                trackContainer->m_particleHypothesis.erase(trackContainer->m_particleHypothesis.begin() + track_index);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR applies the pre-36 workaround also for 36.0.0, since the issue was only fixed in 36.1.0.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/acts-project/acts/commit/94cf81f3f1109210b963977e0904516b949b1154 merged in 36.1.0)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.