### PR TITLE
Bug fix on SiliconPulseDiscretization giving nan values sometimes.

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+06934917acc0fc01b364b53cd25f23764dc2dfe4 # run clang-format in CI
+1fa8ab81db54c7892edd49e0e026e1da65093437 # fix: use clang-format rev: v16.0.6

--- a/src/algorithms/digi/EICROCDigitizationConfig.h
+++ b/src/algorithms/digi/EICROCDigitizationConfig.h
@@ -3,7 +3,8 @@
 
 #pragma once
 
-#include <DD4hep/DD4hepUnits.h>
+//#include <DD4hep/DD4hepUnits.h>
+#include <edm4eic/unit_system.h>
 
 namespace eicrecon {
 
@@ -21,7 +22,7 @@ struct EICROCDigitizationConfig {
       adc_range; // TDC value = time when pulse exceed t_thres. Negative because Silicon voltage is negative when hit
   // period of the sensor clock. Time internal to sensor will all be digitized to integer multiple
   // of tInterval
-  double tMax = 25 * dd4hep::ns; // 25 ns is the period of 40MHz EIC clock
+  double tMax = 25 * edm4eic::unit::ns;//dd4hep::ns; // 25 ns is the period of 40MHz EIC clock
 };
 
 } // namespace eicrecon

--- a/src/algorithms/digi/EICROCDigitizationConfig.h
+++ b/src/algorithms/digi/EICROCDigitizationConfig.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-//#include <DD4hep/DD4hepUnits.h>
 #include <edm4eic/unit_system.h>
 
 namespace eicrecon {
@@ -22,7 +21,7 @@ struct EICROCDigitizationConfig {
       adc_range; // TDC value = time when pulse exceed t_thres. Negative because Silicon voltage is negative when hit
   // period of the sensor clock. Time internal to sensor will all be digitized to integer multiple
   // of tInterval
-  double tMax = 25 * edm4eic::unit::ns;//dd4hep::ns; // 25 ns is the period of 40MHz EIC clock
+  double tMax = 25 * edm4eic::unit::ns;// 25 ns is the period of 40MHz EIC clock
 };
 
 } // namespace eicrecon

--- a/src/algorithms/digi/EICROCDigitizationConfig.h
+++ b/src/algorithms/digi/EICROCDigitizationConfig.h
@@ -21,7 +21,7 @@ struct EICROCDigitizationConfig {
       adc_range; // TDC value = time when pulse exceed t_thres. Negative because Silicon voltage is negative when hit
   // period of the sensor clock. Time internal to sensor will all be digitized to integer multiple
   // of tInterval
-  double tMax = 25 * edm4eic::unit::ns;// 25 ns is the period of 40MHz EIC clock
+  double tMax = 25 * edm4eic::unit::ns; // 25 ns is the period of 40MHz EIC clock
 };
 
 } // namespace eicrecon

--- a/src/algorithms/digi/SiliconPulseDiscretization.cc
+++ b/src/algorithms/digi/SiliconPulseDiscretization.cc
@@ -25,8 +25,12 @@ double SiliconPulseDiscretization::_interpolateOrZero(const TGraph& graph, doubl
   // otherwise, return graph interpolation value
   if (t < tMin || t > tMax)
     return 0;
-  else
-    return graph.Eval(t, nullptr, "S"); // spline interpolation
+  else {
+    double height = graph.Eval(t, nullptr, "S"); // spline interpolation
+    if(!std::isfinite(height))
+        error("Pulse interpolation returns nan. This happen mostly because there are multiple pulse height values at the same time. Did you call PulseCombiner?");
+    return height;
+  }
 }
 
 void SiliconPulseDiscretization::process(const SiliconPulseDiscretization::Input& input,
@@ -44,11 +48,16 @@ void SiliconPulseDiscretization::process(const SiliconPulseDiscretization::Input
 
     // one TGraph per pulse
     // Interpolate the pulse with TGraph
+    auto& graph = Graph4Cells[cellID];
     for (unsigned int i = 0; i < pulse.getAmplitude().size(); i++) {
       auto currTime = time + i * interval;
-      Graph4Cells[cellID].SetPoint(i, currTime + m_cfg.global_offset, pulse.getAmplitude()[i]);
+      graph.SetPoint(graph.GetN(), currTime + m_cfg.global_offset, pulse.getAmplitude()[i]);
     }
   }
+
+  // sort all pulses data points to avoid TGraph::Eval giving nan due to non-monotonic data
+  for(auto& [cellID, graph] : Graph4Cells)
+	  graph.Sort();
 
   // sum all digitized pulses
   for (const auto& [cellID, graph] : Graph4Cells) {

--- a/src/detectors/BTOF/BTOF.cc
+++ b/src/detectors/BTOF/BTOF.cc
@@ -24,7 +24,7 @@
 #include "factories/digi/SiliconPulseGeneration_factory.h"
 #include "factories/digi/SiliconTrackerDigi_factory.h"
 #include "factories/tracking/TrackerHitReconstruction_factory.h"
-//#include "factories/digi/PulseCombiner_factory.h"
+#include "factories/digi/PulseCombiner_factory.h"
 #include "global/pid_lut/PIDLookup_factory.h"
 #include "services/geometry/dd4hep/DD4hep_service.h"
 
@@ -83,9 +83,16 @@ void InitPlugin(JApplication* app) {
       },
       app));
 
+  app->Add(new JOmniFactoryGeneratorT<PulseCombiner_factory>(
+      "TOFBarrelPulseCombiner", {"TOFBarrelSmoothPulses"}, {"TOFBarrelCombinedPulses"},
+      {
+          .minimum_separation = 25 * edm4eic::unit::ns,
+      },
+      app));
+
   double risetime = 0.45 * edm4eic::unit::ns;
   app->Add(new JOmniFactoryGeneratorT<SiliconPulseDiscretization_factory>(
-      "SiliconPulseDiscretization", {"TOFBarrelSmoothPulse"}, {"TOFBarrelPulse"},
+      "SiliconPulseDiscretization", {"TOFBarrelCombinedPulse"}, {"TOFBarrelPulse"},
       {
           .EICROC_period = 25 * edm4eic::unit::ns,
           .local_period  = 25 * edm4eic::unit::ns / 1024,


### PR DESCRIPTION
…scretization, and error is thrown if pulse heights are repeating at the any given time.

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [ x] Bug fix (issue #1802 )
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

Nothing.

### Does this PR change default behavior?

PulseCombiner is enabled before SiliconPulseDiscretization to prevent overlapping pulses from causing errors when the class interpolate the time bins. If there are multiple pulse heights at the same time, this class still won't work, but it will throw an error instead of keep silence. 
