### PR TITLE
fix: improve const-correctness in RichGeo service

### DIFF
--- a/src/detectors/DRICH/DRICH.cc
+++ b/src/detectors/DRICH/DRICH.cc
@@ -74,10 +74,10 @@ void InitPlugin(JApplication* app) {
   TrackPropagationConfig gas_track_cfg;
 
   // get RICH geo service
-  auto richGeoSvc = app->GetService<RichGeo_service>();
-  auto dd4hepGeo  = richGeoSvc->GetDD4hepGeo();
+  auto richGeoSvc       = app->GetService<RichGeo_service>();
+  const auto* dd4hepGeo = richGeoSvc->GetDD4hepGeo();
   if (dd4hepGeo->world().children().contains("DRICH")) {
-    auto actsGeo                 = richGeoSvc->GetActsGeo("DRICH");
+    const auto* actsGeo          = richGeoSvc->GetActsGeo("DRICH");
     auto aerogel_tracking_planes = actsGeo->TrackingPlanes(richgeo::kAerogel, 5);
     auto aerogel_track_point_cut = actsGeo->TrackPointCut(richgeo::kAerogel);
     auto gas_tracking_planes     = actsGeo->TrackingPlanes(richgeo::kGas, 10);

--- a/src/services/geometry/richgeo/ActsGeo.cc
+++ b/src/services/geometry/richgeo/ActsGeo.cc
@@ -21,7 +21,8 @@ richgeo::ActsGeo::ActsGeo(std::string detName_, gsl::not_null<const dd4hep::Dete
     : m_detName(detName_), m_det(det_), m_log(log_) {}
 
 // generate list ACTS disc surfaces, for a given radiator
-std::vector<eicrecon::SurfaceConfig> richgeo::ActsGeo::TrackingPlanes(int radiator, int numPlanes) {
+std::vector<eicrecon::SurfaceConfig> richgeo::ActsGeo::TrackingPlanes(int radiator,
+                                                                      int numPlanes) const {
 
   // output list of surfaces
   std::vector<eicrecon::SurfaceConfig> discs;
@@ -124,7 +125,7 @@ std::vector<eicrecon::SurfaceConfig> richgeo::ActsGeo::TrackingPlanes(int radiat
 }
 
 // generate a cut to remove any track points that should not be used
-std::function<bool(edm4eic::TrackPoint)> richgeo::ActsGeo::TrackPointCut(int radiator) {
+std::function<bool(edm4eic::TrackPoint)> richgeo::ActsGeo::TrackPointCut(int radiator) const {
 
   // reject track points in dRICH gas that are beyond the dRICH mirrors
   // FIXME: assumes the full mirror spheres are much bigger than the dRICH

--- a/src/services/geometry/richgeo/ActsGeo.h
+++ b/src/services/geometry/richgeo/ActsGeo.h
@@ -24,10 +24,10 @@ public:
   ~ActsGeo() {}
 
   // generate list ACTS disc surfaces, for a given radiator
-  std::vector<eicrecon::SurfaceConfig> TrackingPlanes(int radiator, int numPlanes);
+  std::vector<eicrecon::SurfaceConfig> TrackingPlanes(int radiator, int numPlanes) const;
 
   // generate a cut to remove any track points that should not be used
-  std::function<bool(edm4eic::TrackPoint)> TrackPointCut(int radiator);
+  std::function<bool(edm4eic::TrackPoint)> TrackPointCut(int radiator) const;
 
 protected:
   std::string m_detName;

--- a/src/services/geometry/richgeo/IrtGeo.h
+++ b/src/services/geometry/richgeo/IrtGeo.h
@@ -32,7 +32,7 @@ public:
   virtual ~IrtGeo();
 
   // access the full IRT geometry
-  CherenkovDetectorCollection* GetIrtDetectorCollection() { return m_irtDetectorCollection; }
+  CherenkovDetectorCollection* GetIrtDetectorCollection() const { return m_irtDetectorCollection; }
 
 protected:
   // protected methods
@@ -42,7 +42,7 @@ protected:
   void SetRefractiveIndexTable(); // fill table of refractive indices
   // read `VariantParameters` for a vector
   template <class VecT>
-  VecT GetVectorFromVariantParameters(dd4hep::rec::VariantParameters* pars, std::string key) {
+  VecT GetVectorFromVariantParameters(dd4hep::rec::VariantParameters* pars, std::string key) const {
     return VecT(pars->get<double>(key + "_x"), pars->get<double>(key + "_y"),
                 pars->get<double>(key + "_z"));
   }

--- a/src/services/geometry/richgeo/ReadoutGeo.cc
+++ b/src/services/geometry/richgeo/ReadoutGeo.cc
@@ -113,7 +113,7 @@ richgeo::ReadoutGeo::ReadoutGeo(std::string detName_, std::string readoutClass_,
 
 // pixel gap mask
 // FIXME: generalize; this assumes the segmentation is `CartesianGridXY`
-bool richgeo::ReadoutGeo::PixelGapMask(CellIDType cellID, dd4hep::Position pos_hit_global) {
+bool richgeo::ReadoutGeo::PixelGapMask(CellIDType cellID, dd4hep::Position pos_hit_global) const {
   auto pos_pixel_global = m_conv->position(cellID);
   auto pos_pixel_local  = GetSensorLocalPosition(cellID, pos_pixel_global);
   auto pos_hit_local    = GetSensorLocalPosition(cellID, pos_hit_global);
@@ -126,7 +126,7 @@ bool richgeo::ReadoutGeo::PixelGapMask(CellIDType cellID, dd4hep::Position pos_h
 // transform global position `pos` to sensor `cellID` frame position
 // IMPORTANT NOTE: this has only been tested for the dRICH; if you use it, test it carefully...
 dd4hep::Position richgeo::ReadoutGeo::GetSensorLocalPosition(CellIDType cellID,
-                                                             dd4hep::Position pos) {
+                                                             dd4hep::Position pos) const {
 
   // get the VolumeManagerContext for this sensitive detector
   auto context = m_conv->findContext(cellID);

--- a/src/services/geometry/richgeo/ReadoutGeo.h
+++ b/src/services/geometry/richgeo/ReadoutGeo.h
@@ -57,11 +57,11 @@ public:
   }
 
   // pixel gap mask
-  bool PixelGapMask(CellIDType cellID, dd4hep::Position pos_hit_global);
+  bool PixelGapMask(CellIDType cellID, dd4hep::Position pos_hit_global) const;
 
   // transform global position `pos` to sensor `id` frame position
   // IMPORTANT NOTE: this has only been tested for the dRICH; if you use it, test it carefully...
-  dd4hep::Position GetSensorLocalPosition(CellIDType id, dd4hep::Position pos);
+  dd4hep::Position GetSensorLocalPosition(CellIDType id, dd4hep::Position pos) const;
 
   // set RNG seed
   void SetSeed(unsigned long seed) { m_random.SetSeed(seed); }

--- a/src/services/geometry/richgeo/RichGeo_service.cc
+++ b/src/services/geometry/richgeo/RichGeo_service.cc
@@ -57,7 +57,7 @@ richgeo::IrtGeo* RichGeo_service::GetIrtGeo(std::string detector_name) {
 }
 
 // ActsGeo -----------------------------------------------------------
-richgeo::ActsGeo* RichGeo_service::GetActsGeo(std::string detector_name) {
+const richgeo::ActsGeo* RichGeo_service::GetActsGeo(std::string detector_name) {
   // initialize, if not yet initialized
   try {
     m_log->debug("Call RichGeo_service::GetActsGeo initializer");

--- a/src/services/geometry/richgeo/RichGeo_service.h
+++ b/src/services/geometry/richgeo/RichGeo_service.h
@@ -29,7 +29,7 @@ public:
 
   // return pointers to geometry bindings; initializes the bindings upon the first time called
   virtual richgeo::IrtGeo* GetIrtGeo(std::string detector_name);
-  virtual richgeo::ActsGeo* GetActsGeo(std::string detector_name);
+  virtual const richgeo::ActsGeo* GetActsGeo(std::string detector_name);
   virtual std::shared_ptr<richgeo::ReadoutGeo> GetReadoutGeo(std::string detector_name,
                                                              std::string readout_class);
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR improves const-correctness in the RichGeo service classes. This should make it easier to maintain thread-safety by avoiding the use of services (shared resource) as a way to store state information.

Note: This is the low-hanging fruit only.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: services are supposed to be used with const accessors only since multiple threads use them at the same time)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.