### PR TITLE
fix: PFRICH -> RICHEndcapN in PhotoMultiplierHitDigi

### DIFF
--- a/src/global/digi/PhotoMultiplierHitDigi_factory.h
+++ b/src/global/digi/PhotoMultiplierHitDigi_factory.h
@@ -62,7 +62,7 @@ public:
     m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
 
     // Initialize richgeo ReadoutGeo and set random CellID visitor lambda (if a RICH)
-    if (GetPluginName() == "DRICH" || GetPluginName() == "PFRICH") {
+    if (GetPluginName() == "DRICH" || GetPluginName() == "RICHEndcapN") {
       m_RichGeoSvc().GetReadoutGeo(GetPluginName())->SetSeed(config().seed);
       m_algo->SetVisitRngCellIDs(
           [this](std::function<void(PhotoMultiplierHitDigi::CellIDType)> lambda, float p) {


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes the basename for the PFRICH hit collection in the PhotoMultiplierHitDigi to avoid an exception when trying to get the non-existent collection PFRICHHits.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: exception inside call_once in RichGeo_service::GetReadoutGeo)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.