### PR TITLE
fix: `ReconstructedChargedParticleIDs` (unknown) -> `ReconstructedChargedRealPIDParticleIDs` in output collections

### DIFF
--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -180,7 +180,6 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
     "ReconstructedChargedParticleAssociations",
     "MCScatteredElectronAssociations",    // Remove if/when used internally
     "MCNonScatteredElectronAssociations", // Remove if/when used internally
-    "ReconstructedChargedParticleIDs",
     "ReconstructedBreitFrameParticles",
     "CentralTrackSegments",
     "CentralTrackVertices",

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -176,6 +176,7 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
     "ReconstructedTruthSeededChargedParticles",
     "ReconstructedTruthSeededChargedParticleAssociations",
     "ReconstructedChargedRealPIDParticles",
+    "ReconstructedChargedRealPIDParticleIDs",
     "ReconstructedChargedParticles",
     "ReconstructedChargedParticleAssociations",
     "MCScatteredElectronAssociations",    // Remove if/when used internally


### PR DESCRIPTION
### Briefly, what does this PR introduce?
EICrecon tries to write `ReconstructedChargedParticleIDs` to the output file, but that's not a known collection. Remove it from the `output_collections` default value.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.