### PR TITLE
fix(ci): list more open PRs in GitHub API call

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -1035,7 +1035,7 @@ jobs:
       - uses: octokit/request-action@v2.x
         id: query
         with:
-          route: GET /repos/${{ github.repository }}/pulls?state=open
+          route: GET /repos/${{ github.repository }}/pulls?state=open&per_page=100
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Remap open PRs


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR ensures that older PRs are also included in the list of open PRs, and therefore included in the capybara checks. by default only 30 open PRs are returned. This increases it to 100.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: no links in https://github.com/eic/EICrecon/pull/975#issuecomment-1826417435)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.