### PR TITLE
Adopt edm4eic::SimPulse in for current pulse algorithms

### DIFF
--- a/src/algorithms/digi/PulseCombiner.cc
+++ b/src/algorithms/digi/PulseCombiner.cc
@@ -73,15 +73,14 @@ void PulseCombiner::process(const PulseCombiner::Input& input,
 #if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
         // Sum the pulse array
         float integral = std::accumulate(newPulse.begin(), newPulse.end(), 0.0f);
-        sum_pulse.setIntegral(integral);  
-        sum_pulse.setPosition(edm4hep::Vector3f(cluster[0].getPosition().x,
-                                                cluster[0].getPosition().y,
-                                                cluster[0].getPosition().z));
+        sum_pulse.setIntegral(integral);
+        sum_pulse.setPosition(edm4hep::Vector3f(
+            cluster[0].getPosition().x, cluster[0].getPosition().y, cluster[0].getPosition().z));
         for (auto pulse : cluster) {
           sum_pulse.addToPulses(pulse);
           for (auto particle : pulse.getParticles()) {
             sum_pulse.addToParticles(particle);
-          }         
+          }
           // Not sure if we want/need to keep the hits themselves at this point?
           for (auto hit : pulse.getTrackerHits()) {
             sum_pulse.addToTrackerHits(hit);
@@ -91,7 +90,6 @@ void PulseCombiner::process(const PulseCombiner::Input& input,
           }
         }
 #endif
-
       }
       debug("CellID {} has {} pulses, combined into {} clusters", cellID, pulses.size(),
             clusters.size());

--- a/src/algorithms/digi/PulseCombiner.cc
+++ b/src/algorithms/digi/PulseCombiner.cc
@@ -3,12 +3,27 @@
 //
 // Combine pulses into a larger pulse if they are within a certain time of each other
 
+#include <DD4hep/Detector.h>
+#include <DD4hep/IDDescriptor.h>
+#include <DD4hep/Readout.h>
+#include <DDSegmentation/BitFieldCoder.h>
+#include <algorithms/geo.h>
+#include <edm4hep/MCParticle.h>
+#include <edm4hep/SimCalorimeterHit.h>
+#include <edm4hep/SimTrackerHit.h>
+#include <edm4hep/Vector3f.h>
+#include <fmt/core.h>
+#include <podio/RelationRange.h>
+#include <algorithm>
+#include <cmath>
+#include <gsl/pointers>
+#include <map>
 #include <numeric>
-#include <unordered_map>
+#include <stdexcept>
+#include <utility>
 #include <vector>
 
 #include "PulseCombiner.h"
