### PR TITLE
Make CollectionCollector collections optional

### DIFF
--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -161,12 +161,12 @@ void InitPlugin(JApplication* app) {
   }
 
   // Combine the tracks from each module into one collection
-  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track>>(
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track,true>>(
       "TaggerTrackerLocalTracks", outputTrackTags, {"TaggerTrackerLocalTracks"}, app));
 
   // Combine the associations from each module into one collection
   app->Add(new JOmniFactoryGeneratorT<
-           CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation>>(
+           CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation,true>>(
       "TaggerTrackerLocalTrackAssociations", outputTrackAssociationTags,
       {"TaggerTrackerLocalTrackAssociations"}, app));
 

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -161,12 +161,12 @@ void InitPlugin(JApplication* app) {
   }
 
   // Combine the tracks from each module into one collection
-  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track,true>>(
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track, true>>(
       "TaggerTrackerLocalTracks", outputTrackTags, {"TaggerTrackerLocalTracks"}, app));
 
   // Combine the associations from each module into one collection
   app->Add(new JOmniFactoryGeneratorT<
-           CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation,true>>(
+           CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation, true>>(
       "TaggerTrackerLocalTrackAssociations", outputTrackAssociationTags,
       {"TaggerTrackerLocalTrackAssociations"}, app));
 

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -52,7 +52,7 @@ public:
       owner->RegisterInput(this);
       this->collection_names.push_back(default_tag);
       this->is_optional = is_optional;
-      this->type_name = JTypeInfo::demangle<T>();
+      this->type_name   = JTypeInfo::demangle<T>();
     }
 
     const std::vector<const T*>& operator()() { return m_data; }
@@ -60,7 +60,9 @@ public:
   private:
     friend class JOmniFactory;
 
-    void GetCollection(const JEvent& event) { m_data = event.Get<T>(this->collection_names[0], !this->is_optional); }
+    void GetCollection(const JEvent& event) {
+      m_data = event.Get<T>(this->collection_names[0], !this->is_optional);
+    }
   };
 
   template <typename PodioT> class PodioInput : public InputBase {
@@ -68,7 +70,8 @@ public:
     const typename PodioTypeMap<PodioT>::collection_t* m_data;
 
   public:
-    PodioInput(JOmniFactory* owner, std::string default_collection_name = "", bool is_optional = false) {
+    PodioInput(JOmniFactory* owner, std::string default_collection_name = "",
+               bool is_optional = false) {
       owner->RegisterInput(this);
       this->collection_names.push_back(default_collection_name);
       this->is_optional = is_optional;
@@ -90,7 +93,8 @@ public:
     std::vector<const typename PodioTypeMap<PodioT>::collection_t*> m_data;
 
   public:
-    VariadicPodioInput(JOmniFactory* owner, std::vector<std::string> default_names = {}, bool is_optional = false) {
+    VariadicPodioInput(JOmniFactory* owner, std::vector<std::string> default_names = {},
+                       bool is_optional = false) {
       owner->RegisterInput(this);
       this->collection_names = default_names;
       this->type_name        = JTypeInfo::demangle<PodioT>();

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -60,7 +60,7 @@ public:
 
     void GetCollection(const JEvent& event) {
       try {
-        m_data = event.Get<T>(this->collection_names[0],!IsOptional);
+        m_data = event.Get<T>(this->collection_names[0], !IsOptional);
       } catch (const std::exception& e) {
         if constexpr (!IsOptional) {
           throw JException("JOmniFactory: Failed to get collection %s: %s",
@@ -88,7 +88,7 @@ public:
 
     void GetCollection(const JEvent& event) {
       try {
-        m_data = event.GetCollection<PodioT>(this->collection_names[0],!IsOptional);
+        m_data = event.GetCollection<PodioT>(this->collection_names[0], !IsOptional);
       } catch (const std::exception& e) {
         if constexpr (!IsOptional) {
           throw JException("JOmniFactory: Failed to get collection %s: %s",
@@ -121,7 +121,7 @@ public:
       m_data.clear();
       for (auto& coll_name : this->collection_names) {
         try {
-          m_data.push_back(event.GetCollection<PodioT>(coll_name,!IsOptional));
+          m_data.push_back(event.GetCollection<PodioT>(coll_name, !IsOptional));
         } catch (const std::exception& e) {
           if constexpr (!IsOptional) {
             throw JException("JOmniFactory: Failed to get collection %s: %s", coll_name.c_str(),

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -61,7 +61,7 @@ public:
     void GetCollection(const JEvent& event) {
       try {
         m_data = event.Get<T>(this->collection_names[0], !IsOptional);
-      } catch (const JExceptionn& e) {
+      } catch (const JException& e) {
         if constexpr (!IsOptional) {
           throw JException("JOmniFactory: Failed to get collection %s: %s",
                            this->collection_names[0].c_str(), e.what());

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -60,7 +60,7 @@ public:
 
     void GetCollection(const JEvent& event) {
       try {
-        m_data = event.Get<T>(this->collection_names[0], !IsOptional);
+        m_data = event.Get<T>(this->collection_names[0]);
       } catch (const std::exception& e) {
         if constexpr (!IsOptional) {
           throw JException("JOmniFactory: Failed to get collection %s: %s",
@@ -88,7 +88,7 @@ public:
 
     void GetCollection(const JEvent& event) {
       try {
-        m_data = event.GetCollection<PodioT>(this->collection_names[0], !IsOptional);
+        m_data = event.GetCollection<PodioT>(this->collection_names[0]);
       } catch (const std::exception& e) {
         if constexpr (!IsOptional) {
           throw JException("JOmniFactory: Failed to get collection %s: %s",
@@ -121,7 +121,7 @@ public:
       m_data.clear();
       for (auto& coll_name : this->collection_names) {
         try {
-          m_data.push_back(event.GetCollection<PodioT>(coll_name, !IsOptional));
+          m_data.push_back(event.GetCollection<PodioT>(coll_name));
         } catch (const std::exception& e) {
           if constexpr (!IsOptional) {
             throw JException("JOmniFactory: Failed to get collection %s: %s", coll_name.c_str(),

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -42,7 +42,7 @@ public:
     virtual void GetCollection(const JEvent& event) = 0;
   };
 
-  template <typename T, bool IsOptional=false> class Input : public InputBase {
+  template <typename T, bool IsOptional = false> class Input : public InputBase {
 
     std::vector<const T*> m_data;
 
@@ -50,7 +50,7 @@ public:
     Input(JOmniFactory* owner, std::string default_tag = "") {
       owner->RegisterInput(this);
       this->collection_names.push_back(default_tag);
-      this->type_name   = JTypeInfo::demangle<T>();
+      this->type_name = JTypeInfo::demangle<T>();
     }
 
     const std::vector<const T*>& operator()() { return m_data; }
@@ -59,12 +59,12 @@ public:
     friend class JOmniFactory;
 
     void GetCollection(const JEvent& event) {
-      try{
+      try {
         m_data = event.Get<T>(this->collection_names[0], !IsOptional);
       } catch (const std::exception& e) {
         if constexpr (!IsOptional) {
-          throw JException("JOmniFactory: Failed to get collection %s: %s", this->collection_names[0].c_str(),
-                           e.what());
+          throw JException("JOmniFactory: Failed to get collection %s: %s",
+                           this->collection_names[0].c_str(), e.what());
         }
       }
     }
@@ -78,7 +78,7 @@ public:
     PodioInput(JOmniFactory* owner, std::string default_collection_name = "") {
       owner->RegisterInput(this);
       this->collection_names.push_back(default_collection_name);
-      this->type_name   = JTypeInfo::demangle<PodioT>();
+      this->type_name = JTypeInfo::demangle<PodioT>();
     }
 
     const typename PodioTypeMap<PodioT>::collection_t* operator()() { return m_data; }
@@ -91,8 +91,8 @@ public:
         m_data = event.GetCollection<PodioT>(this->collection_names[0], !IsOptional);
       } catch (const std::exception& e) {
         if constexpr (!IsOptional) {
-          throw JException("JOmniFactory: Failed to get collection %s: %s", this->collection_names[0].c_str(),
-                           e.what());
+          throw JException("JOmniFactory: Failed to get collection %s: %s",
+                           this->collection_names[0].c_str(), e.what());
         }
       }
     }

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -61,7 +61,7 @@ public:
     void GetCollection(const JEvent& event) {
       try {
         m_data = event.Get<T>(this->collection_names[0], !IsOptional);
-      } catch (const std::exception& e) {
+      } catch (const JExceptionn& e) {
         if constexpr (!IsOptional) {
           throw JException("JOmniFactory: Failed to get collection %s: %s",
                            this->collection_names[0].c_str(), e.what());
@@ -89,7 +89,7 @@ public:
     void GetCollection(const JEvent& event) {
       try {
         m_data = event.GetCollection<PodioT>(this->collection_names[0], !IsOptional);
-      } catch (const std::exception& e) {
+      } catch (const JException& e) {
         if constexpr (!IsOptional) {
           throw JException("JOmniFactory: Failed to get collection %s: %s",
                            this->collection_names[0].c_str(), e.what());
@@ -122,7 +122,7 @@ public:
       for (auto& coll_name : this->collection_names) {
         try {
           m_data.push_back(event.GetCollection<PodioT>(coll_name, !IsOptional));
-        } catch (const std::exception& e) {
+        } catch (const JException& e) {
           if constexpr (!IsOptional) {
             throw JException("JOmniFactory: Failed to get collection %s: %s", coll_name.c_str(),
                              e.what());

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -60,7 +60,7 @@ public:
 
     void GetCollection(const JEvent& event) {
       try {
-        m_data = event.Get<T>(this->collection_names[0]);
+        m_data = event.Get<T>(this->collection_names[0],!IsOptional);
       } catch (const std::exception& e) {
         if constexpr (!IsOptional) {
           throw JException("JOmniFactory: Failed to get collection %s: %s",
@@ -88,7 +88,7 @@ public:
 
     void GetCollection(const JEvent& event) {
       try {
-        m_data = event.GetCollection<PodioT>(this->collection_names[0]);
+        m_data = event.GetCollection<PodioT>(this->collection_names[0],!IsOptional);
       } catch (const std::exception& e) {
         if constexpr (!IsOptional) {
           throw JException("JOmniFactory: Failed to get collection %s: %s",
@@ -121,7 +121,7 @@ public:
       m_data.clear();
       for (auto& coll_name : this->collection_names) {
         try {
-          m_data.push_back(event.GetCollection<PodioT>(coll_name));
+          m_data.push_back(event.GetCollection<PodioT>(coll_name,!IsOptional));
         } catch (const std::exception& e) {
           if constexpr (!IsOptional) {
             throw JException("JOmniFactory: Failed to get collection %s: %s", coll_name.c_str(),

--- a/src/factories/meta/CollectionCollector_factory.h
+++ b/src/factories/meta/CollectionCollector_factory.h
@@ -15,7 +15,7 @@ private:
   std::unique_ptr<AlgoT> m_algo;
 
   typename JOmniFactory<CollectionCollector_factory<T>>::template VariadicPodioInput<T> m_inputs{
-      this, std::vector<std::string>{""},true};
+      this, std::vector<std::string>{""}, true};
   typename JOmniFactory<CollectionCollector_factory<T>>::template PodioOutput<T> m_output{this};
 
 public:

--- a/src/factories/meta/CollectionCollector_factory.h
+++ b/src/factories/meta/CollectionCollector_factory.h
@@ -6,7 +6,7 @@
 
 namespace eicrecon {
 
-template <class T, bool IsOptional = true>
+template <class T, bool IsOptional = false>
 class CollectionCollector_factory
     : public JOmniFactory<CollectionCollector_factory<T, IsOptional>> {
 public:

--- a/src/factories/meta/CollectionCollector_factory.h
+++ b/src/factories/meta/CollectionCollector_factory.h
@@ -7,15 +7,19 @@
 namespace eicrecon {
 
 template <class T, bool IsOptional = true>
-class CollectionCollector_factory : public JOmniFactory<CollectionCollector_factory<T,IsOptional>> {
+class CollectionCollector_factory
+    : public JOmniFactory<CollectionCollector_factory<T, IsOptional>> {
 public:
   using AlgoT = eicrecon::CollectionCollector<typename T::collection_type>;
 
 private:
   std::unique_ptr<AlgoT> m_algo;
 
-  typename JOmniFactory<CollectionCollector_factory<T,IsOptional>>::template VariadicPodioInput<T,IsOptional> m_inputs{this};
-  typename JOmniFactory<CollectionCollector_factory<T,IsOptional>>::template PodioOutput<T> m_output{this};
+  typename JOmniFactory<CollectionCollector_factory<T, IsOptional>>::template VariadicPodioInput<
+      T, IsOptional>
+      m_inputs{this};
+  typename JOmniFactory<CollectionCollector_factory<T, IsOptional>>::template PodioOutput<T>
+      m_output{this};
 
 public:
   void Configure() {

--- a/src/factories/meta/CollectionCollector_factory.h
+++ b/src/factories/meta/CollectionCollector_factory.h
@@ -6,17 +6,16 @@
 
 namespace eicrecon {
 
-template <class T>
-class CollectionCollector_factory : public JOmniFactory<CollectionCollector_factory<T>> {
+template <class T, bool IsOptional = true>
+class CollectionCollector_factory : public JOmniFactory<CollectionCollector_factory<T,IsOptional>> {
 public:
   using AlgoT = eicrecon::CollectionCollector<typename T::collection_type>;
 
 private:
   std::unique_ptr<AlgoT> m_algo;
 
-  typename JOmniFactory<CollectionCollector_factory<T>>::template VariadicPodioInput<T> m_inputs{
-      this, std::vector<std::string>{""}, true};
-  typename JOmniFactory<CollectionCollector_factory<T>>::template PodioOutput<T> m_output{this};
+  typename JOmniFactory<CollectionCollector_factory<T,IsOptional>>::template VariadicPodioInput<T,IsOptional> m_inputs{this};
+  typename JOmniFactory<CollectionCollector_factory<T,IsOptional>>::template PodioOutput<T> m_output{this};
 
 public:
   void Configure() {

--- a/src/factories/meta/CollectionCollector_factory.h
+++ b/src/factories/meta/CollectionCollector_factory.h
@@ -15,7 +15,7 @@ private:
   std::unique_ptr<AlgoT> m_algo;
 
   typename JOmniFactory<CollectionCollector_factory<T>>::template VariadicPodioInput<T> m_inputs{
-      this};
+      this, std::vector<std::string>{""},true};
   typename JOmniFactory<CollectionCollector_factory<T>>::template PodioOutput<T> m_output{this};
 
 public:

--- a/src/global/beam/beam.cc
+++ b/src/global/beam/beam.cc
@@ -40,7 +40,7 @@ void InitPlugin(JApplication* app) {
       app));
 
   // Combine beam protons and neutrons into beam hadrons
-  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4hep::MCParticle>>(
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4hep::MCParticle,true>>(
       "MCBeamHadrons", {"MCBeamProtons", "MCBeamNeutrons"}, {"MCBeamHadrons"}, app));
 }
 }

--- a/src/global/beam/beam.cc
+++ b/src/global/beam/beam.cc
@@ -40,7 +40,7 @@ void InitPlugin(JApplication* app) {
       app));
 
   // Combine beam protons and neutrons into beam hadrons
-  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4hep::MCParticle,true>>(
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4hep::MCParticle, true>>(
       "MCBeamHadrons", {"MCBeamProtons", "MCBeamNeutrons"}, {"MCBeamHadrons"}, app));
 }
 }

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -78,11 +78,11 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<MC2SmearedParticle_factory>(
       "GeneratedParticles", {"MCParticles"}, {"GeneratedParticles"}, app));
 
-   // Possible calorimeter collections
-   std::vector<std::tuple<std::string, std::string, std::string>> possible_collections =
-   {{"EcalEndcapNHits", "EcalEndcapNClusters", "EcalEndcapNClusterAssociations"},
-    {"EcalBarrelScFiHits", "EcalBarrelScFiClusters", "EcalBarrelScFiClusterAssociations"},
-    {"EcalEndcapPHits", "EcalEndcapPClusters", "EcalEndcapPClusterAssociations"}};
+  // Possible calorimeter collections
+  std::vector<std::tuple<std::string, std::string, std::string>> possible_collections = {
+      {"EcalEndcapNHits", "EcalEndcapNClusters", "EcalEndcapNClusterAssociations"},
+      {"EcalBarrelScFiHits", "EcalBarrelScFiClusters", "EcalBarrelScFiClusterAssociations"},
+      {"EcalEndcapPHits", "EcalEndcapPClusters", "EcalEndcapPClusterAssociations"}};
 
   // Filter out calorimeter collections that are not present in the current configuration
   std::vector<std::string> input_cluster_collections;
@@ -98,15 +98,12 @@ void InitPlugin(JApplication* app) {
   }
 
   app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Cluster>>(
-      "EcalClusters",
-      input_cluster_collections,
-      {"EcalClusters"}, app));
+      "EcalClusters", input_cluster_collections, {"EcalClusters"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<
            CollectionCollector_factory<edm4eic::MCRecoClusterParticleAssociation>>(
-      "EcalClusterAssociations",
-      input_cluster_assoc_collections,
-      {"EcalClusterAssociations"}, app));
+      "EcalClusterAssociations", input_cluster_assoc_collections, {"EcalClusterAssociations"},
+      app));
 
   app->Add(new JOmniFactoryGeneratorT<MatchClusters_factory>(
       "ReconstructedParticlesWithAssoc",

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -78,12 +78,12 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<MC2SmearedParticle_factory>(
       "GeneratedParticles", {"MCParticles"}, {"GeneratedParticles"}, app));
 
-  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Cluster,true>>(
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Cluster, true>>(
       "EcalClusters", {"EcalEndcapNClusters", "EcalBarrelScFiClusters", "EcalEndcapPClusters"},
       {"EcalClusters"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<
-           CollectionCollector_factory<edm4eic::MCRecoClusterParticleAssociation,true>>(
+           CollectionCollector_factory<edm4eic::MCRecoClusterParticleAssociation, true>>(
       "EcalClusterAssociations",
       {"EcalEndcapNClusterAssociations", "EcalBarrelScFiClusterAssociations",
        "EcalEndcapPClusterAssociations"},
@@ -188,7 +188,7 @@ void InitPlugin(JApplication* app) {
       },
       app));
 
-  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Cluster,true>>(
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Cluster, true>>(
       "BarrelClusters",
       {
           "HcalBarrelClusters",

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -79,12 +79,15 @@ void InitPlugin(JApplication* app) {
       "GeneratedParticles", {"MCParticles"}, {"GeneratedParticles"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Cluster>>(
-      "EcalClusters", {"EcalEndcapNClusters", "EcalBarrelScFiClusters", "EcalEndcapPClusters"}, {"EcalClusters"}, app));
+      "EcalClusters", {"EcalEndcapNClusters", "EcalBarrelScFiClusters", "EcalEndcapPClusters"},
+      {"EcalClusters"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<
            CollectionCollector_factory<edm4eic::MCRecoClusterParticleAssociation>>(
-      "EcalClusterAssociations", {"EcalEndcapNClusterAssociations","EcalBarrelScFiClusterAssociations","EcalEndcapPClusterAssociations"}, {"EcalClusterAssociations"},
-      app));
+      "EcalClusterAssociations",
+      {"EcalEndcapNClusterAssociations", "EcalBarrelScFiClusterAssociations",
+       "EcalEndcapPClusterAssociations"},
+      {"EcalClusterAssociations"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<MatchClusters_factory>(
       "ReconstructedParticlesWithAssoc",

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -78,12 +78,12 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<MC2SmearedParticle_factory>(
       "GeneratedParticles", {"MCParticles"}, {"GeneratedParticles"}, app));
 
-  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Cluster>>(
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Cluster,true>>(
       "EcalClusters", {"EcalEndcapNClusters", "EcalBarrelScFiClusters", "EcalEndcapPClusters"},
       {"EcalClusters"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<
-           CollectionCollector_factory<edm4eic::MCRecoClusterParticleAssociation>>(
+           CollectionCollector_factory<edm4eic::MCRecoClusterParticleAssociation,true>>(
       "EcalClusterAssociations",
       {"EcalEndcapNClusterAssociations", "EcalBarrelScFiClusterAssociations",
        "EcalEndcapPClusterAssociations"},
@@ -188,7 +188,7 @@ void InitPlugin(JApplication* app) {
       },
       app));
 
-  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Cluster>>(
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Cluster,true>>(
       "BarrelClusters",
       {
           "HcalBarrelClusters",

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -78,31 +78,12 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<MC2SmearedParticle_factory>(
       "GeneratedParticles", {"MCParticles"}, {"GeneratedParticles"}, app));
 
-  // Possible calorimeter collections
-  std::vector<std::tuple<std::string, std::string, std::string>> possible_collections = {
-      {"EcalEndcapNHits", "EcalEndcapNClusters", "EcalEndcapNClusterAssociations"},
-      {"EcalBarrelScFiHits", "EcalBarrelScFiClusters", "EcalBarrelScFiClusterAssociations"},
-      {"EcalEndcapPHits", "EcalEndcapPClusters", "EcalEndcapPClusterAssociations"}};
-
-  // Filter out calorimeter collections that are not present in the current configuration
-  std::vector<std::string> input_cluster_collections;
-  std::vector<std::string> input_cluster_assoc_collections;
-  auto readouts = app->GetService<DD4hep_service>()->detector()->readouts();
-  for (const auto& [hit_collection, cluster_collection, cluster_assoc_collection] :
-       possible_collections) {
-    if (readouts.find(hit_collection) != readouts.end()) {
-      // Add the collection to the list of input collections
-      input_cluster_collections.push_back(cluster_collection);
-      input_cluster_assoc_collections.push_back(cluster_assoc_collection);
-    }
-  }
-
   app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Cluster>>(
-      "EcalClusters", input_cluster_collections, {"EcalClusters"}, app));
+      "EcalClusters", {"EcalEndcapNClusters", "EcalBarrelScFiClusters", "EcalEndcapPClusters"}, {"EcalClusters"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<
            CollectionCollector_factory<edm4eic::MCRecoClusterParticleAssociation>>(
-      "EcalClusterAssociations", input_cluster_assoc_collections, {"EcalClusterAssociations"},
+      "EcalClusterAssociations", {"EcalEndcapNClusterAssociations","EcalBarrelScFiClusterAssociations","EcalEndcapPClusterAssociations"}, {"EcalClusterAssociations"},
       app));
 
   app->Add(new JOmniFactoryGeneratorT<MatchClusters_factory>(

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -1,20 +1,14 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022 - 2024, Dmitry Romanov, Tyler Kutz, Wouter Deconinck, Dmitry Kalinkin
 
-#include <DD4hep/Detector.h>
 #include <JANA/JApplication.h>
 #include <edm4eic/MCRecoTrackParticleAssociation.h>
 #include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
 #include <edm4eic/TrackCollection.h>
 #include <edm4eic/TrackerHitCollection.h>
 #include <fmt/core.h>
-#include <algorithm>
-#include <gsl/pointers>
 #include <map>
 #include <memory>
-#include <string>
-#include <tuple>
-#include <vector>
 
 #include "ActsToTracks.h"
 #include "ActsToTracks_factory.h"

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -42,7 +42,7 @@ void InitPlugin(JApplication* app) {
       "CentralTrackTruthSeeds", {"MCParticles"}, {"CentralTrackTruthSeeds"}, {}, app));
 
   // Tracker hits collector
-  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::TrackerHit>>(
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::TrackerHit,true>>(
       "CentralTrackingRecHits",
       {"SiBarrelTrackerRecHits", "SiBarrelVertexRecHits", "SiEndcapTrackerRecHits",
        "TOFBarrelRecHits", "TOFEndcapRecHits", "MPGDBarrelRecHits", "OuterMPGDBarrelRecHits",
@@ -52,7 +52,7 @@ void InitPlugin(JApplication* app) {
 
   // Tracker hit associations collector
   app->Add(
-      new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::MCRecoTrackerHitAssociation>>(
+      new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::MCRecoTrackerHitAssociation,true>>(
           "CentralTrackingRawHitAssociations",
           {"SiBarrelRawHitAssociations", "SiBarrelVertexRawHitAssociations",
            "SiEndcapTrackerRawHitAssociations", "TOFBarrelRawHitAssociations",
@@ -217,21 +217,21 @@ void InitPlugin(JApplication* app) {
       app));
 
   // Add central and other tracks
-  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track>>(
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track,true>>(
       "CombinedTracks", {"CentralCKFTracks", "TaggerTrackerTracks"}, {"CombinedTracks"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<
-           CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation>>(
+           CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation,true>>(
       "CombinedTrackAssociations",
       {"CentralCKFTrackAssociations", "TaggerTrackerTrackAssociations"},
       {"CombinedTrackAssociations"}, app));
 
-  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track>>(
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track,true>>(
       "CombinedTruthSeededTracks", {"CentralCKFTruthSeededTracks", "TaggerTrackerTracks"},
       {"CombinedTruthSeededTracks"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<
-           CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation>>(
+           CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation,true>>(
       "CombinedTruthSeededTrackAssociations",
       {"CentralCKFTruthSeededTrackAssociations", "TaggerTrackerTrackAssociations"},
       {"CombinedTruthSeededTrackAssociations"}, app));

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -42,7 +42,7 @@ void InitPlugin(JApplication* app) {
       "CentralTrackTruthSeeds", {"MCParticles"}, {"CentralTrackTruthSeeds"}, {}, app));
 
   // Tracker hits collector
-  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::TrackerHit,true>>(
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::TrackerHit, true>>(
       "CentralTrackingRecHits",
       {"SiBarrelTrackerRecHits", "SiBarrelVertexRecHits", "SiEndcapTrackerRecHits",
        "TOFBarrelRecHits", "TOFEndcapRecHits", "MPGDBarrelRecHits", "OuterMPGDBarrelRecHits",
@@ -51,16 +51,16 @@ void InitPlugin(JApplication* app) {
       app));
 
   // Tracker hit associations collector
-  app->Add(
-      new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::MCRecoTrackerHitAssociation,true>>(
-          "CentralTrackingRawHitAssociations",
-          {"SiBarrelRawHitAssociations", "SiBarrelVertexRawHitAssociations",
-           "SiEndcapTrackerRawHitAssociations", "TOFBarrelRawHitAssociations",
-           "TOFEndcapRawHitAssociations", "MPGDBarrelRawHitAssociations",
-           "OuterMPGDBarrelRawHitAssociations", "BackwardMPGDEndcapRawHitAssociations",
-           "ForwardMPGDEndcapRawHitAssociations", "B0TrackerRawHitAssociations"},
-          {"CentralTrackingRawHitAssociations"}, // Output collection name
-          app));
+  app->Add(new JOmniFactoryGeneratorT<
+           CollectionCollector_factory<edm4eic::MCRecoTrackerHitAssociation, true>>(
+      "CentralTrackingRawHitAssociations",
+      {"SiBarrelRawHitAssociations", "SiBarrelVertexRawHitAssociations",
+       "SiEndcapTrackerRawHitAssociations", "TOFBarrelRawHitAssociations",
+       "TOFEndcapRawHitAssociations", "MPGDBarrelRawHitAssociations",
+       "OuterMPGDBarrelRawHitAssociations", "BackwardMPGDEndcapRawHitAssociations",
+       "ForwardMPGDEndcapRawHitAssociations", "B0TrackerRawHitAssociations"},
+      {"CentralTrackingRawHitAssociations"}, // Output collection name
+      app));
 
   app->Add(new JOmniFactoryGeneratorT<TrackerMeasurementFromHits_factory>(
       "CentralTrackerMeasurements", {"CentralTrackingRecHits"}, {"CentralTrackerMeasurements"},
@@ -217,21 +217,21 @@ void InitPlugin(JApplication* app) {
       app));
 
   // Add central and other tracks
-  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track,true>>(
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track, true>>(
       "CombinedTracks", {"CentralCKFTracks", "TaggerTrackerTracks"}, {"CombinedTracks"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<
-           CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation,true>>(
+           CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation, true>>(
       "CombinedTrackAssociations",
       {"CentralCKFTrackAssociations", "TaggerTrackerTrackAssociations"},
       {"CombinedTrackAssociations"}, app));
 
-  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track,true>>(
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track, true>>(
       "CombinedTruthSeededTracks", {"CentralCKFTruthSeededTracks", "TaggerTrackerTracks"},
       {"CombinedTruthSeededTracks"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<
-           CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation,true>>(
+           CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation, true>>(
       "CombinedTruthSeededTrackAssociations",
       {"CentralCKFTruthSeededTrackAssociations", "TaggerTrackerTrackAssociations"},
       {"CombinedTruthSeededTrackAssociations"}, app));

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -30,7 +30,6 @@
 #include "TracksToParticles_factory.h"
 #include "extensions/jana/JOmniFactoryGeneratorT.h"
 #include "factories/meta/CollectionCollector_factory.h"
-#include "services/geometry/dd4hep/DD4hep_service.h"
 
 //
 extern "C" {
@@ -41,48 +40,23 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<TrackParamTruthInit_factory>(
       "CentralTrackTruthSeeds", {"MCParticles"}, {"CentralTrackTruthSeeds"}, {}, app));
-
-  // Possible collections from arches, brycecanyon and craterlake configurations
-  std::vector<std::tuple<std::string, std::string, std::string, std::string>> possible_collections =
-      {{"SiBarrelHits", "SiBarrelRawHits", "SiBarrelRawHitAssociations", "SiBarrelTrackerRecHits"},
-       {"VertexBarrelHits", "SiBarrelVertexRawHits", "SiBarrelVertexRawHitAssociations",
-        "SiBarrelVertexRecHits"},
-       {"TrackerEndcapHits", "SiEndcapTrackerRawHits", "SiEndcapTrackerRawHitAssociations",
-        "SiEndcapTrackerRecHits"},
-       {"TOFBarrelHits", "TOFBarrelRawHits", "TOFBarrelRawHitAssociations", "TOFBarrelRecHits"},
-       {"TOFEndcapHits", "TOFEndcapRawHits", "TOFEndcapRawHitAssociations", "TOFEndcapRecHits"},
-       {"MPGDBarrelHits", "MPGDBarrelRawHits", "MPGDBarrelRawHitAssociations", "MPGDBarrelRecHits"},
-       {"OuterMPGDBarrelHits", "OuterMPGDBarrelRawHits", "OuterMPGDBarrelRawHitAssociations",
-        "OuterMPGDBarrelRecHits"},
-       {"BackwardMPGDEndcapHits", "BackwardMPGDEndcapRawHits",
-        "BackwardMPGDEndcapRawHitAssociations", "BackwardMPGDEndcapRecHits"},
-       {"ForwardMPGDEndcapHits", "ForwardMPGDEndcapRawHits", "ForwardMPGDEndcapRawHitAssociations",
-        "ForwardMPGDEndcapRecHits"},
-       {"B0TrackerHits", "B0TrackerRawHits", "B0TrackerRawHitAssociations", "B0TrackerRecHits"}};
-
-  // Filter out collections that are not present in the current configuration
-  std::vector<std::string> input_rec_collections;
-  std::vector<std::string> input_raw_assoc_collections;
-  auto readouts = app->GetService<DD4hep_service>()->detector()->readouts();
-  for (const auto& [hit_collection, raw_collection, raw_assoc_collection, rec_collection] :
-       possible_collections) {
-    if (readouts.find(hit_collection) != readouts.end()) {
-      // Add the collection to the list of input collections
-      input_rec_collections.push_back(rec_collection);
-      input_raw_assoc_collections.push_back(raw_assoc_collection);
-    }
-  }
-
+       
   // Tracker hits collector
   app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::TrackerHit>>(
-      "CentralTrackingRecHits", input_rec_collections,
+      "CentralTrackingRecHits", {"SiBarrelTrackerRecHits", "SiBarrelVertexRecHits", "SiEndcapTrackerRecHits",
+        "TOFBarrelRecHits", "TOFEndcapRecHits", "MPGDBarrelRecHits", "OuterMPGDBarrelRecHits",
+        "BackwardMPGDEndcapRecHits", "ForwardMPGDEndcapRecHits", "B0TrackerRecHits"},
       {"CentralTrackingRecHits"}, // Output collection name
       app));
 
   // Tracker hit associations collector
   app->Add(
       new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::MCRecoTrackerHitAssociation>>(
-          "CentralTrackingRawHitAssociations", input_raw_assoc_collections,
+          "CentralTrackingRawHitAssociations", {"SiBarrelRawHitAssociations", "SiBarrelVertexRawHitAssociations",
+            "SiEndcapTrackerRawHitAssociations", "TOFBarrelRawHitAssociations",
+            "TOFEndcapRawHitAssociations", "MPGDBarrelRawHitAssociations",
+            "OuterMPGDBarrelRawHitAssociations", "BackwardMPGDEndcapRawHitAssociations",
+            "ForwardMPGDEndcapRawHitAssociations", "B0TrackerRawHitAssociations"},
           {"CentralTrackingRawHitAssociations"}, // Output collection name
           app));
 
@@ -240,36 +214,22 @@ void InitPlugin(JApplication* app) {
       }},
       app));
 
-  std::vector<std::string> input_track_collections, input_track_assoc_collections;
-  std::vector<std::string> input_truth_track_collections, input_truth_track_assoc_collections;
-  //Check size of input_rec_collections to determine if CentralCKFTracks should be added to the input_track_collections
-  if (input_rec_collections.size() > 0) {
-    input_track_collections.push_back("CentralCKFTracks");
-    input_track_assoc_collections.push_back("CentralCKFTrackAssociations");
-    input_truth_track_collections.push_back("CentralCKFTruthSeededTracks");
-    input_truth_track_assoc_collections.push_back("CentralCKFTruthSeededTrackAssociations");
-  }
-  //Check if the TaggerTracker readout is present in the current configuration
-  if (readouts.find("TaggerTrackerHits") != readouts.end()) {
-    input_track_collections.push_back("TaggerTrackerTracks");
-    input_track_assoc_collections.push_back("TaggerTrackerTrackAssociations");
-    input_truth_track_collections.push_back("TaggerTrackerTracks");
-    input_truth_track_assoc_collections.push_back("TaggerTrackerTrackAssociations");
-  }
-
   // Add central and other tracks
   app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track>>(
-      "CombinedTracks", input_track_collections, {"CombinedTracks"}, app));
+      "CombinedTracks", {"CentralCKFTracks", "TaggerTrackerTracks"}, {"CombinedTracks"}, app));
+
   app->Add(new JOmniFactoryGeneratorT<
            CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation>>(
-      "CombinedTrackAssociations", input_track_assoc_collections, {"CombinedTrackAssociations"},
+      "CombinedTrackAssociations", {"CentralCKFTrackAssociations","TaggerTrackerTrackAssociations"}, {"CombinedTrackAssociations"},
       app));
+
   app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track>>(
-      "CombinedTruthSeededTracks", input_truth_track_collections, {"CombinedTruthSeededTracks"},
+      "CombinedTruthSeededTracks", {"CentralCKFTruthSeededTrackAssociations","TaggerTrackerTrackAssociations"}, {"CombinedTruthSeededTracks"},
       app));
+
   app->Add(new JOmniFactoryGeneratorT<
            CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation>>(
-      "CombinedTruthSeededTrackAssociations", input_truth_track_assoc_collections,
+      "CombinedTruthSeededTrackAssociations", {"CentralCKFTruthSeededTrackAssociations","TaggerTrackerTrackAssociations"},
       {"CombinedTruthSeededTrackAssociations"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<TracksToParticles_factory>(

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -40,23 +40,25 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<TrackParamTruthInit_factory>(
       "CentralTrackTruthSeeds", {"MCParticles"}, {"CentralTrackTruthSeeds"}, {}, app));
-       
+
   // Tracker hits collector
   app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::TrackerHit>>(
-      "CentralTrackingRecHits", {"SiBarrelTrackerRecHits", "SiBarrelVertexRecHits", "SiEndcapTrackerRecHits",
-        "TOFBarrelRecHits", "TOFEndcapRecHits", "MPGDBarrelRecHits", "OuterMPGDBarrelRecHits",
-        "BackwardMPGDEndcapRecHits", "ForwardMPGDEndcapRecHits", "B0TrackerRecHits"},
+      "CentralTrackingRecHits",
+      {"SiBarrelTrackerRecHits", "SiBarrelVertexRecHits", "SiEndcapTrackerRecHits",
+       "TOFBarrelRecHits", "TOFEndcapRecHits", "MPGDBarrelRecHits", "OuterMPGDBarrelRecHits",
+       "BackwardMPGDEndcapRecHits", "ForwardMPGDEndcapRecHits", "B0TrackerRecHits"},
       {"CentralTrackingRecHits"}, // Output collection name
       app));
 
   // Tracker hit associations collector
   app->Add(
       new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::MCRecoTrackerHitAssociation>>(
-          "CentralTrackingRawHitAssociations", {"SiBarrelRawHitAssociations", "SiBarrelVertexRawHitAssociations",
-            "SiEndcapTrackerRawHitAssociations", "TOFBarrelRawHitAssociations",
-            "TOFEndcapRawHitAssociations", "MPGDBarrelRawHitAssociations",
-            "OuterMPGDBarrelRawHitAssociations", "BackwardMPGDEndcapRawHitAssociations",
-            "ForwardMPGDEndcapRawHitAssociations", "B0TrackerRawHitAssociations"},
+          "CentralTrackingRawHitAssociations",
+          {"SiBarrelRawHitAssociations", "SiBarrelVertexRawHitAssociations",
+           "SiEndcapTrackerRawHitAssociations", "TOFBarrelRawHitAssociations",
+           "TOFEndcapRawHitAssociations", "MPGDBarrelRawHitAssociations",
+           "OuterMPGDBarrelRawHitAssociations", "BackwardMPGDEndcapRawHitAssociations",
+           "ForwardMPGDEndcapRawHitAssociations", "B0TrackerRawHitAssociations"},
           {"CentralTrackingRawHitAssociations"}, // Output collection name
           app));
 
@@ -220,16 +222,19 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<
            CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation>>(
-      "CombinedTrackAssociations", {"CentralCKFTrackAssociations","TaggerTrackerTrackAssociations"}, {"CombinedTrackAssociations"},
-      app));
+      "CombinedTrackAssociations",
+      {"CentralCKFTrackAssociations", "TaggerTrackerTrackAssociations"},
+      {"CombinedTrackAssociations"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track>>(
-      "CombinedTruthSeededTracks", {"CentralCKFTruthSeededTrackAssociations","TaggerTrackerTrackAssociations"}, {"CombinedTruthSeededTracks"},
-      app));
+      "CombinedTruthSeededTracks",
+      {"CentralCKFTruthSeededTrackAssociations", "TaggerTrackerTrackAssociations"},
+      {"CombinedTruthSeededTracks"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<
            CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation>>(
-      "CombinedTruthSeededTrackAssociations", {"CentralCKFTruthSeededTrackAssociations","TaggerTrackerTrackAssociations"},
+      "CombinedTruthSeededTrackAssociations",
+      {"CentralCKFTruthSeededTrackAssociations", "TaggerTrackerTrackAssociations"},
       {"CombinedTruthSeededTrackAssociations"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<TracksToParticles_factory>(

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -228,7 +228,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track>>(
       "CombinedTruthSeededTracks",
-      {"CentralCKFTruthSeededTrackAssociations", "TaggerTrackerTrackAssociations"},
+      {"CentralCKFTruthSeededTracks", "TaggerTrackerTracks"},
       {"CombinedTruthSeededTracks"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2022 - 2024, Dmitry Romanov, Tyler Kutz, Wouter Deconinck, Dmitry Kalinkin
+// Copyright (C) 2022 - 2025, Dmitry Romanov, Tyler Kutz, Wouter Deconinck, Dmitry Kalinkin
 
 #include <JANA/JApplication.h>
 #include <edm4eic/MCRecoTrackParticleAssociation.h>

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -227,8 +227,7 @@ void InitPlugin(JApplication* app) {
       {"CombinedTrackAssociations"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track>>(
-      "CombinedTruthSeededTracks",
-      {"CentralCKFTruthSeededTracks", "TaggerTrackerTracks"},
+      "CombinedTruthSeededTracks", {"CentralCKFTruthSeededTracks", "TaggerTrackerTracks"},
       {"CombinedTruthSeededTracks"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<

--- a/src/tests/omnifactory_test/JOmniFactoryTests.cc
+++ b/src/tests/omnifactory_test/JOmniFactoryTests.cc
@@ -433,9 +433,8 @@ TEST_CASE("VariadicPodioOutputTests") {
   REQUIRE(right_hits->size() == 1);
 }
 
-
-
-struct OptionalPodioInputTestAlg : public JOmniFactory<OptionalPodioInputTestAlg, BasicTestAlgConfig> {
+struct OptionalPodioInputTestAlg
+    : public JOmniFactory<OptionalPodioInputTestAlg, BasicTestAlgConfig> {
 
   PodioInput<edm4hep::SimCalorimeterHit, true> m_left_hits_in{this};
   PodioInput<edm4hep::SimCalorimeterHit, true> m_right_hits_in{this};
@@ -468,7 +467,6 @@ struct OptionalPodioInputTestAlg : public JOmniFactory<OptionalPodioInputTestAlg
         m_right_hits_out()->push_back(hit);
       }
     }
-
   }
 };
 
@@ -477,7 +475,8 @@ TEST_CASE("Optional PodioInput") {
   app.AddPlugin("log");
 
   auto facgen = new JOmniFactoryGeneratorT<OptionalPodioInputTestAlg>(
-      "OptionalPodioInputTest", {"left_hits", "right_hits"}, {"left_hits_out","right_hits_out"}, &app);
+      "OptionalPodioInputTest", {"left_hits", "right_hits"}, {"left_hits_out", "right_hits_out"},
+      &app);
 
   app.Add(facgen);
   app.Initialize();
@@ -485,8 +484,6 @@ TEST_CASE("Optional PodioInput") {
   auto event = std::make_shared<JEvent>();
   app.GetService<JComponentManager>()->configure_event(*event);
 
-  
-  
   SECTION("Both collections are set") {
     edm4hep::SimCalorimeterHitCollection left_hits;
     edm4hep::SimCalorimeterHitCollection right_hits;
@@ -495,7 +492,7 @@ TEST_CASE("Optional PodioInput") {
     right_hits.create();
     event->InsertCollection<edm4hep::SimCalorimeterHit>(std::move(left_hits), "left_hits");
     event->InsertCollection<edm4hep::SimCalorimeterHit>(std::move(right_hits), "right_hits");
-    
+
     auto left_hits_out  = event->GetCollection<edm4hep::SimCalorimeterHit>("left_hits_out");
     auto right_hits_out = event->GetCollection<edm4hep::SimCalorimeterHit>("right_hits_out");
     REQUIRE(left_hits_out->size() == 2);
@@ -505,24 +502,23 @@ TEST_CASE("Optional PodioInput") {
     edm4hep::SimCalorimeterHitCollection right_hits;
     right_hits.create();
     event->InsertCollection<edm4hep::SimCalorimeterHit>(std::move(right_hits), "right_hits");
-    
+
     auto left_hits_out  = event->GetCollection<edm4hep::SimCalorimeterHit>("left_hits_out");
     auto right_hits_out = event->GetCollection<edm4hep::SimCalorimeterHit>("right_hits_out");
     REQUIRE(left_hits_out->size() == 0);
     REQUIRE(right_hits_out->size() == 1);
-  }    
+  }
   SECTION("Right hits are not set") {
     edm4hep::SimCalorimeterHitCollection left_hits;
     left_hits.create();
     left_hits.create();
     event->InsertCollection<edm4hep::SimCalorimeterHit>(std::move(left_hits), "left_hits");
-    
+
     auto left_hits_out  = event->GetCollection<edm4hep::SimCalorimeterHit>("left_hits_out");
     auto right_hits_out = event->GetCollection<edm4hep::SimCalorimeterHit>("right_hits_out");
     REQUIRE(left_hits_out->size() == 2);
     REQUIRE(right_hits_out->size() == 0);
   }
-
 }
 
 struct OptionalVariadicPodioInputTestAlg
@@ -544,14 +540,13 @@ struct OptionalVariadicPodioInputTestAlg
     //Set the subset flag
     m_hits_out()->setSubsetCollection();
     //Copy hits to output collections
-    for(const auto& coll : m_hits_in()) {
+    for (const auto& coll : m_hits_in()) {
       if (coll) {
         for (const auto& hit : *coll) {
           m_hits_out()->push_back(hit);
         }
       }
     }
-
   }
 };
 
@@ -560,7 +555,8 @@ TEST_CASE("Optional Variadic Podio Input") {
   app.AddPlugin("log");
 
   auto facgen = new JOmniFactoryGeneratorT<OptionalVariadicPodioInputTestAlg>(
-      "OptionalVariadicPodioInputTest", {"left_hits","center_hits","right_hits"}, {"hits_out"}, &app);
+      "OptionalVariadicPodioInputTest", {"left_hits", "center_hits", "right_hits"}, {"hits_out"},
+      &app);
 
   app.Add(facgen);
   app.Initialize();
@@ -581,23 +577,23 @@ TEST_CASE("Optional Variadic Podio Input") {
     event->InsertCollection<edm4hep::SimCalorimeterHit>(std::move(left_hits), "left_hits");
     event->InsertCollection<edm4hep::SimCalorimeterHit>(std::move(center_hits), "center_hits");
     event->InsertCollection<edm4hep::SimCalorimeterHit>(std::move(right_hits), "right_hits");
-    
-    auto hits_out  = event->GetCollection<edm4hep::SimCalorimeterHit>("hits_out");
-    
+
+    auto hits_out = event->GetCollection<edm4hep::SimCalorimeterHit>("hits_out");
+
     REQUIRE(hits_out->size() == 6);
   }
 
   SECTION("No collections are set") {
-    auto hits_out  = event->GetCollection<edm4hep::SimCalorimeterHit>("hits_out");
-    
+    auto hits_out = event->GetCollection<edm4hep::SimCalorimeterHit>("hits_out");
+
     REQUIRE(hits_out->size() == 0);
   }
   SECTION("Only right collection is set") {
     edm4hep::SimCalorimeterHitCollection right_hits;
     right_hits.create();
     event->InsertCollection<edm4hep::SimCalorimeterHit>(std::move(right_hits), "right_hits");
-    
-    auto hits_out  = event->GetCollection<edm4hep::SimCalorimeterHit>("hits_out");
+
+    auto hits_out = event->GetCollection<edm4hep::SimCalorimeterHit>("hits_out");
     REQUIRE(hits_out->size() == 1);
   }
 }

--- a/src/tests/omnifactory_test/JOmniFactoryTests.cc
+++ b/src/tests/omnifactory_test/JOmniFactoryTests.cc
@@ -432,3 +432,172 @@ TEST_CASE("VariadicPodioOutputTests") {
   REQUIRE(left_hits->size() == 2);
   REQUIRE(right_hits->size() == 1);
 }
+
+
+
+struct OptionalPodioInputTestAlg : public JOmniFactory<OptionalPodioInputTestAlg, BasicTestAlgConfig> {
+
+  PodioInput<edm4hep::SimCalorimeterHit, true> m_left_hits_in{this};
+  PodioInput<edm4hep::SimCalorimeterHit, true> m_right_hits_in{this};
+
+  PodioOutput<edm4hep::SimCalorimeterHit> m_left_hits_out{this};
+  PodioOutput<edm4hep::SimCalorimeterHit> m_right_hits_out{this};
+
+  void Configure() {}
+
+  void ChangeRun(int32_t /* run_number */) {}
+
+  void Process(int32_t /* run_number */, uint64_t /* event_number */) {
+
+    logger()->info("Calling OptionalPodioInputTestAlg::Process");
+
+    m_left_hits_out()  = std::make_unique<edm4hep::SimCalorimeterHitCollection>();
+    m_right_hits_out() = std::make_unique<edm4hep::SimCalorimeterHitCollection>();
+    //Set the subset flag
+    m_left_hits_out()->setSubsetCollection();
+    m_right_hits_out()->setSubsetCollection();
+
+    //Copy hits to output collections
+    if (m_left_hits_in()) {
+      for (const auto& hit : *(m_left_hits_in())) {
+        m_left_hits_out()->push_back(hit);
+      }
+    }
+    if (m_right_hits_in()) {
+      for (const auto& hit : *(m_right_hits_in())) {
+        m_right_hits_out()->push_back(hit);
+      }
+    }
+
+  }
+};
+
+TEST_CASE("Optional PodioInput") {
+  JApplication app;
+  app.AddPlugin("log");
+
+  auto facgen = new JOmniFactoryGeneratorT<OptionalPodioInputTestAlg>(
+      "OptionalPodioInputTest", {"left_hits", "right_hits"}, {"left_hits_out","right_hits_out"}, &app);
+
+  app.Add(facgen);
+  app.Initialize();
+
+  auto event = std::make_shared<JEvent>();
+  app.GetService<JComponentManager>()->configure_event(*event);
+
+  
+  
+  SECTION("Both collections are set") {
+    edm4hep::SimCalorimeterHitCollection left_hits;
+    edm4hep::SimCalorimeterHitCollection right_hits;
+    left_hits.create();
+    left_hits.create();
+    right_hits.create();
+    event->InsertCollection<edm4hep::SimCalorimeterHit>(std::move(left_hits), "left_hits");
+    event->InsertCollection<edm4hep::SimCalorimeterHit>(std::move(right_hits), "right_hits");
+    
+    auto left_hits_out  = event->GetCollection<edm4hep::SimCalorimeterHit>("left_hits_out");
+    auto right_hits_out = event->GetCollection<edm4hep::SimCalorimeterHit>("right_hits_out");
+    REQUIRE(left_hits_out->size() == 2);
+    REQUIRE(right_hits_out->size() == 1);
+  }
+  SECTION("Left hits are not set") {
+    edm4hep::SimCalorimeterHitCollection right_hits;
+    right_hits.create();
+    event->InsertCollection<edm4hep::SimCalorimeterHit>(std::move(right_hits), "right_hits");
+    
+    auto left_hits_out  = event->GetCollection<edm4hep::SimCalorimeterHit>("left_hits_out");
+    auto right_hits_out = event->GetCollection<edm4hep::SimCalorimeterHit>("right_hits_out");
+    REQUIRE(left_hits_out->size() == 0);
+    REQUIRE(right_hits_out->size() == 1);
+  }    
+  SECTION("Right hits are not set") {
+    edm4hep::SimCalorimeterHitCollection left_hits;
+    left_hits.create();
+    left_hits.create();
+    event->InsertCollection<edm4hep::SimCalorimeterHit>(std::move(left_hits), "left_hits");
+    
+    auto left_hits_out  = event->GetCollection<edm4hep::SimCalorimeterHit>("left_hits_out");
+    auto right_hits_out = event->GetCollection<edm4hep::SimCalorimeterHit>("right_hits_out");
+    REQUIRE(left_hits_out->size() == 2);
+    REQUIRE(right_hits_out->size() == 0);
+  }
+
+}
+
+struct OptionalVariadicPodioInputTestAlg
+    : public JOmniFactory<OptionalVariadicPodioInputTestAlg, BasicTestAlgConfig> {
+
+  VariadicPodioInput<edm4hep::SimCalorimeterHit, true> m_hits_in{this};
+
+  PodioOutput<edm4hep::SimCalorimeterHit> m_hits_out{this};
+
+  void Configure() {}
+
+  void ChangeRun(int32_t /* run_number */) {}
+
+  void Process(int32_t /* run_number */, uint64_t /* event_number */) {
+
+    logger()->info("Calling OptionalVariadicPodioInputTestAlg::Process");
+
+    m_hits_out() = std::make_unique<edm4hep::SimCalorimeterHitCollection>();
+    //Set the subset flag
+    m_hits_out()->setSubsetCollection();
+    //Copy hits to output collections
+    for(const auto& coll : m_hits_in()) {
+      if (coll) {
+        for (const auto& hit : *coll) {
+          m_hits_out()->push_back(hit);
+        }
+      }
+    }
+
+  }
+};
+
+TEST_CASE("Optional Variadic Podio Input") {
+  JApplication app;
+  app.AddPlugin("log");
+
+  auto facgen = new JOmniFactoryGeneratorT<OptionalVariadicPodioInputTestAlg>(
+      "OptionalVariadicPodioInputTest", {"left_hits","center_hits","right_hits"}, {"hits_out"}, &app);
+
+  app.Add(facgen);
+  app.Initialize();
+
+  auto event = std::make_shared<JEvent>();
+  app.GetService<JComponentManager>()->configure_event(*event);
+
+  SECTION("All collections are set") {
+    edm4hep::SimCalorimeterHitCollection left_hits;
+    edm4hep::SimCalorimeterHitCollection center_hits;
+    edm4hep::SimCalorimeterHitCollection right_hits;
+    left_hits.create();
+    left_hits.create();
+    left_hits.create();
+    center_hits.create();
+    center_hits.create();
+    right_hits.create();
+    event->InsertCollection<edm4hep::SimCalorimeterHit>(std::move(left_hits), "left_hits");
+    event->InsertCollection<edm4hep::SimCalorimeterHit>(std::move(center_hits), "center_hits");
+    event->InsertCollection<edm4hep::SimCalorimeterHit>(std::move(right_hits), "right_hits");
+    
+    auto hits_out  = event->GetCollection<edm4hep::SimCalorimeterHit>("hits_out");
+    
+    REQUIRE(hits_out->size() == 6);
+  }
+
+  SECTION("No collections are set") {
+    auto hits_out  = event->GetCollection<edm4hep::SimCalorimeterHit>("hits_out");
+    
+    REQUIRE(hits_out->size() == 0);
+  }
+  SECTION("Only right collection is set") {
+    edm4hep::SimCalorimeterHitCollection right_hits;
+    right_hits.create();
+    event->InsertCollection<edm4hep::SimCalorimeterHit>(std::move(right_hits), "right_hits");
+    
+    auto hits_out  = event->GetCollection<edm4hep::SimCalorimeterHit>("hits_out");
+    REQUIRE(hits_out->size() == 1);
+  }
+}

--- a/src/tests/omnifactory_test/JOmniFactoryTests.cc
+++ b/src/tests/omnifactory_test/JOmniFactoryTests.cc
@@ -436,8 +436,8 @@ TEST_CASE("VariadicPodioOutputTests") {
 struct OptionalPodioInputTestAlg
     : public JOmniFactory<OptionalPodioInputTestAlg, BasicTestAlgConfig> {
 
-  PodioInput<edm4hep::SimCalorimeterHit, true> m_left_hits_in{this};
-  PodioInput<edm4hep::SimCalorimeterHit, true> m_right_hits_in{this};
+  PodioInput<edm4hep::SimCalorimeterHit, true>  m_left_hits_in{this};
+  PodioInput<edm4hep::SimCalorimeterHit, false> m_right_hits_in{this};
 
   PodioOutput<edm4hep::SimCalorimeterHit> m_left_hits_out{this};
   PodioOutput<edm4hep::SimCalorimeterHit> m_right_hits_out{this};
@@ -507,6 +507,7 @@ TEST_CASE("Optional PodioInput") {
     auto right_hits_out = event->GetCollection<edm4hep::SimCalorimeterHit>("right_hits_out");
     REQUIRE(left_hits_out->size() == 0);
     REQUIRE(right_hits_out->size() == 1);
+    
   }
   SECTION("Right hits are not set") {
     edm4hep::SimCalorimeterHitCollection left_hits;
@@ -514,10 +515,9 @@ TEST_CASE("Optional PodioInput") {
     left_hits.create();
     event->InsertCollection<edm4hep::SimCalorimeterHit>(std::move(left_hits), "left_hits");
 
-    auto left_hits_out  = event->GetCollection<edm4hep::SimCalorimeterHit>("left_hits_out");
-    auto right_hits_out = event->GetCollection<edm4hep::SimCalorimeterHit>("right_hits_out");
-    REQUIRE(left_hits_out->size() == 2);
-    REQUIRE(right_hits_out->size() == 0);
+    REQUIRE_THROWS(event->GetCollection<edm4hep::SimCalorimeterHit>("left_hits_out"));
+    REQUIRE_THROWS(event->GetCollection<edm4hep::SimCalorimeterHit>("right_hits_out"));
+ 
   }
 }
 

--- a/src/tests/omnifactory_test/JOmniFactoryTests.cc
+++ b/src/tests/omnifactory_test/JOmniFactoryTests.cc
@@ -436,7 +436,7 @@ TEST_CASE("VariadicPodioOutputTests") {
 struct OptionalPodioInputTestAlg
     : public JOmniFactory<OptionalPodioInputTestAlg, BasicTestAlgConfig> {
 
-  PodioInput<edm4hep::SimCalorimeterHit, true>  m_left_hits_in{this};
+  PodioInput<edm4hep::SimCalorimeterHit, true> m_left_hits_in{this};
   PodioInput<edm4hep::SimCalorimeterHit, false> m_right_hits_in{this};
 
   PodioOutput<edm4hep::SimCalorimeterHit> m_left_hits_out{this};
@@ -507,7 +507,6 @@ TEST_CASE("Optional PodioInput") {
     auto right_hits_out = event->GetCollection<edm4hep::SimCalorimeterHit>("right_hits_out");
     REQUIRE(left_hits_out->size() == 0);
     REQUIRE(right_hits_out->size() == 1);
-    
   }
   SECTION("Right hits are not set") {
     edm4hep::SimCalorimeterHitCollection left_hits;
@@ -517,7 +516,6 @@ TEST_CASE("Optional PodioInput") {
 
     REQUIRE_THROWS(event->GetCollection<edm4hep::SimCalorimeterHit>("left_hits_out"));
     REQUIRE_THROWS(event->GetCollection<edm4hep::SimCalorimeterHit>("right_hits_out"));
- 
   }
 }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Allows the creation of ReconstructedParticles using configurations which don't contain the calorimeters, e.g. epic_ip6.xml.

The selection of calorimeter hits included will probably need to change in the future.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No