### PR TITLE
feat: add ActsTrajectoriesMerger

### DIFF
--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -150,14 +150,12 @@ public:
 
   template <typename T> class Output : public OutputBase {
     std::vector<T*> m_data;
-    bool m_owns_data;
 
   public:
-    Output(JOmniFactory* owner, std::string default_tag_name = "", bool owns_data = true) {
+    Output(JOmniFactory* owner, std::string default_tag_name = "") {
       owner->RegisterOutput(this);
       this->collection_names.push_back(default_tag_name);
-      this->type_name   = JTypeInfo::demangle<T>();
-      this->m_owns_data = owns_data;
+      this->type_name = JTypeInfo::demangle<T>();
     }
 
     std::vector<T*>& operator()() { return m_data; }
@@ -166,7 +164,7 @@ public:
     friend class JOmniFactory;
 
     void CreateHelperFactory(JOmniFactory& fac) override {
-      fac.DeclareOutput<T>(this->collection_names[0], this->m_owns_data);
+      fac.DeclareOutput<T>(this->collection_names[0]);
     }
 
     void SetCollection(JOmniFactory& fac) override {

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -150,12 +150,14 @@ public:
 
   template <typename T> class Output : public OutputBase {
     std::vector<T*> m_data;
+    bool m_owns_data;
 
   public:
-    Output(JOmniFactory* owner, std::string default_tag_name = "") {
+    Output(JOmniFactory* owner, std::string default_tag_name = "", bool owns_data = true) {
       owner->RegisterOutput(this);
       this->collection_names.push_back(default_tag_name);
-      this->type_name = JTypeInfo::demangle<T>();
+      this->type_name   = JTypeInfo::demangle<T>();
+      this->m_owns_data = owns_data;
     }
 
     std::vector<T*>& operator()() { return m_data; }
@@ -164,7 +166,7 @@ public:
     friend class JOmniFactory;
 
     void CreateHelperFactory(JOmniFactory& fac) override {
-      fac.DeclareOutput<T>(this->collection_names[0]);
+      fac.DeclareOutput<T>(this->collection_names[0], this->m_owns_data);
     }
 
     void SetCollection(JOmniFactory& fac) override {

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -171,7 +171,7 @@ public:
       fac.SetData<T>(this->collection_names[0], this->m_data);
     }
 
-    void Reset() override {}
+    void Reset() override { m_data.clear(); }
   };
 
   template <typename PodioT> class PodioOutput : public OutputBase {

--- a/src/global/tracking/ActsTrajectoriesMerger_factory.h
+++ b/src/global/tracking/ActsTrajectoriesMerger_factory.h
@@ -1,0 +1,39 @@
+// Created by Joe Osborn
+// Subject to the terms in the LICENSE file found in the top-level directory.
+//
+
+#pragma once
+
+#include <ActsExamples/EventData/Trajectories.hpp>
+#include <JANA/JEvent.h>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "extensions/jana/JOmniFactory.h"
+
+namespace eicrecon {
+
+class ActsTrajectoriesMerger_factory : public JOmniFactory<ActsTrajectoriesMerger_factory> {
+private:
+  Input<ActsExamples::Trajectories> m_acts_trajectories1_input{this};
+  Input<ActsExamples::Trajectories> m_acts_trajectories2_input{this};
+  Output<const ActsExamples::Trajectories> m_acts_trajectories_output{this};
+
+public:
+  void Configure() {}
+
+  void ChangeRun(int64_t run_number) {}
+
+  void Process(int64_t run_number, uint64_t event_number) {
+    m_acts_trajectories_output().insert(m_acts_trajectories_output().end(),
+                                        m_acts_trajectories1_input().begin(),
+                                        m_acts_trajectories1_input().end());
+    m_acts_trajectories_output().insert(m_acts_trajectories_output().end(),
+                                        m_acts_trajectories2_input().begin(),
+                                        m_acts_trajectories2_input().end());
+  }
+};
+
+} // namespace eicrecon

--- a/src/global/tracking/ActsTrajectoriesMerger_factory.h
+++ b/src/global/tracking/ActsTrajectoriesMerger_factory.h
@@ -1,6 +1,5 @@
-// Created by Joe Osborn
-// Subject to the terms in the LICENSE file found in the top-level directory.
-//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2025 Wouter Deconinck
 
 #pragma once
 

--- a/src/global/tracking/ActsTrajectoriesMerger_factory.h
+++ b/src/global/tracking/ActsTrajectoriesMerger_factory.h
@@ -18,7 +18,7 @@ class ActsTrajectoriesMerger_factory : public JOmniFactory<ActsTrajectoriesMerge
 private:
   Input<ActsExamples::Trajectories> m_acts_trajectories1_input{this};
   Input<ActsExamples::Trajectories> m_acts_trajectories2_input{this};
-  Output<ActsExamples::Trajectories> m_acts_trajectories_output{this, "", /* owns_data = */ false};
+  Output<ActsExamples::Trajectories> m_acts_trajectories_output{this};
 
 public:
   void Configure() {}

--- a/src/global/tracking/ActsTrajectoriesMerger_factory.h
+++ b/src/global/tracking/ActsTrajectoriesMerger_factory.h
@@ -26,7 +26,7 @@ public:
   void ChangeRun(int32_t /* run_number */) {}
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
-    for (auto traj : m_acts_trajectories1_input()) {
+    for (const auto& traj : m_acts_trajectories1_input()) {
       ActsExamples::Trajectories::IndexedParameters trackParameters;
       for (auto tip : traj->tips()) {
         trackParameters.insert({tip, traj->trackParameters(tip)});
@@ -34,7 +34,7 @@ public:
       m_acts_trajectories_output().push_back(
           new ActsExamples::Trajectories(traj->multiTrajectory(), traj->tips(), trackParameters));
     }
-    for (auto traj : m_acts_trajectories2_input()) {
+    for (const auto& traj : m_acts_trajectories2_input()) {
       ActsExamples::Trajectories::IndexedParameters trackParameters;
       for (auto tip : traj->tips()) {
         trackParameters.insert({tip, traj->trackParameters(tip)});

--- a/src/global/tracking/ActsTrajectoriesMerger_factory.h
+++ b/src/global/tracking/ActsTrajectoriesMerger_factory.h
@@ -23,9 +23,9 @@ private:
 public:
   void Configure() {}
 
-  void ChangeRun(int64_t run_number) {}
+  void ChangeRun(int32_t /* run_number */) {}
 
-  void Process(int64_t run_number, uint64_t event_number) {
+  void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     for (auto traj : m_acts_trajectories1_input()) {
       ActsExamples::Trajectories::IndexedParameters trackParameters;
       for (auto tip : traj->tips()) {


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR pulls the ActsTrajectoriesMerger and non-owning JOmniFactory Output support out of #1744.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #1744)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.