### PR TITLE
fix: slight modification of maximum weight with unsigned indices

### DIFF
--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -238,13 +238,17 @@ void FarDetectorLinearTracking::ConvertClusters(
 
     // Determine the MCParticle associated with this measurement based on the weights
     // Get hit in measurement with max weight
-    float maxWeight = 0;
-    int maxIndex    = -1;
-    for (int i = 0; i < cluster.getWeights().size(); ++i) {
+    float maxWeight      = 0;
+    std::size_t maxIndex = cluster.getWeights().size();
+    for (std::size_t i = 0; i < cluster.getWeights().size(); ++i) {
       if (cluster.getWeights()[i] > maxWeight) {
         maxWeight = cluster.getWeights()[i];
         maxIndex  = i;
       }
+    }
+    if (maxIndex == cluster.getWeights().size()) {
+      // no maximum found (e.g. all weights zero, cluster size zero)
+      continue;
     }
     auto maxHit = cluster.getHits()[maxIndex];
     // Get associated raw hit

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -29,6 +29,7 @@
 #include <Eigen/SVD>
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <unordered_map>
 #include <utility>
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR modifies the maximum weight determination in the FarDetectorLinearTracking algorithm to allow the use of unsigned indices and avoid compiler warnings. This has (had) a possible corner case when all weights are zero or the number of entries is zero, when previous a negative index would be used. These are now skipped.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: only use unsigned integers as index)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.