### PR TITLE
feat: separate PhotoMultiplierHitDigi readout/detector/plugin names

### DIFF
--- a/src/algorithms/digi/PhotoMultiplierHitDigiConfig.h
+++ b/src/algorithms/digi/PhotoMultiplierHitDigiConfig.h
@@ -8,6 +8,10 @@
 namespace eicrecon {
 class PhotoMultiplierHitDigiConfig {
 public:
+  // Detector and readout identifiers
+  std::string detectorName{""};
+  std::string readoutClass{""};
+
   // random number generator seed
   /* FIXME: don't use 0 if `TRandomMixMax` is the RNG, it can get "stuck"
        * FIXME: remove this warning when this issue is resolved:

--- a/src/detectors/DRICH/DRICH.cc
+++ b/src/detectors/DRICH/DRICH.cc
@@ -47,7 +47,9 @@ void InitPlugin(JApplication* app) {
 
   // digitization
   PhotoMultiplierHitDigiConfig digi_cfg;
-  digi_cfg.seed = 5;                   // FIXME: set to 0 for a 'unique' seed, but
+  digi_cfg.detectorName = "DRICH";
+  digi_cfg.readoutClass = "DRICHHits";
+  digi_cfg.seed         = 5;           // FIXME: set to 0 for a 'unique' seed, but
                                        // that seems to delay the RNG from actually randomizing
   digi_cfg.hitTimeWindow   = 20.0;     // [ns]
   digi_cfg.timeResolution  = 1 / 16.0; // [ns]

--- a/src/detectors/PFRICH/PFRICH.cc
+++ b/src/detectors/PFRICH/PFRICH.cc
@@ -34,7 +34,9 @@ void InitPlugin(JApplication* app) {
 
   // digitization
   PhotoMultiplierHitDigiConfig digi_cfg;
-  digi_cfg.seed = 5;                   // FIXME: set to 0 for a 'unique' seed, but
+  digi_cfg.detectorName = "RICHEndcapN";
+  digi_cfg.readoutClass = "RICHEndcapNHits";
+  digi_cfg.seed         = 5;           // FIXME: set to 0 for a 'unique' seed, but
                                        // that seems to delay the RNG from actually randomizing
   digi_cfg.hitTimeWindow   = 20.0;     // [ns]
   digi_cfg.timeResolution  = 1 / 16.0; // [ns]

--- a/src/global/digi/PhotoMultiplierHitDigi_factory.h
+++ b/src/global/digi/PhotoMultiplierHitDigi_factory.h
@@ -65,14 +65,20 @@ public:
 
     // Initialize richgeo ReadoutGeo and set random CellID visitor lambda (if a RICH)
     if (GetPluginName() == "DRICH" || GetPluginName() == "PFRICH") {
-      m_RichGeoSvc().GetReadoutGeo(GetPluginName())->SetSeed(config().seed);
+      m_RichGeoSvc()
+          .GetReadoutGeo(config().detectorName, config().readoutClass)
+          ->SetSeed(config().seed);
       m_algo->SetVisitRngCellIDs(
           [this](std::function<void(PhotoMultiplierHitDigi::CellIDType)> lambda, float p) {
-            m_RichGeoSvc().GetReadoutGeo(GetPluginName())->VisitAllRngPixels(lambda, p);
+            m_RichGeoSvc()
+                .GetReadoutGeo(config().detectorName, config().readoutClass)
+                ->VisitAllRngPixels(lambda, p);
           });
       m_algo->SetPixelGapMask(
           [this](PhotoMultiplierHitDigi::CellIDType cellID, dd4hep::Position pos) {
-            return m_RichGeoSvc().GetReadoutGeo(GetPluginName())->PixelGapMask(cellID, pos);
+            return m_RichGeoSvc()
+                .GetReadoutGeo(config().detectorName, config().readoutClass)
+                ->PixelGapMask(cellID, pos);
           });
     }
 

--- a/src/global/digi/PhotoMultiplierHitDigi_factory.h
+++ b/src/global/digi/PhotoMultiplierHitDigi_factory.h
@@ -37,6 +37,8 @@ private:
   PodioOutput<edm4eic::RawTrackerHit> m_raw_hits_output{this};
   PodioOutput<edm4eic::MCRecoTrackerHitAssociation> m_raw_assocs_output{this};
 
+  ParameterRef<std::string> m_detectorName{this, "detectorName", config().detectorName, ""};
+  ParameterRef<std::string> m_readoutClass{this, "readoutClass", config().readoutClass, ""};
   ParameterRef<unsigned long> m_seed{this, "seed", config().seed, "random number generator seed"};
   ParameterRef<double> m_hitTimeWindow{this, "hitTimeWindow", config().hitTimeWindow, ""};
   ParameterRef<double> m_timeResolution{this, "timeResolution", config().timeResolution, ""};

--- a/src/services/geometry/richgeo/ActsGeo.cc
+++ b/src/services/geometry/richgeo/ActsGeo.cc
@@ -7,7 +7,6 @@
 #include <Evaluator/DD4hepUnits.h>
 #include <Math/GenVector/Cartesian3D.h>
 #include <Math/GenVector/DisplacementVector3D.h>
-#include <ctype.h>
 #include <edm4hep/Vector3f.h>
 #include <fmt/core.h>
 #include <algorithm>

--- a/src/services/geometry/richgeo/ActsGeo.cc
+++ b/src/services/geometry/richgeo/ActsGeo.cc
@@ -114,7 +114,7 @@ std::vector<eicrecon::SurfaceConfig> richgeo::ActsGeo::TrackingPlanes(int radiat
   }
 
   // pfRICH DD4hep-ACTS bindings --------------------------------------------------------------------
-  else if (m_detName == "PFRICH") {
+  else if (m_detName == "RICHEndcapN") {
     m_log->error("TODO: pfRICH DD4hep-ACTS bindings have not yet been implemented");
   }
 

--- a/src/services/geometry/richgeo/ActsGeo.cc
+++ b/src/services/geometry/richgeo/ActsGeo.cc
@@ -19,10 +19,7 @@
 // constructor
 richgeo::ActsGeo::ActsGeo(std::string detName_, gsl::not_null<const dd4hep::Detector*> det_,
                           std::shared_ptr<spdlog::logger> log_)
-    : m_detName(detName_), m_det(det_), m_log(log_) {
-  // capitalize m_detName
-  std::transform(m_detName.begin(), m_detName.end(), m_detName.begin(), ::toupper);
-}
+    : m_detName(detName_), m_det(det_), m_log(log_) {}
 
 // generate list ACTS disc surfaces, for a given radiator
 std::vector<eicrecon::SurfaceConfig> richgeo::ActsGeo::TrackingPlanes(int radiator, int numPlanes) {

--- a/src/services/geometry/richgeo/ReadoutGeo.cc
+++ b/src/services/geometry/richgeo/ReadoutGeo.cc
@@ -24,10 +24,11 @@
 #include "services/geometry/richgeo/RichGeo.h"
 
 // constructor
-richgeo::ReadoutGeo::ReadoutGeo(std::string detName_, gsl::not_null<const dd4hep::Detector*> det_,
+richgeo::ReadoutGeo::ReadoutGeo(std::string detName_, std::string readoutClass_,
+                                gsl::not_null<const dd4hep::Detector*> det_,
                                 gsl::not_null<const dd4hep::rec::CellIDPositionConverter*> conv_,
                                 std::shared_ptr<spdlog::logger> log_)
-    : m_detName(detName_), m_det(det_), m_conv(conv_), m_log(log_) {
+    : m_detName(detName_), m_readoutClass(readoutClass_), m_det(det_), m_conv(conv_), m_log(log_) {
   // capitalize m_detName
   std::transform(m_detName.begin(), m_detName.end(), m_detName.begin(), ::toupper);
 
@@ -41,7 +42,7 @@ richgeo::ReadoutGeo::ReadoutGeo(std::string detName_, gsl::not_null<const dd4hep
   m_rngCellIDs = [](std::function<void(CellIDType)> lambda, float p) { return; };
 
   // common objects
-  m_readoutCoder = m_det->readout(m_detName + "Hits").idSpec().decoder();
+  m_readoutCoder = m_det->readout(m_readoutClass).idSpec().decoder();
   m_detRich      = m_det->detector(m_detName);
   m_systemID     = m_detRich.id();
 

--- a/src/services/geometry/richgeo/ReadoutGeo.cc
+++ b/src/services/geometry/richgeo/ReadoutGeo.cc
@@ -29,9 +29,6 @@ richgeo::ReadoutGeo::ReadoutGeo(std::string detName_, std::string readoutClass_,
                                 gsl::not_null<const dd4hep::rec::CellIDPositionConverter*> conv_,
                                 std::shared_ptr<spdlog::logger> log_)
     : m_detName(detName_), m_readoutClass(readoutClass_), m_det(det_), m_conv(conv_), m_log(log_) {
-  // capitalize m_detName
-  std::transform(m_detName.begin(), m_detName.end(), m_detName.begin(), ::toupper);
-
   // random number generators
   m_random.SetSeed(1); // default seed
 

--- a/src/services/geometry/richgeo/ReadoutGeo.cc
+++ b/src/services/geometry/richgeo/ReadoutGeo.cc
@@ -15,9 +15,7 @@
 #include <Math/GenVector/Cartesian3D.h>
 #include <Math/GenVector/DisplacementVector3D.h>
 #include <TGeoMatrix.h>
-#include <ctype.h>
 #include <fmt/core.h>
-#include <algorithm>
 #include <cmath>
 #include <map>
 

--- a/src/services/geometry/richgeo/ReadoutGeo.cc
+++ b/src/services/geometry/richgeo/ReadoutGeo.cc
@@ -104,7 +104,7 @@ richgeo::ReadoutGeo::ReadoutGeo(std::string detName_, std::string readoutClass_,
   }
 
   // pfRICH readout --------------------------------------------------------------------
-  else if (m_detName == "PFRICH") {
+  else if (m_detName == "RICHEndcapN") {
     m_log->error("TODO: pfRICH readout bindings have not yet been implemented");
   }
 

--- a/src/services/geometry/richgeo/ReadoutGeo.h
+++ b/src/services/geometry/richgeo/ReadoutGeo.h
@@ -27,7 +27,8 @@ namespace richgeo {
 class ReadoutGeo {
 public:
   // constructor
-  ReadoutGeo(std::string detName_, gsl::not_null<const dd4hep::Detector*> det_,
+  ReadoutGeo(std::string detName_, std::string readoutClass_,
+             gsl::not_null<const dd4hep::Detector*> det_,
              gsl::not_null<const dd4hep::rec::CellIDPositionConverter*> conv_,
              std::shared_ptr<spdlog::logger> log_);
   ~ReadoutGeo() {}
@@ -69,6 +70,7 @@ protected:
   // common objects
   std::shared_ptr<spdlog::logger> m_log;
   std::string m_detName;
+  std::string m_readoutClass;
   gsl::not_null<const dd4hep::Detector*> m_det;
   gsl::not_null<const dd4hep::rec::CellIDPositionConverter*> m_conv;
   dd4hep::DetElement m_detRich;

--- a/src/services/geometry/richgeo/RichGeo_service.cc
+++ b/src/services/geometry/richgeo/RichGeo_service.cc
@@ -47,7 +47,8 @@ richgeo::IrtGeo* RichGeo_service::GetIrtGeo(std::string detector_name) {
       else
         throw JException(fmt::format("IrtGeo is not defined for detector '{}'", detector_name));
     };
-    std::call_once(m_init_irt, initialize);
+    std::lock_guard<std::mutex> lock(m_init_lock);
+    std::call_once(m_init_irt[detector_name], initialize);
   } catch (std::exception& ex) {
     throw JException(ex.what());
   }
@@ -65,7 +66,8 @@ richgeo::ActsGeo* RichGeo_service::GetActsGeo(std::string detector_name) {
         throw JException("RichGeo_service m_dd4hepGeo==null which should never be!");
       m_actsGeo = new richgeo::ActsGeo(detector_name, m_dd4hepGeo, m_log);
     };
-    std::call_once(m_init_acts, initialize);
+    std::lock_guard<std::mutex> lock(m_init_lock);
+    std::call_once(m_init_acts[detector_name], initialize);
   } catch (std::exception& ex) {
     throw JException(ex.what());
   }
@@ -84,7 +86,8 @@ std::shared_ptr<richgeo::ReadoutGeo> RichGeo_service::GetReadoutGeo(std::string 
       m_readoutGeo = std::make_shared<richgeo::ReadoutGeo>(detector_name, readout_class,
                                                            m_dd4hepGeo, m_converter, m_log);
     };
-    std::call_once(m_init_readout, initialize);
+    std::lock_guard<std::mutex> lock(m_init_lock);
+    std::call_once(m_init_readout[detector_name], initialize);
   } catch (std::exception& ex) {
     throw JException(ex.what());
   }

--- a/src/services/geometry/richgeo/RichGeo_service.cc
+++ b/src/services/geometry/richgeo/RichGeo_service.cc
@@ -42,7 +42,6 @@ richgeo::IrtGeo* RichGeo_service::GetIrtGeo(std::string detector_name) {
         throw JException("RichGeo_service m_dd4hepGeo==null which should never be!");
       // instantiate IrtGeo-derived object, depending on detector
       auto which_rich = detector_name;
-      std::transform(which_rich.begin(), which_rich.end(), which_rich.begin(), ::toupper);
       if (which_rich == "DRICH")
         m_irtGeo = new richgeo::IrtGeoDRICH(m_dd4hepGeo, m_converter, m_log);
       else if (which_rich == "PFRICH")

--- a/src/services/geometry/richgeo/RichGeo_service.cc
+++ b/src/services/geometry/richgeo/RichGeo_service.cc
@@ -4,9 +4,7 @@
 #include "RichGeo_service.h"
 
 #include <JANA/JException.h>
-#include <ctype.h>
 #include <fmt/core.h>
-#include <algorithm>
 #include <exception>
 #include <gsl/pointers>
 

--- a/src/services/geometry/richgeo/RichGeo_service.cc
+++ b/src/services/geometry/richgeo/RichGeo_service.cc
@@ -44,7 +44,7 @@ richgeo::IrtGeo* RichGeo_service::GetIrtGeo(std::string detector_name) {
       auto which_rich = detector_name;
       if (which_rich == "DRICH")
         m_irtGeo = new richgeo::IrtGeoDRICH(m_dd4hepGeo, m_converter, m_log);
-      else if (which_rich == "PFRICH")
+      else if (which_rich == "RICHEndcapN")
         m_irtGeo = new richgeo::IrtGeoPFRICH(m_dd4hepGeo, m_converter, m_log);
       else
         throw JException(fmt::format("IrtGeo is not defined for detector '{}'", detector_name));

--- a/src/services/geometry/richgeo/RichGeo_service.cc
+++ b/src/services/geometry/richgeo/RichGeo_service.cc
@@ -76,15 +76,16 @@ richgeo::ActsGeo* RichGeo_service::GetActsGeo(std::string detector_name) {
 }
 
 // ReadoutGeo -----------------------------------------------------------
-std::shared_ptr<richgeo::ReadoutGeo> RichGeo_service::GetReadoutGeo(std::string detector_name) {
+std::shared_ptr<richgeo::ReadoutGeo> RichGeo_service::GetReadoutGeo(std::string detector_name,
+                                                                    std::string readout_class) {
   // initialize, if not yet initialized
   try {
     m_log->debug("Call RichGeo_service::GetReadoutGeo initializer");
-    auto initialize = [this, &detector_name]() {
+    auto initialize = [this, &detector_name, &readout_class]() {
       if (!m_dd4hepGeo)
         throw JException("RichGeo_service m_dd4hepGeo==null which should never be!");
-      m_readoutGeo =
-          std::make_shared<richgeo::ReadoutGeo>(detector_name, m_dd4hepGeo, m_converter, m_log);
+      m_readoutGeo = std::make_shared<richgeo::ReadoutGeo>(detector_name, readout_class,
+                                                           m_dd4hepGeo, m_converter, m_log);
     };
     std::call_once(m_init_readout, initialize);
   } catch (std::exception& ex) {

--- a/src/services/geometry/richgeo/RichGeo_service.h
+++ b/src/services/geometry/richgeo/RichGeo_service.h
@@ -7,6 +7,7 @@
 #include <DDRec/CellIDPositionConverter.h>
 // JANA
 #include <JANA/JApplication.h>
+#include <JANA/JServiceFwd.h>
 #include <JANA/Services/JServiceLocator.h>
 #include <spdlog/logger.h>
 #include <memory>

--- a/src/services/geometry/richgeo/RichGeo_service.h
+++ b/src/services/geometry/richgeo/RichGeo_service.h
@@ -36,9 +36,11 @@ private:
   RichGeo_service() = default;
   void acquire_services(JServiceLocator*) override;
 
-  std::once_flag m_init_irt;
-  std::once_flag m_init_acts;
-  std::once_flag m_init_readout;
+  std::mutex m_init_lock;
+  std::map<std::string, std::once_flag> m_init_irt;
+  std::map<std::string, std::once_flag> m_init_acts;
+  std::map<std::string, std::once_flag> m_init_readout;
+
   JApplication* m_app                                     = nullptr;
   const dd4hep::Detector* m_dd4hepGeo                     = nullptr;
   const dd4hep::rec::CellIDPositionConverter* m_converter = nullptr;

--- a/src/services/geometry/richgeo/RichGeo_service.h
+++ b/src/services/geometry/richgeo/RichGeo_service.h
@@ -10,6 +10,7 @@
 #include <JANA/JServiceFwd.h>
 #include <JANA/Services/JServiceLocator.h>
 #include <spdlog/logger.h>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <string>

--- a/src/services/geometry/richgeo/RichGeo_service.h
+++ b/src/services/geometry/richgeo/RichGeo_service.h
@@ -28,7 +28,8 @@ public:
   // return pointers to geometry bindings; initializes the bindings upon the first time called
   virtual richgeo::IrtGeo* GetIrtGeo(std::string detector_name);
   virtual richgeo::ActsGeo* GetActsGeo(std::string detector_name);
-  virtual std::shared_ptr<richgeo::ReadoutGeo> GetReadoutGeo(std::string detector_name);
+  virtual std::shared_ptr<richgeo::ReadoutGeo> GetReadoutGeo(std::string detector_name,
+                                                             std::string readout_class);
 
 private:
   RichGeo_service() = default;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The PhotoMultiplierHitDigi factory (and algorithm, to lesser extent) assume that plugin name == detector name, and readout == plugin name + "Hits". That's not true for the PFRICH plugin, RICHEndcapN detector, RICHEndcapNHits readout. 

This PR disentangles and corrects the detector and readout passed for the PFRICH, avoiding an exception in the RichGeo service.

Note that this doesn't leave everything in a perfect state (the configuration lambdas that are being set in the factory are non-ideal), but it's the minimum amount of work to sanitize this to avoid the exception and get the PFRICH to get digitized again (at least in theory; I don't know if the PFRICH hits are actually stored).

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.