### PR TITLE
fix: avoid pessimizing moves where RVO copy elision

### DIFF
--- a/src/algorithms/reco/ChargedReconstructedParticleSelector.h
+++ b/src/algorithms/reco/ChargedReconstructedParticleSelector.h
@@ -34,7 +34,7 @@ public:
       }
     }
 
-    return std::move(outputs);
+    return outputs;
   }
 };
 

--- a/src/algorithms/reco/MC2SmearedParticle.cc
+++ b/src/algorithms/reco/MC2SmearedParticle.cc
@@ -7,7 +7,6 @@
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
 #include <fmt/core.h>
-#include <utility>
 
 void eicrecon::MC2SmearedParticle::init(std::shared_ptr<spdlog::logger> logger) { m_log = logger; }
 

--- a/src/algorithms/reco/MC2SmearedParticle.cc
+++ b/src/algorithms/reco/MC2SmearedParticle.cc
@@ -43,5 +43,5 @@ eicrecon::MC2SmearedParticle::produce(const edm4hep::MCParticleCollection* mc_pa
     rec_part.setCovMatrix({0, 0, 0, 0});
     rec_part.setPDG(mc_particle.getPDG());
   }
-  return std::move(rec_particles);
+  return rec_particles;
 }

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -187,5 +187,5 @@ std::unique_ptr<edm4eic::VertexCollection> eicrecon::IterativeVertexFinder::prod
 
   } // end for vtx
 
-  return std::move(outputVertices);
+  return outputVertices;
 }

--- a/src/algorithms/tracking/TrackParamTruthInit.cc
+++ b/src/algorithms/tracking/TrackParamTruthInit.cc
@@ -18,7 +18,6 @@
 #include <cstdlib>
 #include <limits>
 #include <memory>
-#include <utility>
 
 #include "extensions/spdlog/SpdlogFormatters.h" // IWYU pragma: keep
 

--- a/src/algorithms/tracking/TrackParamTruthInit.cc
+++ b/src/algorithms/tracking/TrackParamTruthInit.cc
@@ -139,5 +139,5 @@ eicrecon::TrackParamTruthInit::produce(const edm4hep::MCParticleCollection* mcpa
     }
   }
 
-  return std::move(track_parameters);
+  return track_parameters;
 }

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -175,7 +175,7 @@ eicrecon::TrackSeeding::produce(const edm4eic::TrackerHitCollection& trk_hits) {
     delete sp;
   }
 
-  return std::move(trackparams);
+  return trackparams;
 }
 
 std::vector<const eicrecon::SpacePoint*>
@@ -276,7 +276,7 @@ eicrecon::TrackSeeding::makeTrackParams(SeedContainer& seeds) {
     trackparam.setCovariance(cov);
   }
 
-  return std::move(trackparams);
+  return trackparams;
 }
 std::pair<float, float>
 eicrecon::TrackSeeding::findPCA(std::tuple<float, float, float>& circleParams) const {

--- a/src/algorithms/tracking/TrackerHitReconstruction.cc
+++ b/src/algorithms/tracking/TrackerHitReconstruction.cc
@@ -89,7 +89,7 @@ TrackerHitReconstruction::process(const edm4eic::RawTrackerHitCollection& raw_hi
 #endif
   }
 
-  return std::move(rec_hits);
+  return rec_hits;
 }
 
 } // namespace eicrecon

--- a/src/algorithms/tracking/TrackerHitReconstruction.cc
+++ b/src/algorithms/tracking/TrackerHitReconstruction.cc
@@ -13,7 +13,6 @@
 #include <spdlog/common.h>
 #include <cstddef>
 #include <iterator>
-#include <utility>
 #include <vector>
 
 namespace eicrecon {

--- a/src/algorithms/tracking/TrackerMeasurementFromHits.cc
+++ b/src/algorithms/tracking/TrackerMeasurementFromHits.cc
@@ -144,6 +144,6 @@ TrackerMeasurementFromHits::produce(const edm4eic::TrackerHitCollection& trk_hit
   m_log->debug("All hits processed. Hits size: {}  measurements->size: {}", trk_hits.size(),
                meas2Ds->size());
 
-  return std::move(meas2Ds);
+  return meas2Ds;
 }
 } // namespace eicrecon


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes several pessimizing moves where return value optimization and copy elision are likely to take effect anyway.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: pessimizing moves)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.