### PR TITLE
fix: virtual destructor for ActsGeometryProvider to avoid warning

### DIFF
--- a/src/algorithms/tracking/ActsGeometryProvider.h
+++ b/src/algorithms/tracking/ActsGeometryProvider.h
@@ -40,7 +40,9 @@ void draw_surfaces(std::shared_ptr<const Acts::TrackingGeometry> trk_geo,
 
 class ActsGeometryProvider {
 public:
-  ActsGeometryProvider() {}
+  ActsGeometryProvider(){};
+  virtual ~ActsGeometryProvider() = default;
+
   using VolumeSurfaceMap = std::unordered_map<uint64_t, const Acts::Surface*>;
 
   virtual void initialize(const dd4hep::Detector* dd4hep_geo, std::string material_file,


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR ensures that the ActsGeometryProvider gets a proper vtable by defining a virtual destructor.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: compiler warns about virtual functions in classes without vtable)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.