### PR TITLE
fix: mark static RichGeo functions as maybe_unused

### DIFF
--- a/src/services/geometry/richgeo/RichGeo.h
+++ b/src/services/geometry/richgeo/RichGeo.h
@@ -34,7 +34,8 @@ public:
 enum radiator_enum { kAerogel, kGas, nRadiators };
 
 // return radiator name associated with index
-static std::string RadiatorName(int num, std::shared_ptr<spdlog::logger> m_log = nullptr) {
+[[maybe_unused]] static std::string RadiatorName(int num,
+                                                 std::shared_ptr<spdlog::logger> m_log = nullptr) {
   if (num == kAerogel)
     return "Aerogel";
   else if (num == kGas)
@@ -49,7 +50,8 @@ static std::string RadiatorName(int num, std::shared_ptr<spdlog::logger> m_log =
 }
 
 // return radiator index associated with name
-static int RadiatorNum(std::string name, std::shared_ptr<spdlog::logger> m_log = nullptr) {
+[[maybe_unused]] static int RadiatorNum(std::string name,
+                                        std::shared_ptr<spdlog::logger> m_log = nullptr) {
   if (name == "Aerogel")
     return kAerogel;
   else if (name == "Gas")
@@ -63,12 +65,14 @@ static int RadiatorNum(std::string name, std::shared_ptr<spdlog::logger> m_log =
   }
 }
 
-static int RadiatorNum(const char* name, std::shared_ptr<spdlog::logger> m_log = nullptr) {
+[[maybe_unused]] static int RadiatorNum(const char* name,
+                                        std::shared_ptr<spdlog::logger> m_log = nullptr) {
   return RadiatorNum(std::string(name), m_log);
 }
 
 // search string `input` for a radiator name; return corresponding index
-static int ParseRadiatorName(std::string input, std::shared_ptr<spdlog::logger> m_log = nullptr) {
+[[maybe_unused]] static int ParseRadiatorName(std::string input,
+                                              std::shared_ptr<spdlog::logger> m_log = nullptr) {
   if (input.find("aerogel") != std::string::npos)
     return kAerogel;
   else if (input.find("Aerogel") != std::string::npos)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Since static functions in headers are considered unused for any translation unit that includes the header but doesn't use the function, this PR marks the RichGeo helper functions as `maybe_unused`.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: spurious unused function warning/errors)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.