### PR TITLE
fix: check scattered electron size in InclusiveKinematics*

### DIFF
--- a/src/algorithms/reco/InclusiveKinematicsDA.cc
+++ b/src/algorithms/reco/InclusiveKinematicsDA.cc
@@ -55,6 +55,10 @@ void InclusiveKinematicsDA::process(const InclusiveKinematicsDA::Input& input,
   auto boost = determine_boost(ei, pi);
 
   // Get electron angle
+  if (escat->size() == 0) {
+    debug("No scattered electron found");
+    return;
+  }
   auto kf = escat->at(0);
   PxPyPzEVector e_lab(kf.getMomentum().x, kf.getMomentum().y, kf.getMomentum().z, kf.getEnergy());
   PxPyPzEVector e_boosted = apply_boost(boost, e_lab);

--- a/src/algorithms/reco/InclusiveKinematicsESigma.cc
+++ b/src/algorithms/reco/InclusiveKinematicsESigma.cc
@@ -56,6 +56,10 @@ void InclusiveKinematicsESigma::process(const InclusiveKinematicsESigma::Input& 
 
   // Get electron variables
   auto kf = escat->at(0);
+  if (escat->size() == 0) {
+    debug("No scattered electron found");
+    return;
+  }
   PxPyPzEVector e_lab(kf.getMomentum().x, kf.getMomentum().y, kf.getMomentum().z, kf.getEnergy());
   PxPyPzEVector e_boosted = apply_boost(boost, e_lab);
   auto pt_e               = e_boosted.Pt();

--- a/src/algorithms/reco/InclusiveKinematicsJB.cc
+++ b/src/algorithms/reco/InclusiveKinematicsJB.cc
@@ -71,7 +71,11 @@ void InclusiveKinematicsJB::process(const InclusiveKinematicsJB::Input& input,
   const auto nu_jb           = Q2_jb / (2. * m_proton * x_jb);
   const auto W_jb            = sqrt(m_proton * m_proton + 2 * m_proton * nu_jb - Q2_jb);
   auto kin                   = kinematics->create(x_jb, Q2_jb, W_jb, y_jb, nu_jb);
-  kin.setScat(escat->at(0));
+  if (escat->size() == 0) {
+    debug("No scattered electron found");
+  } else {
+    kin.setScat(escat->at(0));
+  }
 
   debug("x,Q2,W,y,nu = {},{},{},{},{}", kin.getX(), kin.getQ2(), kin.getW(), kin.getY(),
         kin.getNu());

--- a/src/algorithms/reco/InclusiveKinematicsSigma.cc
+++ b/src/algorithms/reco/InclusiveKinematicsSigma.cc
@@ -54,6 +54,10 @@ void InclusiveKinematicsSigma::process(const InclusiveKinematicsSigma::Input& in
   auto boost = determine_boost(ei, pi);
 
   // Get electron variables
+  if (escat->size() == 0) {
+    debug("No scattered electron found");
+    return;
+  }
   auto kf = escat->at(0);
   PxPyPzEVector e_lab(kf.getMomentum().x, kf.getMomentum().y, kf.getMomentum().z, kf.getEnergy());
   PxPyPzEVector e_boosted = apply_boost(boost, e_lab);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR applies #1795 to the scattered electron as well. This fixes e.g. https://github.com/eic/EICrecon/actions/runs/14553024479/job/40826864227?pr=975#step:7:3282.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: more exception thrown, e.g. https://github.com/eic/EICrecon/actions/runs/14553024479/job/40826864227?pr=975#step:7:3282)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.