### PR TITLE
fix: a few loose ends to avoid compiler warnings

### DIFF
--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -158,7 +158,6 @@ CKFTracking::process(const edm4eic::TrackParametersCollection& init_trk_params,
 #endif
     // ---
     // Create ACTS measurements
-    std::array<Acts::BoundIndices, 2> indices{Acts::eBoundLoc0, Acts::eBoundLoc1};
 
     Acts::ActsVector<2> loc = Acts::Vector2::Zero();
     loc[Acts::eBoundLoc0]   = meas2D.getLoc().a;
@@ -171,6 +170,7 @@ CKFTracking::process(const edm4eic::TrackParametersCollection& init_trk_params,
     cov(1, 0)                     = meas2D.getCovariance().xy;
 
 #if Acts_VERSION_MAJOR > 37 || (Acts_VERSION_MAJOR == 37 && Acts_VERSION_MINOR >= 1)
+    std::array<Acts::BoundIndices, 2> indices{Acts::eBoundLoc0, Acts::eBoundLoc1};
     Acts::visit_measurement(
         indices.size(), [&](auto dim) -> ActsExamples::VariableBoundMeasurementProxy {
           if constexpr (dim == indices.size()) {
@@ -181,6 +181,7 @@ CKFTracking::process(const edm4eic::TrackParametersCollection& init_trk_params,
           }
         });
 #elif Acts_VERSION_MAJOR == 37 && Acts_VERSION_MINOR == 0
+    std::array<Acts::BoundIndices, 2> indices{Acts::eBoundLoc0, Acts::eBoundLoc1};
     Acts::visit_measurement(
         indices.size(), [&](auto dim) -> ActsExamples::VariableBoundMeasurementProxy {
           if constexpr (dim == indices.size()) {

--- a/src/algorithms/tracking/SpacePoint.h
+++ b/src/algorithms/tracking/SpacePoint.h
@@ -47,9 +47,6 @@ public:
 };
 
 inline bool operator==(SpacePoint a, SpacePoint b) { return (a.getObjectID() == b.getObjectID()); }
-static bool spCompare(SpacePoint r, SpacePoint s) {
-  return std::hypot(r.x(), r.y(), r.z()) < std::hypot(s.x(), s.y(), s.z());
-}
 
 using SpacePointPtr = std::unique_ptr<SpacePoint>;
 /// Container of sim seed

--- a/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.cc
@@ -329,7 +329,7 @@ void femc_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event) 
     //loop over input_tower_sim and find if there is already a tower with the same cellID
     bool found = false;
     for (auto& tower : input_tower_sim) {
-      if (tower.cellID == cellID) {
+      if (tower.cellID == static_cast<decltype(tower.cellID)>(cellID)) {
         tower.energy += energy;
         found = true;
         break;
@@ -384,7 +384,7 @@ void femc_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event) 
     //loop over input_tower_rec and find if there is already a tower with the same cellID
     bool found = false;
     for (auto& tower : input_tower_rec) {
-      if (tower.cellID == cellID) {
+      if (tower.cellID == static_cast<decltype(tower.cellID)>(cellID)) {
         tower.energy += energy;
         found = true;
         break;

--- a/src/benchmarks/reconstruction/lfhcal_studies/clusterizer_MA.h
+++ b/src/benchmarks/reconstruction/lfhcal_studies/clusterizer_MA.h
@@ -75,7 +75,7 @@ bool acompareCl(clustersStrct lhs, clustersStrct rhs) { return lhs.cluster_E > r
 //**************************************************************************************************************//
 clustersStrct findMACluster(
     float seed,                                    // minimum seed energy
-    float agg,                                     // minimum aggregation energy
+    float /* agg */,                               // minimum aggregation energy
     std::vector<towersStrct>& input_towers_temp,   // temporary full tower array
     std::vector<towersStrct>& cluster_towers_temp, // towers associated to cluster
     //                               std::vector<int> clslabels_temp              // MC labels in cluster

--- a/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
@@ -400,7 +400,7 @@ void lfhcal_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event
     //loop over input_tower_sim and find if there is already a tower with the same cellID
     bool found = false;
     for (auto& tower : input_tower_sim) {
-      if (tower.cellID == cellID) {
+      if (tower.cellID == static_cast<decltype(tower.cellID)>(cellID)) {
         tower.energy += energy;
         found = true;
         break;
@@ -468,7 +468,7 @@ void lfhcal_studiesProcessor::Process(const std::shared_ptr<const JEvent>& event
     //loop over input_tower_rec and find if there is already a tower with the same cellID
     bool found = false;
     for (auto& tower : input_tower_rec) {
-      if (tower.cellID == cellID) {
+      if (tower.cellID == static_cast<decltype(tower.cellID)>(cellID)) {
         tower.energy += energy;
         found = true;
         break;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes some remaining loose ends: unused variables with ifdefs, unused functions, unused arguments, casting to decltypes.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: compiler warnings)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.