### PR TITLE
feat: use algorithms logger service in IrtCherenkovParticleID

### DIFF
--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -240,6 +240,17 @@ macro(plugin_add_algorithms _name)
     find_package(algorithms REQUIRED)
   endif()
 
+  if(${_name}_WITH_LIBRARY)
+    target_compile_definitions(
+      ${PLUGIN_NAME}_library PRIVATE "algorithms_VERSION_MAJOR=${algorithms_VERSION_MAJOR}"
+                                     "algorithms_VERSION_MINOR=${algorithms_VERSION_MINOR}")
+  endif()
+  if(${_name}_WITH_PLUGIN)
+    target_compile_definitions(
+      ${PLUGIN_NAME}_plugin PRIVATE "algorithms_VERSION_MAJOR=${algorithms_VERSION_MAJOR}"
+                                    "algorithms_VERSION_MINOR=${algorithms_VERSION_MINOR}")
+  endif()
+
   plugin_link_libraries(${_name} algorithms::algocore)
 
 endmacro()

--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -242,13 +242,15 @@ macro(plugin_add_algorithms _name)
 
   if(${_name}_WITH_LIBRARY)
     target_compile_definitions(
-      ${PLUGIN_NAME}_library PRIVATE "algorithms_VERSION_MAJOR=${algorithms_VERSION_MAJOR}"
-                                     "algorithms_VERSION_MINOR=${algorithms_VERSION_MINOR}")
+      ${PLUGIN_NAME}_library
+      PRIVATE "algorithms_VERSION_MAJOR=${algorithms_VERSION_MAJOR}"
+              "algorithms_VERSION_MINOR=${algorithms_VERSION_MINOR}")
   endif()
   if(${_name}_WITH_PLUGIN)
     target_compile_definitions(
-      ${PLUGIN_NAME}_plugin PRIVATE "algorithms_VERSION_MAJOR=${algorithms_VERSION_MAJOR}"
-                                    "algorithms_VERSION_MINOR=${algorithms_VERSION_MINOR}")
+      ${PLUGIN_NAME}_plugin
+      PRIVATE "algorithms_VERSION_MAJOR=${algorithms_VERSION_MAJOR}"
+              "algorithms_VERSION_MINOR=${algorithms_VERSION_MINOR}")
   endif()
 
   plugin_link_libraries(${_name} algorithms::algocore)

--- a/src/algorithms/pid/IrtCherenkovParticleID.cc
+++ b/src/algorithms/pid/IrtCherenkovParticleID.cc
@@ -21,19 +21,18 @@
 #include <fmt/format.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
-#include <spdlog/common.h>
 #include <algorithm>
 #include <cstddef>
 #include <functional>
 #include <gsl/pointers>
 #include <iterator>
+#include <memory>
 #include <set>
 #include <stdexcept>
 #include <utility>
 #include <vector>
 
 #include "algorithms/pid/IrtCherenkovParticleIDConfig.h"
