### PR TITLE
fix: avoid signed/unsigned comparisons

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterTruthClustering.cc
+++ b/src/algorithms/calorimetry/CalorimeterTruthClustering.cc
@@ -47,7 +47,8 @@ void CalorimeterTruthClustering::process(const CalorimeterTruthClustering::Input
     // FIXME: to be fixed so proper object tracking can be done without
     // FIXME: requiring Collection classes be used to manage all objects.
     std::size_t mcIndex;
-    if ((hit.getObjectID().index >= 0) && (hit.getObjectID().index < mc->size())) {
+    if ((hit.getObjectID().index >= 0) &&
+        (hit.getObjectID().index < static_cast<long>(mc->size()))) {
       mcIndex = hit.getObjectID().index;
     } else {
       mcIndex      = 0;

--- a/src/algorithms/digi/PulseNoise.cc
+++ b/src/algorithms/digi/PulseNoise.cc
@@ -8,6 +8,7 @@
 #include <edm4hep/SimCalorimeterHit.h>
 #include <edm4hep/SimTrackerHit.h>
 #include <podio/RelationRange.h>
+#include <cstddef>
 #include <gsl/pointers>
 #include <vector>
 
@@ -33,7 +34,7 @@ void PulseNoise::process(const PulseNoise::Input& input, const PulseNoise::Outpu
 
     float integral = 0;
     //Add noise to the pulse
-    for (int i = 0; i < pulse.getAmplitude().size(); i++) {
+    for (std::size_t i = 0; i < pulse.getAmplitude().size(); i++) {
       double noise     = m_noise(generator) * m_cfg.scale;
       double amplitude = pulse.getAmplitude()[i] + noise;
       out_pulse.addToAmplitude(amplitude);

--- a/src/algorithms/digi/SiliconPulseGeneration.cc
+++ b/src/algorithms/digi/SiliconPulseGeneration.cc
@@ -12,6 +12,7 @@
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
 #include <cmath>
+#include <cstddef>
 #include <functional>
 #include <gsl/pointers>
 #include <stdexcept>
@@ -74,7 +75,7 @@ public:
   EvaluatorPulse(const std::string& expression, const std::vector<double>& params) {
 
     std::vector<std::string> keys = {"time", "charge"};
-    for (int i = 0; i < params.size(); i++) {
+    for (std::size_t i = 0; i < params.size(); i++) {
       std::string p = "param" + std::to_string(i);
       //Check the expression contains the parameter
       if (expression.find(p) == std::string::npos) {

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -59,7 +59,7 @@ void FarDetectorLinearTracking::process(const FarDetectorLinearTracking::Input& 
   auto [outputTracks, assocTracks]  = output;
 
   // Check the number of input collections is correct
-  int nCollections = inputhits.size();
+  std::size_t nCollections = inputhits.size();
   if (nCollections != m_cfg.n_layer) {
     error("Wrong number of input collections passed to algorithm");
     return;
@@ -87,7 +87,7 @@ void FarDetectorLinearTracking::process(const FarDetectorLinearTracking::Input& 
   Eigen::MatrixXd hitMatrix(3, m_cfg.n_layer);
 
   // Create vector to store indexes of hits in the track
-  std::vector<int> layerHitIndex(m_cfg.n_layer, 0);
+  std::vector<std::size_t> layerHitIndex(m_cfg.n_layer, 0);
 
   int layer = 0;
 
@@ -103,7 +103,7 @@ void FarDetectorLinearTracking::process(const FarDetectorLinearTracking::Input& 
 
     // If valid hit combination, move to the next layer or check the combination
     if (isValid) {
-      if (layer == m_cfg.n_layer - 1) {
+      if (layer == static_cast<long>(m_cfg.n_layer) - 1) {
         // Check the combination, if chi2 limit is passed, add the track to the output
         checkHitCombination(&hitMatrix, outputTracks, assocTracks, inputhits, assocParts,
                             layerHitIndex);
@@ -138,7 +138,7 @@ void FarDetectorLinearTracking::checkHitCombination(
     edm4eic::MCRecoTrackParticleAssociationCollection* assocTracks,
     const std::vector<gsl::not_null<const edm4eic::Measurement2DCollection*>>& inputHits,
     const std::vector<std::vector<edm4hep::MCParticle>>& assocParts,
-    const std::vector<int>& layerHitIndex) const {
+    const std::vector<std::size_t>& layerHitIndex) const {
 
   Eigen::Vector3d weightedAnchor = (*hitMatrix) * m_layerWeights / (m_layerWeights.sum());
 
@@ -171,7 +171,7 @@ void FarDetectorLinearTracking::checkHitCombination(
   float time{0};                                            // Time at this point [ns]
   float timeError{0};                                       // Error on the time at this point
   float charge{-1};                                         // Charge of the particle
-  int32_t ndf{m_cfg.n_layer - 1};                           // Number of degrees of freedom
+  int32_t ndf{static_cast<int32_t>(m_cfg.n_layer) - 1};     // Number of degrees of freedom
   int32_t pdg{11};                                          // PDG code of the particle
 
   // Create the track
@@ -181,7 +181,7 @@ void FarDetectorLinearTracking::checkHitCombination(
 
   // Add Measurement2D relations and count occurrence of particles contributing to the track
   std::unordered_map<const edm4hep::MCParticle*, int> particleCount;
-  for (int layer = 0; layer < layerHitIndex.size(); layer++) {
+  for (std::size_t layer = 0; layer < layerHitIndex.size(); layer++) {
     track.addToMeasurements((*inputHits[layer])[layerHitIndex[layer]]);
     const auto& assocParticle = assocParts[layer][layerHitIndex[layer]];
     particleCount[&assocParticle]++;

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.h
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.h
@@ -12,6 +12,7 @@
 #include <edm4eic/TrackCollection.h>
 #include <edm4hep/MCParticle.h>
 #include <Eigen/Core>
+#include <cstddef>
 #include <gsl/pointers>
 #include <optional>
 #include <string>
@@ -56,7 +57,7 @@ private:
       edm4eic::MCRecoTrackParticleAssociationCollection* assocTracks,
       const std::vector<gsl::not_null<const edm4eic::Measurement2DCollection*>>& inputHits,
       const std::vector<std::vector<edm4hep::MCParticle>>& assocParts,
-      const std::vector<int>& layerHitIndex) const;
+      const std::vector<std::size_t>& layerHitIndex) const;
 
   /** Check if the last two hits are within a certain angle of the optimum direction **/
   bool checkHitPair(const Eigen::Vector3d& hit1, const Eigen::Vector3d& hit2) const;

--- a/src/algorithms/fardetectors/FarDetectorLinearTrackingConfig.h
+++ b/src/algorithms/fardetectors/FarDetectorLinearTrackingConfig.h
@@ -6,9 +6,9 @@
 namespace eicrecon {
 struct FarDetectorLinearTrackingConfig {
 
-  int layer_hits_max{10};
+  std::size_t layer_hits_max{10};
   float chi2_max{0.001};
-  int n_layer{4};
+  std::size_t n_layer{4};
 
   // Restrict hit direction
   bool restrict_direction{true};

--- a/src/algorithms/onnx/CalorimeterParticleIDPostML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPostML.cc
@@ -35,7 +35,7 @@ void CalorimeterParticleIDPostML::process(const CalorimeterParticleIDPostML::Inp
         fmt::format("Expected tensor rank to be 2, but it is {}", prediction_tensor.shape_size()));
   }
 
-  if (prediction_tensor.getShape(0) != in_clusters->size()) {
+  if (prediction_tensor.getShape(0) != static_cast<long>(in_clusters->size())) {
     error("Length mismatch between tensor's 0th axis and number of clusters: {} != {}",
           prediction_tensor.getShape(0), in_clusters->size());
     throw std::runtime_error(

--- a/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
@@ -65,7 +65,7 @@ void CalorimeterParticleIDPreML::process(const CalorimeterParticleIDPreML::Input
     auto pos = cluster.getPosition();
     feature_tensor.addToFloatData(edm4hep::utils::anglePolar(pos));
     feature_tensor.addToFloatData(edm4hep::utils::angleAzimuthal(pos));
-    for (int par_ix = 0; par_ix < cluster.shapeParameters_size(); par_ix++) {
+    for (std::size_t par_ix = 0; par_ix < cluster.shapeParameters_size(); par_ix++) {
       feature_tensor.addToFloatData(cluster.getShapeParameters(par_ix));
     }
 

--- a/src/algorithms/onnx/ONNXInference.cc
+++ b/src/algorithms/onnx/ONNXInference.cc
@@ -121,7 +121,7 @@ void ONNXInference::process(const ONNXInference::Input& input,
   std::vector<float> input_tensor_values;
   std::vector<Ort::Value> input_tensors;
 
-  for (int ix = 0; ix < m_input_names.size(); ix++) {
+  for (std::size_t ix = 0; ix < m_input_names.size(); ix++) {
     edm4eic::Tensor in_tensor = in_tensors[ix]->at(0);
     if (in_tensor.getElementType() == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
       input_tensors.emplace_back(

--- a/src/algorithms/tracking/TrackerMeasurementFromHits.cc
+++ b/src/algorithms/tracking/TrackerMeasurementFromHits.cc
@@ -37,7 +37,7 @@ void TrackerMeasurementFromHits::init(const dd4hep::Detector* detector,
   m_converter       = converter;
   m_log             = logger;
   m_acts_context    = std::move(acts_context);
-  m_detid_b0tracker = m_dd4hepGeo->constant<int>("B0Tracker_Station_1_ID");
+  m_detid_b0tracker = m_dd4hepGeo->constant<unsigned long>("B0Tracker_Station_1_ID");
 }
 
 std::unique_ptr<edm4eic::Measurement2DCollection>

--- a/src/algorithms/tracking/TrackerMeasurementFromHits.h
+++ b/src/algorithms/tracking/TrackerMeasurementFromHits.h
@@ -37,7 +37,7 @@ private:
   std::shared_ptr<const ActsGeometryProvider> m_acts_context;
 
   /// Detector-specific information
-  int m_detid_b0tracker;
+  unsigned long m_detid_b0tracker;
 };
 
 } // namespace eicrecon

--- a/src/factories/fardetectors/FarDetectorLinearTracking_factory.h
+++ b/src/factories/fardetectors/FarDetectorLinearTracking_factory.h
@@ -29,8 +29,8 @@ private:
   PodioOutput<edm4eic::Track> m_tracks_output{this};
   PodioOutput<edm4eic::MCRecoTrackParticleAssociation> m_tracks_association_output{this};
 
-  ParameterRef<int> n_layer{this, "numLayers", config().n_layer};
-  ParameterRef<int> layer_hits_max{this, "layerHitsMax", config().layer_hits_max};
+  ParameterRef<std::size_t> n_layer{this, "numLayers", config().n_layer};
+  ParameterRef<std::size_t> layer_hits_max{this, "layerHitsMax", config().layer_hits_max};
   ParameterRef<float> chi2_max{this, "chi2Max", config().chi2_max};
 
 public:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR avoids signed/unsigned integer comparisons by using size_t for array sizes and explicitly casting unsigned integers into signed equivalents (with inevitable narrowing) where necessary.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: avoid signed and unsigned integer comparisons)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.