### PR TITLE
fix: use GeoSvc in TrackClusterMerger instead of init(ptr)

### DIFF
--- a/src/algorithms/calorimetry/TrackClusterMergeSplitter.cc
+++ b/src/algorithms/calorimetry/TrackClusterMergeSplitter.cc
@@ -21,10 +21,10 @@ namespace eicrecon {
 // --------------------------------------------------------------------------
 //! Initialize algorithm
 // --------------------------------------------------------------------------
-void TrackClusterMergeSplitter::init(const dd4hep::Detector* detector) {
+void TrackClusterMergeSplitter::init() {
 
   // grab detector id
-  m_idCalo = detector->constant<int>(m_cfg.idCalo);
+  m_idCalo = m_geo.detector()->constant<int>(m_cfg.idCalo);
   debug("Collecting projections to detector with system id {}", m_idCalo);
 
 } // end 'init(dd4hep::Detector*)'

--- a/src/algorithms/calorimetry/TrackClusterMergeSplitter.cc
+++ b/src/algorithms/calorimetry/TrackClusterMergeSplitter.cc
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2024 Derek Anderson
 
+#include <DD4hep/Detector.h>
 #include <edm4eic/CalorimeterHit.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>

--- a/src/algorithms/calorimetry/TrackClusterMergeSplitter.h
+++ b/src/algorithms/calorimetry/TrackClusterMergeSplitter.h
@@ -5,6 +5,7 @@
 
 #include <DD4hep/Detector.h>
 #include <algorithms/algorithm.h>
+#include <algorithms/geo.h>
 #include <edm4eic/ProtoClusterCollection.h>
 #include <edm4eic/TrackPoint.h>
 #include <edm4eic/TrackSegmentCollection.h>

--- a/src/algorithms/calorimetry/TrackClusterMergeSplitter.h
+++ b/src/algorithms/calorimetry/TrackClusterMergeSplitter.h
@@ -79,10 +79,12 @@ public:
             "Merges or splits clusters based on tracks projected to them."} {}
 
   // public methods
-  void init(const dd4hep::Detector* detector);
+  void init();
   void process(const Input&, const Output&) const final;
 
 private:
+  const algorithms::GeoSvc& m_geo = algorithms::GeoSvc::instance();
+
   // private methods
   void get_projections(const edm4eic::TrackSegmentCollection* projections,
                        VecProj& relevant_projects) const;

--- a/src/algorithms/calorimetry/TrackClusterMergeSplitter.h
+++ b/src/algorithms/calorimetry/TrackClusterMergeSplitter.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <DD4hep/Detector.h>
 #include <algorithms/algorithm.h>
 #include <algorithms/geo.h>
 #include <edm4eic/ProtoClusterCollection.h>

--- a/src/factories/calorimetry/TrackClusterMergeSplitter_factory.h
+++ b/src/factories/calorimetry/TrackClusterMergeSplitter_factory.h
@@ -50,7 +50,7 @@ public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>(GetPrefix());
     m_algo->applyConfig(config());
-    m_algo->init(m_geoSvc().detector());
+    m_algo->init();
   }
 
   void ChangeRun(int64_t run_number) { /* nothing to do here */


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR modifies the TrackClusterMerger to use the algorithms GeoSvc instead of getting the detector geometry by pointer through the init function.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: algorithms interface does not allow init args)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.