-#include "algorithms/pid/Tools.h"
 
 namespace eicrecon {
 

--- a/src/algorithms/pid/IrtCherenkovParticleID.cc
+++ b/src/algorithms/pid/IrtCherenkovParticleID.cc
@@ -44,7 +44,13 @@ void IrtCherenkovParticleID::init(CherenkovDetectorCollection* irt_det_coll) {
   debug() << m_cfg << endmsg;
 
   // inform the user if a cheat mode is enabled
-  m_cfg.PrintCheats(this);
+  auto print_cheat = [this](auto name, bool val, auto desc) {
+    if (val)
+      warning("CHEAT MODE '{}' ENABLED: {}", name, desc);
+  };
+  print_cheat("cheatPhotonVertex", m_cfg.cheatPhotonVertex,
+              "use MC photon vertex, wavelength, refractive index");
+  print_cheat("cheatTrueRadiator", m_cfg.cheatTrueRadiator, "use MC truth to obtain true radiator");
 
   // extract the the relevant `CherenkovDetector`, set to `m_irt_det`
   auto& detectors = m_irt_det_coll->GetDetectors();

--- a/src/algorithms/pid/IrtCherenkovParticleID.cc
+++ b/src/algorithms/pid/IrtCherenkovParticleID.cc
@@ -41,7 +41,7 @@ void IrtCherenkovParticleID::init(CherenkovDetectorCollection* irt_det_coll) {
   m_irt_det_coll = irt_det_coll;
 
   // print the configuration parameters
-  m_cfg.Print<algorithms::LogLevel::kDebug>(this);
+  debug() << m_cfg << endmsg;
 
   // inform the user if a cheat mode is enabled
   m_cfg.PrintCheats(this);

--- a/src/algorithms/pid/IrtCherenkovParticleID.cc
+++ b/src/algorithms/pid/IrtCherenkovParticleID.cc
@@ -10,6 +10,7 @@
 #include <IRT/SinglePDF.h>
 #include <TString.h>
 #include <TVector3.h>
+#include <algorithms/logger.h>
 #include <edm4eic/CherenkovParticleIDHypothesis.h>
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/TrackPoint.h>

--- a/src/algorithms/pid/IrtCherenkovParticleID.cc
+++ b/src/algorithms/pid/IrtCherenkovParticleID.cc
@@ -42,10 +42,10 @@ void IrtCherenkovParticleID::init(CherenkovDetectorCollection* irt_det_coll) {
   m_irt_det_coll = irt_det_coll;
 
   // print the configuration parameters
-  m_cfg.Print(m_log, spdlog::level::debug);
+  m_cfg.Print<algorithms::LogLevel::kDebug>(this);
 
   // inform the user if a cheat mode is enabled
-  m_cfg.PrintCheats(m_log);
+  m_cfg.PrintCheats(this);
 
   // extract the the relevant `CherenkovDetector`, set to `m_irt_det`
   auto& detectors = m_irt_det_coll->GetDetectors();

--- a/src/algorithms/pid/IrtCherenkovParticleID.cc
+++ b/src/algorithms/pid/IrtCherenkovParticleID.cc
@@ -37,11 +37,9 @@
 
 namespace eicrecon {
 
-void IrtCherenkovParticleID::init(CherenkovDetectorCollection* irt_det_coll,
-                                  std::shared_ptr<spdlog::logger>& logger) {
+void IrtCherenkovParticleID::init(CherenkovDetectorCollection* irt_det_coll) {
   // members
   m_irt_det_coll = irt_det_coll;
-  m_log          = logger;
 
   // print the configuration parameters
   m_cfg.Print(m_log, spdlog::level::debug);
@@ -54,34 +52,33 @@ void IrtCherenkovParticleID::init(CherenkovDetectorCollection* irt_det_coll,
   if (detectors.size() == 0)
     throw std::runtime_error("No CherenkovDetectors found in input collection `irt_det_coll`");
   if (detectors.size() > 1)
-    m_log->warn("IrtCherenkovParticleID currently only supports 1 CherenkovDetector at a time; "
-                "taking the first");
+    warning("IrtCherenkovParticleID currently only supports 1 CherenkovDetector at a time; "
+            "taking the first");
   auto this_detector = *detectors.begin();
   m_det_name         = this_detector.first;
   m_irt_det          = this_detector.second;
-  m_log->debug("Initializing IrtCherenkovParticleID algorithm for CherenkovDetector '{}'",
-               m_det_name);
+  debug("Initializing IrtCherenkovParticleID algorithm for CherenkovDetector '{}'", m_det_name);
 
   // readout decoding
   m_cell_mask = m_irt_det->GetReadoutCellMask();
-  m_log->debug("readout cellMask = {:#X}", m_cell_mask);
+  debug("readout cellMask = {:#X}", m_cell_mask);
 
   // rebin refractive index tables to have `m_cfg.numRIndexBins` bins
-  m_log->trace("Rebinning refractive index tables to have {} bins", m_cfg.numRIndexBins);
+  trace("Rebinning refractive index tables to have {} bins", m_cfg.numRIndexBins);
   for (auto [rad_name, irt_rad] : m_irt_det->Radiators()) {
     auto ri_lookup_table_orig = irt_rad->m_ri_lookup_table;
     irt_rad->m_ri_lookup_table.clear();
     irt_rad->m_ri_lookup_table = Tools::ApplyFineBinning(ri_lookup_table_orig, m_cfg.numRIndexBins);
-    // m_log->trace("- {}", rad_name);
-    // for(auto [energy,rindex] : irt_rad->m_ri_lookup_table) m_log->trace("  {:>5} eV   {:<}", energy, rindex);
+    // trace("- {}", rad_name);
+    // for(auto [energy,rindex] : irt_rad->m_ri_lookup_table) trace("  {:>5} eV   {:<}", energy, rindex);
   }
 
   // build `m_pid_radiators`, the list of radiators to use for PID
-  m_log->debug("Obtain List of Radiators:");
+  debug("Obtain List of Radiators:");
   for (auto [rad_name, irt_rad] : m_irt_det->Radiators()) {
     if (rad_name != "Filter") {
       m_pid_radiators.insert({std::string(rad_name), irt_rad});
-      m_log->debug("- {}", rad_name.Data());
+      debug("- {}", rad_name.Data());
     }
   }
 
@@ -103,19 +100,18 @@ void IrtCherenkovParticleID::init(CherenkovDetectorCollection* irt_det_coll,
         else if (cfg_rad.smearingMode == "gaussian")
           irt_rad->SetGaussianSmearing(cfg_rad.smearing);
         else
-          m_log->error("Unknown smearing mode '{}' for {} radiator", cfg_rad.smearingMode,
-                       rad_name);
+          error("Unknown smearing mode '{}' for {} radiator", cfg_rad.smearingMode, rad_name);
       }
     } else
-      m_log->error("Cannot find radiator '{}' in IrtCherenkovParticleIDConfig instance", rad_name);
+      error("Cannot find radiator '{}' in IrtCherenkovParticleIDConfig instance", rad_name);
   }
 
   // get PDG info for the particles we want to identify in PID
-  m_log->debug("List of particles for PID:");
+  debug("List of particles for PID:");
   for (auto pdg : m_cfg.pdgList) {
     auto mass = m_particleSvc.particle(pdg).mass;
     m_pdg_mass.insert({pdg, mass});
-    m_log->debug("  {:>8}  M={} GeV", pdg, mass);
+    debug("  {:>8}  M={} GeV", pdg, mass);
   }
 }
 
@@ -126,9 +122,9 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
   auto [out_aerogel_particleIDs, out_gas_particleIDs] = output;
 
   // logging
-  m_log->trace("{:=^70}", " call IrtCherenkovParticleID::AlgorithmProcess ");
-  m_log->trace("number of raw sensor hits: {}", in_raw_hits->size());
-  m_log->trace("number of raw sensor hit with associated photons: {}", in_hit_assocs->size());
+  trace("{:=^70}", " call IrtCherenkovParticleID::AlgorithmProcess ");
+  trace("number of raw sensor hits: {}", in_raw_hits->size());
+  trace("number of raw sensor hit with associated photons: {}", in_hit_assocs->size());
 
   std::map<std::string, const edm4eic::TrackSegmentCollection*> in_charged_particles{
       {"Aerogel", in_aerogel_tracks},
@@ -151,17 +147,17 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
         in_charged_particles.begin(), in_charged_particles.end(),
         std::back_inserter(in_charged_particle_sizes),
         [](const auto& in_charged_particle) { return in_charged_particle.second->size(); });
-    m_log->error("radiators have differing numbers of TrackSegments {}",
-                 fmt::join(in_charged_particle_sizes, ", "));
+    error("radiators have differing numbers of TrackSegments {}",
+          fmt::join(in_charged_particle_sizes, ", "));
     return;
   }
 
   // loop over charged particles ********************************************
-  m_log->trace("{:#<70}", "### CHARGED PARTICLES ");
+  trace("{:#<70}", "### CHARGED PARTICLES ");
   std::size_t num_charged_particles = in_charged_particle_size_distribution.begin()->first;
-  for (long i_charged_particle = 0; i_charged_particle < num_charged_particles;
+  for (std::size_t i_charged_particle = 0; i_charged_particle < num_charged_particles;
        i_charged_particle++) {
-    m_log->trace("{:-<70}", fmt::format("--- charged particle #{} ", i_charged_particle));
+    trace("{:-<70}", fmt::format("--- charged particle #{} ", i_charged_particle));
 
     // start an `irt_particle`, for `IRT`
     auto irt_particle = std::make_unique<ChargedParticle>();
@@ -172,7 +168,7 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
       // get the `charged_particle` for this radiator
       auto charged_particle_list_it = in_charged_particles.find(rad_name);
       if (charged_particle_list_it == in_charged_particles.end()) {
-        m_log->error("Cannot find radiator '{}' in `in_charged_particles`", rad_name);
+        error("Cannot find radiator '{}' in `in_charged_particles`", rad_name);
         continue;
       }
       const auto* charged_particle_list = charged_particle_list_it->second;
@@ -180,7 +176,7 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
 
       // set number of bins for this radiator and charged particle
       if (charged_particle.points_size() == 0) {
-        m_log->trace("No propagated track points in radiator '{}'", rad_name);
+        trace("No propagated track points in radiator '{}'", rad_name);
         continue;
       }
       irt_rad->SetTrajectoryBinCount(charged_particle.points_size() - 1);
@@ -193,7 +189,7 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
 
       // loop over `TrackPoint`s of this `charged_particle`, adding each to the IRT radiator
       irt_rad->ResetLocations();
-      m_log->trace("TrackPoints in '{}' radiator:", rad_name);
+      trace("TrackPoints in '{}' radiator:", rad_name);
       for (const auto& point : charged_particle.getPoints()) {
         TVector3 position = Tools::PodioVector3_to_TVector3(point.position);
         TVector3 momentum = Tools::PodioVector3_to_TVector3(point.momentum);
@@ -203,7 +199,7 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
       }
 
       // loop over raw hits ***************************************************
-      m_log->trace("{:#<70}", "### SENSOR HITS ");
+      trace("{:#<70}", "### SENSOR HITS ");
       for (const auto& raw_hit : *in_raw_hits) {
 
         // get MC photon(s), typically only used by cheat modes or trace logging
@@ -228,11 +224,11 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
 #endif
                 mc_photon_found = true;
                 if (mc_photon.getPDG() != -22)
-                  m_log->warn("non-opticalphoton hit: PDG = {}", mc_photon.getPDG());
+                  warning("non-opticalphoton hit: PDG = {}", mc_photon.getPDG());
 #if EDM4EIC_VERSION_MAJOR >= 6
 #else
                 } else if (m_cfg.CheatModeEnabled())
-                  m_log->error("cheat mode enabled, but no MC photons provided");
+                  error("cheat mode enabled, but no MC photons provided");
 #endif
                 break;
               }
@@ -258,15 +254,15 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
         TVector3 pixel_pos = m_irt_det->m_ReadoutIDToPosition(cell_id);
 
         // trace logging
-        if (m_log->level() <= spdlog::level::trace) {
-          m_log->trace("cell_id={:#X}  sensor_id={:#X}", cell_id, sensor_id);
+        if (level() <= spdlog::level::trace) {
+          trace("cell_id={:#X}  sensor_id={:#X}", cell_id, sensor_id);
           Tools::PrintTVector3(m_log, "pixel position", pixel_pos);
           if (mc_photon_found) {
             TVector3 mc_endpoint = Tools::PodioVector3_to_TVector3(mc_photon.getEndpoint());
             Tools::PrintTVector3(m_log, "photon endpoint", mc_endpoint);
-            m_log->trace("{:>30} = {}", "dist( pixel,  photon )", (pixel_pos - mc_endpoint).Mag());
+            trace("{:>30} = {}", "dist( pixel,  photon )", (pixel_pos - mc_endpoint).Mag());
           } else
-            m_log->trace("  no MC photon found; probably a noise hit");
+            trace("  no MC photon found; probably a noise hit");
         }
 
         // start new IRT photon
@@ -292,11 +288,11 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
           auto ri_set = Tools::GetFinelyBinnedTableEntry(irt_rad->m_ri_lookup_table, mom, &ri);
           if (ri_set) {
             irt_photon->SetVertexRefractiveIndex(ri);
-            m_log->trace("{:>30} = {}", "refractive index", ri);
+            trace("{:>30} = {}", "refractive index", ri);
           } else
-            m_log->warn("Tools::GetFinelyBinnedTableEntry failed to lookup refractive index for "
-                        "momentum {} eV",
-                        mom);
+            warning("Tools::GetFinelyBinnedTableEntry failed to lookup refractive index for "
+                    "momentum {} eV",
+                    mom);
         }
 
         // add each `irt_photon` to the radiator history
@@ -316,7 +312,7 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
     // particle identification +++++++++++++++++++++++++++++++++++++++++++++++++++++
 
     // define a mass hypothesis for each particle we want to check
-    m_log->trace("{:+^70}", " PARTICLE IDENTIFICATION ");
+    trace("{:+^70}", " PARTICLE IDENTIFICATION ");
     CherenkovPID irt_pid;
     std::unordered_map<int, MassHypothesis*> pdg_to_hyp; // `pdg` -> hypothesis
     for (auto [pdg, mass] : m_pdg_mass) {
@@ -326,11 +322,11 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
 
     // run IRT PID
     irt_particle->PIDReconstruction(irt_pid);
-    m_log->trace("{:-^70}", " IRT RESULTS ");
+    trace("{:-^70}", " IRT RESULTS ");
 
     // loop over radiators
     for (auto [rad_name, irt_rad] : m_pid_radiators) {
-      m_log->trace("-> {} Radiator (ID={}):", rad_name, irt_rad->m_ID);
+      trace("-> {} Radiator (ID={}):", rad_name, irt_rad->m_ID);
 
       // Cherenkov angle (theta) estimate
       unsigned npe      = 0;
@@ -341,10 +337,10 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
       // loop over this radiator's photons, and decide which to include in the theta estimate
       auto* irt_rad_history = irt_particle->FindRadiatorHistory(irt_rad);
       if (irt_rad_history == nullptr) {
-        m_log->trace("  No radiator history; skip");
+        trace("  No radiator history; skip");
         continue;
       }
-      m_log->trace("  Photoelectrons:");
+      trace("  Photoelectrons:");
       for (auto* irt_photon : irt_rad_history->Photons()) {
 
         // check whether this photon was selected by at least one mass hypothesis
@@ -418,7 +414,7 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
       } // end hypothesis loop
 
       // logging
-      Tools::PrintCherenkovEstimate(m_log, out_cherenkov_pid);
+      Tools::PrintCherenkovEstimate(logger(), out_cherenkov_pid);
 
       // relate charged particle projection
       auto charged_particle_list_it = in_charged_particles.find("Merged");
@@ -427,7 +423,7 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
         auto charged_particle             = charged_particle_list->at(i_charged_particle);
         out_cherenkov_pid.setChargedParticle(charged_particle);
       } else
-        m_log->error("Cannot find radiator 'Merged' in `in_charged_particles`");
+        error("Cannot find radiator 'Merged' in `in_charged_particles`");
 
       // relate hit associations
       for (const auto& hit_assoc : *in_hit_assocs)

--- a/src/algorithms/pid/IrtCherenkovParticleID.h
+++ b/src/algorithms/pid/IrtCherenkovParticleID.h
@@ -19,7 +19,6 @@
 #include <string_view>
 #include <unordered_map>
 #include <utility>
-#include <vector>
 
 // EICrecon
 #include "algorithms/interfaces/ParticleSvc.h"

--- a/src/algorithms/pid/IrtCherenkovParticleID.h
+++ b/src/algorithms/pid/IrtCherenkovParticleID.h
@@ -7,18 +7,15 @@
 #include <IRT/CherenkovDetectorCollection.h>
 #include <IRT/CherenkovRadiator.h>
 #include <algorithms/algorithm.h>
-#include <algorithms/logger.h>
 #include <edm4eic/CherenkovParticleIDCollection.h>
 #include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
 #include <edm4eic/RawTrackerHitCollection.h>
 #include <edm4eic/TrackSegmentCollection.h>
-#include <fmt/core.h>
 #include <stdint.h>
 #include <map>
 #include <string>
 #include <string_view>
 #include <unordered_map>
-#include <utility>
 
 // EICrecon
 #include "algorithms/interfaces/ParticleSvc.h"

--- a/src/algorithms/pid/IrtCherenkovParticleID.h
+++ b/src/algorithms/pid/IrtCherenkovParticleID.h
@@ -68,7 +68,7 @@ public:
 private:
   template <algorithms::LogLevel lvl, typename... T>
   constexpr void log(fmt::format_string<T...> fmt, T&&... args) const {
-    log<lvl>(fmt, std::forward<decltype(args)>(args)...);
+    algorithms::LoggerMixin::log<lvl>(fmt, std::forward<decltype(args)>(args)...);
   }
 
   friend class IrtCherenkovParticleIDConfig;

--- a/src/algorithms/pid/IrtCherenkovParticleID.h
+++ b/src/algorithms/pid/IrtCherenkovParticleID.h
@@ -68,7 +68,7 @@ public:
 private:
   template <algorithms::LogLevel lvl, typename... T>
   constexpr void log(fmt::format_string<T...> fmt, T&&... args) const {
-    algorithms::LoggerMixin::log<lvl>(fmt, std::forward<decltype(args)>(args)...);
+    algorithms::LoggerMixin::report_fmt<lvl>(fmt, std::forward<decltype(args)>(args)...);
   }
 
   friend class IrtCherenkovParticleIDConfig;

--- a/src/algorithms/pid/IrtCherenkovParticleID.h
+++ b/src/algorithms/pid/IrtCherenkovParticleID.h
@@ -76,4 +76,45 @@ private:
   std::unordered_map<int, double> m_pdg_mass;
   std::map<std::string, CherenkovRadiator*> m_pid_radiators;
 };
+
+// Definition of IrtCherenkovParticleIDConfig::Print* requires class IrtCherenkovParticleID, but
+// circular dependency prevents it from being in IrtCherenkovParticleIDConfig.h
+
+// print warnings about cheat modes
+template <algorithms::LogLevel lvl>
+void IrtCherenkovParticleIDConfig::PrintCheats(const eicrecon::IrtCherenkovParticleID* logger,
+                                               bool printAll) {
+  auto print_param = [&logger, &printAll](auto name, bool val, auto desc) {
+    if (printAll)
+      logger->log<lvl>("  {:>20} = {:<}", name, val);
+    else if (val)
+      logger->warning("CHEAT MODE '{}' ENABLED: {}", name, desc);
+  };
+  print_param("cheatPhotonVertex", cheatPhotonVertex,
+              "use MC photon vertex, wavelength, refractive index");
+  print_param("cheatTrueRadiator", cheatTrueRadiator, "use MC truth to obtain true radiator");
+}
+
+// print all parameters
+template <algorithms::LogLevel lvl>
+void IrtCherenkovParticleIDConfig::Print(const eicrecon::IrtCherenkovParticleID* logger) {
+  logger->log<lvl>("{:=^60}", " IrtCherenkovParticleIDConfig Settings ");
+  auto print_param = [&logger](auto name, auto val) {
+    logger->log<lvl>("  {:>20} = {:<}", name, val);
+  };
+  print_param("numRIndexBins", numRIndexBins);
+  PrintCheats<lvl>(logger, true);
+  logger->log<lvl>("pdgList:");
+  for (const auto& pdg : pdgList)
+    logger->log<lvl>("  {}", pdg);
+  for (const auto& [name, rad] : radiators) {
+    logger->log<lvl>("{:-<60}", fmt::format("--- {} config ", name));
+    print_param("smearingMode", rad.smearingMode);
+    print_param("smearing", rad.smearing);
+    print_param("referenceRIndex", rad.referenceRIndex);
+    print_param("attenuation", rad.attenuation);
+  }
+  logger->log<lvl>("{:=^60}", "");
+}
+
 } // namespace eicrecon

--- a/src/algorithms/pid/IrtCherenkovParticleID.h
+++ b/src/algorithms/pid/IrtCherenkovParticleID.h
@@ -68,7 +68,12 @@ public:
 private:
   template <algorithms::LogLevel lvl, typename... T>
   constexpr void log(fmt::format_string<T...> fmt, T&&... args) const {
+#if algorithms_VERSION_MAJOR > 1 || (algorithms_VERSION_MAJOR == 1 && algorithms_VERSION_MINOR > 1)
     algorithms::LoggerMixin::report_fmt<lvl>(fmt, std::forward<decltype(args)>(args)...);
+#else
+    // all logging to info
+    info(fmt::format(fmt, std::forward<decltype(args)>(args)...));
+#endif
   }
 
   friend class IrtCherenkovParticleIDConfig;

--- a/src/algorithms/pid/IrtCherenkovParticleID.h
+++ b/src/algorithms/pid/IrtCherenkovParticleID.h
@@ -111,26 +111,4 @@ void IrtCherenkovParticleIDConfig::PrintCheats(const eicrecon::IrtCherenkovParti
   print_param("cheatTrueRadiator", cheatTrueRadiator, "use MC truth to obtain true radiator");
 }
 
-// print all parameters
-template <algorithms::LogLevel lvl>
-void IrtCherenkovParticleIDConfig::Print(const eicrecon::IrtCherenkovParticleID* logger) {
-  logger->log<lvl>("{:=^60}", " IrtCherenkovParticleIDConfig Settings ");
-  auto print_param = [&logger](auto name, auto val) {
-    logger->log<lvl>("  {:>20} = {:<}", name, val);
-  };
-  print_param("numRIndexBins", numRIndexBins);
-  PrintCheats<lvl>(logger, true);
-  logger->log<lvl>("pdgList:");
-  for (const auto& pdg : pdgList)
-    logger->log<lvl>("  {}", pdg);
-  for (const auto& [name, rad] : radiators) {
-    logger->log<lvl>("{:-<60}", fmt::format("--- {} config ", name));
-    print_param("smearingMode", rad.smearingMode);
-    print_param("smearing", rad.smearing);
-    print_param("referenceRIndex", rad.referenceRIndex);
-    print_param("attenuation", rad.attenuation);
-  }
-  logger->log<lvl>("{:=^60}", "");
-}
-
 } // namespace eicrecon

--- a/src/algorithms/pid/IrtCherenkovParticleID.h
+++ b/src/algorithms/pid/IrtCherenkovParticleID.h
@@ -24,7 +24,6 @@
 #include "algorithms/interfaces/ParticleSvc.h"
 #include "algorithms/interfaces/WithPodConfig.h"
 #include "algorithms/pid/IrtCherenkovParticleIDConfig.h"
-#include "algorithms/pid/Tools.h"
 
 namespace eicrecon {
 
@@ -42,8 +41,7 @@ using IrtCherenkovParticleIDAlgorithm = algorithms::Algorithm<
                        edm4eic::CherenkovParticleIDCollection>>;
 
 class IrtCherenkovParticleID : public IrtCherenkovParticleIDAlgorithm,
-                               public WithPodConfig<IrtCherenkovParticleIDConfig>,
-                               private Tools<IrtCherenkovParticleID> {
+                               public WithPodConfig<IrtCherenkovParticleIDConfig> {
 
 public:
   IrtCherenkovParticleID(std::string_view name)
@@ -52,8 +50,7 @@ public:
                                          "inputMergedTrackSegments", "inputRawHits",
                                          "inputRawHitAssociations"},
                                         {"outputAerogelParticleIDs", "outputGasParticleIDs"},
-                                        "Effectively 'zip' the input particle IDs"}
-      , Tools(this) {}
+                                        "Effectively 'zip' the input particle IDs"} {}
 
   // FIXME: init() must not take arguments
 #pragma GCC diagnostic push
@@ -76,8 +73,6 @@ private:
     info(fmt::format(fmt, std::forward<decltype(args)>(args)...));
 #endif
   }
-
-  friend class Tools;
 
 private:
   CherenkovDetectorCollection* m_irt_det_coll;

--- a/src/algorithms/pid/IrtCherenkovParticleID.h
+++ b/src/algorithms/pid/IrtCherenkovParticleID.h
@@ -57,6 +57,15 @@ public:
   void process(const Input&, const Output&) const;
 
 private:
+  template <algorithms::LogLevel lvl, typename... T>
+  constexpr void log(fmt::format_string<T...> fmt, T&&... args) const {
+    log<lvl>(fmt, std::forward<decltype(args)>(args)...);
+  }
+
+  friend class IrtCherenkovParticleIDConfig;
+  friend class Tools;
+
+private:
   CherenkovDetectorCollection* m_irt_det_coll;
   CherenkovDetector* m_irt_det;
 

--- a/src/algorithms/pid/IrtCherenkovParticleID.h
+++ b/src/algorithms/pid/IrtCherenkovParticleID.h
@@ -64,17 +64,6 @@ public:
   void process(const Input&, const Output&) const;
 
 private:
-  template <algorithms::LogLevel lvl, typename... T>
-  constexpr void log(fmt::format_string<T...> fmt, T&&... args) const {
-#if algorithms_VERSION_MAJOR > 1 || (algorithms_VERSION_MAJOR == 1 && algorithms_VERSION_MINOR > 1)
-    algorithms::LoggerMixin::report_fmt<lvl>(fmt, std::forward<decltype(args)>(args)...);
-#else
-    // all logging to info
-    info(fmt::format(fmt, std::forward<decltype(args)>(args)...));
-#endif
-  }
-
-private:
   CherenkovDetectorCollection* m_irt_det_coll;
   CherenkovDetector* m_irt_det;
 

--- a/src/algorithms/pid/IrtCherenkovParticleID.h
+++ b/src/algorithms/pid/IrtCherenkovParticleID.h
@@ -7,17 +7,19 @@
 #include <IRT/CherenkovDetectorCollection.h>
 #include <IRT/CherenkovRadiator.h>
 #include <algorithms/algorithm.h>
+#include <algorithms/logger.h>
 #include <edm4eic/CherenkovParticleIDCollection.h>
 #include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
 #include <edm4eic/RawTrackerHitCollection.h>
 #include <edm4eic/TrackSegmentCollection.h>
-#include <spdlog/logger.h>
+#include <fmt/core.h>
 #include <stdint.h>
 #include <map>
-#include <memory>
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 // EICrecon
 #include "algorithms/interfaces/ParticleSvc.h"

--- a/src/algorithms/pid/IrtCherenkovParticleID.h
+++ b/src/algorithms/pid/IrtCherenkovParticleID.h
@@ -51,12 +51,11 @@ public:
                                         {"outputAerogelParticleIDs", "outputGasParticleIDs"},
                                         "Effectively 'zip' the input particle IDs"} {}
 
-  void init(CherenkovDetectorCollection* irt_det_coll, std::shared_ptr<spdlog::logger>& logger);
+  void init(CherenkovDetectorCollection* irt_det_coll);
 
   void process(const Input&, const Output&) const;
 
 private:
-  std::shared_ptr<spdlog::logger> m_log;
   CherenkovDetectorCollection* m_irt_det_coll;
   CherenkovDetector* m_irt_det;
 

--- a/src/algorithms/pid/IrtCherenkovParticleID.h
+++ b/src/algorithms/pid/IrtCherenkovParticleID.h
@@ -20,9 +20,10 @@
 #include <unordered_map>
 
 // EICrecon
-#include "IrtCherenkovParticleIDConfig.h"
 #include "algorithms/interfaces/ParticleSvc.h"
 #include "algorithms/interfaces/WithPodConfig.h"
+#include "algorithms/pid/IrtCherenkovParticleIDConfig.h"
+#include "algorithms/pid/Tools.h"
 
 namespace eicrecon {
 

--- a/src/algorithms/pid/IrtCherenkovParticleID.h
+++ b/src/algorithms/pid/IrtCherenkovParticleID.h
@@ -54,7 +54,14 @@ public:
                                         "Effectively 'zip' the input particle IDs"}
       , Tools(this) {}
 
+  // FIXME: init() must not take arguments
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Woverloaded-virtual"
   void init(CherenkovDetectorCollection* irt_det_coll);
+#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 
   void process(const Input&, const Output&) const;
 

--- a/src/algorithms/pid/IrtCherenkovParticleID.h
+++ b/src/algorithms/pid/IrtCherenkovParticleID.h
@@ -41,7 +41,8 @@ using IrtCherenkovParticleIDAlgorithm = algorithms::Algorithm<
                        edm4eic::CherenkovParticleIDCollection>>;
 
 class IrtCherenkovParticleID : public IrtCherenkovParticleIDAlgorithm,
-                               public WithPodConfig<IrtCherenkovParticleIDConfig> {
+                               public WithPodConfig<IrtCherenkovParticleIDConfig>,
+                               private Tools<IrtCherenkovParticleID> {
 
 public:
   IrtCherenkovParticleID(std::string_view name)
@@ -50,7 +51,8 @@ public:
                                          "inputMergedTrackSegments", "inputRawHits",
                                          "inputRawHitAssociations"},
                                         {"outputAerogelParticleIDs", "outputGasParticleIDs"},
-                                        "Effectively 'zip' the input particle IDs"} {}
+                                        "Effectively 'zip' the input particle IDs"}
+      , Tools(this) {}
 
   void init(CherenkovDetectorCollection* irt_det_coll);
 

