### PR TITLE
fix: avoid geoManager->GetCurrentMatrix in LGADChargeSharing::_global2Local

### DIFF
--- a/src/algorithms/digi/LGADChargeSharing.cc
+++ b/src/algorithms/digi/LGADChargeSharing.cc
@@ -69,7 +69,8 @@ void LGADChargeSharing::process(const LGADChargeSharing::Input& input,
   auto [sharedHits]    = output;
 
   for (const auto& hit : *simhits) {
-    auto cellID = hit.getCellID();
+    auto cellID         = hit.getCellID();
+    const auto* context = m_converter->findContext(cellID);
 
     std::unordered_set<dd4hep::rec::CellID> dp;
     std::vector<dd4hep::rec::CellID> neighbors;
@@ -80,6 +81,7 @@ void LGADChargeSharing::process(const LGADChargeSharing::Input& input,
     auto momentum     = hit.getMomentum();
     auto truePos      = hit.getPosition();
     auto localPos_hit = this->_global2Local(
+        context,
         dd4hep::Position(truePos.x * dd4hep::mm, truePos.y * dd4hep::mm, truePos.z * dd4hep::mm));
 
     for (const auto neighbor : neighbors) {
@@ -163,17 +165,18 @@ double LGADChargeSharing::_integralGaus(double mean, double sd, double low_lim,
 }
 
 dd4hep::Position LGADChargeSharing::_cell2LocalPosition(const dd4hep::rec::CellID& cell) const {
-  auto position = m_converter->position(cell); // global position
-  return this->_global2Local(position);
+  auto context  = m_converter->findContext(cell); // volume context
+  auto position = m_converter->position(cell);    // global position
+  return this->_global2Local(context, position);
 }
 
-dd4hep::Position LGADChargeSharing::_global2Local(const dd4hep::Position& pos) const {
-  auto geoManager = m_detector->world().volume()->GetGeoManager();
-  auto currMatrix = geoManager->GetCurrentMatrix();
+dd4hep::Position LGADChargeSharing::_global2Local(const dd4hep::VolumeManagerContext* context,
+                                                  const dd4hep::Position& pos) const {
+  auto nodeMatrix = context->element.nominal().worldTransformation();
 
   double g[3], l[3];
   pos.GetCoordinates(g);
-  currMatrix->MasterToLocal(g, l);
+  nodeMatrix.MasterToLocal(g, l);
   dd4hep::Position position;
   position.SetCoordinates(l);
   return position;

--- a/src/algorithms/digi/LGADChargeSharing.cc
+++ b/src/algorithms/digi/LGADChargeSharing.cc
@@ -3,22 +3,20 @@
 //
 // Spread energy deposition from one strip to neighboring strips within sensor boundaries
 
+#include <DD4hep/Alignments.h>
 #include <DD4hep/DetElement.h>
-#include <DD4hep/Handle.h>
 #include <DD4hep/Readout.h>
 #include <DD4hep/Segmentations.h>
-#include <DD4hep/Volumes.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <Math/GenVector/Cartesian3D.h>
 #include <Math/GenVector/DisplacementVector3D.h>
-#include <TGeoManager.h>
 #include <TGeoMatrix.h>
-#include <TGeoVolume.h>
 #include <algorithms/geo.h>
 #include <algorithms/service.h>
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
 #include <fmt/core.h>
+#include <algorithm>
 #include <cmath>
 #include <gsl/pointers>
 #include <stdexcept>

--- a/src/algorithms/digi/LGADChargeSharing.h
+++ b/src/algorithms/digi/LGADChargeSharing.h
@@ -43,7 +43,8 @@ private:
                                  std::unordered_set<dd4hep::rec::CellID>& dp) const;
   double _integralGaus(double mean, double sd, double low_lim, double up_lim) const;
   dd4hep::Position _cell2LocalPosition(const dd4hep::rec::CellID& cell) const;
-  dd4hep::Position _global2Local(const dd4hep::Position& pos) const;
+  dd4hep::Position _global2Local(const dd4hep::VolumeManagerContext* context,
+                                 const dd4hep::Position& pos) const;
 
   const dd4hep::DDSegmentation::BitFieldCoder* m_decoder  = nullptr;
   const dd4hep::Detector* m_detector                      = nullptr;

--- a/src/algorithms/digi/LGADChargeSharing.h
+++ b/src/algorithms/digi/LGADChargeSharing.h
@@ -7,6 +7,7 @@
 
 #include <DD4hep/IDDescriptor.h>
 #include <DD4hep/Objects.h>
+#include <DD4hep/VolumeManager.h>
 #include <DDRec/CellIDPositionConverter.h>
 #include <DDSegmentation/BitFieldCoder.h>
 #include <algorithms/algorithm.h>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR avoids a thread-unsafe geoManager->GetCurrentMatrix() call which relies on cached state in the geoManager object.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.