### PR TITLE
fix: clang-format with AlignTrailingComments: Kind: Leave

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -14,4 +14,7 @@ NamespaceIndentation: Inner
 AlignConsecutiveAssignments: true
 SortIncludes: Never
 ReflowComments: false
+AlignTrailingComments:
+  Kind:            Leave
+  OverEmptyLines:  0
 ...

--- a/src/algorithms/calorimetry/CalorimeterClusterShape.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterShape.cc
@@ -214,7 +214,7 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
         out_assoc.setWeight(in_assoc.getWeight());
       }
     } // end input association loop
-  }   // end input cluster loop
+  } // end input cluster loop
   debug("Completed processing input clusters");
 
 } // end 'process(Input&, Output&)'

--- a/src/algorithms/calorimetry/HEXPLIT.h
+++ b/src/algorithms/calorimetry/HEXPLIT.h
@@ -14,7 +14,7 @@
 #include <algorithms/geo.h>
 #include <edm4eic/CalorimeterHitCollection.h>
 #include <gsl/pointers>
-#include <string>      // for basic_string
+#include <string> // for basic_string
 #include <string_view> // for string_view
 #include <vector>
 

--- a/src/algorithms/calorimetry/TrackClusterMergeSplitter.cc
+++ b/src/algorithms/calorimetry/TrackClusterMergeSplitter.cc
@@ -351,7 +351,7 @@ void TrackClusterMergeSplitter::merge_and_split_clusters(
       }
 
     } // end hits to merge loop
-  }   // end clusters to merge loop
+  } // end clusters to merge loop
 
 } // end 'merge_and_split_clusters(VecClust&, VecProj&, edm4eic::MutableCluster&)'
 