--- a/src/algorithms/pid/IrtCherenkovParticleID.h
+++ b/src/algorithms/pid/IrtCherenkovParticleID.h
@@ -78,7 +78,6 @@ private:
 #endif
   }
 
-  friend class IrtCherenkovParticleIDConfig;
   friend class Tools;
 
 private:
@@ -92,23 +91,5 @@ private:
   std::unordered_map<int, double> m_pdg_mass;
   std::map<std::string, CherenkovRadiator*> m_pid_radiators;
 };
-
-// Definition of IrtCherenkovParticleIDConfig::Print* requires class IrtCherenkovParticleID, but
-// circular dependency prevents it from being in IrtCherenkovParticleIDConfig.h
-
-// print warnings about cheat modes
-template <algorithms::LogLevel lvl>
-void IrtCherenkovParticleIDConfig::PrintCheats(const eicrecon::IrtCherenkovParticleID* logger,
-                                               bool printAll) {
-  auto print_param = [&logger, &printAll](auto name, bool val, auto desc) {
-    if (printAll)
-      logger->log<lvl>("  {:>20} = {:<}", name, val);
-    else if (val)
-      logger->warning("CHEAT MODE '{}' ENABLED: {}", name, desc);
-  };
-  print_param("cheatPhotonVertex", cheatPhotonVertex,
-              "use MC photon vertex, wavelength, refractive index");
-  print_param("cheatTrueRadiator", cheatTrueRadiator, "use MC truth to obtain true radiator");
-}
 
 } // namespace eicrecon

