### PR TITLE
[Backport v1.24] Use pixel-style MPDG readout for tracking until efficiency issues are resolved

### DIFF
--- a/src/detectors/MPGD/MPGD.cc
+++ b/src/detectors/MPGD/MPGD.cc
@@ -29,7 +29,8 @@ void InitPlugin(JApplication *app) {
 
     // PIXEL DIGITIZATION?
     // It's encoded in bit pattern "SiFactoryPattern": 0x1=CyMBaL, 0x2=OuterBarrel, ...
-    unsigned int SiFactoryPattern = 0x0; // Default = no SiliconTrackerDigi
+    // unsigned int SiFactoryPattern = 0x0; // no SiliconTrackerDigi
+    unsigned int SiFactoryPattern = 0x3; // using SiliconTrackerDigi
     std::string SiFactoryPattern_str;
     app->SetDefaultParameter("MPGD:SiFactoryPattern",SiFactoryPattern_str,
                              "Hexadecimal Pattern of MPGDs digitized via \"SiliconTrackerDigi\"");


### PR DESCRIPTION
As presented in the tracking WG meeting
([https://indico.bnl.gov/event/27589/contributions/105659/attachments/60986/104773/tracking1_040325.pdf](https://indico.bnl.gov/event/27589/contributions/105659/attachments/60986/104773/tracking1_040325.pdf)), the updated 2D MPGD digitization leads to inefficiencies for the Barrel MPGD.

This PR restores the previous digitization scheme as the default, where the hits are used in the track reconstruction with high efficiency. Once the 2D readout can demonstrate comparable results, we will switch over.

Results with 2D digitization:

<img width="647" alt="image1"
src="https://github.com/user-attachments/assets/5785ed7a-faa3-44d7-a8ba-b566edde82b8" />

Results with pixel-style (SVT-like) digitization:

<img width="653" alt="image2"
src="https://github.com/user-attachments/assets/217d8ae4-7d7f-4a65-9b49-ce1b6a5bc4a7" />

- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

- [x] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @ShujieL @ybedfer

need to make to their code?
No

Yes, it restores previous barrel MPGD digitization scheme as default.

cc #1819 

(cherry picked from commit b2d08908cecb1fb812afc1f240cb1289620f83a6)