--- a/src/algorithms/digi/SiliconPulseGenerationConfig.h
+++ b/src/algorithms/digi/SiliconPulseGenerationConfig.h
@@ -10,10 +10,10 @@ namespace eicrecon {
 struct SiliconPulseGenerationConfig {
   // Parameters of Silicon signal generation
   std::string pulse_shape_function       = "LandauPulse"; // Pulse shape function
-  std::vector<double> pulse_shape_params = {1.0, 0.1};    // Parameters of the pulse shape function
+  std::vector<double> pulse_shape_params = {1.0, 0.1}; // Parameters of the pulse shape function
   double ignore_thres                    = 10; // When EDep drops below this value pulse stops
   double timestep          = 0.2 * edm4eic::unit::ns; // Minimum digitization time step
-  double min_sampling_time = 0 * edm4eic::unit::ns;   // Minimum sampling time
+  double min_sampling_time = 0 * edm4eic::unit::ns; // Minimum sampling time
   uint32_t max_time_bins   = 10000;
 };
 

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -172,12 +172,12 @@ void FarDetectorLinearTracking::checkHitCombination(
   int32_t type{0};                                          // Type of track
   edm4hep::Vector3f position(outPos.x, outPos.y, outPos.z); // Position of the trajectory point [mm]
   edm4hep::Vector3f momentum(outVec.x, outVec.y, outVec.z); // 3-momentum at the point [GeV]
-  edm4eic::Cov6f positionMomentumCovariance;                // Error on the position
-  float time{0};                                            // Time at this point [ns]
-  float timeError{0};                                       // Error on the time at this point
-  float charge{-1};                                         // Charge of the particle
-  int32_t ndf{static_cast<int32_t>(m_cfg.n_layer) - 1};     // Number of degrees of freedom
-  int32_t pdg{11};                                          // PDG code of the particle
+  edm4eic::Cov6f positionMomentumCovariance; // Error on the position
+  float time{0}; // Time at this point [ns]
+  float timeError{0}; // Error on the time at this point
+  float charge{-1}; // Charge of the particle
+  int32_t ndf{static_cast<int32_t>(m_cfg.n_layer) - 1}; // Number of degrees of freedom
+  int32_t pdg{11}; // PDG code of the particle
 
   // Create the track
   auto track = (*outputTracks)

--- a/src/algorithms/fardetectors/FarDetectorMLReconstruction.cc
+++ b/src/algorithms/fardetectors/FarDetectorMLReconstruction.cc
@@ -108,7 +108,7 @@ void FarDetectorMLReconstruction::process(const FarDetectorMLReconstruction::Inp
     // TODO: Add time and momentum errors
     // Plane Point
     edm4hep::Vector2f loc(0, 0); // Vertex estimate
-    uint64_t surface = 0;        //Not used in this context
+    uint64_t surface = 0; //Not used in this context
     float theta      = edm4eic::anglePolar(momentum);
     float phi        = edm4eic::angleAzimuthal(momentum);
     float qOverP     = charge / edm4eic::magnitude(momentum);

--- a/src/algorithms/pid/MergeParticleID.cc
+++ b/src/algorithms/pid/MergeParticleID.cc
@@ -138,9 +138,9 @@ void MergeParticleID::process(const MergeParticleID::Input& input,
       trace(Tools::HypothesisTableHead(6));
 
       // merge scalar members
-      out_npe += in_pid.getNpe();                                           // sum
+      out_npe += in_pid.getNpe(); // sum
       out_refractiveIndex += in_pid.getNpe() * in_pid.getRefractiveIndex(); // NPE-weighted average
-      out_photonEnergy += in_pid.getNpe() * in_pid.getPhotonEnergy();       // NPE-weighted average
+      out_photonEnergy += in_pid.getNpe() * in_pid.getPhotonEnergy(); // NPE-weighted average
 
       // merge photon Cherenkov angles
       for (auto in_photon_vec : in_pid.getThetaPhiPhotons()) {

--- a/src/algorithms/pid_lut/PIDLookup.cc
+++ b/src/algorithms/pid_lut/PIDLookup.cc
@@ -91,25 +91,25 @@ void PIDLookup::process(const Input& input, const Output& output) const {
       recopart.addToParticleIDs(
           partids_out->create(m_cfg.system,                            // std::int32_t type
                               std::copysign(11, -charge),              // std::int32_t PDG
-                              0,                                       // std::int32_t algorithmType
+                              0, // std::int32_t algorithmType
                               static_cast<float>(entry->prob_electron) // float likelihood
                               ));
       recopart.addToParticleIDs(
-          partids_out->create(m_cfg.system,                        // std::int32_t type
-                              std::copysign(211, charge),          // std::int32_t PDG
-                              0,                                   // std::int32_t algorithmType
+          partids_out->create(m_cfg.system, // std::int32_t type
+                              std::copysign(211, charge), // std::int32_t PDG
+                              0, // std::int32_t algorithmType
                               static_cast<float>(entry->prob_pion) // float likelihood
                               ));
       recopart.addToParticleIDs(
-          partids_out->create(m_cfg.system,                        // std::int32_t type
-                              std::copysign(321, charge),          // std::int32_t PDG
-                              0,                                   // std::int32_t algorithmType
+          partids_out->create(m_cfg.system, // std::int32_t type
+                              std::copysign(321, charge), // std::int32_t PDG
+                              0, // std::int32_t algorithmType
                               static_cast<float>(entry->prob_kaon) // float likelihood
                               ));
       recopart.addToParticleIDs(
-          partids_out->create(m_cfg.system,                          // std::int32_t type
-                              std::copysign(2212, charge),           // std::int32_t PDG
-                              0,                                     // std::int32_t algorithmType
+          partids_out->create(m_cfg.system, // std::int32_t type
+                              std::copysign(2212, charge), // std::int32_t PDG
+                              0, // std::int32_t algorithmType
                               static_cast<float>(entry->prob_proton) // float likelihood
                               ));
 

--- a/src/algorithms/reco/JetReconstructionConfig.h
+++ b/src/algorithms/reco/JetReconstructionConfig.h
@@ -12,16 +12,16 @@ struct JetReconstructionConfig {
 
   float rJet                 = 1.0;                // jet resolution  parameter
   float pJet                 = -1.0;               // exponent for generalized kt algorithms
-  double minCstPt            = 0.2 * dd4hep::GeV;  // minimum pT of objects fed to cluster sequence
+  double minCstPt            = 0.2 * dd4hep::GeV; // minimum pT of objects fed to cluster sequence
   double maxCstPt            = 100. * dd4hep::GeV; // maximum pT of objects fed to clsuter sequence
-  double minJetPt            = 1.0 * dd4hep::GeV;  // minimum jet pT
-  double ghostMaxRap         = 3.5;                // maximum rapidity of ghosts
-  double ghostArea           = 0.01;               // area per ghost
+  double minJetPt            = 1.0 * dd4hep::GeV; // minimum jet pT
+  double ghostMaxRap         = 3.5; // maximum rapidity of ghosts
+  double ghostArea           = 0.01; // area per ghost
   int numGhostRepeat         = 1; // number of times a ghost is reused per grid site
   std::string jetAlgo        = "antikt_algorithm"; // jet finding algorithm
-  std::string recombScheme   = "E_scheme";         // particle recombination scheme
-  std::string areaType       = "active_area";      // type of area calculated
-  std::string jetContribAlgo = "Centauro";         // contributed algorithm name
+  std::string recombScheme   = "E_scheme"; // particle recombination scheme
+  std::string areaType       = "active_area"; // type of area calculated
+  std::string jetContribAlgo = "Centauro"; // contributed algorithm name
 };
 
 } // namespace eicrecon

--- a/src/algorithms/tracking/ActsToTracks.cc
+++ b/src/algorithms/tracking/ActsToTracks.cc
@@ -136,8 +136,8 @@ void ActsToTracks::process(const Input& input, const Output& output) const {
       track.setCharge( // Particle charge
           std::copysign(1., parameter[Acts::eBoundQOverP]));
       track.setChi2(trajectoryState.chi2Sum); // Total chi2
-      track.setNdf(trajectoryState.NDF);      // Number of degrees of freedom
-      track.setPdg(                           // PDG particle ID hypothesis
+      track.setNdf(trajectoryState.NDF); // Number of degrees of freedom
+      track.setPdg( // PDG particle ID hypothesis
           boundParam.particleHypothesis().absolutePdg());
       track.setTrajectory(trajectory); // Trajectory of this track
 

--- a/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
+++ b/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
@@ -27,20 +27,20 @@ struct OrthogonalTrackSeedingConfig {
   float deltaRMaxBottomSP =
       200. * Acts::UnitConstants::mm; // Max distance in r between middle and bottom SP in one seed
   float collisionRegionMin = -250 * Acts::UnitConstants::mm; // Min z for primary vertex
-  float collisionRegionMax = 250 * Acts::UnitConstants::mm;  // Max z for primary vertex
+  float collisionRegionMax = 250 * Acts::UnitConstants::mm; // Max z for primary vertex
 
   unsigned int maxSeedsPerSpM = 0; // max number of seeds a single middle sp can belong to - 1
   float cotThetaMax =
       1.0 / tan(2. * atan(exp(-4.0))); // Cotangent of max theta angle (based on eta)
 
-  float sigmaScattering  = 5;   // How many standard devs of scattering angles to consider
+  float sigmaScattering  = 5; // How many standard devs of scattering angles to consider
   float radLengthPerSeed = 0.1; // Average radiation lengths of material on the length of a seed
   float minPt            = (100. * Acts::UnitConstants::MeV) /
                 cotThetaMax; // MeV (in Acts units of GeV) - minimum transverse momentum
   float bFieldInZ =
       1.7 * Acts::UnitConstants::T; // T (in Acts units of GeV/[e*mm]) - Magnetic field strength
-  float beamPosX  = 0;              // x offset for beam position
-  float beamPosY  = 0;              // y offset for beam position
+  float beamPosX  = 0; // x offset for beam position
+  float beamPosY  = 0; // y offset for beam position
   float impactMax = 3. * Acts::UnitConstants::mm; // Maximum transverse PCA allowed
   float rMinMiddle =
       20. * Acts::UnitConstants::mm; // Middle spacepoint must fall between these two radii
@@ -89,12 +89,12 @@ struct OrthogonalTrackSeedingConfig {
 
   //////////////////////////////////////
   ///Seed Covariance Error Matrix
-  float locaError   = 1.5 * Acts::UnitConstants::mm;    //Error on Loc a
-  float locbError   = 1.5 * Acts::UnitConstants::mm;    //Error on Loc b
-  float phiError    = 0.02 * Acts::UnitConstants::rad;  //Error on phi
+  float locaError   = 1.5 * Acts::UnitConstants::mm; //Error on Loc a
+  float locbError   = 1.5 * Acts::UnitConstants::mm; //Error on Loc b
+  float phiError    = 0.02 * Acts::UnitConstants::rad; //Error on phi
   float thetaError  = 0.002 * Acts::UnitConstants::rad; //Error on theta
   float qOverPError = 0.025 / Acts::UnitConstants::GeV; //Error on q over p
-  float timeError   = 0.1 * Acts::UnitConstants::mm;    //Error on time
+  float timeError   = 0.1 * Acts::UnitConstants::mm; //Error on time
   // Note: Acts native time units are mm: https://acts.readthedocs.io/en/latest/core/definitions/units.html
 };
 } // namespace eicrecon

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -262,17 +262,17 @@ eicrecon::TrackSeeding::makeTrackParams(SeedContainer& seeds) {
     trackparam.setType(-1); // type --> seed(-1)
     trackparam.setLoc({static_cast<float>(localpos(0)),
                        static_cast<float>(localpos(1))}); // 2d location on surface
-    trackparam.setPhi(static_cast<float>(phi));           // phi [rad]
-    trackparam.setTheta(theta);                           //theta [rad]
-    trackparam.setQOverP(qOverP);                         // Q/p [e/GeV]
-    trackparam.setTime(10);                               // time in ns
+    trackparam.setPhi(static_cast<float>(phi)); // phi [rad]
+    trackparam.setTheta(theta); //theta [rad]
+    trackparam.setQOverP(qOverP); // Q/p [e/GeV]
+    trackparam.setTime(10); // time in ns
     edm4eic::Cov6f cov;
-    cov(0, 0) = m_cfg.locaError / Acts::UnitConstants::mm;    // loc0
-    cov(1, 1) = m_cfg.locbError / Acts::UnitConstants::mm;    // loc1
-    cov(2, 2) = m_cfg.phiError / Acts::UnitConstants::rad;    // phi
-    cov(3, 3) = m_cfg.thetaError / Acts::UnitConstants::rad;  // theta
+    cov(0, 0) = m_cfg.locaError / Acts::UnitConstants::mm; // loc0
+    cov(1, 1) = m_cfg.locbError / Acts::UnitConstants::mm; // loc1
+    cov(2, 2) = m_cfg.phiError / Acts::UnitConstants::rad; // phi
+    cov(3, 3) = m_cfg.thetaError / Acts::UnitConstants::rad; // theta
     cov(4, 4) = m_cfg.qOverPError * Acts::UnitConstants::GeV; // qOverP
-    cov(5, 5) = m_cfg.timeError / Acts::UnitConstants::ns;    // time
+    cov(5, 5) = m_cfg.timeError / Acts::UnitConstants::ns; // time
     trackparam.setCovariance(cov);
   }
 
@@ -428,15 +428,15 @@ eicrecon::TrackSeeding::lineFit(std::vector<std::pair<float, float>>& positions)
   double ysum  = 0;
   double xysum = 0;
   for (const auto& [r, z] : positions) {
-    xsum  = xsum + r;               //calculate sigma(xi)
-    ysum  = ysum + z;               //calculate sigma(yi)
+    xsum  = xsum + r; //calculate sigma(xi)
+    ysum  = ysum + z; //calculate sigma(yi)
     x2sum = x2sum + std::pow(r, 2); //calculate sigma(x^2i)
-    xysum = xysum + r * z;          //calculate sigma(xi*yi)
+    xysum = xysum + r * z; //calculate sigma(xi*yi)
   }
 
   const auto npts          = positions.size();
   const double denominator = (x2sum * npts - std::pow(xsum, 2));
-  const float a            = (xysum * npts - xsum * ysum) / denominator;  //calculate slope
+  const float a            = (xysum * npts - xsum * ysum) / denominator; //calculate slope
   const float b            = (x2sum * ysum - xsum * xysum) / denominator; //calculate intercept
   return std::make_tuple(a, b);
 }

--- a/src/algorithms/tracking/TrackerHitReconstruction.cc
+++ b/src/algorithms/tracking/TrackerHitReconstruction.cc
@@ -80,9 +80,9 @@ TrackerHitReconstruction::process(const edm4eic::RawTrackerHitCollection& raw_hi
                                             get_variance(dim[1] / mm), // variance (see note above)
                                             std::size(dim) > 2 ? get_variance(dim[2] / mm) : 0.},
                          static_cast<float>((double)(raw_hit.getTimeStamp()) / 1000.0), // ns
-                         m_cfg.timeResolution,                                          // in ns
+                         m_cfg.timeResolution, // in ns
                          static_cast<float>(raw_hit.getCharge() / 1.0e6), // Collected energy (GeV)
-                         0.0F);                                           // Error on the energy
+                         0.0F); // Error on the energy
 #if EDM4EIC_VERSION_MAJOR >= 7
     rec_hit.setRawHit(raw_hit);
 #endif

--- a/src/algorithms/tracking/TrackerMeasurementFromHits.cc
+++ b/src/algorithms/tracking/TrackerMeasurementFromHits.cc
@@ -134,11 +134,11 @@ TrackerMeasurementFromHits::produce(const edm4eic::TrackerHitCollection& trk_hit
     meas2D.setSurface(surface->geometryId().value()); // Surface for bound coordinates (geometryID)
     meas2D.setLoc(
         {static_cast<float>(pos[0]), static_cast<float>(pos[1])}); // 2D location on surface
-    meas2D.setTime(hit.getTime());                                 // Measurement time
+    meas2D.setTime(hit.getTime()); // Measurement time
     // fixme: no off-diagonal terms. cov(0,1) = cov(1,0)??
     meas2D.setCovariance({cov(0, 0), cov(1, 1), hit.getTimeError() * hit.getTimeError(),
                           cov(0, 1)}); // Covariance on location and time
-    meas2D.addToWeights(1.0);          // Weight for each of the hits, mirrors hits array
+    meas2D.addToWeights(1.0); // Weight for each of the hits, mirrors hits array
     meas2D.addToHits(hit);
   }
 

--- a/src/benchmarks/reconstruction/lfhcal_studies/clusterizer_MA.h
+++ b/src/benchmarks/reconstruction/lfhcal_studies/clusterizer_MA.h
@@ -74,9 +74,9 @@ bool acompareCl(clustersStrct lhs, clustersStrct rhs) { return lhs.cluster_E > r
 //**************************************************************************************************************//
 //**************************************************************************************************************//
 clustersStrct findMACluster(
-    float seed,                                    // minimum seed energy
-    float /* agg */,                               // minimum aggregation energy
-    std::vector<towersStrct>& input_towers_temp,   // temporary full tower array
+    float seed, // minimum seed energy
+    float /* agg */, // minimum aggregation energy
+    std::vector<towersStrct>& input_towers_temp, // temporary full tower array
     std::vector<towersStrct>& cluster_towers_temp, // towers associated to cluster
     //                               std::vector<int> clslabels_temp              // MC labels in cluster
     float aggMargin = 1.0 // aggregation margin

--- a/src/detectors/B0ECAL/B0ECAL.cc
+++ b/src/detectors/B0ECAL/B0ECAL.cc
@@ -97,7 +97,7 @@ void InitPlugin(JApplication* app) {
             "B0ECalHits"
       }, // edm4hep::SimCalorimeterHitCollection
 #endif
-      {"B0ECalClustersWithoutShapes",             // edm4eic::Cluster
+      {"B0ECalClustersWithoutShapes", // edm4eic::Cluster
        "B0ECalClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 3.6, .enableEtaBounds = false},
       app));
@@ -118,7 +118,7 @@ void InitPlugin(JApplication* app) {
             "B0ECalHits"
       }, // edm4hep::SimCalorimeterHitCollection
 #endif
-      {"B0ECalTruthClustersWithoutShapes",             // edm4eic::Cluster
+      {"B0ECalTruthClustersWithoutShapes", // edm4eic::Cluster
        "B0ECalTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 6.2, .enableEtaBounds = false},
       app));

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -112,7 +112,7 @@ void InitPlugin(JApplication* app) {
             "EcalBarrelScFiHits"
       }, // edm4hep::SimCalorimeterHitCollection
 #endif
-      {"EcalBarrelScFiClustersWithoutShapes",             // edm4eic::Cluster
+      {"EcalBarrelScFiClustersWithoutShapes", // edm4eic::Cluster
        "EcalBarrelScFiClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 6.2, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -161,7 +161,7 @@ void InitPlugin(JApplication* app) {
           .pedSigmaADC     = EcalBarrelImaging_pedSigmaADC, // not needed; use only thresholdValue
           .resolutionTDC   = EcalBarrelImaging_resolutionTDC,
           .thresholdFactor = 0.0, // use only thresholdValue
-          .thresholdValue  = 41,  // 8192 ADC counts/3 MeV * 0.015 MeV (desired threshold) = 41
+          .thresholdValue  = 41, // 8192 ADC counts/3 MeV * 0.015 MeV (desired threshold) = 41
           .sampFrac        = "0.00429453",
           .readout         = "EcalBarrelImagingHits",
           .layerField      = "layer",
@@ -174,7 +174,7 @@ void InitPlugin(JApplication* app) {
       {"EcalBarrelImagingProtoClusters"},
       {
           .neighbourLayersRange = 2, //  # id diff for adjacent layer
-          .localDistXY          = {2.0 * dd4hep::mm, 2 * dd4hep::mm},     //  # same layer
+          .localDistXY          = {2.0 * dd4hep::mm, 2 * dd4hep::mm}, //  # same layer
           .layerDistEtaPhi      = {10 * dd4hep::mrad, 10 * dd4hep::mrad}, //  # adjacent layer
           .sectorDist           = 3.0 * dd4hep::cm,
           .minClusterHitEdep    = 0,

--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -77,8 +77,8 @@ void InitPlugin(JApplication* app) {
           .pedMeanADC      = HcalBarrel_pedMeanADC,
           .pedSigmaADC     = HcalBarrel_pedSigmaADC, // not used; relying on energy cut
           .resolutionTDC   = HcalBarrel_resolutionTDC,
-          .thresholdFactor = 0.0,     // not used; relying on flat ADC cut
-          .thresholdValue  = 33,      // pedSigmaADC + thresholdValue = half-MIP (333 ADC)
+          .thresholdFactor = 0.0, // not used; relying on flat ADC cut
+          .thresholdValue  = 33, // pedSigmaADC + thresholdValue = half-MIP (333 ADC)
           .sampFrac        = "0.033", // average, from sPHENIX simulations
           .readout         = "HcalBarrelHits",
           .layerField      = "",
@@ -135,7 +135,7 @@ void InitPlugin(JApplication* app) {
             "HcalBarrelHits"
       }, // edm4hep::SimCalorimeterHitCollection
 #endif
-      {"HcalBarrelClustersWithoutShapes",             // edm4eic::Cluster
+      {"HcalBarrelClustersWithoutShapes", // edm4eic::Cluster
        "HcalBarrelClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 6.2, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -158,7 +158,7 @@ void InitPlugin(JApplication* app) {
             "HcalBarrelHits"
       }, // edm4hep::SimCalorimeterHitCollection
 #endif
-      {"HcalBarrelTruthClustersWithoutShapes",             // edm4eic::Cluster
+      {"HcalBarrelTruthClustersWithoutShapes", // edm4eic::Cluster
        "HcalBarrelTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 6.2, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -195,7 +195,7 @@ void InitPlugin(JApplication* app) {
             "HcalBarrelHits"
       }, // edm4hep::SimCalorimeterHitCollection
 #endif
-      {"HcalBarrelSplitMergeClustersWithoutShapes",             // edm4eic::Cluster
+      {"HcalBarrelSplitMergeClustersWithoutShapes", // edm4eic::Cluster
        "HcalBarrelSplitMergeClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 6.2, .enableEtaBounds = false},
       app // TODO: Remove me once fixed

--- a/src/detectors/DIRC/DIRC.cc
+++ b/src/detectors/DIRC/DIRC.cc
@@ -30,8 +30,8 @@ void InitPlugin(JApplication* app) {
   // digitization
   PhotoMultiplierHitDigiConfig digi_cfg;
   digi_cfg.seed = 5;                   // FIXME: set to 0 for a 'unique' seed, but
-                                       // that seems to delay the RNG from actually randomizing
-  digi_cfg.hitTimeWindow   = 20.0;     // [ns]
+      // that seems to delay the RNG from actually randomizing
+  digi_cfg.hitTimeWindow   = 20.0; // [ns]
   digi_cfg.timeResolution  = 1 / 16.0; // [ns]
   digi_cfg.speMean         = 80.0;
   digi_cfg.speError        = 16.0;

--- a/src/detectors/DRICH/DRICH.cc
+++ b/src/detectors/DRICH/DRICH.cc
@@ -50,8 +50,8 @@ void InitPlugin(JApplication* app) {
   digi_cfg.detectorName = "DRICH";
   digi_cfg.readoutClass = "DRICHHits";
   digi_cfg.seed         = 5;           // FIXME: set to 0 for a 'unique' seed, but
-                                       // that seems to delay the RNG from actually randomizing
-  digi_cfg.hitTimeWindow   = 20.0;     // [ns]
+      // that seems to delay the RNG from actually randomizing
+  digi_cfg.hitTimeWindow   = 20.0; // [ns]
   digi_cfg.timeResolution  = 1 / 16.0; // [ns]
   digi_cfg.speMean         = 80.0;
   digi_cfg.speError        = 16.0;
@@ -60,7 +60,7 @@ void InitPlugin(JApplication* app) {
   digi_cfg.enablePixelGaps = true;
   digi_cfg.safetyFactor    = 0.7;
   digi_cfg.enableNoise     = false;
-  digi_cfg.noiseRate       = 20000;             // [Hz]
+  digi_cfg.noiseRate       = 20000; // [Hz]
   digi_cfg.noiseTimeWindow = 20.0 * dd4hep::ns; // [ns]
   digi_cfg.quantumEfficiency.clear();
   digi_cfg.quantumEfficiency = {// wavelength units are [nm]

--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -115,7 +115,7 @@ void InitPlugin(JApplication* app) {
             "EcalEndcapNHits"
       }, // edm4hep::SimCalorimeterHitCollection
 #endif
-      {"EcalEndcapNTruthClustersWithoutShapes",             // edm4eic::Cluster
+      {"EcalEndcapNTruthClustersWithoutShapes", // edm4eic::Cluster
        "EcalEndcapNTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 4.6, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -143,7 +143,7 @@ void InitPlugin(JApplication* app) {
       },                                               // edm4hep::SimCalorimeterHitCollection
 #endif
 #if EDM4EIC_VERSION_MAJOR >= 8
-      {"EcalEndcapNClustersWithoutPIDAndShapes",             // edm4eic::Cluster
+      {"EcalEndcapNClustersWithoutPIDAndShapes", // edm4eic::Cluster
        "EcalEndcapNClusterAssociationsWithoutPIDAndShapes"}, // edm4eic::MCRecoClusterParticleAssociation
 #else
       {"EcalEndcapNClustersWithoutShapes",             // edm4eic::Cluster
@@ -236,7 +236,7 @@ void InitPlugin(JApplication* app) {
             "EcalEndcapNHits"
       }, // edm4hep::SimCalorimeterHitCollection
 #endif
-      {"EcalEndcapNSplitMergeClustersWithoutShapes",             // edm4eic::Cluster
+      {"EcalEndcapNSplitMergeClustersWithoutShapes", // edm4eic::Cluster
        "EcalEndcapNSplitMergeClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 3.6, .enableEtaBounds = false},
       app // TODO: Remove me once fixed

--- a/src/detectors/EHCAL/EHCAL.cc
+++ b/src/detectors/EHCAL/EHCAL.cc
@@ -117,7 +117,7 @@ void InitPlugin(JApplication* app) {
             "HcalEndcapNHits"
       }, // edm4hep::SimCalorimeterHitCollection
 #endif
-      {"HcalEndcapNTruthClustersWithoutShapes",             // edm4eic::Cluster
+      {"HcalEndcapNTruthClustersWithoutShapes", // edm4eic::Cluster
        "HcalEndcapNTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 6.2, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -138,7 +138,7 @@ void InitPlugin(JApplication* app) {
             "HcalEndcapNHits"
       }, // edm4hep::SimCalorimeterHitCollection
 #endif
-      {"HcalEndcapNClustersWithoutShapes",             // edm4eic::Cluster
+      {"HcalEndcapNClustersWithoutShapes", // edm4eic::Cluster
        "HcalEndcapNClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {
           .energyWeight    = "log",
@@ -177,7 +177,7 @@ void InitPlugin(JApplication* app) {
             "HcalEndcapNHits"
       }, // edm4hep::SimCalorimeterHitCollection
 #endif
-      {"HcalEndcapNSplitMergeClustersWithoutShapes",             // edm4eic::Cluster
+      {"HcalEndcapNSplitMergeClustersWithoutShapes", // edm4eic::Cluster
        "HcalEndcapNSplitMergeClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 6.2, .enableEtaBounds = false},
       app // TODO: Remove me once fixed

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -108,7 +108,7 @@ void InitPlugin(JApplication* app) {
             "EcalEndcapPHits"
       }, // edm4hep::SimCalorimeterHitCollection
 #endif
-      {"EcalEndcapPTruthClustersWithoutShapes",             // edm4eic::Cluster
+      {"EcalEndcapPTruthClustersWithoutShapes", // edm4eic::Cluster
        "EcalEndcapPTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 6.2, .enableEtaBounds = true},
       app // TODO: Remove me once fixed
@@ -131,7 +131,7 @@ void InitPlugin(JApplication* app) {
             "EcalEndcapPHits"
       }, // edm4hep::SimCalorimeterHitCollection
 #endif
-      {"EcalEndcapPClustersWithoutShapes",             // edm4eic::Cluster
+      {"EcalEndcapPClustersWithoutShapes", // edm4eic::Cluster
        "EcalEndcapPClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {
           .energyWeight    = "log",
@@ -173,7 +173,7 @@ void InitPlugin(JApplication* app) {
             "EcalEndcapPHits"
       }, // edm4hep::SimCalorimeterHitCollection
 #endif
-      {"EcalEndcapPSplitMergeClustersWithoutShapes",             // edm4eic::Cluster
+      {"EcalEndcapPSplitMergeClustersWithoutShapes", // edm4eic::Cluster
        "EcalEndcapPSplitMergeClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 3.6, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -267,7 +267,7 @@ void InitPlugin(JApplication* app) {
             "EcalEndcapPInsertHits"
       }, // edm4hep::SimCalorimeterHitCollection
 #endif
-      {"EcalEndcapPInsertTruthClustersWithoutShapes",             // edm4eic::Cluster
+      {"EcalEndcapPInsertTruthClustersWithoutShapes", // edm4eic::Cluster
        "EcalEndcapPInsertTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 6.2, .enableEtaBounds = true},
       app // TODO: Remove me once fixed
@@ -291,7 +291,7 @@ void InitPlugin(JApplication* app) {
             "EcalEndcapPInsertHits"
       }, // edm4hep::SimCalorimeterHitCollection
 #endif
-      {"EcalEndcapPInsertClustersWithoutShapes",             // edm4eic::Cluster
+      {"EcalEndcapPInsertClustersWithoutShapes", // edm4eic::Cluster
        "EcalEndcapPInsertClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {
           .energyWeight    = "log",

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -141,7 +141,7 @@ void InitPlugin(JApplication* app) {
             "HcalEndcapPInsertHits"
       }, // edm4hep::SimCalorimeterHitCollection
 #endif
-      {"HcalEndcapPInsertTruthClustersWithoutShapes",             // edm4eic::Cluster
+      {"HcalEndcapPInsertTruthClustersWithoutShapes", // edm4eic::Cluster
        "HcalEndcapPInsertTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 0.0257, .logWeightBase = 3.6, .enableEtaBounds = true},
       app // TODO: Remove me once fixed
@@ -165,7 +165,7 @@ void InitPlugin(JApplication* app) {
             "HcalEndcapPInsertHits"
       }, // edm4hep::SimCalorimeterHitCollection
 #endif
-      {"HcalEndcapPInsertClustersWithoutShapes",             // edm4eic::Cluster
+      {"HcalEndcapPInsertClustersWithoutShapes", // edm4eic::Cluster
        "HcalEndcapPInsertClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {
           .energyWeight    = "log",
@@ -290,7 +290,7 @@ void InitPlugin(JApplication* app) {
             "LFHCALHits"
       }, // edm4hep::SimCalorimeterHitCollection
 #endif
-      {"LFHCALTruthClustersWithoutShapes",             // edm4eic::Cluster
+      {"LFHCALTruthClustersWithoutShapes", // edm4eic::Cluster
        "LFHCALTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 4.5, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -313,7 +313,7 @@ void InitPlugin(JApplication* app) {
             "LFHCALHits"
       }, // edm4hep::SimCalorimeterHitCollection
 #endif
-      {"LFHCALClustersWithoutShapes",             // edm4eic::Cluster
+      {"LFHCALClustersWithoutShapes", // edm4eic::Cluster
        "LFHCALClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {
           .energyWeight    = "log",
@@ -353,7 +353,7 @@ void InitPlugin(JApplication* app) {
             "LFHCALHits"
       }, // edm4hep::SimCalorimeterHitCollection
 #endif
-      {"LFHCALSplitMergeClustersWithoutShapes",             // edm4eic::Cluster
+      {"LFHCALSplitMergeClustersWithoutShapes", // edm4eic::Cluster
        "LFHCALSplitMergeClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 4.5, .enableEtaBounds = false},
       app // TODO: Remove me once fixed

--- a/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
+++ b/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
@@ -124,7 +124,7 @@ void InitPlugin(JApplication* app) {
             "EcalLumiSpecHits"
       }, // edm4hep::SimCalorimeterHitCollection
 #endif
-      {"EcalLumiSpecTruthClustersWithoutShapes",             // edm4eic::Cluster
+      {"EcalLumiSpecTruthClustersWithoutShapes", // edm4eic::Cluster
        "EcalLumiSpecTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 4.6, .enableEtaBounds = false},
       app // TODO: Remove me once fixed

--- a/src/detectors/PFRICH/PFRICH.cc
+++ b/src/detectors/PFRICH/PFRICH.cc
@@ -37,8 +37,8 @@ void InitPlugin(JApplication* app) {
   digi_cfg.detectorName = "RICHEndcapN";
   digi_cfg.readoutClass = "RICHEndcapNHits";
   digi_cfg.seed         = 5;           // FIXME: set to 0 for a 'unique' seed, but
-                                       // that seems to delay the RNG from actually randomizing
-  digi_cfg.hitTimeWindow   = 20.0;     // [ns]
+      // that seems to delay the RNG from actually randomizing
+  digi_cfg.hitTimeWindow   = 20.0; // [ns]
   digi_cfg.timeResolution  = 1 / 16.0; // [ns]
   digi_cfg.speMean         = 80.0;
   digi_cfg.speError        = 16.0;
@@ -47,7 +47,7 @@ void InitPlugin(JApplication* app) {
   digi_cfg.enablePixelGaps = true;
   digi_cfg.safetyFactor    = 0.7;
   digi_cfg.enableNoise     = false;
-  digi_cfg.noiseRate       = 20000;             // [Hz]
+  digi_cfg.noiseRate       = 20000; // [Hz]
   digi_cfg.noiseTimeWindow = 20.0 * dd4hep::ns; // [ns]
   digi_cfg.quantumEfficiency.clear();
   digi_cfg.quantumEfficiency = {// wavelength units are [nm]

--- a/src/detectors/RPOTS/RPOTS.cc
+++ b/src/detectors/RPOTS/RPOTS.cc
@@ -61,9 +61,9 @@ void InitPlugin(JApplication* app) {
                            {0.0204108951, -0.139318692},
                        },
 
-                   .local_x_offset = -1209.29,   //-0.339334, these are the local coordinate values
+                   .local_x_offset = -1209.29, //-0.339334, these are the local coordinate values
                    .local_y_offset = 0.00132511, //-0.000299454,
-                   .local_x_slope_offset = -45.4772,    //-0.219603248,
+                   .local_x_slope_offset = -45.4772, //-0.219603248,
                    .local_y_slope_offset = 0.000745498, //-0.000176128,
 
                },
@@ -82,9 +82,9 @@ void InitPlugin(JApplication* app) {
                            {0.0222482, -0.0923779},
                        },
 
-                   .local_x_offset = -1209.29,   //-0.339334, these are the local coordinate values
+                   .local_x_offset = -1209.29, //-0.339334, these are the local coordinate values
                    .local_y_offset = 0.00132511, //-0.000299454,
-                   .local_x_slope_offset = -45.4772,    //-0.219603248,
+                   .local_x_slope_offset = -45.4772, //-0.219603248,
                    .local_y_slope_offset = 0.000745498, //-0.000176128,
 
                },
@@ -103,9 +103,9 @@ void InitPlugin(JApplication* app) {
                            {0.0226283320, -0.082666019},
                        },
 
-                   .local_x_offset       = -1209.27,   //-0.329072,
+                   .local_x_offset       = -1209.27, //-0.329072,
                    .local_y_offset       = 0.00355218, //-0.00028343,
-                   .local_x_slope_offset = -45.4737,   //-0.218525084,
+                   .local_x_slope_offset = -45.4737, //-0.218525084,
                    .local_y_slope_offset = 0.00204394, //-0.00015321,
 
                },
@@ -120,9 +120,9 @@ void InitPlugin(JApplication* app) {
                        },
                    .aY = {{0.4914400000, 4.53857451}, {0.0179664765, 0.004160679}},
 
-                   .local_x_offset       = -1209.22,   //-0.283273,
+                   .local_x_offset       = -1209.22, //-0.283273,
                    .local_y_offset       = 0.00868737, //-0.00552451,
-                   .local_x_slope_offset = -45.4641,   //-0.21174031,
+                   .local_x_slope_offset = -45.4641, //-0.21174031,
                    .local_y_slope_offset = 0.00498786, //-0.003212011,
 
                }},

--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -231,7 +231,7 @@ void InitPlugin(JApplication* app) {
        .minClusterHitEdep    = 100.0 * dd4hep::keV,
        .minClusterCenterEdep = 1.0 * dd4hep::MeV,
        .transverseEnergyProfileMetric{}, // = "globalDistEtaPhi",
-       .transverseEnergyProfileScale{},  // = 1.,
+       .transverseEnergyProfileScale{}, // = 1.,
        .transverseEnergyProfileScaleUnits{}},
       app));
 

--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -127,7 +127,7 @@ void InitPlugin(JApplication* app) {
             "EcalFarForwardZDCHits"
       }, // edm4hep::SimCalorimeterHitCollection
 #endif
-      {"EcalFarForwardZDCClustersWithoutShapes",             // edm4eic::Cluster
+      {"EcalFarForwardZDCClustersWithoutShapes", // edm4eic::Cluster
        "EcalFarForwardZDCClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {
           .energyWeight    = "log",
@@ -246,7 +246,7 @@ void InitPlugin(JApplication* app) {
             "HcalFarForwardZDCHits"
       }, // edm4hep::SimCalorimeterHitCollection
 #endif
-      {"HcalFarForwardZDCClustersWithoutShapes",             // edm4eic::Cluster
+      {"HcalFarForwardZDCClustersWithoutShapes", // edm4eic::Cluster
        "HcalFarForwardZDCClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight        = "log",
        .sampFrac            = 0.0203,
@@ -307,7 +307,7 @@ void InitPlugin(JApplication* app) {
             "HcalFarForwardZDCHits"
       }, // edm4hep::SimCalorimeterHitCollection
 #endif
-      {"HcalFarForwardZDCTruthClustersWithoutShapes",             // edm4eic::Cluster
+      {"HcalFarForwardZDCTruthClustersWithoutShapes", // edm4eic::Cluster
        "HcalFarForwardZDCTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 3.6, .enableEtaBounds = false},
       app // TODO: Remove me once fixed

--- a/src/global/pid/pid.cc
+++ b/src/global/pid/pid.cc
@@ -23,12 +23,12 @@ void InitPlugin(JApplication* app) {
       {
           "ReconstructedChargedWithoutPIDParticles",            // edm4eic::ReconstructedParticle
           "ReconstructedChargedWithoutPIDParticleAssociations", // edm4eic::MCRecoParticleAssociationCollection
-          "DRICHMergedIrtCherenkovParticleID",                  // edm4eic::CherenkovParticleID
+          "DRICHMergedIrtCherenkovParticleID", // edm4eic::CherenkovParticleID
       },
       {
-          "ReconstructedChargedRealPIDParticles",            // edm4eic::ReconstructedParticle
+          "ReconstructedChargedRealPIDParticles", // edm4eic::ReconstructedParticle
           "ReconstructedChargedRealPIDParticleAssociations", // edm4eic::MCRecoParticleAssociationCollection
-          "ReconstructedChargedRealPIDParticleIDs",          // edm4hep::ParticleID
+          "ReconstructedChargedRealPIDParticleIDs", // edm4hep::ParticleID
       },
       app));
 }

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -102,7 +102,7 @@ void InitPlugin(JApplication* app) {
           "EcalClusterAssociations",
       },
       {
-          "ReconstructedParticles",           // edm4eic::ReconstructedParticle
+          "ReconstructedParticles", // edm4eic::ReconstructedParticle
           "ReconstructedParticleAssociations" // edm4eic::MCRecoParticleAssociation
       },
       app));
@@ -156,7 +156,7 @@ void InitPlugin(JApplication* app) {
       "ReconstructedElectronsForDIS", {"ReconstructedParticles"}, {"ReconstructedElectronsForDIS"},
       {
           .min_energy_over_momentum = 0.7, // GeV
-          .max_energy_over_momentum = 1.3  // GeV
+          .max_energy_over_momentum = 1.3 // GeV
       },
       app));
 
@@ -186,7 +186,7 @@ void InitPlugin(JApplication* app) {
       {"ReconstructedChargedParticles", "ReconstructedElectronsForDIS"},
       {"ScatteredElectronsEMinusPz"},
       {
-          .minEMinusPz = 0,         // GeV
+          .minEMinusPz = 0, // GeV
           .maxEMinusPz = 10000000.0 // GeV
       },
       app));
@@ -220,7 +220,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<FarForwardNeutralsReconstruction_factory>(
       "ReconstructedFarForwardZDCNeutrons",
-      {"HcalFarForwardZDCClusters"},          // edm4eic::ClusterCollection
+      {"HcalFarForwardZDCClusters"}, // edm4eic::ClusterCollection
       {"ReconstructedFarForwardZDCNeutrals"}, // edm4eic::ReconstrutedParticleCollection,
       {.neutronScaleCorrCoeffHcal = {-0.11, -1.5, 0},
        .gammaScaleCorrCoeffHcal   = {0, -.13, 0},

--- a/src/services/geometry/richgeo/IrtGeoDRICH.cc
+++ b/src/services/geometry/richgeo/IrtGeoDRICH.cc
@@ -58,7 +58,7 @@ void richgeo::IrtGeoDRICH::DD4hep_to_IRT() {
   m_irtPhotonDetector = new CherenkovPhotonDetector(nullptr, nullptr);
   m_irtDetector->SetReadoutCellMask(cellMask);
   m_irtDetectorCollection->AddPhotonDetector(m_irtDetector,      // Cherenkov detector
-                                             nullptr,            // G4LogicalVolume (inaccessible?)
+                                             nullptr, // G4LogicalVolume (inaccessible?)
                                              m_irtPhotonDetector // photon detector
   );
   m_log->debug("cellMask = {:#X}", cellMask);
@@ -79,22 +79,22 @@ void richgeo::IrtGeoDRICH::DD4hep_to_IRT() {
   m_filterFlatSurface   = new FlatSurface(TVector3(0, 0, filterZpos), normX, normY);
   for (int isec = 0; isec < nSectors; isec++) {
     auto* aerogelFlatRadiator = m_irtDetectorCollection->AddFlatRadiator(
-        m_irtDetector,                  // Cherenkov detector
+        m_irtDetector, // Cherenkov detector
         RadiatorName(kAerogel).c_str(), // name
-        isec,                           // path
-        (G4LogicalVolume*)(0x1),        // G4LogicalVolume (inaccessible? use an integer instead)
-        nullptr,                        // G4RadiatorMaterial
-        m_aerogelFlatSurface,           // surface
-        aerogelThickness                // surface thickness
+        isec, // path
+        (G4LogicalVolume*)(0x1), // G4LogicalVolume (inaccessible? use an integer instead)
+        nullptr, // G4RadiatorMaterial
+        m_aerogelFlatSurface, // surface
+        aerogelThickness // surface thickness
     );
     auto* filterFlatRadiator = m_irtDetectorCollection->AddFlatRadiator(
-        m_irtDetector,           // Cherenkov detector
-        "Filter",                // name
-        isec,                    // path
+        m_irtDetector, // Cherenkov detector
+        "Filter", // name
+        isec, // path
         (G4LogicalVolume*)(0x2), // G4LogicalVolume (inaccessible? use an integer instead)
-        nullptr,                 // G4RadiatorMaterial
-        m_filterFlatSurface,     // surface
-        filterThickness          // surface thickness
+        nullptr, // G4RadiatorMaterial
+        m_filterFlatSurface, // surface
+        filterThickness // surface thickness
     );
     aerogelFlatRadiator->SetAlternativeMaterialName(aerogelMaterial.c_str());
     filterFlatRadiator->SetAlternativeMaterialName(filterMaterial.c_str());
@@ -117,8 +117,8 @@ void richgeo::IrtGeoDRICH::DD4hep_to_IRT() {
         TVector3(mirrorCenter.x(), mirrorCenter.y(), mirrorCenter.z()), mirrorRadius);
     m_mirrorOpticalBoundary =
         new OpticalBoundary(m_irtDetector->GetContainerVolume(), // CherenkovRadiator radiator
-                            m_mirrorSphericalSurface,            // surface
-                            false                                // bool refractive
+                            m_mirrorSphericalSurface, // surface
+                            false // bool refractive
         );
     m_irtDetector->AddOpticalBoundary(isec, m_mirrorOpticalBoundary);
     m_log->debug("");
@@ -176,10 +176,10 @@ void richgeo::IrtGeoDRICH::DD4hep_to_IRT() {
         m_sensorFlatSurface = new FlatSurface(TVector3(posSensor.x(), posSensor.y(), posSensor.z()),
                                               TVector3(normXdir.x(), normXdir.y(), normXdir.z()),
                                               TVector3(normYdir.x(), normYdir.y(), normYdir.z()));
-        m_irtDetector->CreatePhotonDetectorInstance(isec,                // sector
+        m_irtDetector->CreatePhotonDetectorInstance(isec, // sector
                                                     m_irtPhotonDetector, // CherenkovPhotonDetector
-                                                    sensorID,            // copy number
-                                                    m_sensorFlatSurface  // surface
+                                                    sensorID, // copy number
+                                                    m_sensorFlatSurface // surface
         );
         m_log->trace("{} {:#X} {}   {:5.2f} {:5.2f} {:5.2f}   {:5.2f} {:5.2f} {:5.2f}   {:5.2f} "
                      "{:5.2f} {:5.2f}",

--- a/src/services/geometry/richgeo/IrtGeoPFRICH.cc
+++ b/src/services/geometry/richgeo/IrtGeoPFRICH.cc
@@ -57,7 +57,7 @@ void richgeo::IrtGeoPFRICH::DD4hep_to_IRT() {
   m_irtPhotonDetector = new CherenkovPhotonDetector(nullptr, nullptr);
   m_irtDetector->SetReadoutCellMask(cellMask);
   m_irtDetectorCollection->AddPhotonDetector(m_irtDetector,      // Cherenkov detector
-                                             nullptr,            // G4LogicalVolume (inaccessible?)
+                                             nullptr, // G4LogicalVolume (inaccessible?)
                                              m_irtPhotonDetector // photon detector
   );
   m_log->debug("cellMask = {:#X}", cellMask);
@@ -75,22 +75,22 @@ void richgeo::IrtGeoPFRICH::DD4hep_to_IRT() {
   m_aerogelFlatSurface      = new FlatSurface(TVector3(0, 0, aerogelZpos), normX, normY);
   m_filterFlatSurface       = new FlatSurface(TVector3(0, 0, filterZpos), normX, normY);
   auto* aerogelFlatRadiator = m_irtDetectorCollection->AddFlatRadiator(
-      m_irtDetector,                  // Cherenkov detector
+      m_irtDetector, // Cherenkov detector
       RadiatorName(kAerogel).c_str(), // name
-      0,                              // path
-      (G4LogicalVolume*)(0x1),        // G4LogicalVolume (inaccessible? use an integer instead)
-      nullptr,                        // G4RadiatorMaterial
-      m_aerogelFlatSurface,           // surface
-      aerogelThickness                // surface thickness
+      0, // path
+      (G4LogicalVolume*)(0x1), // G4LogicalVolume (inaccessible? use an integer instead)
+      nullptr, // G4RadiatorMaterial
+      m_aerogelFlatSurface, // surface
+      aerogelThickness // surface thickness
   );
   auto* filterFlatRadiator = m_irtDetectorCollection->AddFlatRadiator(
-      m_irtDetector,           // Cherenkov detector
-      "Filter",                // name
-      0,                       // path
+      m_irtDetector, // Cherenkov detector
+      "Filter", // name
+      0, // path
       (G4LogicalVolume*)(0x2), // G4LogicalVolume (inaccessible? use an integer instead)
-      nullptr,                 // G4RadiatorMaterial
-      m_filterFlatSurface,     // surface
-      filterThickness          // surface thickness
+      nullptr, // G4RadiatorMaterial
+      m_filterFlatSurface, // surface
+      filterThickness // surface thickness
   );
   aerogelFlatRadiator->SetAlternativeMaterialName(aerogelMaterial.c_str());
   filterFlatRadiator->SetAlternativeMaterialName(filterMaterial.c_str());
@@ -157,10 +157,10 @@ void richgeo::IrtGeoPFRICH::DD4hep_to_IRT() {
       m_sensorFlatSurface = new FlatSurface(
           TVector3(posSensorSurface.x(), posSensorSurface.y(), posSensorSurface.z()),
           TVector3(sensorGlobalNormX), TVector3(sensorGlobalNormY));
-      m_irtDetector->CreatePhotonDetectorInstance(0,                   // sector
+      m_irtDetector->CreatePhotonDetectorInstance(0, // sector
                                                   m_irtPhotonDetector, // CherenkovPhotonDetector
-                                                  imod,                // copy number
-                                                  m_sensorFlatSurface  // surface
+                                                  imod, // copy number
+                                                  m_sensorFlatSurface // surface
       );
       m_log->trace("sensor: id={:#08X} pos=({:5.2f}, {:5.2f}, {:5.2f}) normX=({:5.2f}, {:5.2f}, "
                    "{:5.2f}) normY=({:5.2f}, {:5.2f}, {:5.2f})",
@@ -178,7 +178,7 @@ void richgeo::IrtGeoPFRICH::DD4hep_to_IRT() {
       }
 
     } // if sensor found
-  }   // search for sensors
+  } // search for sensors
 
   // set reference refractive indices // NOTE: numbers may be overridden externally
   std::map<const char*, double> rIndices;

--- a/src/services/geometry/richgeo/ReadoutGeo.cc
+++ b/src/services/geometry/richgeo/ReadoutGeo.cc
@@ -81,7 +81,7 @@ richgeo::ReadoutGeo::ReadoutGeo(std::string detName_, std::string readoutClass_,
           } // end xy-segmentation loop
         }
       } // end sensor loop (for all sectors)
-    };  // end definition of m_loopCellIDs
+    }; // end definition of m_loopCellIDs
 
     // define k random cell IDs generator
     m_rngCellIDs = [this](std::function<void(CellIDType)> lambda, float p) {

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -186,7 +186,7 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
     "ReconstructedChargedRealPIDParticleIDs",
     "ReconstructedChargedParticles",
     "ReconstructedChargedParticleAssociations",
-    "MCScatteredElectronAssociations",    // Remove if/when used internally
+    "MCScatteredElectronAssociations", // Remove if/when used internally
     "MCNonScatteredElectronAssociations", // Remove if/when used internally
     "ReconstructedBreitFrameParticles",
     "CentralTrackSegments",

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
@@ -108,24 +108,24 @@ TEST_CASE("the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]") {
       edm4hep::Vector3d(),                                  // edm4hep::Vector3d vertex
       edm4hep::Vector3d(),                                  // edm4hep::Vector3d endpoint
       edm4hep::Vector3f(),                                  // edm4hep::Vector3f momentum
-      edm4hep::Vector3f(),                                  // edm4hep::Vector3f momentumAtEndpoint
-      edm4hep::Vector3f(),                                  // edm4hep::Vector3f spin
-      edm4hep::Vector2i()                                   // edm4hep::Vector2i colorFlow
+      edm4hep::Vector3f(), // edm4hep::Vector3f momentumAtEndpoint
+      edm4hep::Vector3f(), // edm4hep::Vector3f spin
+      edm4hep::Vector2i() // edm4hep::Vector2i colorFlow
   );
 
   mcpart12.addToParents(mcpart11);
   mcpart11.addToDaughters(mcpart12);
 
-  auto contrib11 = contribs_coll.create(0,                         // int32_t PDG
+  auto contrib11 = contribs_coll.create(0, // int32_t PDG
                                         0.05 * edm4eic::unit::GeV, // float energy
-                                        0.0,                       // float time
-                                        edm4hep::Vector3f()        // edm4hep::Vector3f stepPosition
+                                        0.0, // float time
+                                        edm4hep::Vector3f() // edm4hep::Vector3f stepPosition
   );
   contrib11.setParticle(mcpart11);
-  auto contrib12 = contribs_coll.create(0,                         // int32_t PDG
+  auto contrib12 = contribs_coll.create(0, // int32_t PDG
                                         0.05 * edm4eic::unit::GeV, // float energy
-                                        0.0,                       // float time
-                                        edm4hep::Vector3f()        // edm4hep::Vector3f stepPosition
+                                        0.0, // float time
+                                        edm4hep::Vector3f() // edm4hep::Vector3f stepPosition
   );
   contrib12.setParticle(mcpart12);
 
@@ -161,24 +161,24 @@ TEST_CASE("the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]") {
   pclust.addToWeights(1);
 
   auto mcpart2 = mcparts_coll.create(
-      211,                                                  // std::int32_t PDG
-      0,                                                    // std::int32_t generatorStatus
+      211, // std::int32_t PDG
+      0, // std::int32_t generatorStatus
       (0x1 << edm4hep::MCParticle::BITCreatedInSimulation), // std::int32_t simulatorStatus
-      0.,                                                   // float charge
-      0.,                                                   // float time
-      0.,                                                   // double mass
-      edm4hep::Vector3d(),                                  // edm4hep::Vector3d vertex
-      edm4hep::Vector3d(),                                  // edm4hep::Vector3d endpoint
-      edm4hep::Vector3f(),                                  // edm4hep::Vector3f momentum
-      edm4hep::Vector3f(),                                  // edm4hep::Vector3f momentumAtEndpoint
-      edm4hep::Vector3f(),                                  // edm4hep::Vector3f spin
-      edm4hep::Vector2i()                                   // edm4hep::Vector2i colorFlow
+      0., // float charge
+      0., // float time
+      0., // double mass
+      edm4hep::Vector3d(), // edm4hep::Vector3d vertex
+      edm4hep::Vector3d(), // edm4hep::Vector3d endpoint
+      edm4hep::Vector3f(), // edm4hep::Vector3f momentum
+      edm4hep::Vector3f(), // edm4hep::Vector3f momentumAtEndpoint
+      edm4hep::Vector3f(), // edm4hep::Vector3f spin
+      edm4hep::Vector2i() // edm4hep::Vector2i colorFlow
   );
 
-  auto contrib2 = contribs_coll.create(0,                        // int32_t PDG
+  auto contrib2 = contribs_coll.create(0, // int32_t PDG
                                        0.1 * edm4eic::unit::GeV, // float energy
-                                       0.0,                      // float time
-                                       edm4hep::Vector3f()       // edm4hep::Vector3f stepPosition
+                                       0.0, // float time
+                                       edm4hep::Vector3f() // edm4hep::Vector3f stepPosition
   );
   contrib2.setParticle(mcpart2);
 

--- a/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
@@ -67,15 +67,15 @@ TEST_CASE("the clustering algorithm runs", "[CalorimeterHitDigi]") {
         edm4hep::Vector3f({0. /* mm */, 0. /* mm */, 0. /* mm */}) // edm4hep::Vector3f position
     );
     mhit.addToContributions(calohits->create(
-        0,                                                         // std::int32_t PDG
-        0.5 /* GeV */,                                             // float energy
-        7.0 /* ns */,                                              // float time
+        0, // std::int32_t PDG
+        0.5 /* GeV */, // float energy
+        7.0 /* ns */, // float time
         edm4hep::Vector3f({0. /* mm */, 0. /* mm */, 0. /* mm */}) // edm4hep::Vector3f stepPosition
         ));
     mhit.addToContributions(calohits->create(
-        0,                                                         // std::int32_t PDG
-        0.5 /* GeV */,                                             // float energy
-        9.0 /* ns */,                                              // float time
+        0, // std::int32_t PDG
+        0.5 /* GeV */, // float energy
+        9.0 /* ns */, // float time
         edm4hep::Vector3f({0. /* mm */, 0. /* mm */, 0. /* mm */}) // edm4hep::Vector3f stepPosition
         ));
 

--- a/src/tests/algorithms_test/calorimetry_CalorimeterIslandCluster.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterIslandCluster.cc
@@ -115,27 +115,27 @@ TEST_CASE("the clustering algorithm runs", "[CalorimeterIslandCluster]") {
       edm4eic::CalorimeterHitCollection hits_coll;
       hits_coll.create(
           id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
-          5.0,                                                   // float energy,
-          0.0,                                                   // float energyError,
-          0.0,                                                   // float time,
-          0.0,                                                   // float timeError,
-          edm4hep::Vector3f(0.0, 0.0, 0.0),                      // edm4hep::Vector3f position,
-          edm4hep::Vector3f(1.0, 1.0, 0.0),                      // edm4hep::Vector3f dimension,
-          0,                                                     // std::int32_t sector,
-          0,                                                     // std::int32_t layer,
-          edm4hep::Vector3f(0.0, 0.0, 0.0)                       // edm4hep::Vector3f local
+          5.0, // float energy,
+          0.0, // float energyError,
+          0.0, // float time,
+          0.0, // float timeError,
+          edm4hep::Vector3f(0.0, 0.0, 0.0), // edm4hep::Vector3f position,
+          edm4hep::Vector3f(1.0, 1.0, 0.0), // edm4hep::Vector3f dimension,
+          0, // std::int32_t sector,
+          0, // std::int32_t layer,
+          edm4hep::Vector3f(0.0, 0.0, 0.0) // edm4hep::Vector3f local
       );
       hits_coll.create(
           id_desc.encode({{"system", 255}, {"x", 1}, {"y", 0}}), // std::uint64_t cellID,
-          6.0,                                                   // float energy,
-          0.0,                                                   // float energyError,
-          0.0,                                                   // float time,
-          0.0,                                                   // float timeError,
-          edm4hep::Vector3f(0.0, 0.0, 0.0),                      // edm4hep::Vector3f position,
-          edm4hep::Vector3f(1.0, 1.0, 0.0),                      // edm4hep::Vector3f dimension,
-          0,                                                     // std::int32_t sector,
-          0,                                                     // std::int32_t layer,
-          edm4hep::Vector3f(0.9 /* mm */, 0.9 /* mm */, 0.0)     // edm4hep::Vector3f local
+          6.0, // float energy,
+          0.0, // float energyError,
+          0.0, // float time,
+          0.0, // float timeError,
+          edm4hep::Vector3f(0.0, 0.0, 0.0), // edm4hep::Vector3f position,
+          edm4hep::Vector3f(1.0, 1.0, 0.0), // edm4hep::Vector3f dimension,
+          0, // std::int32_t sector,
+          0, // std::int32_t layer,
+          edm4hep::Vector3f(0.9 /* mm */, 0.9 /* mm */, 0.0) // edm4hep::Vector3f local
       );
       auto protoclust_coll = std::make_unique<edm4eic::ProtoClusterCollection>();
       algo.process({&hits_coll}, {protoclust_coll.get()});
@@ -173,25 +173,25 @@ TEST_CASE("the clustering algorithm runs", "[CalorimeterIslandCluster]") {
 
     edm4eic::CalorimeterHitCollection hits_coll;
     hits_coll.create(id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
-                     5.0,                                                   // float energy,
-                     0.0,                                                   // float energyError,
-                     0.0,                                                   // float time,
-                     0.0,                                                   // float timeError,
+                     5.0, // float energy,
+                     0.0, // float energyError,
+                     0.0, // float time,
+                     0.0, // float timeError,
                      edm4hep::Vector3f(0.0, 0.0, 0.0), // edm4hep::Vector3f position,
                      edm4hep::Vector3f(1.0, 1.0, 0.0), // edm4hep::Vector3f dimension,
-                     0,                                // std::int32_t sector,
-                     0,                                // std::int32_t layer,
-                     edm4hep::Vector3f(0.0, 0.0, 0.0)  // edm4hep::Vector3f local
+                     0, // std::int32_t sector,
+                     0, // std::int32_t layer,
+                     edm4hep::Vector3f(0.0, 0.0, 0.0) // edm4hep::Vector3f local
     );
     hits_coll.create(id_desc.encode({{"system", 255}, {"x", 1}, {"y", 0}}), // std::uint64_t cellID,
-                     1.0,                                                   // float energy,
-                     0.0,                                                   // float energyError,
-                     0.0,                                                   // float time,
-                     0.0,                                                   // float timeError,
+                     1.0, // float energy,
+                     0.0, // float energyError,
+                     0.0, // float time,
+                     0.0, // float timeError,
                      edm4hep::Vector3f(0.0, 0.0, 0.0), // edm4hep::Vector3f position,
                      edm4hep::Vector3f(1.0, 1.0, 0.0), // edm4hep::Vector3f dimension,
-                     0,                                // std::int32_t sector,
-                     0,                                // std::int32_t layer,
+                     0, // std::int32_t sector,
+                     0, // std::int32_t layer,
                      edm4hep::Vector3f(0.9 /* mm */, 0.9 /* mm */, 0.0) // edm4hep::Vector3f local
     );
 
@@ -207,15 +207,15 @@ TEST_CASE("the clustering algorithm runs", "[CalorimeterIslandCluster]") {
         id_desc.encode({{"system", 255},
                         {"x", test_diagonal_cluster ? 1 : 2},
                         {"y", test_diagonal_cluster ? 1 : 0}}), // std::uint64_t cellID,
-        6.0,                                                    // float energy,
-        0.0,                                                    // float energyError,
-        0.0,                                                    // float time,
-        0.0,                                                    // float timeError,
-        edm4hep::Vector3f(0.0, 0.0, 0.0),                       // edm4hep::Vector3f position,
-        edm4hep::Vector3f(1.0, 1.0, 0.0),                       // edm4hep::Vector3f dimension,
-        0,                                                      // std::int32_t sector,
-        0,                                                      // std::int32_t layer,
-        edm4hep::Vector3f(1.8 /* mm */, 1.8 /* mm */, 0.0)      // edm4hep::Vector3f local
+        6.0, // float energy,
+        0.0, // float energyError,
+        0.0, // float time,
+        0.0, // float timeError,
+        edm4hep::Vector3f(0.0, 0.0, 0.0), // edm4hep::Vector3f position,
+        edm4hep::Vector3f(1.0, 1.0, 0.0), // edm4hep::Vector3f dimension,
+        0, // std::int32_t sector,
+        0, // std::int32_t layer,
+        edm4hep::Vector3f(1.8 /* mm */, 1.8 /* mm */, 0.0) // edm4hep::Vector3f local
     );
     auto protoclust_coll = std::make_unique<edm4eic::ProtoClusterCollection>();
     algo.process({&hits_coll}, {protoclust_coll.get()});

--- a/src/tests/algorithms_test/calorimetry_HEXPLIT.cc
+++ b/src/tests/algorithms_test/calorimetry_HEXPLIT.cc
@@ -9,17 +9,17 @@
 #include <catch2/catch_test_macros.hpp> // for AssertionHandler, operator""_catch_sr, StringRef, REQUIRE, operator<, operator==, operator>, TEST_CASE
 #include <edm4eic/CalorimeterHitCollection.h> // for CalorimeterHitCollection, MutableCalorimeterHit, CalorimeterHitMutableCollectionIterator
 #include <edm4hep/Vector3f.h> // for Vector3f
-#include <spdlog/common.h>    // for level_enum
-#include <spdlog/logger.h>    // for logger
-#include <spdlog/spdlog.h>    // for default_logger
-#include <array>              // for array
-#include <cmath>              // for sqrt, abs
+#include <spdlog/common.h> // for level_enum
+#include <spdlog/logger.h> // for logger
+#include <spdlog/spdlog.h> // for default_logger
+#include <array> // for array
+#include <cmath> // for sqrt, abs
 #include <cstddef>
 #include <gsl/pointers>
-#include <memory>  // for allocator, unique_ptr, make_unique, shared_ptr, __shared_ptr_access
+#include <memory> // for allocator, unique_ptr, make_unique, shared_ptr, __shared_ptr_access
 #include <utility> // for pair
 
-#include "algorithms/calorimetry/HEXPLIT.h"       // for HEXPLIT
+#include "algorithms/calorimetry/HEXPLIT.h" // for HEXPLIT
 #include "algorithms/calorimetry/HEXPLITConfig.h" // for HEXPLITConfig
 
 using eicrecon::HEXPLIT;
@@ -61,16 +61,16 @@ TEST_CASE("the subcell-splitting algorithm runs", "[HEXPLIT]") {
                              50 * dd4hep::MeV};
   for (std::size_t i = 0; i < 5; i++) {
     hits_coll.create(
-        id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}),   // std::uint64_t cellID,
-        E[i],                                                    // float energy,
-        0.0,                                                     // float energyError,
-        0.0,                                                     // float time,
-        0.0,                                                     // float timeError,
+        id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
+        E[i], // float energy,
+        0.0, // float energyError,
+        0.0, // float time,
+        0.0, // float timeError,
         edm4hep::Vector3f(x[i], y[i], layer[i] * layer_spacing), // edm4hep::Vector3f position,
-        dimension,                                               // edm4hep::Vector3f dimension,
-        0,                                                       // std::int32_t sector,
-        layer[i],                                                // std::int32_t layer,
-        edm4hep::Vector3f(x[i], y[i], layer[i] * layer_spacing)  // edm4hep::Vector3f local
+        dimension, // edm4hep::Vector3f dimension,
+        0, // std::int32_t sector,
+        layer[i], // std::int32_t layer,
+        edm4hep::Vector3f(x[i], y[i], layer[i] * layer_spacing) // edm4hep::Vector3f local
     );
   }
 

--- a/src/tests/algorithms_test/calorimetry_ImagingTopoCluster.cc
+++ b/src/tests/algorithms_test/calorimetry_ImagingTopoCluster.cc
@@ -56,10 +56,10 @@ TEST_CASE("the clustering algorithm runs", "[ImagingTopoCluster]") {
           0.0,                                                      // float time,
           0.0,                                                      // float timeError,
           edm4hep::Vector3f(0.0, 0.0, 0.0),                         // edm4hep::Vector3f position,
-          edm4hep::Vector3f(0.0, 0.0, 0.0),                         // edm4hep::Vector3f dimension,
-          0,                                                        // std::int32_t sector,
-          0,                                                        // std::int32_t layer,
-          edm4hep::Vector3f(0.0, 0.0, 0.0)                          // edm4hep::Vector3f local
+          edm4hep::Vector3f(0.0, 0.0, 0.0), // edm4hep::Vector3f dimension,
+          0, // std::int32_t sector,
+          0, // std::int32_t layer,
+          edm4hep::Vector3f(0.0, 0.0, 0.0) // edm4hep::Vector3f local
       );
       auto protoclust_coll = std::make_unique<edm4eic::ProtoClusterCollection>();
       algo.process({&hits_coll}, {protoclust_coll.get()});
@@ -74,28 +74,28 @@ TEST_CASE("the clustering algorithm runs", "[ImagingTopoCluster]") {
       hits_coll.create(
           id_desc.encode(
               {{"system", 255}, {"x", 0}, {"y", 0}, {"layer", 0}}), // std::uint64_t cellID,
-          5.0,                                                      // float energy,
-          0.0,                                                      // float energyError,
-          0.0,                                                      // float time,
-          0.0,                                                      // float timeError,
-          edm4hep::Vector3f(0.0, 0.0, 0.0),                         // edm4hep::Vector3f position,
-          edm4hep::Vector3f(1.0, 1.0, 0.0),                         // edm4hep::Vector3f dimension,
-          0,                                                        // std::int32_t sector,
-          0,                                                        // std::int32_t layer,
-          edm4hep::Vector3f(0.0, 0.0, 0.0)                          // edm4hep::Vector3f local
+          5.0, // float energy,
+          0.0, // float energyError,
+          0.0, // float time,
+          0.0, // float timeError,
+          edm4hep::Vector3f(0.0, 0.0, 0.0), // edm4hep::Vector3f position,
+          edm4hep::Vector3f(1.0, 1.0, 0.0), // edm4hep::Vector3f dimension,
+          0, // std::int32_t sector,
+          0, // std::int32_t layer,
+          edm4hep::Vector3f(0.0, 0.0, 0.0) // edm4hep::Vector3f local
       );
       hits_coll.create(
           id_desc.encode(
               {{"system", 255}, {"x", 2}, {"y", 2}, {"layer", 0}}), // std::uint64_t cellID,
-          6.0,                                                      // float energy,
-          0.0,                                                      // float energyError,
-          0.0,                                                      // float time,
-          0.0,                                                      // float timeError,
-          edm4hep::Vector3f(1.1, 1.1, 0.0),                         // edm4hep::Vector3f position,
-          edm4hep::Vector3f(1.0, 1.0, 0.0),                         // edm4hep::Vector3f dimension,
-          0,                                                        // std::int32_t sector,
-          0,                                                        // std::int32_t layer,
-          edm4hep::Vector3f(1.1 /* mm */, 1.1 /* mm */, 0.0)        // edm4hep::Vector3f local
+          6.0, // float energy,
+          0.0, // float energyError,
+          0.0, // float time,
+          0.0, // float timeError,
+          edm4hep::Vector3f(1.1, 1.1, 0.0), // edm4hep::Vector3f position,
+          edm4hep::Vector3f(1.0, 1.0, 0.0), // edm4hep::Vector3f dimension,
+          0, // std::int32_t sector,
+          0, // std::int32_t layer,
+          edm4hep::Vector3f(1.1 /* mm */, 1.1 /* mm */, 0.0) // edm4hep::Vector3f local
       );
       auto protoclust_coll = std::make_unique<edm4eic::ProtoClusterCollection>();
       algo.process({&hits_coll}, {protoclust_coll.get()});
@@ -111,27 +111,27 @@ TEST_CASE("the clustering algorithm runs", "[ImagingTopoCluster]") {
       edm4eic::CalorimeterHitCollection hits_coll;
       hits_coll.create(
           id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
-          5.0,                                                   // float energy,
-          0.0,                                                   // float energyError,
-          0.0,                                                   // float time,
-          0.0,                                                   // float timeError,
-          edm4hep::Vector3f(0.0, 0.0, 0.0),                      // edm4hep::Vector3f position,
-          edm4hep::Vector3f(1.0, 1.0, 0.0),                      // edm4hep::Vector3f dimension,
-          0,                                                     // std::int32_t sector,
-          0,                                                     // std::int32_t layer,
-          edm4hep::Vector3f(0.0, 0.0, 0.0)                       // edm4hep::Vector3f local
+          5.0, // float energy,
+          0.0, // float energyError,
+          0.0, // float time,
+          0.0, // float timeError,
+          edm4hep::Vector3f(0.0, 0.0, 0.0), // edm4hep::Vector3f position,
+          edm4hep::Vector3f(1.0, 1.0, 0.0), // edm4hep::Vector3f dimension,
+          0, // std::int32_t sector,
+          0, // std::int32_t layer,
+          edm4hep::Vector3f(0.0, 0.0, 0.0) // edm4hep::Vector3f local
       );
       hits_coll.create(
           id_desc.encode({{"system", 255}, {"x", 1}, {"y", 0}}), // std::uint64_t cellID,
-          6.0,                                                   // float energy,
-          0.0,                                                   // float energyError,
-          0.0,                                                   // float time,
-          0.0,                                                   // float timeError,
-          edm4hep::Vector3f(0.9, 0.9, 0.0),                      // edm4hep::Vector3f position,
-          edm4hep::Vector3f(1.0, 1.0, 0.0),                      // edm4hep::Vector3f dimension,
-          0,                                                     // std::int32_t sector,
-          0,                                                     // std::int32_t layer,
-          edm4hep::Vector3f(0.9 /* mm */, 0.9 /* mm */, 0.0)     // edm4hep::Vector3f local
+          6.0, // float energy,
+          0.0, // float energyError,
+          0.0, // float time,
+          0.0, // float timeError,
+          edm4hep::Vector3f(0.9, 0.9, 0.0), // edm4hep::Vector3f position,
+          edm4hep::Vector3f(1.0, 1.0, 0.0), // edm4hep::Vector3f dimension,
+          0, // std::int32_t sector,
+          0, // std::int32_t layer,
+          edm4hep::Vector3f(0.9 /* mm */, 0.9 /* mm */, 0.0) // edm4hep::Vector3f local
       );
       auto protoclust_coll = std::make_unique<edm4eic::ProtoClusterCollection>();
       algo.process({&hits_coll}, {protoclust_coll.get()});
@@ -153,41 +153,41 @@ TEST_CASE("the clustering algorithm runs", "[ImagingTopoCluster]") {
     hits_coll.create(
         id_desc.encode(
             {{"system", 255}, {"x", 0}, {"y", 0}, {"layer", 0}}), // std::uint64_t cellID,
-        5.0,                                                      // float energy,
-        0.0,                                                      // float energyError,
-        0.0,                                                      // float time,
-        0.0,                                                      // float timeError,
-        edm4hep::Vector3f(0.0, 0.0, 0.0),                         // edm4hep::Vector3f position,
-        edm4hep::Vector3f(1.0, 1.0, 0.0),                         // edm4hep::Vector3f dimension,
-        0,                                                        // std::int32_t sector,
-        0,                                                        // std::int32_t layer,
-        edm4hep::Vector3f(0.0, 0.0, 0.0)                          // edm4hep::Vector3f local
+        5.0, // float energy,
+        0.0, // float energyError,
+        0.0, // float time,
+        0.0, // float timeError,
+        edm4hep::Vector3f(0.0, 0.0, 0.0), // edm4hep::Vector3f position,
+        edm4hep::Vector3f(1.0, 1.0, 0.0), // edm4hep::Vector3f dimension,
+        0, // std::int32_t sector,
+        0, // std::int32_t layer,
+        edm4hep::Vector3f(0.0, 0.0, 0.0) // edm4hep::Vector3f local
     );
     hits_coll.create(
         id_desc.encode(
             {{"system", 255}, {"x", 1}, {"y", 0}, {"layer", 1}}), // std::uint64_t cellID,
-        1.0,                                                      // float energy,
-        0.0,                                                      // float energyError,
-        0.0,                                                      // float time,
-        0.0,                                                      // float timeError,
-        edm4hep::Vector3f(0.9, 0.9, 0.0),                         // edm4hep::Vector3f position,
-        edm4hep::Vector3f(1.0, 1.0, 0.0),                         // edm4hep::Vector3f dimension,
-        0,                                                        // std::int32_t sector,
-        1,                                                        // std::int32_t layer,
-        edm4hep::Vector3f(0.9 /* mm */, 0.9 /* mm */, 0.0)        // edm4hep::Vector3f local
+        1.0, // float energy,
+        0.0, // float energyError,
+        0.0, // float time,
+        0.0, // float timeError,
+        edm4hep::Vector3f(0.9, 0.9, 0.0), // edm4hep::Vector3f position,
+        edm4hep::Vector3f(1.0, 1.0, 0.0), // edm4hep::Vector3f dimension,
+        0, // std::int32_t sector,
+        1, // std::int32_t layer,
+        edm4hep::Vector3f(0.9 /* mm */, 0.9 /* mm */, 0.0) // edm4hep::Vector3f local
     );
     hits_coll.create(
         id_desc.encode(
             {{"system", 255}, {"x", 2}, {"y", 0}, {"layer", 0}}), // std::uint64_t cellID,
-        6.0,                                                      // float energy,
-        0.0,                                                      // float energyError,
-        0.0,                                                      // float time,
-        0.0,                                                      // float timeError,
-        edm4hep::Vector3f(1.8, 1.8, 0.0),                         // edm4hep::Vector3f position,
-        edm4hep::Vector3f(1.0, 1.0, 0.0),                         // edm4hep::Vector3f dimension,
-        0,                                                        // std::int32_t sector,
-        0,                                                        // std::int32_t layer,
-        edm4hep::Vector3f(1.8 /* mm */, 1.8 /* mm */, 0.0)        // edm4hep::Vector3f local
+        6.0, // float energy,
+        0.0, // float energyError,
+        0.0, // float time,
+        0.0, // float timeError,
+        edm4hep::Vector3f(1.8, 1.8, 0.0), // edm4hep::Vector3f position,
+        edm4hep::Vector3f(1.0, 1.0, 0.0), // edm4hep::Vector3f dimension,
+        0, // std::int32_t sector,
+        0, // std::int32_t layer,
+        edm4hep::Vector3f(1.8 /* mm */, 1.8 /* mm */, 0.0) // edm4hep::Vector3f local
     );
     auto protoclust_coll = std::make_unique<edm4eic::ProtoClusterCollection>();
     algo.process({&hits_coll}, {protoclust_coll.get()});

--- a/src/tests/algorithms_test/digi_EICROCDigitization.cc
+++ b/src/tests/algorithms_test/digi_EICROCDigitization.cc
@@ -123,7 +123,7 @@ TEST_CASE("the Silicon charge sharing algorithm runs", "[EICROCDigitization]") {
 
       pulse.setCellID(cellID);
       pulse.setCharge(1.); // placeholder
-      pulse.setTime(0.);   // placeholder
+      pulse.setTime(0.); // placeholder
       pulse.setInterval(1);
 
       int test_peak_TDC   = static_cast<int>(0.5 * cfg.tdc_range);

--- a/src/tests/algorithms_test/tracking_SiliconSimpleCluster.cc
+++ b/src/tests/algorithms_test/tracking_SiliconSimpleCluster.cc
@@ -41,12 +41,12 @@ TEST_CASE("the clustering algorithm runs", "[FarDetectorTrackerCluster]") {
   SECTION("on a single pixel") {
     edm4eic::TrackerHitCollection hits_coll;
     hits_coll.create(id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
-                     edm4hep::Vector3f(0.0, 0.0, 0.0),                      // Vector3f position,
-                     edm4eic::CovDiag3f(),                                  // Cov3f cov,
-                     0.0,                                                   // float time
-                     0.0,                                                   // float timeError,
-                     5.0,                                                   // float edep,
-                     0.0                                                    // float edepError
+                     edm4hep::Vector3f(0.0, 0.0, 0.0), // Vector3f position,
+                     edm4eic::CovDiag3f(), // Cov3f cov,
+                     0.0, // float time
+                     0.0, // float timeError,
+                     5.0, // float edep,
+                     0.0 // float edepError
     );
 
     edm4eic::Measurement2DCollection clusterPositions;
@@ -63,21 +63,21 @@ TEST_CASE("the clustering algorithm runs", "[FarDetectorTrackerCluster]") {
     edm4eic::TrackerHitCollection hits_coll;
     hits_coll.create(
         id_desc.encode({{"system", 255}, {"x", 0}, {"y", 10}}), // std::uint64_t cellID,
-        edm4hep::Vector3f(0.0, 0.0, 0.0),                       // Vector3f position,
-        edm4eic::CovDiag3f(),                                   // Cov3f cov,
-        5.0,                                                    // float time
-        0.0,                                                    // float timeError,
-        5.0,                                                    // float edep,
-        0.0                                                     // float edepError
+        edm4hep::Vector3f(0.0, 0.0, 0.0), // Vector3f position,
+        edm4eic::CovDiag3f(), // Cov3f cov,
+        5.0, // float time
+        0.0, // float timeError,
+        5.0, // float edep,
+        0.0 // float edepError
     );
     hits_coll.create(
         id_desc.encode({{"system", 255}, {"x", 10}, {"y", 0}}), // std::uint64_t cellID,
-        edm4hep::Vector3f(0.0, 0.0, 0.0),                       // Vector3f position,
-        edm4eic::CovDiag3f(),                                   // Cov3f cov,
-        5.0,                                                    // float time
-        0.0,                                                    // float timeError,
-        5.0,                                                    // float edep,
-        0.0                                                     // float edepError
+        edm4hep::Vector3f(0.0, 0.0, 0.0), // Vector3f position,
+        edm4eic::CovDiag3f(), // Cov3f cov,
+        5.0, // float time
+        0.0, // float timeError,
+        5.0, // float edep,
+        0.0 // float edepError
     );
 
     edm4eic::Measurement2DCollection clusterPositions;
@@ -91,20 +91,20 @@ TEST_CASE("the clustering algorithm runs", "[FarDetectorTrackerCluster]") {
   SECTION("on two adjacent pixels") {
     edm4eic::TrackerHitCollection hits_coll;
     hits_coll.create(id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
-                     edm4hep::Vector3f(0.0, 0.0, 0.0),                      // Vector3f position,
-                     edm4eic::CovDiag3f(),                                  // Cov3f cov,
-                     5.0,                                                   // float time
-                     0.0,                                                   // float timeError,
-                     5.0,                                                   // float edep,
-                     0.0                                                    // float edepError
+                     edm4hep::Vector3f(0.0, 0.0, 0.0), // Vector3f position,
+                     edm4eic::CovDiag3f(), // Cov3f cov,
+                     5.0, // float time
+                     0.0, // float timeError,
+                     5.0, // float edep,
+                     0.0 // float edepError
     );
     hits_coll.create(id_desc.encode({{"system", 255}, {"x", 1}, {"y", 0}}), // std::uint64_t cellID,
-                     edm4hep::Vector3f(0.0, 0.0, 0.0),                      // Vector3f position,
-                     edm4eic::CovDiag3f(),                                  // Cov3f cov,
-                     5.0,                                                   // float time
-                     0.0,                                                   // float timeError,
-                     5.0,                                                   // float edep,
-                     0.0                                                    // float edepError
+                     edm4hep::Vector3f(0.0, 0.0, 0.0), // Vector3f position,
+                     edm4eic::CovDiag3f(), // Cov3f cov,
+                     5.0, // float time
+                     0.0, // float timeError,
+                     5.0, // float edep,
+                     0.0 // float edepError
     );
 
     edm4eic::Measurement2DCollection clusterPositions;
@@ -118,20 +118,20 @@ TEST_CASE("the clustering algorithm runs", "[FarDetectorTrackerCluster]") {
   SECTION("on two adjacent pixels outwith the time separation") {
     edm4eic::TrackerHitCollection hits_coll;
     hits_coll.create(id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
-                     edm4hep::Vector3f(0.0, 0.0, 0.0),                      // Vector3f position,
-                     edm4eic::CovDiag3f(),                                  // Cov3f cov,
-                     0.0,                                                   // float time
-                     0.0,                                                   // float timeError,
-                     5.0,                                                   // float edep,
-                     0.0                                                    // float edepError
+                     edm4hep::Vector3f(0.0, 0.0, 0.0), // Vector3f position,
+                     edm4eic::CovDiag3f(), // Cov3f cov,
+                     0.0, // float time
+                     0.0, // float timeError,
+                     5.0, // float edep,
+                     0.0 // float edepError
     );
     hits_coll.create(id_desc.encode({{"system", 255}, {"x", 1}, {"y", 0}}), // std::uint64_t cellID,
-                     edm4hep::Vector3f(0.0, 0.0, 0.0),                      // Vector3f position,
-                     edm4eic::CovDiag3f(),                                  // Cov3f cov,
-                     1.1 * cfg.hit_time_limit,                              // float time
-                     0.0,                                                   // float timeError,
-                     5.0,                                                   // float edep,
-                     0.0                                                    // float edepError
+                     edm4hep::Vector3f(0.0, 0.0, 0.0), // Vector3f position,
+                     edm4eic::CovDiag3f(), // Cov3f cov,
+                     1.1 * cfg.hit_time_limit, // float time
+                     0.0, // float timeError,
+                     5.0, // float edep,
+                     0.0 // float edepError
     );
 
     edm4eic::Measurement2DCollection clusterPositions;
@@ -151,30 +151,30 @@ TEST_CASE("the clustering algorithm runs", "[FarDetectorTrackerCluster]") {
 
     edm4eic::TrackerHitCollection hits_coll;
     hits_coll.create(id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}), // std::uint64_t cellID,
-                     edm4hep::Vector3f(0.0, 0.0, 0.0),                      // Vector3f position,
-                     edm4eic::CovDiag3f(),                                  // Cov3f cov,
-                     0.0,                                                   // float time
-                     0.0,                                                   // float timeError,
-                     pixelCharges[0],                                       // float edep,
-                     0.0                                                    // float edepError
+                     edm4hep::Vector3f(0.0, 0.0, 0.0), // Vector3f position,
+                     edm4eic::CovDiag3f(), // Cov3f cov,
+                     0.0, // float time
+                     0.0, // float timeError,
+                     pixelCharges[0], // float edep,
+                     0.0 // float edepError
     );
     hits_coll.create(id_desc.encode({{"system", 255}, {"x", 1}, {"y", 0}}), // std::uint64_t cellID,
-                     edm4hep::Vector3f(0.0, 0.0, 0.0),                      // Vector3f position,
-                     edm4eic::CovDiag3f(),                                  // Cov3f cov,
-                     pixel2Time,                                            // float time
-                     0.0,                                                   // float timeError,
-                     pixelCharges[1],                                       // float edep,
-                     0.0                                                    // float edepError
+                     edm4hep::Vector3f(0.0, 0.0, 0.0), // Vector3f position,
+                     edm4eic::CovDiag3f(), // Cov3f cov,
+                     pixel2Time, // float time
+                     0.0, // float timeError,
+                     pixelCharges[1], // float edep,
+                     0.0 // float edepError
     );
     hits_coll.create(
         id_desc.encode(
             {{"system", 255}, {"x", pixel3[0]}, {"y", pixel3[1]}}), // std::uint64_t cellID,
-        edm4hep::Vector3f(0.0, 0.0, 0.0),                           // Vector3f position,
-        edm4eic::CovDiag3f(),                                       // Cov3f cov,
-        0.0,                                                        // float time
-        0.0,                                                        // float timeError,
-        pixelCharges[2],                                            // float edep,
-        0.0                                                         // float edepError
+        edm4hep::Vector3f(0.0, 0.0, 0.0), // Vector3f position,
+        edm4eic::CovDiag3f(), // Cov3f cov,
+        0.0, // float time
+        0.0, // float timeError,
+        pixelCharges[2], // float edep,
+        0.0 // float edepError
     );
 
     edm4eic::Measurement2DCollection clusterPositions;

--- a/src/tests/omnifactory_test/JOmniFactoryTests.cc
+++ b/src/tests/omnifactory_test/JOmniFactoryTests.cc
@@ -215,20 +215,20 @@ TEST_CASE("Wiring itself is correctly defaulted") {
                                                                            "BCalLeftHits");
 
   // Overrides won't happen until factory gets Init()ed. However, defaults will be applied immediately
-  REQUIRE(b->bucket_count() == 42);        // Not provided by wiring
+  REQUIRE(b->bucket_count() == 42); // Not provided by wiring
   REQUIRE(b->config().bucket_count == 42); // Not provided by wiring
 
-  REQUIRE(b->threshold() == 6.1);        // Provided by wiring
+  REQUIRE(b->threshold() == 6.1); // Provided by wiring
   REQUIRE(b->config().threshold == 6.1); // Provided by wiring
 
   // Trigger JMF::Execute(), in order to trigger Init(), in order to Configure()s all Parameter fields...
   auto lefthits = event->Get<edm4hep::SimCalorimeterHit>("BCalLeftHits");
 
   // We didn't override the config values via the parameter manager, so all of these should be the same
-  REQUIRE(b->bucket_count() == 42);        // Not provided by wiring
+  REQUIRE(b->bucket_count() == 42); // Not provided by wiring
   REQUIRE(b->config().bucket_count == 42); // Not provided by wiring
 
-  REQUIRE(b->threshold() == 6.1);        // Provided by wiring
+  REQUIRE(b->threshold() == 6.1); // Provided by wiring
   REQUIRE(b->config().threshold == 6.1); // Provided by wiring
 
   b->logger()->info("Showing the full table of config parameters");

--- a/src/utilities/eicrecon/eicrecon_cli.cpp
+++ b/src/utilities/eicrecon/eicrecon_cli.cpp
@@ -289,7 +289,7 @@ JApplication* CreateJApplication(UserOptions& options) {
   // If the user hasn't specified a timeout (on cmd line or in config file), set the timeout to
   // something reasonably high
   if (para_mgr->FindParameter("jana:timeout") == nullptr) {
-    para_mgr->SetParameter("jana:timeout", 180);        // seconds
+    para_mgr->SetParameter("jana:timeout", 180); // seconds
     para_mgr->SetParameter("jana:warmup_timeout", 180); // seconds
   }
 
@@ -409,7 +409,7 @@ int Execute(JApplication* app, UserOptions& options) {
   } else if (options.flags[Benchmark]) {
     JSignalHandler::register_handlers(app);
     // Run JANA in benchmark mode
-    JBenchmarker benchmarker(app);  // Benchmarking params override default params
+    JBenchmarker benchmarker(app); // Benchmarking params override default params
     benchmarker.RunUntilFinished(); // Benchmarker will control JApp Run/Stop
   } else if (options.flags[ListFactories]) {
     app->Initialize();


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR reformats some files for better stability with newer clang-format defaults (see #1801). This gets rid of the conflicting behavior in e.g.
```diff
       }
 
     } // end hits to merge loop
-  }   // end clusters to merge loop
+  } // end clusters to merge loop
 
 } // end 'merge_and_split_clusters(VecClust&, VecProj&, edm4eic::MutableCluster&)'
```
But it also generally looks worse... You just can't win.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: clang-format 16.0.6 and 20.0.0 are not consistent with our .clang-format)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.