### PR TITLE
fix: use std::log to avoid confusion with logger functions

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -142,7 +142,7 @@ CalorimeterClusterRecoCoG::reconstruct(const edm4eic::ProtoCluster& pcl) const {
 
   double logWeightBase = m_cfg.logWeightBase;
   if (m_cfg.logWeightBaseCoeffs.size() != 0) {
-    double l      = log(cl.getEnergy() / m_cfg.logWeightBase_Eref);
+    double l      = std::log(cl.getEnergy() / m_cfg.logWeightBase_Eref);
     logWeightBase = 0;
     for (std::size_t i = 0; i < m_cfg.logWeightBaseCoeffs.size(); i++) {
       logWeightBase += m_cfg.logWeightBaseCoeffs[i] * pow(l, i);

--- a/src/algorithms/calorimetry/CalorimeterClusterShape.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterShape.cc
@@ -78,7 +78,7 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
     // set up base for weights
     double logWeightBase = m_cfg.logWeightBase;
     if (m_cfg.logWeightBaseCoeffs.size() != 0) {
-      double l      = log(out_clust.getEnergy() / m_cfg.logWeightBase_Eref);
+      double l      = std::log(out_clust.getEnergy() / m_cfg.logWeightBase_Eref);
       logWeightBase = 0;
       for (std::size_t i = 0; i < m_cfg.logWeightBaseCoeffs.size(); i++) {
         logWeightBase += m_cfg.logWeightBaseCoeffs[i] * pow(l, i);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR replaces two instances of `log` with `std::log` to avoid confusion with logger functions.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.