--- a/src/algorithms/pid/IrtCherenkovParticleIDConfig.h
+++ b/src/algorithms/pid/IrtCherenkovParticleIDConfig.h
@@ -9,8 +9,6 @@
 
 namespace eicrecon {
 
-class IrtCherenkovParticleID;
-
 // radiator config parameters
 struct RadiatorConfig {
   double referenceRIndex;   // reference radiator refractive index

--- a/src/algorithms/pid/IrtCherenkovParticleIDConfig.h
+++ b/src/algorithms/pid/IrtCherenkovParticleIDConfig.h
@@ -48,10 +48,6 @@ public:
   //
   /////////////////////////////////////////////////////
 
-  // print warnings about cheat modes
-  template <algorithms::LogLevel lvl = algorithms::LogLevel::kDebug>
-  void PrintCheats(const eicrecon::IrtCherenkovParticleID* logger, bool printAll = false);
-
   // boolean: true if any cheat mode is enabled
   bool CheatModeEnabled() const { return cheatPhotonVertex || cheatTrueRadiator; }
 
@@ -62,7 +58,8 @@ public:
       os << fmt::format("  {:>20} = {:<}", name, val) << std::endl;
     };
     print_param("numRIndexBins", cfg.numRIndexBins);
-    //PrintCheats<lvl>(logger, true);
+    print_param("cheatPhotonVertex", cfg.cheatPhotonVertex);
+    print_param("cheatTrueRadiator", cfg.cheatTrueRadiator);
     os << "pdgList:" << std::endl;
     for (const auto& pdg : cfg.pdgList)
       os << fmt::format("  {}", pdg) << std::endl;

--- a/src/algorithms/pid/IrtCherenkovParticleIDConfig.h
+++ b/src/algorithms/pid/IrtCherenkovParticleIDConfig.h
@@ -4,9 +4,12 @@
 #pragma once
 
 #include <Evaluator/DD4hepUnits.h>
+#include <algorithms/logger.h>
 #include <spdlog/spdlog.h>
 
 namespace eicrecon {
+
+class IrtCherenkovParticleID;
 
 // radiator config parameters
 struct RadiatorConfig {
@@ -46,42 +49,14 @@ public:
   /////////////////////////////////////////////////////
 
   // print warnings about cheat modes
-  void PrintCheats(std::shared_ptr<spdlog::logger> m_log,
-                   spdlog::level::level_enum lvl = spdlog::level::debug, bool printAll = false) {
-    auto print_param = [&m_log, &lvl, &printAll](auto name, bool val, auto desc) {
-      if (printAll)
-        m_log->log(lvl, "  {:>20} = {:<}", name, val);
-      else if (val)
-        m_log->warn("CHEAT MODE '{}' ENABLED: {}", name, desc);
-    };
-    print_param("cheatPhotonVertex", cheatPhotonVertex,
-                "use MC photon vertex, wavelength, refractive index");
-    print_param("cheatTrueRadiator", cheatTrueRadiator, "use MC truth to obtain true radiator");
-  }
+  template <algorithms::LogLevel lvl = algorithms::LogLevel::kDebug>
+  void PrintCheats(const eicrecon::IrtCherenkovParticleID* logger, bool printAll = false);
 
   // boolean: true if any cheat mode is enabled
   bool CheatModeEnabled() const { return cheatPhotonVertex || cheatTrueRadiator; }
 
   // print all parameters
-  void Print(std::shared_ptr<spdlog::logger> m_log,
-             spdlog::level::level_enum lvl = spdlog::level::debug) {
-    m_log->log(lvl, "{:=^60}", " IrtCherenkovParticleIDConfig Settings ");
-    auto print_param = [&m_log, &lvl](auto name, auto val) {
-      m_log->log(lvl, "  {:>20} = {:<}", name, val);
-    };
-    print_param("numRIndexBins", numRIndexBins);
-    PrintCheats(m_log, lvl, true);
-    m_log->log(lvl, "pdgList:");
-    for (const auto& pdg : pdgList)
-      m_log->log(lvl, "  {}", pdg);
-    for (const auto& [name, rad] : radiators) {
-      m_log->log(lvl, "{:-<60}", fmt::format("--- {} config ", name));
-      print_param("smearingMode", rad.smearingMode);
-      print_param("smearing", rad.smearing);
-      print_param("referenceRIndex", rad.referenceRIndex);
-      print_param("attenuation", rad.attenuation);
-    }
-    m_log->log(lvl, "{:=^60}", "");
-  }
+  template <algorithms::LogLevel lvl = algorithms::LogLevel::kDebug>
+  void Print(const eicrecon::IrtCherenkovParticleID* logger);
 };
 } // namespace eicrecon

--- a/src/algorithms/pid/IrtCherenkovParticleIDConfig.h
+++ b/src/algorithms/pid/IrtCherenkovParticleIDConfig.h
@@ -55,8 +55,27 @@ public:
   // boolean: true if any cheat mode is enabled
   bool CheatModeEnabled() const { return cheatPhotonVertex || cheatTrueRadiator; }
 
-  // print all parameters
-  template <algorithms::LogLevel lvl = algorithms::LogLevel::kDebug>
-  void Print(const eicrecon::IrtCherenkovParticleID* logger);
+  // stream all parameters
+  friend std::ostream& operator<<(std::ostream& os, const IrtCherenkovParticleIDConfig& cfg) {
+    os << fmt::format("{:=^60}", " IrtCherenkovParticleIDConfig Settings ") << std::endl;
+    auto print_param = [&os](auto name, auto val) {
+      os << fmt::format("  {:>20} = {:<}", name, val) << std::endl;
+    };
+    print_param("numRIndexBins", cfg.numRIndexBins);
+    //PrintCheats<lvl>(logger, true);
+    os << "pdgList:" << std::endl;
+    for (const auto& pdg : cfg.pdgList)
+      os << fmt::format("  {}", pdg) << std::endl;
+    for (const auto& [name, rad] : cfg.radiators) {
+      os << fmt::format("{:-<60}", fmt::format("--- {} config ", name)) << std::endl;
+      print_param("smearingMode", rad.smearingMode);
+      print_param("smearing", rad.smearing);
+      print_param("referenceRIndex", rad.referenceRIndex);
+      print_param("attenuation", rad.attenuation);
+    }
+    os << fmt::format("{:=^60}", "") << std::endl;
+    return os;
+  };
 };
+
 } // namespace eicrecon

