### PR TITLE
fix: avoid getMCParticle deprecation warning in FarDetectorLinearTracking

### DIFF
--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -13,6 +13,7 @@
 #include <edm4eic/RawTrackerHit.h>
 #include <edm4eic/TrackCollection.h>
 #include <edm4eic/TrackerHit.h>
+#include <edm4hep/EDM4hepVersion.h>
 #include <edm4hep/MCParticle.h>
 #include <edm4hep/SimTrackerHit.h>
 #include <edm4hep/Vector2f.h>
@@ -253,8 +254,12 @@ void FarDetectorLinearTracking::ConvertClusters(
     // Loop over the hit associations to find the associated MCParticle
     for (const auto& hit_assoc : assoc_hits) {
       if (hit_assoc.getRawHit() == rawHit) {
-        auto mcParticle = hit_assoc.getSimHit().getMCParticle();
-        assocParticles.push_back(mcParticle);
+#if EDM4HEP_BUILD_VERSION >= EDM4HEP_VERSION(0, 99, 0)
+        auto particle = hit_assoc.getSimHit().getParticle();
+#else
+        auto particle = hit_assoc.getSimHit().getMCParticle();
+#endif
+        assocParticles.push_back(particle);
         break;
       }
     }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR avoids the deprecation warning in FarDetectorLinearTracking due to the use of the field `MCParticle` which was renamed to `particle` in EDM4hep-0.99.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: warnings in compilation are bugs)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.