-#include <algorithms/geo.h>
 
 namespace eicrecon {
 

--- a/src/algorithms/digi/PulseCombiner.cc
+++ b/src/algorithms/digi/PulseCombiner.cc
@@ -70,7 +70,7 @@ void PulseCombiner::process(const PulseCombiner::Input& input,
           sum_pulse.addToAmplitude(pulse);
         }
 
-#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+#if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
         // Sum the pulse array
         float integral = std::accumulate(newPulse.begin(), newPulse.end(), 0.0f);
         sum_pulse.setIntegral(integral);

--- a/src/algorithms/digi/PulseCombiner.cc
+++ b/src/algorithms/digi/PulseCombiner.cc
@@ -3,12 +3,13 @@
 //
 // Combine pulses into a larger pulse if they are within a certain time of each other
 
+#include <numeric>
 #include <unordered_map>
 #include <vector>
 
 #include "PulseCombiner.h"
 #include <algorithms/geo.h>
-#include <numeric>
+
 namespace eicrecon {
 
 void PulseCombiner::init() {

--- a/src/algorithms/digi/PulseCombiner.cc
+++ b/src/algorithms/digi/PulseCombiner.cc
@@ -8,7 +8,7 @@
 
 #include "PulseCombiner.h"
 #include <algorithms/geo.h>
-
+#include <numeric>
 namespace eicrecon {
 
 void PulseCombiner::init() {
@@ -74,10 +74,14 @@ void PulseCombiner::process(const PulseCombiner::Input& input,
         // Sum the pulse array
         float integral = std::accumulate(newPulse.begin(), newPulse.end(), 0.0f);
         sum_pulse.setIntegral(integral);  
-        sum_pulse.setPosition(cluster[0].getPosition());
+        sum_pulse.setPosition(edm4hep::Vector3f(cluster[0].getPosition().x,
+                                                cluster[0].getPosition().y,
+                                                cluster[0].getPosition().z));
         for (auto pulse : cluster) {
           sum_pulse.addToPulses(pulse);
-          sum_pulse.addToParticles(pulse.getParticle());          
+          for (auto particle : pulse.getParticles()) {
+            sum_pulse.addToParticles(particle);
+          }         
           // Not sure if we want/need to keep the hits themselves at this point?
           for (auto hit : pulse.getTrackerHits()) {
             sum_pulse.addToTrackerHits(hit);

--- a/src/algorithms/digi/PulseCombiner.cc
+++ b/src/algorithms/digi/PulseCombiner.cc
@@ -81,7 +81,6 @@ void PulseCombiner::process(const PulseCombiner::Input& input,
           for (auto particle : pulse.getParticles()) {
             sum_pulse.addToParticles(particle);
           }
-          // Not sure if we want/need to keep the hits themselves at this point?
           for (auto hit : pulse.getTrackerHits()) {
             sum_pulse.addToTrackerHits(hit);
           }

--- a/src/algorithms/digi/PulseCombiner.h
+++ b/src/algorithms/digi/PulseCombiner.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <algorithms/algorithm.h>
+#include <edm4eic/EDM4eicVersion.h>
 #if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
 #include <edm4eic/SimPulseCollection.h>
 #else

--- a/src/algorithms/digi/PulseCombiner.h
+++ b/src/algorithms/digi/PulseCombiner.h
@@ -24,9 +24,9 @@
 namespace eicrecon {
 
 #if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
-  using PulseType       = edm4eic::SimPulse;
+using PulseType = edm4eic::SimPulse;
 #else
-  using PulseType       = edm4hep::TimeSeries;
+using PulseType = edm4hep::TimeSeries;
 #endif
 
 using PulseCombinerAlgorithm =
@@ -42,8 +42,7 @@ public:
   void process(const Input&, const Output&) const final;
 
 private:
-  std::vector<std::vector<PulseType>>
-  clusterPulses(const std::vector<PulseType> pulses) const;
+  std::vector<std::vector<PulseType>> clusterPulses(const std::vector<PulseType> pulses) const;
   std::vector<float> sumPulses(const std::vector<PulseType> pulses) const;
   uint64_t m_detector_bitmask = 0xFFFFFFFFFFFFFFFF;
 };

--- a/src/algorithms/digi/PulseCombiner.h
+++ b/src/algorithms/digi/PulseCombiner.h
@@ -8,15 +8,15 @@
 
 #include <algorithms/algorithm.h>
 #include <edm4eic/EDM4eicVersion.h>
+#include <cstdint>
 #if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
 #include <edm4eic/SimPulseCollection.h>
 #else
 #include <edm4hep/TimeSeriesCollection.h>
 #endif
-#include <memory>
 #include <string>
 #include <string_view>
-#include <edm4eic/unit_system.h>
+#include <vector>
 
 #include "algorithms/digi/PulseCombinerConfig.h"
 #include "algorithms/interfaces/WithPodConfig.h"

--- a/src/algorithms/digi/PulseCombiner.h
+++ b/src/algorithms/digi/PulseCombiner.h
@@ -8,7 +8,7 @@
 
 #include <algorithms/algorithm.h>
 #include <edm4eic/EDM4eicVersion.h>
-#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+#if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
 #include <edm4eic/SimPulseCollection.h>
 #else
 #include <edm4hep/TimeSeriesCollection.h>
@@ -23,7 +23,7 @@
 
 namespace eicrecon {
 
-#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+#if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
 using PulseType = edm4eic::SimPulse;
 #else
 using PulseType = edm4hep::TimeSeries;

--- a/src/algorithms/digi/PulseCombiner.h
+++ b/src/algorithms/digi/PulseCombiner.h
@@ -7,7 +7,11 @@
 #pragma once
 
 #include <algorithms/algorithm.h>
+#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+#include <edm4eic/SimPulseCollection.h>
+#else
 #include <edm4hep/TimeSeriesCollection.h>
+#endif
 #include <memory>
 #include <string>
 #include <string_view>
@@ -18,9 +22,15 @@
 
 namespace eicrecon {
 
+#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+  using PulseType       = edm4eic::SimPulse;
+#else
+  using PulseType       = edm4hep::TimeSeries;
+#endif
+
 using PulseCombinerAlgorithm =
-    algorithms::Algorithm<algorithms::Input<edm4hep::TimeSeriesCollection>,
-                          algorithms::Output<edm4hep::TimeSeriesCollection>>;
+    algorithms::Algorithm<algorithms::Input<PulseType::collection_type>,
+                          algorithms::Output<PulseType::collection_type>>;
 
 class PulseCombiner : public PulseCombinerAlgorithm, public WithPodConfig<PulseCombinerConfig> {
 
@@ -31,9 +41,9 @@ public:
   void process(const Input&, const Output&) const final;
 
 private:
-  std::vector<std::vector<edm4hep::TimeSeries>>
-  clusterPulses(const std::vector<edm4hep::TimeSeries> pulses) const;
-  std::vector<float> sumPulses(const std::vector<edm4hep::TimeSeries> pulses) const;
+  std::vector<std::vector<PulseType>>
+  clusterPulses(const std::vector<PulseType> pulses) const;
+  std::vector<float> sumPulses(const std::vector<PulseType> pulses) const;
   uint64_t m_detector_bitmask = 0xFFFFFFFFFFFFFFFF;
 };
 

--- a/src/algorithms/digi/PulseNoise.cc
+++ b/src/algorithms/digi/PulseNoise.cc
@@ -30,7 +30,7 @@ void PulseNoise::process(const PulseNoise::Input& input, const PulseNoise::Outpu
     float integral = 0;
     //Add noise to the pulse
     for (int i = 0; i < pulse.getAmplitude().size(); i++) {
-      double noise = m_noise(generator) * m_cfg.scale;
+      double noise     = m_noise(generator) * m_cfg.scale;
       double amplitude = pulse.getAmplitude()[i] + noise;
       out_pulse.addToAmplitude(amplitude);
       integral += amplitude;
@@ -40,7 +40,7 @@ void PulseNoise::process(const PulseNoise::Input& input, const PulseNoise::Outpu
     out_pulse.setIntegral(integral);
     out_pulse.setPosition(pulse.getPosition());
     out_pulse.addToPulses(pulse);
-    
+
     for (auto particle : pulse.getParticles()) {
       out_pulse.addToParticles(particle);
     }

--- a/src/algorithms/digi/PulseNoise.cc
+++ b/src/algorithms/digi/PulseNoise.cc
@@ -4,8 +4,12 @@
 // Adds noise to a time series pulse
 //
 
+#include <edm4hep/MCParticle.h>
+#include <edm4hep/SimCalorimeterHit.h>
+#include <edm4hep/SimTrackerHit.h>
 #include <podio/RelationRange.h>
 #include <gsl/pointers>
+#include <vector>
 
 #include "PulseNoise.h"
 

--- a/src/algorithms/digi/PulseNoise.cc
+++ b/src/algorithms/digi/PulseNoise.cc
@@ -35,7 +35,7 @@ void PulseNoise::process(const PulseNoise::Input& input, const PulseNoise::Outpu
       integral += pulse.getAmplitude()[i] + noise;
     }
 
-#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+#if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
     out_pulse.setIntegral(integral);
     out_pulse.setPosition(pulse.getPosition());
     for (auto subpulse : pulse.getPulses()) {

--- a/src/algorithms/digi/PulseNoise.cc
+++ b/src/algorithms/digi/PulseNoise.cc
@@ -37,18 +37,21 @@ void PulseNoise::process(const PulseNoise::Input& input, const PulseNoise::Outpu
 
 #if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
     out_pulse.setIntegral(integral);  
-    out_pulse.setPosition(cluster[0].getPosition());
-    for (auto pulse : cluster) {
-      out_pulse.addToPulses(pulse);
-      out_pulse.addToParticles(pulse.getParticle());          
-      // Not sure if we want/need to keep the hits themselves at this point?
-      for (auto hit : pulse.getTrackerHits()) {
-        out_pulse.addToTrackerHits(hit);
-      }
-      for (auto hit : pulse.getCalorimeterHits()) {
-        out_pulse.addToCalorimeterHits(hit);
-      }
+    out_pulse.setPosition(pulse.getPosition());
+    for (auto subpulse : pulse.getPulses()) {
+      out_pulse.addToPulses(subpulse);
     }
+    for (auto particle : pulse.getParticles()) {
+      out_pulse.addToParticles(particle);
+    }                  
+    // Not sure if we want/need to keep the hits themselves at this point?
+    for (auto hit : pulse.getTrackerHits()) {
+      out_pulse.addToTrackerHits(hit);
+    }
+    for (auto hit : pulse.getCalorimeterHits()) {
+      out_pulse.addToCalorimeterHits(hit);
+    }
+  
 #endif
   }
 

--- a/src/algorithms/digi/PulseNoise.cc
+++ b/src/algorithms/digi/PulseNoise.cc
@@ -36,14 +36,14 @@ void PulseNoise::process(const PulseNoise::Input& input, const PulseNoise::Outpu
     }
 
 #if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
-    out_pulse.setIntegral(integral);  
+    out_pulse.setIntegral(integral);
     out_pulse.setPosition(pulse.getPosition());
     for (auto subpulse : pulse.getPulses()) {
       out_pulse.addToPulses(subpulse);
     }
     for (auto particle : pulse.getParticles()) {
       out_pulse.addToParticles(particle);
-    }                  
+    }
     // Not sure if we want/need to keep the hits themselves at this point?
     for (auto hit : pulse.getTrackerHits()) {
       out_pulse.addToTrackerHits(hit);
@@ -51,7 +51,7 @@ void PulseNoise::process(const PulseNoise::Input& input, const PulseNoise::Outpu
     for (auto hit : pulse.getCalorimeterHits()) {
       out_pulse.addToCalorimeterHits(hit);
     }
-  
+
 #endif
   }
 

--- a/src/algorithms/digi/PulseNoise.cc
+++ b/src/algorithms/digi/PulseNoise.cc
@@ -31,16 +31,16 @@ void PulseNoise::process(const PulseNoise::Input& input, const PulseNoise::Outpu
     //Add noise to the pulse
     for (int i = 0; i < pulse.getAmplitude().size(); i++) {
       double noise = m_noise(generator) * m_cfg.scale;
-      out_pulse.addToAmplitude(pulse.getAmplitude()[i] + noise);
-      integral += pulse.getAmplitude()[i] + noise;
+      double amplitude = pulse.getAmplitude()[i] + noise;
+      out_pulse.addToAmplitude(amplitude);
+      integral += amplitude;
     }
 
 #if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
     out_pulse.setIntegral(integral);
     out_pulse.setPosition(pulse.getPosition());
-    for (auto subpulse : pulse.getPulses()) {
-      out_pulse.addToPulses(subpulse);
-    }
+    out_pulse.addToPulses(pulse);
+    
     for (auto particle : pulse.getParticles()) {
       out_pulse.addToParticles(particle);
     }

--- a/src/algorithms/digi/PulseNoise.h
+++ b/src/algorithms/digi/PulseNoise.h
@@ -24,14 +24,13 @@
 namespace eicrecon {
 
 #if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
-using PulseType       = edm4eic::SimPulse;
+using PulseType = edm4eic::SimPulse;
 #else
-using PulseType       = edm4hep::TimeSeries;
+using PulseType = edm4hep::TimeSeries;
 #endif
 
-using PulseNoiseAlgorithm =
-    algorithms::Algorithm<algorithms::Input<PulseType::collection_type>,
-                          algorithms::Output<PulseType::collection_type>>;
+using PulseNoiseAlgorithm = algorithms::Algorithm<algorithms::Input<PulseType::collection_type>,
+                                                  algorithms::Output<PulseType::collection_type>>;
 
 class PulseNoise : public PulseNoiseAlgorithm, public WithPodConfig<PulseNoiseConfig> {
 

--- a/src/algorithms/digi/PulseNoise.h
+++ b/src/algorithms/digi/PulseNoise.h
@@ -8,7 +8,12 @@
 
 #include <DDDigi/noise/FalphaNoise.h>
 #include <algorithms/algorithm.h>
+#include <edm4eic/EDM4eicVersion.h>
+#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+#include <edm4eic/SimPulseCollection.h>
+#else
 #include <edm4hep/TimeSeriesCollection.h>
+#endif
 #include <random>
 #include <string>
 #include <string_view>

--- a/src/algorithms/digi/PulseNoise.h
+++ b/src/algorithms/digi/PulseNoise.h
@@ -9,7 +9,7 @@
 #include <DDDigi/noise/FalphaNoise.h>
 #include <algorithms/algorithm.h>
 #include <edm4eic/EDM4eicVersion.h>
-#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+#if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
 #include <edm4eic/SimPulseCollection.h>
 #else
 #include <edm4hep/TimeSeriesCollection.h>
@@ -23,7 +23,7 @@
 
 namespace eicrecon {
 
-#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+#if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
 using PulseType = edm4eic::SimPulse;
 #else
 using PulseType = edm4hep::TimeSeries;

--- a/src/algorithms/digi/PulseNoise.h
+++ b/src/algorithms/digi/PulseNoise.h
@@ -18,9 +18,15 @@
 
 namespace eicrecon {
 
+#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+using PulseType       = edm4eic::SimPulse;
+#else
+using PulseType       = edm4hep::TimeSeries;
+#endif
+
 using PulseNoiseAlgorithm =
-    algorithms::Algorithm<algorithms::Input<edm4hep::TimeSeriesCollection>,
-                          algorithms::Output<edm4hep::TimeSeriesCollection>>;
+    algorithms::Algorithm<algorithms::Input<PulseType::collection_type>,
+                          algorithms::Output<PulseType::collection_type>>;
 
 class PulseNoise : public PulseNoiseAlgorithm, public WithPodConfig<PulseNoiseConfig> {
 

--- a/src/algorithms/digi/SiliconPulseDiscretization.cc
+++ b/src/algorithms/digi/SiliconPulseDiscretization.cc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2025 Chun Yuen Tsang, Simon Gardner
+// Copyright (C) 2025 Chun Yuen Tsang
 //
-// Adds noise to a time series pulse
+// Creates a discrete pulse from a continuous pulse
 //
 
 #include <DDRec/CellIDPositionConverter.h>

--- a/src/algorithms/digi/SiliconPulseDiscretization.h
+++ b/src/algorithms/digi/SiliconPulseDiscretization.h
@@ -10,7 +10,7 @@
 #include <algorithms/algorithm.h>
 #include <edm4hep/RawTimeSeriesCollection.h>
 #include <edm4eic/EDM4eicVersion.h>
-#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+#if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
 #include <edm4eic/SimPulseCollection.h>
 #else
 #include <edm4hep/TimeSeriesCollection.h>
@@ -23,7 +23,7 @@
 
 namespace eicrecon {
 
-#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+#if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
 using PulseType = edm4eic::SimPulse;
 #else
 using PulseType = edm4hep::TimeSeries;

--- a/src/algorithms/digi/SiliconPulseDiscretization.h
+++ b/src/algorithms/digi/SiliconPulseDiscretization.h
@@ -22,11 +22,11 @@
 #include "algorithms/interfaces/WithPodConfig.h"
 
 namespace eicrecon {
-  
+
 #if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
-using PulseType       = edm4eic::SimPulse;
+using PulseType = edm4eic::SimPulse;
 #else
-using PulseType       = edm4hep::TimeSeries;
+using PulseType = edm4hep::TimeSeries;
 #endif
 
 using SiliconPulseDiscretizationAlgorithm =

--- a/src/algorithms/digi/SiliconPulseDiscretization.h
+++ b/src/algorithms/digi/SiliconPulseDiscretization.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2025 Simon Gardner
+// Copyright (C) 2025 Chun Yuen Tsang
 //
-// Adds noise to a time series pulse
+// Creates a discrete pulse from a continuous pulse
 //
 
 #pragma once
@@ -9,7 +9,12 @@
 #include <TGraph.h>
 #include <algorithms/algorithm.h>
 #include <edm4hep/RawTimeSeriesCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
+#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+#include <edm4eic/SimPulseCollection.h>
+#else
 #include <edm4hep/TimeSeriesCollection.h>
+#endif
 #include <string>
 #include <string_view>
 
@@ -17,9 +22,15 @@
 #include "algorithms/interfaces/WithPodConfig.h"
 
 namespace eicrecon {
+  
+#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+using PulseType       = edm4eic::SimPulse;
+#else
+using PulseType       = edm4hep::TimeSeries;
+#endif
 
 using SiliconPulseDiscretizationAlgorithm =
-    algorithms::Algorithm<algorithms::Input<edm4hep::TimeSeriesCollection>,
+    algorithms::Algorithm<algorithms::Input<PulseType::collection_type>,
                           algorithms::Output<edm4hep::RawTimeSeriesCollection>>;
 
 class SiliconPulseDiscretization : public SiliconPulseDiscretizationAlgorithm,

--- a/src/algorithms/digi/SiliconPulseGeneration.cc
+++ b/src/algorithms/digi/SiliconPulseGeneration.cc
@@ -179,14 +179,11 @@ void SiliconPulseGeneration::process(const SiliconPulseGeneration::Input& input,
 
 #if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
     time_series.setIntegral(integral);
-    time_series.setPosition(edm4hep::Vector3f(hit.getPosition().x, 
-                                              hit.getPosition().y,
-                                              hit.getPosition().z));
+    time_series.setPosition(
+        edm4hep::Vector3f(hit.getPosition().x, hit.getPosition().y, hit.getPosition().z));
     time_series.addToTrackerHits(hit);
     time_series.addToParticles(hit.getParticle());
-#endif  
-
-
+#endif
   }
 
 } // SiliconPulseGeneration:process

--- a/src/algorithms/digi/SiliconPulseGeneration.cc
+++ b/src/algorithms/digi/SiliconPulseGeneration.cc
@@ -156,6 +156,7 @@ void SiliconPulseGeneration::process(const SiliconPulseGeneration::Input& input,
 
     bool passed_threshold = false;
     int skip_bins         = 0;
+    float integral        = 0;
 
     for (int i = 0; i < m_cfg.max_time_bins; i++) {
       double t    = signal_time + i * m_cfg.timestep - time;
@@ -171,9 +172,19 @@ void SiliconPulseGeneration::process(const SiliconPulseGeneration::Input& input,
       }
       passed_threshold = true;
       time_series.addToAmplitude(signal);
+      integral += signal;
     }
 
     time_series.setTime(signal_time + skip_bins * m_cfg.timestep);
+
+#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+    time_series.setIntegral(integral);
+    time_series.setPosition(hit.getPosition());
+    time_series.addToTrackerHits(hit);
+    time_series.addToParticles(hit.getParticle());
+#endif  
+
+
   }
 
 } // SiliconPulseGeneration:process

--- a/src/algorithms/digi/SiliconPulseGeneration.cc
+++ b/src/algorithms/digi/SiliconPulseGeneration.cc
@@ -179,7 +179,9 @@ void SiliconPulseGeneration::process(const SiliconPulseGeneration::Input& input,
 
 #if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
     time_series.setIntegral(integral);
-    time_series.setPosition(hit.getPosition());
+    time_series.setPosition(edm4hep::Vector3f(hit.getPosition().x, 
+                                              hit.getPosition().y,
+                                              hit.getPosition().z));
     time_series.addToTrackerHits(hit);
     time_series.addToParticles(hit.getParticle());
 #endif  

--- a/src/algorithms/digi/SiliconPulseGeneration.cc
+++ b/src/algorithms/digi/SiliconPulseGeneration.cc
@@ -9,6 +9,8 @@
 #include <RtypesCore.h>
 #include <TMath.h>
 #include <algorithms/service.h>
+#include <edm4hep/Vector3d.h>
+#include <edm4hep/Vector3f.h>
 #include <cmath>
 #include <functional>
 #include <gsl/pointers>

--- a/src/algorithms/digi/SiliconPulseGeneration.cc
+++ b/src/algorithms/digi/SiliconPulseGeneration.cc
@@ -177,7 +177,7 @@ void SiliconPulseGeneration::process(const SiliconPulseGeneration::Input& input,
 
     time_series.setTime(signal_time + skip_bins * m_cfg.timestep);
 
-#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+#if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
     time_series.setIntegral(integral);
     time_series.setPosition(
         edm4hep::Vector3f(hit.getPosition().x, hit.getPosition().y, hit.getPosition().z));

--- a/src/algorithms/digi/SiliconPulseGeneration.h
+++ b/src/algorithms/digi/SiliconPulseGeneration.h
@@ -9,7 +9,7 @@
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/unit_system.h>
 #include <edm4hep/SimTrackerHitCollection.h>
-#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+#if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
 #include <edm4eic/SimPulseCollection.h>
 #else
 #include <edm4hep/TimeSeriesCollection.h>
@@ -23,7 +23,7 @@
 
 namespace eicrecon {
 
-#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+#if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
 using PulseType = edm4eic::SimPulse;
 #else
 using PulseType = edm4hep::TimeSeries;

--- a/src/algorithms/digi/SiliconPulseGeneration.h
+++ b/src/algorithms/digi/SiliconPulseGeneration.h
@@ -9,7 +9,7 @@
 #include <edm4eic/unit_system.h>
 #include <edm4hep/SimTrackerHitCollection.h>
 #if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
-#include <edm4eic/SimPulse.h>
+#include <edm4eic/SimPulseCollection.h>
 #else
 #include <edm4hep/TimeSeriesCollection.h>
 #endif
@@ -27,7 +27,7 @@ class SignalPulse;
 using SiliconPulseGenerationAlgorithm =
     algorithms::Algorithm<algorithms::Input<edm4hep::SimTrackerHitCollection>,
 #if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
-                          algorithms::Output<edm4eic::SimPulse>>;
+                          algorithms::Output<edm4eic::SimPulseCollection>>;
 #else
                           algorithms::Output<edm4hep::TimeSeriesCollection>>;
 #endif

--- a/src/algorithms/digi/SiliconPulseGeneration.h
+++ b/src/algorithms/digi/SiliconPulseGeneration.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <algorithms/algorithm.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/unit_system.h>
 #include <edm4hep/SimTrackerHitCollection.h>
 #if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
@@ -22,15 +23,17 @@
 
 namespace eicrecon {
 
-class SignalPulse;
+#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+  using PulseType       = edm4eic::SimPulse;
+#else
+  using PulseType       = edm4hep::TimeSeries;
+#endif
 
 using SiliconPulseGenerationAlgorithm =
     algorithms::Algorithm<algorithms::Input<edm4hep::SimTrackerHitCollection>,
-#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
-                          algorithms::Output<edm4eic::SimPulseCollection>>;
-#else
-                          algorithms::Output<edm4hep::TimeSeriesCollection>>;
-#endif
+                          algorithms::Output<PulseType::collection_type>>;
+
+class SignalPulse;
 
 class SiliconPulseGeneration : public SiliconPulseGenerationAlgorithm,
                                public WithPodConfig<SiliconPulseGenerationConfig> {

--- a/src/algorithms/digi/SiliconPulseGeneration.h
+++ b/src/algorithms/digi/SiliconPulseGeneration.h
@@ -8,7 +8,11 @@
 #include <algorithms/algorithm.h>
 #include <edm4eic/unit_system.h>
 #include <edm4hep/SimTrackerHitCollection.h>
+#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+#include <edm4eic/SimPulse.h>
+#else
 #include <edm4hep/TimeSeriesCollection.h>
+#endif
 #include <memory>
 #include <string>
 #include <string_view>
@@ -22,7 +26,11 @@ class SignalPulse;
 
 using SiliconPulseGenerationAlgorithm =
     algorithms::Algorithm<algorithms::Input<edm4hep::SimTrackerHitCollection>,
+#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+                          algorithms::Output<edm4eic::SimPulse>>;
+#else
                           algorithms::Output<edm4hep::TimeSeriesCollection>>;
+#endif
 
 class SiliconPulseGeneration : public SiliconPulseGenerationAlgorithm,
                                public WithPodConfig<SiliconPulseGenerationConfig> {

--- a/src/algorithms/digi/SiliconPulseGeneration.h
+++ b/src/algorithms/digi/SiliconPulseGeneration.h
@@ -24,9 +24,9 @@
 namespace eicrecon {
 
 #if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
-  using PulseType       = edm4eic::SimPulse;
+using PulseType = edm4eic::SimPulse;
 #else
-  using PulseType       = edm4hep::TimeSeries;
+using PulseType = edm4hep::TimeSeries;
 #endif
 
 using SiliconPulseGenerationAlgorithm =

--- a/src/factories/digi/PulseCombiner_factory.h
+++ b/src/factories/digi/PulseCombiner_factory.h
@@ -16,7 +16,7 @@ public:
 
 private:
   std::unique_ptr<AlgoT> m_algo;
-#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+#if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
   PodioInput<edm4eic::SimPulse> m_in_pulses{this};
   PodioOutput<edm4eic::SimPulse> m_out_pulses{this};
 #else

--- a/src/factories/digi/PulseCombiner_factory.h
+++ b/src/factories/digi/PulseCombiner_factory.h
@@ -16,10 +16,13 @@ public:
 
 private:
   std::unique_ptr<AlgoT> m_algo;
-
+#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+  PodioInput<edm4eic::SimPulse> m_in_pulses{this};
+  PodioOutput<edm4eic::SimPulse> m_out_pulses{this};
+#else
   PodioInput<edm4hep::TimeSeries> m_in_pulses{this};
-
   PodioOutput<edm4hep::TimeSeries> m_out_pulses{this};
+#endif
 
   ParameterRef<double> m_minimum_separation{this, "minimumSeperation", config().minimum_separation};
   ParameterRef<std::string> m_readout{this, "readout", config().readout};

--- a/src/factories/digi/PulseNoise_factory.h
+++ b/src/factories/digi/PulseNoise_factory.h
@@ -18,9 +18,13 @@ public:
 private:
   std::unique_ptr<AlgoT> m_algo;
 
+#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+  PodioInput<edm4eic::SimPulse> m_in_pulses{this};
+  PodioOutput<edm4eic::SimPulse> m_out_pulses{this};
+#else
   PodioInput<edm4hep::TimeSeries> m_in_pulses{this};
-
   PodioOutput<edm4hep::TimeSeries> m_out_pulses{this};
+#endif
 
   ParameterRef<size_t> m_poles{this, "poles", config().poles};
   ParameterRef<double> m_variance{this, "variance", config().variance};

--- a/src/factories/digi/PulseNoise_factory.h
+++ b/src/factories/digi/PulseNoise_factory.h
@@ -7,7 +7,6 @@
 
 #include "algorithms/digi/PulseNoise.h"
 #include "extensions/jana/JOmniFactory.h"
-#include "services/algorithms_init/AlgorithmsInit_service.h"
 
 namespace eicrecon {
 

--- a/src/factories/digi/PulseNoise_factory.h
+++ b/src/factories/digi/PulseNoise_factory.h
@@ -17,7 +17,7 @@ public:
 private:
   std::unique_ptr<AlgoT> m_algo;
 
-#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+#if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
   PodioInput<edm4eic::SimPulse> m_in_pulses{this};
   PodioOutput<edm4eic::SimPulse> m_out_pulses{this};
 #else

--- a/src/factories/digi/SiliconPulseDiscretization_factory.h
+++ b/src/factories/digi/SiliconPulseDiscretization_factory.h
@@ -18,7 +18,7 @@ public:
 private:
   std::unique_ptr<AlgoT> m_algo;
 
-#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+#if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
   PodioInput<edm4eic::SimPulse> m_in_pulses{this};
 #else
   PodioInput<edm4hep::TimeSeries> m_in_pulses{this};

--- a/src/factories/digi/SiliconPulseDiscretization_factory.h
+++ b/src/factories/digi/SiliconPulseDiscretization_factory.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2025 Simon Gardner
+// Copyright (C) 2025 Chun Yuen Tsang
 
 #pragma once
 
@@ -18,7 +18,11 @@ public:
 private:
   std::unique_ptr<AlgoT> m_algo;
 
+  #if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+  PodioInput<edm4eic::SimPulse> m_in_pulses{this};
+  #else
   PodioInput<edm4hep::TimeSeries> m_in_pulses{this};
+  #endif
   PodioOutput<edm4hep::RawTimeSeries> m_out_pulses{this};
 
   ParameterRef<double> m_EICROC_period{this, "EICROCPeriod", config().EICROC_period};

--- a/src/factories/digi/SiliconPulseDiscretization_factory.h
+++ b/src/factories/digi/SiliconPulseDiscretization_factory.h
@@ -18,11 +18,11 @@ public:
 private:
   std::unique_ptr<AlgoT> m_algo;
 
-  #if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
   PodioInput<edm4eic::SimPulse> m_in_pulses{this};
-  #else
+#else
   PodioInput<edm4hep::TimeSeries> m_in_pulses{this};
-  #endif
+#endif
   PodioOutput<edm4hep::RawTimeSeries> m_out_pulses{this};
 
   ParameterRef<double> m_EICROC_period{this, "EICROCPeriod", config().EICROC_period};

--- a/src/factories/digi/SiliconPulseGeneration_factory.h
+++ b/src/factories/digi/SiliconPulseGeneration_factory.h
@@ -20,7 +20,7 @@ private:
   std::unique_ptr<AlgoT> m_algo;
 
   PodioInput<edm4hep::SimTrackerHit> m_in_sim_hits{this};
-#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+#if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
   PodioOutput<edm4eic::SimPulse> m_out_pulses{this};
 #else
   PodioOutput<edm4hep::TimeSeries> m_out_pulses{this};

--- a/src/factories/digi/SiliconPulseGeneration_factory.h
+++ b/src/factories/digi/SiliconPulseGeneration_factory.h
@@ -20,8 +20,11 @@ private:
   std::unique_ptr<AlgoT> m_algo;
 
   PodioInput<edm4hep::SimTrackerHit> m_in_sim_hits{this};
-
+#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+  PodioOutput<edm4eic::SimPulse> m_out_pulses{this};
+#else
   PodioOutput<edm4hep::TimeSeries> m_out_pulses{this};
+#endif
 
   ParameterRef<std::string> m_pulse_shape_function{this, "pulseShapeFunction",
                                                    config().pulse_shape_function};

--- a/src/tests/algorithms_test/digi_SiliconPulseGeneration.cc
+++ b/src/tests/algorithms_test/digi_SiliconPulseGeneration.cc
@@ -5,7 +5,7 @@
 #include <catch2/generators/catch_generators.hpp>
 #include <edm4eic/unit_system.h>
 #include <edm4hep/SimTrackerHitCollection.h>
-#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+#if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
 #include <edm4eic/SimPulseCollection.h>
 #else
 #include <edm4hep/TimeSeriesCollection.h>
@@ -20,7 +20,7 @@
 #include "algorithms/digi/SiliconPulseGeneration.h"
 #include "algorithms/digi/SiliconPulseGenerationConfig.h"
 
-#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+#if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
 using PulseType = edm4eic::SimPulse;
 #else
 using PulseType = edm4hep::TimeSeries;

--- a/src/tests/algorithms_test/digi_SiliconPulseGeneration.cc
+++ b/src/tests/algorithms_test/digi_SiliconPulseGeneration.cc
@@ -5,7 +5,11 @@
 #include <catch2/generators/catch_generators.hpp>
 #include <edm4eic/unit_system.h>
 #include <edm4hep/SimTrackerHitCollection.h>
+#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+#include <edm4eic/SimPulseCollection.h>
+#else
 #include <edm4hep/TimeSeriesCollection.h>
+#endif
 #include <podio/RelationRange.h>
 #include <cmath>
 #include <memory>
@@ -15,6 +19,12 @@
 
 #include "algorithms/digi/SiliconPulseGeneration.h"
 #include "algorithms/digi/SiliconPulseGenerationConfig.h"
+
+#if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
+  using PulseType       = edm4eic::SimPulse;
+#else
+  using PulseType       = edm4hep::TimeSeries;
+#endif
 
 TEST_CASE("SiliconPulseGeneration generates correct number of pulses", "[SiliconPulseGeneration]") {
 
@@ -35,7 +45,7 @@ TEST_CASE("SiliconPulseGeneration generates correct number of pulses", "[Silicon
       hits_coll.create(12345 + i, 10.0, 5.0); // cellID, charge, time
     }
 
-    auto pulses = std::make_unique<edm4hep::TimeSeriesCollection>();
+    auto pulses = std::make_unique<PulseType::collection_type>();
 
     auto input  = std::make_tuple(&hits_coll);
     auto output = std::make_tuple(pulses.get());
@@ -83,7 +93,7 @@ TEST_CASE("Test the EvaluatorSvc pulse generation with a square pulse",
   edm4hep::SimTrackerHitCollection hits_coll;
   hits_coll.create(12345, charge, time); // cellID, charge, time
 
-  auto pulses = std::make_unique<edm4hep::TimeSeriesCollection>();
+  auto pulses = std::make_unique<PulseType::collection_type>();
 
   auto input  = std::make_tuple(&hits_coll);
   auto output = std::make_tuple(pulses.get());

--- a/src/tests/algorithms_test/digi_SiliconPulseGeneration.cc
+++ b/src/tests/algorithms_test/digi_SiliconPulseGeneration.cc
@@ -21,9 +21,9 @@
 #include "algorithms/digi/SiliconPulseGenerationConfig.h"
 
 #if EDM4EIC_VERSION_MAJOR >= 8 && EDM4EIC_VERSION_MINOR >= 1
-  using PulseType       = edm4eic::SimPulse;
+using PulseType = edm4eic::SimPulse;
 #else
-  using PulseType       = edm4hep::TimeSeries;
+using PulseType = edm4hep::TimeSeries;
 #endif
 
 TEST_CASE("SiliconPulseGeneration generates correct number of pulses", "[SiliconPulseGeneration]") {

--- a/src/tests/algorithms_test/digi_SiliconPulseGeneration.cc
+++ b/src/tests/algorithms_test/digi_SiliconPulseGeneration.cc
@@ -3,6 +3,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/unit_system.h>
 #include <edm4hep/SimTrackerHitCollection.h>
 #if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Allows the new SimPulse to be used by the current developing pulse algorithms

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
Outputs edm4eic::SimPulse rather than edm4hep::TimeSeries when the edm4eic version is >=8.1