--- a/src/algorithms/pid/MergeParticleID.cc
+++ b/src/algorithms/pid/MergeParticleID.cc
@@ -66,12 +66,12 @@ void MergeParticleID::process(const MergeParticleID::Input& input,
   std::unordered_map<decltype(podio::ObjectID::index),
                      std::vector<std::pair<std::size_t, std::size_t>>>
       particle_pids;
-  m_log->trace("{:-<70}", "Build `particle_pids` indexing data structure ");
+  trace("{:-<70}", "Build `particle_pids` indexing data structure ");
 
   // loop over list of PID collections
   for (std::size_t idx_coll = 0; idx_coll < in_pid_collections_list.size(); idx_coll++) {
     const auto& in_pid_collection = in_pid_collections_list.at(idx_coll);
-    m_log->trace("idx_col={}", idx_coll);
+    trace("idx_col={}", idx_coll);
 
     // loop over this PID collection
     for (std::size_t idx_pid = 0; idx_pid < in_pid_collection->size(); idx_pid++) {
@@ -79,12 +79,12 @@ void MergeParticleID::process(const MergeParticleID::Input& input,
       const auto& in_pid                   = in_pid_collection->at(idx_pid);
       auto& charged_particle_track_segment = in_pid.getChargedParticle();
       if (!charged_particle_track_segment.isAvailable()) {
-        m_log->error("PID object found with no charged particle");
+        error("PID object found with no charged particle");
         continue;
       }
       auto id_particle = charged_particle_track_segment.getObjectID().index;
       auto idx_paired  = std::make_pair(idx_coll, idx_pid);
-      m_log->trace("  idx_pid={}  id_particle={}", idx_pid, id_particle);
+      trace("  idx_pid={}  id_particle={}", idx_pid, id_particle);
 
       // insert in `particle_pids`
       auto it = particle_pids.find(id_particle);
@@ -96,12 +96,12 @@ void MergeParticleID::process(const MergeParticleID::Input& input,
   }
 
   // trace logging
-  if (m_log->level() <= spdlog::level::trace) {
-    m_log->trace("{:-<70}", "Resulting `particle_pids` ");
+  if (level() <= algorithms::LogLevel::kTrace) {
+    trace("{:-<70}", "Resulting `particle_pids` ");
     for (auto& [id_particle, idx_paired_list] : particle_pids) {
-      m_log->trace("id_particle={}", id_particle);
+      trace("id_particle={}", id_particle);
       for (auto& [idx_coll, idx_pid] : idx_paired_list)
-        m_log->trace("  (idx_coll, idx_pid) = ({}, {})", idx_coll, idx_pid);
+        trace("  (idx_coll, idx_pid) = ({}, {})", idx_coll, idx_pid);
     }
   }
 
@@ -109,13 +109,13 @@ void MergeParticleID::process(const MergeParticleID::Input& input,
 
   // loop over charged particles, combine weights from the associated `CherenkovParticleID` objects
   // and create a merged output `CherenkovParticleID` object
-  m_log->trace("{:-<70}", "Begin Merging PID Objects ");
+  trace("{:-<70}", "Begin Merging PID Objects ");
   for (auto& [id_particle, idx_paired_list] : particle_pids) {
 
     // trace logging
-    m_log->trace("Charged Particle:");
-    m_log->trace("  id = {}", id_particle);
-    m_log->trace("  PID Hypotheses:");
+    trace("Charged Particle:");
+    trace("  id = {}", id_particle);
+    trace("  PID Hypotheses:");
 
     // create mutable output `CherenkovParticleID` object `out_pid`
     auto out_pid                                            = out_pids->create();
@@ -133,9 +133,8 @@ void MergeParticleID::process(const MergeParticleID::Input& input,
       const auto& in_pid = in_pid_collections_list.at(idx_coll)->at(idx_pid);
 
       // logging
-      m_log->trace("    Hypotheses for PID result (idx_coll, idx_pid) = ({}, {}):", idx_coll,
-                   idx_pid);
       Tools::PrintHypothesisTableHead(m_log, 6);
+      trace("    Hypotheses for PID result (idx_coll, idx_pid) = ({}, {}):", idx_coll, idx_pid);
 
       // merge scalar members
       out_npe += in_pid.getNpe();                                           // sum
@@ -192,8 +191,8 @@ void MergeParticleID::process(const MergeParticleID::Input& input,
       out_pid.addToHypotheses(out_hyp);
 
     // logging: print merged hypothesis table
-    m_log->trace("    => merged hypothesis weights:");
     Tools::PrintHypothesisTableHead(m_log, 6);
+    trace("    => merged hypothesis weights:");
     for (auto out_hyp : out_pid.getHypotheses())
       Tools::PrintHypothesisTableLine(m_log, out_hyp, 6);
 

--- a/src/algorithms/pid/MergeParticleID.cc
+++ b/src/algorithms/pid/MergeParticleID.cc
@@ -132,7 +132,7 @@ void MergeParticleID::process(const MergeParticleID::Input& input,
 
       // logging
       trace("    Hypotheses for PID result (idx_coll, idx_pid) = ({}, {}):", idx_coll, idx_pid);
-      PrintHypothesisTableHead(6);
+      trace(HypothesisTableHead(6));
 
       // merge scalar members
       out_npe += in_pid.getNpe();                                           // sum
@@ -149,7 +149,7 @@ void MergeParticleID::process(const MergeParticleID::Input& input,
 
       // merge PDG hypotheses, combining their weights and other members
       for (auto in_hyp : in_pid.getHypotheses()) {
-        PrintHypothesisTableLine(in_hyp, 6);
+        trace(HypothesisTableLine(in_hyp, 6));
         auto out_hyp_it = pdg_2_out_hyp.find(in_hyp.PDG);
         if (out_hyp_it == pdg_2_out_hyp.end()) {
           edm4eic::CherenkovParticleIDHypothesis out_hyp;
@@ -190,9 +190,9 @@ void MergeParticleID::process(const MergeParticleID::Input& input,
 
     // logging: print merged hypothesis table
     trace("    => merged hypothesis weights:");
-    PrintHypothesisTableHead(6);
+    trace(HypothesisTableHead(6));
     for (auto out_hyp : out_pid.getHypotheses())
-      PrintHypothesisTableLine(out_hyp, 6);
+      trace(HypothesisTableLine(out_hyp, 6));
 
   } // end `particle_pids` loop over charged particles
 }

--- a/src/algorithms/pid/MergeParticleID.cc
+++ b/src/algorithms/pid/MergeParticleID.cc
@@ -18,7 +18,6 @@
 #include <utility>
 
 #include "algorithms/pid/MergeParticleIDConfig.h"
-#include "algorithms/pid/Tools.h"
 
 namespace eicrecon {
 
@@ -133,8 +132,8 @@ void MergeParticleID::process(const MergeParticleID::Input& input,
       const auto& in_pid = in_pid_collections_list.at(idx_coll)->at(idx_pid);
 
       // logging
-      Tools::PrintHypothesisTableHead(m_log, 6);
       trace("    Hypotheses for PID result (idx_coll, idx_pid) = ({}, {}):", idx_coll, idx_pid);
+      PrintHypothesisTableHead(6);
 
       // merge scalar members
       out_npe += in_pid.getNpe();                                           // sum
@@ -151,7 +150,7 @@ void MergeParticleID::process(const MergeParticleID::Input& input,
 
       // merge PDG hypotheses, combining their weights and other members
       for (auto in_hyp : in_pid.getHypotheses()) {
-        Tools::PrintHypothesisTableLine(m_log, in_hyp, 6);
+        PrintHypothesisTableLine(in_hyp, 6);
         auto out_hyp_it = pdg_2_out_hyp.find(in_hyp.PDG);
         if (out_hyp_it == pdg_2_out_hyp.end()) {
           edm4eic::CherenkovParticleIDHypothesis out_hyp;
@@ -191,10 +190,10 @@ void MergeParticleID::process(const MergeParticleID::Input& input,
       out_pid.addToHypotheses(out_hyp);
 
     // logging: print merged hypothesis table
-    Tools::PrintHypothesisTableHead(m_log, 6);
     trace("    => merged hypothesis weights:");
+    PrintHypothesisTableHead(6);
     for (auto out_hyp : out_pid.getHypotheses())
-      Tools::PrintHypothesisTableLine(m_log, out_hyp, 6);
+      PrintHypothesisTableLine(out_hyp, 6);
 
   } // end `particle_pids` loop over charged particles
 }

--- a/src/algorithms/pid/MergeParticleID.cc
+++ b/src/algorithms/pid/MergeParticleID.cc
@@ -3,6 +3,7 @@
 
 #include "MergeParticleID.h"
 
+#include <algorithms/logger.h>
 #include <edm4eic/CherenkovParticleIDHypothesis.h>
 #include <edm4eic/TrackSegmentCollection.h>
 #include <edm4hep/Vector2f.h>
@@ -21,10 +22,7 @@
 
 namespace eicrecon {
 
-void MergeParticleID::init(std::shared_ptr<spdlog::logger>& logger) {
-  m_log = logger;
-  m_cfg.Print(m_log, spdlog::level::debug);
-}
+void MergeParticleID::init() { m_cfg.Print<algorithms::LogLevel::kDebug>(this); }
 
 void MergeParticleID::process(const MergeParticleID::Input& input,
                               const MergeParticleID::Output& output) const {

--- a/src/algorithms/pid/MergeParticleID.cc
+++ b/src/algorithms/pid/MergeParticleID.cc
@@ -10,7 +10,6 @@
 #include <fmt/core.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
-#include <spdlog/common.h>
 #include <cstddef>
 #include <gsl/pointers>
 #include <stdexcept>

--- a/src/algorithms/pid/MergeParticleID.cc
+++ b/src/algorithms/pid/MergeParticleID.cc
@@ -17,6 +17,7 @@
 #include <utility>
 
 #include "algorithms/pid/MergeParticleIDConfig.h"
+#include "algorithms/pid/Tools.h"
 
 namespace eicrecon {
 
@@ -132,7 +133,7 @@ void MergeParticleID::process(const MergeParticleID::Input& input,
 
       // logging
       trace("    Hypotheses for PID result (idx_coll, idx_pid) = ({}, {}):", idx_coll, idx_pid);
-      trace(HypothesisTableHead(6));
+      trace(Tools::HypothesisTableHead(6));
 
       // merge scalar members
       out_npe += in_pid.getNpe();                                           // sum
@@ -149,7 +150,7 @@ void MergeParticleID::process(const MergeParticleID::Input& input,
 
       // merge PDG hypotheses, combining their weights and other members
       for (auto in_hyp : in_pid.getHypotheses()) {
-        trace(HypothesisTableLine(in_hyp, 6));
+        trace(Tools::HypothesisTableLine(in_hyp, 6));
         auto out_hyp_it = pdg_2_out_hyp.find(in_hyp.PDG);
         if (out_hyp_it == pdg_2_out_hyp.end()) {
           edm4eic::CherenkovParticleIDHypothesis out_hyp;
@@ -190,9 +191,9 @@ void MergeParticleID::process(const MergeParticleID::Input& input,
 
     // logging: print merged hypothesis table
     trace("    => merged hypothesis weights:");
-    trace(HypothesisTableHead(6));
+    trace(Tools::HypothesisTableHead(6));
     for (auto out_hyp : out_pid.getHypotheses())
-      trace(HypothesisTableLine(out_hyp, 6));
+      trace(Tools::HypothesisTableLine(out_hyp, 6));
 
   } // end `particle_pids` loop over charged particles
 }

--- a/src/algorithms/pid/MergeParticleID.cc
+++ b/src/algorithms/pid/MergeParticleID.cc
@@ -20,7 +20,7 @@
 
 namespace eicrecon {
 
-void MergeParticleID::init() { m_cfg.Print<algorithms::LogLevel::kDebug>(this); }
+void MergeParticleID::init() { debug() << m_cfg << endmsg; }
 
 void MergeParticleID::process(const MergeParticleID::Input& input,
                               const MergeParticleID::Output& output) const {

--- a/src/algorithms/pid/MergeParticleID.h
+++ b/src/algorithms/pid/MergeParticleID.h
@@ -7,12 +7,9 @@
 
 // data model
 #include <algorithms/algorithm.h>
-#include <algorithms/logger.h>
 #include <edm4eic/CherenkovParticleIDCollection.h>
-#include <fmt/core.h>
 #include <string>
 #include <string_view>
-#include <utility>
 #include <vector>
 
 // EICrecon

--- a/src/algorithms/pid/MergeParticleID.h
+++ b/src/algorithms/pid/MergeParticleID.h
@@ -35,7 +35,7 @@ public:
                                  {"outputTrackSegments"},
                                  "Effectively 'zip' the input particle IDs"} {}
 
-  void init(std::shared_ptr<spdlog::logger>& logger);
+  void init();
 
   // - input: a list of particle ID collections, which we want to merge together
   // - output: the merged particle ID collection
@@ -44,7 +44,6 @@ public:
   void process(const Input&, const Output&) const final;
 
 private:
-  std::shared_ptr<spdlog::logger> m_log;
   template <algorithms::LogLevel lvl, typename... T>
   constexpr void log(fmt::format_string<T...> fmt, T&&... args) const {
     log<lvl>(fmt, std::forward<decltype(args)>(args)...);
@@ -53,4 +52,18 @@ private:
   friend class MergeParticleIDConfig;
   friend class Tools;
 };
+
+// Definition of MergeParticleIDConfig::Print requires class MergeParticleID, but
+// circular dependency prevents it from being in MergeParticleIDConfig.h
+template <algorithms::LogLevel lvl>
+constexpr void MergeParticleIDConfig::Print(const MergeParticleID* logger) const {
+  // print all parameters
+  logger->log<lvl>("{:=^60}", " MergeParticleIDConfig Settings ");
+  auto print_param = [&logger](auto name, auto val) {
+    logger->log<lvl>("  {:>20} = {:<}", name, val);
+  };
+  print_param("mergeMode", mergeMode);
+  logger->log<lvl>("{:=^60}", "");
+}
+
 } // namespace eicrecon

--- a/src/algorithms/pid/MergeParticleID.h
+++ b/src/algorithms/pid/MergeParticleID.h
@@ -42,17 +42,6 @@ public:
   // - overload this function to support different collections from other PID subsystems, or to support
   //   merging PID results from overlapping subsystems
   void process(const Input&, const Output&) const final;
-
-private:
-  template <algorithms::LogLevel lvl, typename... T>
-  constexpr void log(fmt::format_string<T...> fmt, T&&... args) const {
-#if algorithms_VERSION_MAJOR > 1 || (algorithms_VERSION_MAJOR == 1 && algorithms_VERSION_MINOR > 1)
-    algorithms::LoggerMixin::report_fmt<lvl>(fmt, std::forward<decltype(args)>(args)...);
-#else
-    // all logging to info
-    info(fmt::format(fmt, std::forward<decltype(args)>(args)...));
-#endif
-  }
 };
 
 } // namespace eicrecon

--- a/src/algorithms/pid/MergeParticleID.h
+++ b/src/algorithms/pid/MergeParticleID.h
@@ -7,11 +7,12 @@
 
 // data model
 #include <algorithms/algorithm.h>
+#include <algorithms/logger.h>
 #include <edm4eic/CherenkovParticleIDCollection.h>
-#include <spdlog/logger.h>
-#include <memory>
+#include <fmt/core.h>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 // EICrecon

--- a/src/algorithms/pid/MergeParticleID.h
+++ b/src/algorithms/pid/MergeParticleID.h
@@ -48,7 +48,7 @@ public:
 private:
   template <algorithms::LogLevel lvl, typename... T>
   constexpr void log(fmt::format_string<T...> fmt, T&&... args) const {
-    algorithms::LoggerMixin::log<lvl>(fmt, std::forward<decltype(args)>(args)...);
+    algorithms::LoggerMixin::report_fmt<lvl>(fmt, std::forward<decltype(args)>(args)...);
   }
 
   friend class MergeParticleIDConfig;

--- a/src/algorithms/pid/MergeParticleID.h
+++ b/src/algorithms/pid/MergeParticleID.h
@@ -15,8 +15,9 @@
 #include <vector>
 
 // EICrecon
-#include "MergeParticleIDConfig.h"
 #include "algorithms/interfaces/WithPodConfig.h"
+#include "algorithms/pid/MergeParticleIDConfig.h"
+#include "algorithms/pid/Tools.h"
 
 namespace eicrecon {
 

--- a/src/algorithms/pid/MergeParticleID.h
+++ b/src/algorithms/pid/MergeParticleID.h
@@ -57,21 +57,7 @@ private:
 #endif
   }
 
-  friend class MergeParticleIDConfig;
   friend class Tools;
 };
-
-// Definition of MergeParticleIDConfig::Print requires class MergeParticleID, but
-// circular dependency prevents it from being in MergeParticleIDConfig.h
-template <algorithms::LogLevel lvl>
-constexpr void MergeParticleIDConfig::Print(const MergeParticleID* logger) const {
-  // print all parameters
-  logger->log<lvl>("{:=^60}", " MergeParticleIDConfig Settings ");
-  auto print_param = [&logger](auto name, auto val) {
-    logger->log<lvl>("  {:>20} = {:<}", name, val);
-  };
-  print_param("mergeMode", mergeMode);
-  logger->log<lvl>("{:=^60}", "");
-}
 
 } // namespace eicrecon

--- a/src/algorithms/pid/MergeParticleID.h
+++ b/src/algorithms/pid/MergeParticleID.h
@@ -45,5 +45,12 @@ public:
 
 private:
   std::shared_ptr<spdlog::logger> m_log;
+  template <algorithms::LogLevel lvl, typename... T>
+  constexpr void log(fmt::format_string<T...> fmt, T&&... args) const {
+    log<lvl>(fmt, std::forward<decltype(args)>(args)...);
+  }
+
+  friend class MergeParticleIDConfig;
+  friend class Tools;
 };
 } // namespace eicrecon

--- a/src/algorithms/pid/MergeParticleID.h
+++ b/src/algorithms/pid/MergeParticleID.h
@@ -48,7 +48,12 @@ public:
 private:
   template <algorithms::LogLevel lvl, typename... T>
   constexpr void log(fmt::format_string<T...> fmt, T&&... args) const {
+#if algorithms_VERSION_MAJOR > 1 || (algorithms_VERSION_MAJOR == 1 && algorithms_VERSION_MINOR > 1)
     algorithms::LoggerMixin::report_fmt<lvl>(fmt, std::forward<decltype(args)>(args)...);
+#else
+    // all logging to info
+    info(fmt::format(fmt, std::forward<decltype(args)>(args)...));
+#endif
   }
 
   friend class MergeParticleIDConfig;

--- a/src/algorithms/pid/MergeParticleID.h
+++ b/src/algorithms/pid/MergeParticleID.h
@@ -26,14 +26,16 @@ using MergeParticleIDAlgorithm = algorithms::Algorithm<
     algorithms::Output<edm4eic::CherenkovParticleIDCollection>>;
 
 class MergeParticleID : public MergeParticleIDAlgorithm,
-                        public WithPodConfig<MergeParticleIDConfig> {
+                        public WithPodConfig<MergeParticleIDConfig>,
+                        private Tools<MergeParticleID> {
 
 public:
   MergeParticleID(std::string_view name)
       : MergeParticleIDAlgorithm{name,
                                  {"inputTrackSegments"},
                                  {"outputTrackSegments"},
-                                 "Effectively 'zip' the input particle IDs"} {}
+                                 "Effectively 'zip' the input particle IDs"}
+      , Tools(this) {}
 
   void init();
 

--- a/src/algorithms/pid/MergeParticleID.h
+++ b/src/algorithms/pid/MergeParticleID.h
@@ -18,7 +18,6 @@
 // EICrecon
 #include "algorithms/interfaces/WithPodConfig.h"
 #include "algorithms/pid/MergeParticleIDConfig.h"
-#include "algorithms/pid/Tools.h"
 
 namespace eicrecon {
 
@@ -27,16 +26,14 @@ using MergeParticleIDAlgorithm = algorithms::Algorithm<
     algorithms::Output<edm4eic::CherenkovParticleIDCollection>>;
 
 class MergeParticleID : public MergeParticleIDAlgorithm,
-                        public WithPodConfig<MergeParticleIDConfig>,
-                        private Tools<MergeParticleID> {
+                        public WithPodConfig<MergeParticleIDConfig> {
 
 public:
   MergeParticleID(std::string_view name)
       : MergeParticleIDAlgorithm{name,
                                  {"inputTrackSegments"},
                                  {"outputTrackSegments"},
-                                 "Effectively 'zip' the input particle IDs"}
-      , Tools(this) {}
+                                 "Effectively 'zip' the input particle IDs"} {}
 
   void init();
 
@@ -56,8 +53,6 @@ private:
     info(fmt::format(fmt, std::forward<decltype(args)>(args)...));
 #endif
   }
-
-  friend class Tools;
 };
 
 } // namespace eicrecon

--- a/src/algorithms/pid/MergeParticleID.h
+++ b/src/algorithms/pid/MergeParticleID.h
@@ -48,7 +48,7 @@ public:
 private:
   template <algorithms::LogLevel lvl, typename... T>
   constexpr void log(fmt::format_string<T...> fmt, T&&... args) const {
-    log<lvl>(fmt, std::forward<decltype(args)>(args)...);
+    algorithms::LoggerMixin::log<lvl>(fmt, std::forward<decltype(args)>(args)...);
   }
 
   friend class MergeParticleIDConfig;

--- a/src/algorithms/pid/MergeParticleIDConfig.h
+++ b/src/algorithms/pid/MergeParticleIDConfig.h
@@ -8,8 +8,6 @@
 
 namespace eicrecon {
 
-class MergeParticleID;
-
 class MergeParticleIDConfig {
 public:
   /////////////////////////////////////////////////////

--- a/src/algorithms/pid/MergeParticleIDConfig.h
+++ b/src/algorithms/pid/MergeParticleIDConfig.h
@@ -3,9 +3,12 @@
 
 #pragma once
 
+#include <algorithms/logger.h>
 #include <spdlog/spdlog.h>
 
 namespace eicrecon {
+
+class MergeParticleID;
 
 class MergeParticleIDConfig {
 public:
@@ -21,14 +24,7 @@ public:
   /////////////////////////////////////////////////////
 
   // print all parameters
-  void Print(std::shared_ptr<spdlog::logger> m_log,
-             spdlog::level::level_enum lvl = spdlog::level::debug) {
-    m_log->log(lvl, "{:=^60}", " MergeParticleIDConfig Settings ");
-    auto print_param = [&m_log, &lvl](auto name, auto val) {
-      m_log->log(lvl, "  {:>20} = {:<}", name, val);
-    };
-    print_param("mergeMode", mergeMode);
-    m_log->log(lvl, "{:=^60}", "");
-  }
+  template <algorithms::LogLevel lvl = algorithms::LogLevel::kDebug>
+  constexpr void Print(const MergeParticleID* logger) const;
 };
 } // namespace eicrecon

--- a/src/algorithms/pid/MergeParticleIDConfig.h
+++ b/src/algorithms/pid/MergeParticleIDConfig.h
@@ -23,8 +23,17 @@ public:
   //
   /////////////////////////////////////////////////////
 
-  // print all parameters
-  template <algorithms::LogLevel lvl = algorithms::LogLevel::kDebug>
-  constexpr void Print(const MergeParticleID* logger) const;
+  // stream all parameters
+  friend std::ostream& operator<<(std::ostream& os, const MergeParticleIDConfig& cfg) {
+    // print all parameters
+    os << fmt::format("{:=^60}", " MergeParticleIDConfig Settings ") << std::endl;
+    auto print_param = [&os](auto name, auto val) {
+      os << fmt::format("  {:>20} = {:<}", name, val) << std::endl;
+    };
+    print_param("mergeMode", cfg.mergeMode);
+    os << fmt::format("{:=^60}", "") << std::endl;
+    return os;
+  }
 };
+
 } // namespace eicrecon

--- a/src/algorithms/pid/Tools.h
+++ b/src/algorithms/pid/Tools.h
@@ -10,7 +10,7 @@
 // general
 #include <map>
 #include <math.h>
-#include <spdlog/spdlog.h>
+#include <algorithms/logger.h>
 
 // ROOT
 #include <TVector3.h>
@@ -25,8 +25,13 @@
 namespace eicrecon {
 
 // Tools class, filled with miscellaneous helper functions
-class Tools {
+template <class T> class Tools {
+private:
+  T* m_logger{nullptr};
+
 public:
+  Tools(T* logger) : m_logger(logger){};
+
   // -------------------------------------------------------------------------------------
 
   // h*c constant, for wavelength <=> energy conversion [GeV*nm]

--- a/src/algorithms/pid/Tools.h
+++ b/src/algorithms/pid/Tools.h
@@ -40,11 +40,11 @@ public:
   // -------------------------------------------------------------------------------------
   // Radiator IDs
 
-  static std::unordered_map<int, std::string> GetRadiatorIDs() {
+  std::unordered_map<int, std::string> GetRadiatorIDs() const {
     return std::unordered_map<int, std::string>{{0, "Aerogel"}, {1, "Gas"}};
   }
 
-  static std::string GetRadiatorName(int id) {
+  std::string GetRadiatorName(int id) const {
     std::string name;
     try {
       name = GetRadiatorIDs().at(id);
@@ -55,7 +55,7 @@ public:
     return name;
   }
 
-  static int GetRadiatorID(std::string name) {
+  int GetRadiatorID(std::string name) const {
     for (auto& [id, name_tmp] : GetRadiatorIDs())
       if (name == name_tmp)
         return id;
@@ -68,8 +68,8 @@ public:
   // Table rebinning and lookup
 
   // Rebin input table `input` to have `nbins+1` equidistant bins; returns the rebinned table
-  static std::vector<std::pair<double, double>>
-  ApplyFineBinning(const std::vector<std::pair<double, double>>& input, unsigned nbins) {
+  std::vector<std::pair<double, double>>
+  ApplyFineBinning(const std::vector<std::pair<double, double>>& input, unsigned nbins) const {
     std::vector<std::pair<double, double>> ret;
 
     // Well, could have probably just reordered the initial vector;
@@ -112,8 +112,8 @@ public:
 
   // Find the bin in table `table` that contains entry `argument` in the first column and
   // sets `entry` to the corresponding element of the second column; returns true if successful
-  static bool GetFinelyBinnedTableEntry(const std::vector<std::pair<double, double>>& table,
-                                        double argument, double* entry) {
+  bool GetFinelyBinnedTableEntry(const std::vector<std::pair<double, double>>& table,
+                                 double argument, double* entry) const {
     // Get the tabulated table reference; perform sanity checks;
     //const std::vector<std::pair<double, double>> &qe = u_quantumEfficiency.value();
     unsigned dim = table.size();
@@ -140,65 +140,63 @@ public:
 
   // -------------------------------------------------------------------------------------
   // convert PODIO vector datatype to ROOT TVector3
-  template <class PodioVector3> static TVector3 PodioVector3_to_TVector3(const PodioVector3 v) {
+  template <class PodioVector3> TVector3 PodioVector3_to_TVector3(const PodioVector3 v) const {
     return TVector3(v.x, v.y, v.z);
   }
   // convert ROOT::Math::Vector to ROOT TVector3
-  template <class MathVector3> static TVector3 MathVector3_to_TVector3(MathVector3 v) {
+  template <class MathVector3> TVector3 MathVector3_to_TVector3(MathVector3 v) const {
     return TVector3(v.x(), v.y(), v.z());
   }
 
   // -------------------------------------------------------------------------------------
 
   // printing: vectors
-  static void PrintTVector3(std::shared_ptr<spdlog::logger> m_log, std::string name, TVector3 vec,
-                            int nameBuffer                = 30,
-                            spdlog::level::level_enum lvl = spdlog::level::trace) {
-    m_log->log(lvl, "{:>{}} = ( {:>10.2f} {:>10.2f} {:>10.2f} )", name, nameBuffer, vec.x(),
-               vec.y(), vec.z());
+  template <algorithms::LogLevel lvl = algorithms::LogLevel::kTrace>
+  void PrintTVector3(std::string name, TVector3 vec, int nameBuffer = 30) const {
+    m_logger->template log<lvl>("{:>{}} = ( {:>10.2f} {:>10.2f} {:>10.2f} )", name, nameBuffer,
+                                vec.x(), vec.y(), vec.z());
   }
 
   // printing: hypothesis tables
-  static void PrintHypothesisTableHead(std::shared_ptr<spdlog::logger> m_log, int indent = 4,
-                                       spdlog::level::level_enum lvl = spdlog::level::trace) {
-    m_log->log(lvl, "{:{}}{:>6}  {:>10}  {:>10}", "", indent, "PDG", "Weight", "NPE");
+  template <algorithms::LogLevel lvl = algorithms::LogLevel::kTrace>
+  void PrintHypothesisTableHead(int indent = 4) const {
+    m_logger->template log<lvl>("{:{}}{:>6}  {:>10}  {:>10}", "", indent, "PDG", "Weight", "NPE");
   }
-  static void PrintHypothesisTableLine(std::shared_ptr<spdlog::logger> m_log,
-                                       edm4eic::CherenkovParticleIDHypothesis hyp, int indent = 4,
-                                       spdlog::level::level_enum lvl = spdlog::level::trace) {
-    m_log->log(lvl, "{:{}}{:>6}  {:>10.8}  {:>10.8}", "", indent, hyp.PDG, hyp.weight, hyp.npe);
+  template <algorithms::LogLevel lvl = algorithms::LogLevel::kTrace>
+  void PrintHypothesisTableLine(edm4eic::CherenkovParticleIDHypothesis hyp, int indent = 4) const {
+    m_logger->template log<lvl>("{:{}}{:>6}  {:>10.8}  {:>10.8}", "", indent, hyp.PDG, hyp.weight,
+                                hyp.npe);
   }
-  static void PrintHypothesisTableLine(std::shared_ptr<spdlog::logger> m_log,
-                                       edm4hep::ParticleID hyp, int indent = 4,
-                                       spdlog::level::level_enum lvl = spdlog::level::trace) {
+  template <algorithms::LogLevel lvl = algorithms::LogLevel::kTrace>
+  void PrintHypothesisTableLine(edm4hep::ParticleID hyp, int indent = 4) const {
     float npe =
         hyp.parameters_size() > 0 ? hyp.getParameters(0) : -1; // assume NPE is the first parameter
-    m_log->log(lvl, "{:{}}{:>6}  {:>10.8}  {:>10.8}", "", indent, hyp.getPDG(), hyp.getLikelihood(),
-               npe);
+    m_logger->template log<lvl>("{:{}}{:>6}  {:>10.8}  {:>10.8}", "", indent, hyp.getPDG(),
+                                hyp.getLikelihood(), npe);
   }
 
   // printing: Cherenkov angle estimate
-  static void PrintCherenkovEstimate(std::shared_ptr<spdlog::logger> m_log,
-                                     edm4eic::CherenkovParticleID pid, bool printHypotheses = true,
-                                     int indent                    = 2,
-                                     spdlog::level::level_enum lvl = spdlog::level::trace) {
-    if (m_log->level() <= lvl) {
+  template <algorithms::LogLevel lvl = algorithms::LogLevel::kTrace>
+  void PrintCherenkovEstimate(edm4eic::CherenkovParticleID pid, bool printHypotheses = true,
+                              int indent = 2) const {
+    if (m_logger->level() <= lvl) {
       double thetaAve = 0;
       if (pid.getNpe() > 0)
         for (const auto& [theta, phi] : pid.getThetaPhiPhotons())
           thetaAve += theta / pid.getNpe();
-      m_log->log(lvl, "{:{}}Cherenkov Angle Estimate:", "", indent);
-      m_log->log(lvl, "{:{}}  {:>16}:  {:>10}", "", indent, "NPE", pid.getNpe());
-      m_log->log(lvl, "{:{}}  {:>16}:  {:>10.8} mrad", "", indent, "<theta>",
-                 thetaAve * 1e3); // [rad] -> [mrad]
-      m_log->log(lvl, "{:{}}  {:>16}:  {:>10.8}", "", indent, "<rindex>", pid.getRefractiveIndex());
-      m_log->log(lvl, "{:{}}  {:>16}:  {:>10.8} eV", "", indent, "<energy>",
-                 pid.getPhotonEnergy() * 1e9); // [GeV] -> [eV]
+      m_logger->template log<lvl>("{:{}}Cherenkov Angle Estimate:", "", indent);
+      m_logger->template log<lvl>("{:{}}  {:>16}:  {:>10}", "", indent, "NPE", pid.getNpe());
+      m_logger->template log<lvl>("{:{}}  {:>16}:  {:>10.8} mrad", "", indent, "<theta>",
+                                  thetaAve * 1e3); // [rad] -> [mrad]
+      m_logger->template log<lvl>("{:{}}  {:>16}:  {:>10.8}", "", indent, "<rindex>",
+                                  pid.getRefractiveIndex());
+      m_logger->template log<lvl>("{:{}}  {:>16}:  {:>10.8} eV", "", indent, "<energy>",
+                                  pid.getPhotonEnergy() * 1e9); // [GeV] -> [eV]
       if (printHypotheses) {
-        m_log->log(lvl, "{:{}}Mass Hypotheses:", "", indent);
-        Tools::PrintHypothesisTableHead(m_log, indent + 2);
+        m_logger->template log<lvl>("{:{}}Mass Hypotheses:", "", indent);
+        PrintHypothesisTableHead(indent + 2);
         for (const auto& hyp : pid.getHypotheses())
-          Tools::PrintHypothesisTableLine(m_log, hyp, indent + 2);
+          PrintHypothesisTableLine(hyp, indent + 2);
       }
     }
   }

--- a/src/algorithms/pid/Tools.h
+++ b/src/algorithms/pid/Tools.h
@@ -146,55 +146,26 @@ public:
   // -------------------------------------------------------------------------------------
 
   // printing: vectors
-  template <algorithms::LogLevel lvl = algorithms::LogLevel::kTrace>
-  void PrintTVector3(std::string name, TVector3 vec, int nameBuffer = 30) const {
-    m_logger->template log<lvl>("{:>{}} = ( {:>10.2f} {:>10.2f} {:>10.2f} )", name, nameBuffer,
-                                vec.x(), vec.y(), vec.z());
+  std::string PrintTVector3(std::string name, TVector3 vec, int nameBuffer = 30) const {
+    return fmt::format("{:>{}} = ( {:>10.2f} {:>10.2f} {:>10.2f} )", name, nameBuffer, vec.x(),
+                       vec.y(), vec.z());
   }
 
   // printing: hypothesis tables
-  template <algorithms::LogLevel lvl = algorithms::LogLevel::kTrace>
-  void PrintHypothesisTableHead(int indent = 4) const {
-    m_logger->template log<lvl>("{:{}}{:>6}  {:>10}  {:>10}", "", indent, "PDG", "Weight", "NPE");
+  std::string HypothesisTableHead(int indent = 4) const {
+    return fmt::format("{:{}}{:>6}  {:>10}  {:>10}", "", indent, "PDG", "Weight", "NPE");
   }
-  template <algorithms::LogLevel lvl = algorithms::LogLevel::kTrace>
-  void PrintHypothesisTableLine(edm4eic::CherenkovParticleIDHypothesis hyp, int indent = 4) const {
-    m_logger->template log<lvl>("{:{}}{:>6}  {:>10.8}  {:>10.8}", "", indent, hyp.PDG, hyp.weight,
-                                hyp.npe);
+  std::string HypothesisTableLine(edm4eic::CherenkovParticleIDHypothesis hyp,
+                                  int indent = 4) const {
+    return fmt::format("{:{}}{:>6}  {:>10.8}  {:>10.8}", "", indent, hyp.PDG, hyp.weight, hyp.npe);
   }
-  template <algorithms::LogLevel lvl = algorithms::LogLevel::kTrace>
-  void PrintHypothesisTableLine(edm4hep::ParticleID hyp, int indent = 4) const {
+  std::string HypothesisTableLine(edm4hep::ParticleID hyp, int indent = 4) const {
     float npe =
         hyp.parameters_size() > 0 ? hyp.getParameters(0) : -1; // assume NPE is the first parameter
-    m_logger->template log<lvl>("{:{}}{:>6}  {:>10.8}  {:>10.8}", "", indent, hyp.getPDG(),
-                                hyp.getLikelihood(), npe);
-  }
-
-  // printing: Cherenkov angle estimate
-  template <algorithms::LogLevel lvl = algorithms::LogLevel::kTrace>
-  void PrintCherenkovEstimate(edm4eic::CherenkovParticleID pid, bool printHypotheses = true,
-                              int indent = 2) const {
-    if (m_logger->level() <= lvl) {
-      double thetaAve = 0;
-      if (pid.getNpe() > 0)
-        for (const auto& [theta, phi] : pid.getThetaPhiPhotons())
-          thetaAve += theta / pid.getNpe();
-      m_logger->template log<lvl>("{:{}}Cherenkov Angle Estimate:", "", indent);
-      m_logger->template log<lvl>("{:{}}  {:>16}:  {:>10}", "", indent, "NPE", pid.getNpe());
-      m_logger->template log<lvl>("{:{}}  {:>16}:  {:>10.8} mrad", "", indent, "<theta>",
-                                  thetaAve * 1e3); // [rad] -> [mrad]
-      m_logger->template log<lvl>("{:{}}  {:>16}:  {:>10.8}", "", indent, "<rindex>",
-                                  pid.getRefractiveIndex());
-      m_logger->template log<lvl>("{:{}}  {:>16}:  {:>10.8} eV", "", indent, "<energy>",
-                                  pid.getPhotonEnergy() * 1e9); // [GeV] -> [eV]
-      if (printHypotheses) {
-        m_logger->template log<lvl>("{:{}}Mass Hypotheses:", "", indent);
-        PrintHypothesisTableHead(indent + 2);
-        for (const auto& hyp : pid.getHypotheses())
-          PrintHypothesisTableLine(hyp, indent + 2);
-      }
-    }
+    return fmt::format("{:{}}{:>6}  {:>10.8}  {:>10.8}", "", indent, hyp.getPDG(),
+                       hyp.getLikelihood(), npe);
   }
 
 }; // class Tools
+
 } // namespace eicrecon

--- a/src/algorithms/pid/Tools.h
+++ b/src/algorithms/pid/Tools.h
@@ -33,11 +33,6 @@ public:
   Tools(T* logger) : m_logger(logger){};
 
   // -------------------------------------------------------------------------------------
-
-  // h*c constant, for wavelength <=> energy conversion [GeV*nm]
-  static constexpr double HC = dd4hep::h_Planck * dd4hep::c_light / (dd4hep::GeV * dd4hep::nm);
-
-  // -------------------------------------------------------------------------------------
   // Radiator IDs
 
   std::unordered_map<int, std::string> GetRadiatorIDs() const {

--- a/src/algorithms/pid/Tools.h
+++ b/src/algorithms/pid/Tools.h
@@ -24,22 +24,17 @@
 
 namespace eicrecon {
 
-// Tools class, filled with miscellaneous helper functions
-template <class T> class Tools {
-private:
-  T* m_logger{nullptr};
-
-public:
-  Tools(T* logger) : m_logger(logger){};
+// Tools namespace, filled with miscellaneous helper functions
+namespace Tools {
 
   // -------------------------------------------------------------------------------------
   // Radiator IDs
 
-  std::unordered_map<int, std::string> GetRadiatorIDs() const {
+  static std::unordered_map<int, std::string> GetRadiatorIDs() {
     return std::unordered_map<int, std::string>{{0, "Aerogel"}, {1, "Gas"}};
   }
 
-  std::string GetRadiatorName(int id) const {
+  static std::string GetRadiatorName(int id) {
     std::string name;
     try {
       name = GetRadiatorIDs().at(id);
@@ -50,7 +45,7 @@ public:
     return name;
   }
 
-  int GetRadiatorID(std::string name) const {
+  static int GetRadiatorID(std::string name) {
     for (auto& [id, name_tmp] : GetRadiatorIDs())
       if (name == name_tmp)
         return id;
@@ -63,8 +58,8 @@ public:
   // Table rebinning and lookup
 
   // Rebin input table `input` to have `nbins+1` equidistant bins; returns the rebinned table
-  std::vector<std::pair<double, double>>
-  ApplyFineBinning(const std::vector<std::pair<double, double>>& input, unsigned nbins) const {
+  static std::vector<std::pair<double, double>>
+  ApplyFineBinning(const std::vector<std::pair<double, double>>& input, unsigned nbins) {
     std::vector<std::pair<double, double>> ret;
 
     // Well, could have probably just reordered the initial vector;
@@ -107,8 +102,8 @@ public:
 
   // Find the bin in table `table` that contains entry `argument` in the first column and
   // sets `entry` to the corresponding element of the second column; returns true if successful
-  bool GetFinelyBinnedTableEntry(const std::vector<std::pair<double, double>>& table,
-                                 double argument, double* entry) const {
+  static bool GetFinelyBinnedTableEntry(const std::vector<std::pair<double, double>>& table,
+                                        double argument, double* entry) {
     // Get the tabulated table reference; perform sanity checks;
     //const std::vector<std::pair<double, double>> &qe = u_quantumEfficiency.value();
     unsigned dim = table.size();
@@ -135,37 +130,37 @@ public:
 
   // -------------------------------------------------------------------------------------
   // convert PODIO vector datatype to ROOT TVector3
-  template <class PodioVector3> TVector3 PodioVector3_to_TVector3(const PodioVector3 v) const {
+  template <class PodioVector3> TVector3 PodioVector3_to_TVector3(const PodioVector3 v) {
     return TVector3(v.x, v.y, v.z);
   }
   // convert ROOT::Math::Vector to ROOT TVector3
-  template <class MathVector3> TVector3 MathVector3_to_TVector3(MathVector3 v) const {
+  template <class MathVector3> TVector3 MathVector3_to_TVector3(MathVector3 v) {
     return TVector3(v.x(), v.y(), v.z());
   }
 
   // -------------------------------------------------------------------------------------
 
   // printing: vectors
-  std::string PrintTVector3(std::string name, TVector3 vec, int nameBuffer = 30) const {
+  static std::string PrintTVector3(std::string name, TVector3 vec, int nameBuffer = 30) {
     return fmt::format("{:>{}} = ( {:>10.2f} {:>10.2f} {:>10.2f} )", name, nameBuffer, vec.x(),
                        vec.y(), vec.z());
   }
 
   // printing: hypothesis tables
-  std::string HypothesisTableHead(int indent = 4) const {
+  static std::string HypothesisTableHead(int indent = 4) {
     return fmt::format("{:{}}{:>6}  {:>10}  {:>10}", "", indent, "PDG", "Weight", "NPE");
   }
-  std::string HypothesisTableLine(edm4eic::CherenkovParticleIDHypothesis hyp,
-                                  int indent = 4) const {
+  static std::string HypothesisTableLine(edm4eic::CherenkovParticleIDHypothesis hyp,
+                                         int indent = 4) {
     return fmt::format("{:{}}{:>6}  {:>10.8}  {:>10.8}", "", indent, hyp.PDG, hyp.weight, hyp.npe);
   }
-  std::string HypothesisTableLine(edm4hep::ParticleID hyp, int indent = 4) const {
+  static std::string HypothesisTableLine(edm4hep::ParticleID hyp, int indent = 4) {
     float npe =
         hyp.parameters_size() > 0 ? hyp.getParameters(0) : -1; // assume NPE is the first parameter
     return fmt::format("{:{}}{:>6}  {:>10.8}  {:>10.8}", "", indent, hyp.getPDG(),
                        hyp.getLikelihood(), npe);
   }
 
-}; // class Tools
+}; // namespace Tools
 
 } // namespace eicrecon

--- a/src/global/pid/IrtCherenkovParticleID_factory.h
+++ b/src/global/pid/IrtCherenkovParticleID_factory.h
@@ -66,7 +66,7 @@ public:
     m_algo = std::make_unique<AlgoT>(GetPrefix());
     m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
     m_algo->applyConfig(config());
-    m_algo->init(m_RichGeoSvc().GetIrtGeo("DRICH")->GetIrtDetectorCollection(), logger());
+    m_algo->init(m_RichGeoSvc().GetIrtGeo("DRICH")->GetIrtDetectorCollection());
   }
 
   void ChangeRun(int32_t /* run_number */) {}

--- a/src/global/pid/MergeCherenkovParticleID_factory.h
+++ b/src/global/pid/MergeCherenkovParticleID_factory.h
@@ -41,7 +41,7 @@ public:
     m_algo = std::make_unique<AlgoT>(GetPrefix());
     m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
     m_algo->applyConfig(config());
-    m_algo->init(logger());
+    m_algo->init();
   }
 
   void ChangeRun(int32_t /* run_number */) {}

--- a/src/tests/algorithms_test/pid_MergeParticleID.cc
+++ b/src/tests/algorithms_test/pid_MergeParticleID.cc
@@ -145,7 +145,7 @@ TEST_CASE("the PID MergeParticleID algorithm runs", "[MergeParticleID]") {
     eicrecon::MergeParticleIDConfig cfg;
     cfg.mergeMode = eicrecon::MergeParticleIDConfig::kAddWeights;
     algo.applyConfig(cfg);
-    algo.init(logger);
+    algo.init();
 
     auto result = std::make_unique<edm4eic::CherenkovParticleIDCollection>();
     algo.process({coll_cherenkov_list}, {result.get()});
@@ -213,7 +213,7 @@ TEST_CASE("the PID MergeParticleID algorithm runs", "[MergeParticleID]") {
     eicrecon::MergeParticleIDConfig cfg;
     cfg.mergeMode = eicrecon::MergeParticleIDConfig::kMultiplyWeights;
     algo.applyConfig(cfg);
-    algo.init(logger);
+    algo.init();
 
     auto result = std::make_unique<edm4eic::CherenkovParticleIDCollection>();
     algo.process({coll_cherenkov_list}, {result.get()});


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR ensures that IrtCherenkovParticleID uses the algorithms logger, so it does not have to be passed by the factory.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: migration to algorithms)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.