### PR TITLE
Update FEMC for new geometry:

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitDigiConfig.h
+++ b/src/algorithms/calorimetry/CalorimeterHitDigiConfig.h
@@ -29,6 +29,9 @@ namespace eicrecon {
     std::string              readout{""};
     std::vector<std::string> fields{};
 
+    //SiPM Saturation
+    double                   totalPixel{0};
+    double                   nPhotonPerGeV{0};        
   };
 
 } // eicrecon

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -1,3 +1,4 @@
+
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2021 - 2024, Chao Peng, Sylvester Joosten, Whitney Armstrong, David Lawrence, Friederike Bock, Wouter Deconinck, Kolja Kauder, Sebouh Paul
 
@@ -8,6 +9,7 @@
 #include <string>
 
 #include "algorithms/calorimetry/CalorimeterHitDigiConfig.h"
+#include "algorithms/calorimetry/CalorimeterHitRecoConfig.h"
 #include "extensions/jana/JOmniFactoryGeneratorT.h"
 #include "factories/calorimetry/CalorimeterClusterRecoCoG_factory.h"
 #include "factories/calorimetry/CalorimeterHitDigi_factory.h"
@@ -23,55 +25,119 @@ extern "C" {
         using namespace eicrecon;
 
         InitJANAPlugin(app);
+
+	auto log_service = app->GetService<Log_service>();
+        auto mLog = log_service->logger("FEMC");
+	
+	int SiPMSaturation=1;
+	std::string opt("ON");
+	app->SetDefaultParameter("FEMC:SiPMSaturation",opt,"Turn ON(default) or OFF SiPM Saturation");
+        if(opt.find("OFF") != std::string::npos ||
+	   opt.find("off") != std::string::npos ||
+	   opt.find("Off") != std::string::npos ){
+	  mLog->info("SiPM Saturation OFF");
+	  SiPMSaturation=0;
+	}else{
+	  mLog->info("SiPM Saturation ON");
+	}
+	
         // Make sure digi and reco use the same value
         decltype(CalorimeterHitDigiConfig::capADC)        EcalEndcapP_capADC = 16384; //16384, assuming 14 bits. For approximate HGCROC resolution use 65536
-        decltype(CalorimeterHitDigiConfig::dyRangeADC)    EcalEndcapP_dyRangeADC = 3 * dd4hep::GeV;
+        decltype(CalorimeterHitDigiConfig::dyRangeADC)    EcalEndcapP_dyRangeADC = 100 * dd4hep::GeV;
         decltype(CalorimeterHitDigiConfig::pedMeanADC)    EcalEndcapP_pedMeanADC = 200;
         decltype(CalorimeterHitDigiConfig::pedSigmaADC)   EcalEndcapP_pedSigmaADC = 2.4576;
         decltype(CalorimeterHitDigiConfig::resolutionTDC) EcalEndcapP_resolutionTDC = 10 * dd4hep::picosecond;
-        app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-          "EcalEndcapPRawHits",
-          {"EcalEndcapPHits"},
+        const double sampFrac=0.03;
+        decltype(CalorimeterHitDigiConfig::corrMeanScale) EcalEndcapP_corrMeanScale = Form("%f",1.0/sampFrac);
+        decltype(CalorimeterHitRecoConfig::sampFrac)      EcalEndcapP_sampFrac = Form("%f",sampFrac);
+        decltype(CalorimeterHitDigiConfig::nPhotonPerGeV) EcalEndcapP_nPhotonPerGeV = 1500;
+        decltype(CalorimeterHitDigiConfig::totalPixel)    EcalEndcapP_totalPixel = 4*159565;
+	if(SiPMSaturation==0) EcalEndcapP_totalPixel=0;
+	
+	int fEcalHomoScfi = 0;
+        try {
+          auto detector = app->GetService<DD4hep_service>()->detector();
+	  fEcalHomoScfi = detector->constant<int>("ForwardEcal_Homogeneous_Scfi");
+	  if(fEcalHomoScfi<=1) mLog->info("Homogeneous geometry loaded");
+	  else                 mLog->info("ScFi geometry loaded");
+        } catch(...){};
+
+	if(fEcalHomoScfi<=1){
+	  app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
+           "EcalEndcapPRawHits",
+           {"EcalEndcapPHits"},
 #if EDM4EIC_VERSION_MAJOR >= 7
-          {"EcalEndcapPRawHits", "EcalEndcapPRawHitAssociations"},
+           {"EcalEndcapPRawHits", "EcalEndcapPRawHitAssociations"},
 #else
-          {"EcalEndcapPRawHits"},
+           {"EcalEndcapPRawHits"},
 #endif
-          {
-            .eRes = {0.11333 * sqrt(dd4hep::GeV), 0.03, 0.0 * dd4hep::GeV}, // (11.333% / sqrt(E)) \oplus 3%
-            .tRes = 0.0,
-            .threshold = 0.0,
-             // .threshold = 15 * dd4hep::MeV for a single tower, applied on ADC level
-            .capADC = EcalEndcapP_capADC,
-            .capTime =  100, // given in ns, 4 samples in HGCROC
-            .dyRangeADC = EcalEndcapP_dyRangeADC,
-            .pedMeanADC = EcalEndcapP_pedMeanADC,
-            .pedSigmaADC = EcalEndcapP_pedSigmaADC,
-            .resolutionTDC = EcalEndcapP_resolutionTDC,
-            .corrMeanScale = "0.03",
-            .readout = "EcalEndcapPHits",
-          },
-          app   // TODO: Remove me once fixed
-        ));
+           {
+	     .eRes = {0.11333 * sqrt(dd4hep::GeV), 0.03, 0.0 * dd4hep::GeV}, // (11.333% / sqrt(E)) \oplus 3%
+	     .tRes = 0.0,
+	     .threshold = 0.0, // 15MeV threshold for a single tower will be applied on ADC at Reco below
+	     .capADC = EcalEndcapP_capADC,
+	     .capTime =  100, // given in ns, 4 samples in HGCROC
+	     .dyRangeADC = EcalEndcapP_dyRangeADC,
+	     .pedMeanADC = EcalEndcapP_pedMeanADC,
+	     .pedSigmaADC = EcalEndcapP_pedSigmaADC,
+	     .resolutionTDC = EcalEndcapP_resolutionTDC,
+	     .corrMeanScale = "1.0",
+	     .readout = "EcalEndcapPHits",
+	     .totalPixel = EcalEndcapP_totalPixel,
+	     .nPhotonPerGeV = EcalEndcapP_nPhotonPerGeV,
+	   },
+	   app   // TODO: Remove me once fixed
+         ));
+	}else if(fEcalHomoScfi==2){
+	  app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
+           "EcalEndcapPRawHits",
+           {"EcalEndcapPHits"},
+#if EDM4EIC_VERSION_MAJOR >= 7
+           {"EcalEndcapPRawHits", "EcalEndcapPRawHitAssociations"},
+#else
+           {"EcalEndcapPRawHits"},
+#endif
+           {
+	     .eRes = {0.0,0.0,0.0},
+	     .tRes = 0.0,
+	     .threshold = 0.0, // 15MeV threshold for a single tower will be applied on ADC at Reco below
+	     .capADC = EcalEndcapP_capADC,
+	     .capTime =  100, // given in ns, 4 samples in HGCROC
+	     .dyRangeADC = EcalEndcapP_dyRangeADC,
+	     .pedMeanADC = EcalEndcapP_pedMeanADC,
+	     .pedSigmaADC = EcalEndcapP_pedSigmaADC,
+	     .resolutionTDC = EcalEndcapP_resolutionTDC,
+	     .corrMeanScale = EcalEndcapP_corrMeanScale,
+	     .readout = "EcalEndcapPHits",
+	     .fields  = {"fiberx","fibery","x","y"},
+	     .totalPixel = EcalEndcapP_totalPixel,
+	     .nPhotonPerGeV = EcalEndcapP_nPhotonPerGeV,
+	   },
+	   app   // TODO: Remove me once fixed
+         ));
+	}
+
         app->Add(new JOmniFactoryGeneratorT<CalorimeterHitReco_factory>(
           "EcalEndcapPRecHits", {"EcalEndcapPRawHits"}, {"EcalEndcapPRecHits"},
           {
-            .capADC = EcalEndcapP_capADC,
-            .dyRangeADC = EcalEndcapP_dyRangeADC,
-            .pedMeanADC = EcalEndcapP_pedMeanADC,
-            .pedSigmaADC = EcalEndcapP_pedSigmaADC,
-            .resolutionTDC = EcalEndcapP_resolutionTDC,
-            .thresholdFactor = 0.0,
-            .thresholdValue = 2, // The ADC of a 15 MeV particle is adc = 200 + 15 * 0.03 * ( 1.0 + 0) / 3000 * 16384 = 200 + 2.4576
-            .sampFrac  = "0.03",
-            .readout = "EcalEndcapPHits",
-          },
-          app   // TODO: Remove me once fixed
-        ));
+	    .capADC = EcalEndcapP_capADC,
+	    .dyRangeADC = EcalEndcapP_dyRangeADC,
+	    .pedMeanADC = EcalEndcapP_pedMeanADC,
+	    .pedSigmaADC = EcalEndcapP_pedSigmaADC,
+	    .resolutionTDC = EcalEndcapP_resolutionTDC,
+	    .thresholdFactor = 0.0,
+	    .thresholdValue = 2, // The ADC of a 15 MeV particle is adc = 200 + 15 * 0.03 * ( 1.0 + 0) / 3000 * 16384 = 200 + 2.4576
+	    .sampFrac  = "1.0", // alerady taken care in DIGI code above
+	    .readout = "EcalEndcapPHits",
+	  },
+	  app   // TODO: Remove me once fixed									  ));
+        ));		   
+
         app->Add(new JOmniFactoryGeneratorT<CalorimeterTruthClustering_factory>(
           "EcalEndcapPTruthProtoClusters", {"EcalEndcapPRecHits", "EcalEndcapPHits"}, {"EcalEndcapPTruthProtoClusters"},
           app   // TODO: Remove me once fixed
         ));
+
         app->Add(new JOmniFactoryGeneratorT<CalorimeterIslandCluster_factory>(
           "EcalEndcapPIslandProtoClusters", {"EcalEndcapPRecHits"}, {"EcalEndcapPIslandProtoClusters"},
           {
@@ -201,136 +267,6 @@ extern "C" {
              "EcalEndcapPSplitMergeClusterAssociationsWithoutShapes"},
             {"EcalEndcapPSplitMergeClusters",
              "EcalEndcapPSplitMergeClusterAssociations"},
-            {
-              .energyWeight = "log",
-              .logWeightBase = 3.6
-            },
-            app
-          )
-        );
-
-        // Insert is identical to regular Ecal
-        app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-          "EcalEndcapPInsertRawHits",
-          {"EcalEndcapPInsertHits"},
-#if EDM4EIC_VERSION_MAJOR >= 7
-          {"EcalEndcapPInsertRawHits", "EcalEndcapPInsertRawHitAssociations"},
-#else
-          {"EcalEndcapPInsertRawHits"},
-#endif
-          {
-            .eRes = {0.11333 * sqrt(dd4hep::GeV), 0.03, 0.0 * dd4hep::GeV}, // (11.333% / sqrt(E)) \oplus 3%
-            .tRes = 0.0,
-            .threshold = 0.0,
-             // .threshold = 15 * dd4hep::MeV for a single tower, applied on ADC level
-            .capADC = EcalEndcapP_capADC,
-            .capTime =  100, // given in ns, 4 samples in HGCROC
-            .dyRangeADC = EcalEndcapP_dyRangeADC,
-            .pedMeanADC = EcalEndcapP_pedMeanADC,
-            .pedSigmaADC = EcalEndcapP_pedSigmaADC,
-            .resolutionTDC = EcalEndcapP_resolutionTDC,
-            .corrMeanScale = "0.03",
-            .readout = "EcalEndcapPInsertHits",
-          },
-          app   // TODO: Remove me once fixed
-        ));
-        app->Add(new JOmniFactoryGeneratorT<CalorimeterHitReco_factory>(
-          "EcalEndcapPInsertRecHits", {"EcalEndcapPInsertRawHits"}, {"EcalEndcapPInsertRecHits"},
-          {
-            .capADC = EcalEndcapP_capADC,
-            .dyRangeADC = EcalEndcapP_dyRangeADC,
-            .pedMeanADC = EcalEndcapP_pedMeanADC,
-            .pedSigmaADC = EcalEndcapP_pedSigmaADC,
-            .resolutionTDC = EcalEndcapP_resolutionTDC,
-            .thresholdFactor = 0.0,
-            .thresholdValue = 2, // The ADC of a 15 MeV particle is adc = 200 + 15 * 0.03 * ( 1.0 + 0) / 3000 * 16384 = 200 + 2.4576
-            .sampFrac = "0.03",
-            .readout = "EcalEndcapPInsertHits",
-          },
-          app   // TODO: Remove me once fixed
-        ));
-        app->Add(new JOmniFactoryGeneratorT<CalorimeterTruthClustering_factory>(
-          "EcalEndcapPInsertTruthProtoClusters", {"EcalEndcapPInsertRecHits", "EcalEndcapPInsertHits"}, {"EcalEndcapPInsertTruthProtoClusters"},
-          app   // TODO: Remove me once fixed
-        ));
-        app->Add(new JOmniFactoryGeneratorT<CalorimeterIslandCluster_factory>(
-          "EcalEndcapPInsertIslandProtoClusters", {"EcalEndcapPInsertRecHits"}, {"EcalEndcapPInsertIslandProtoClusters"},
-          {
-            .sectorDist = 5.0 * dd4hep::cm,
-            .dimScaledLocalDistXY = {1.5,1.5},
-            .splitCluster = false,
-            .minClusterHitEdep = 0.0 * dd4hep::MeV,
-            .minClusterCenterEdep = 60.0 * dd4hep::MeV,
-            .transverseEnergyProfileMetric = "dimScaledLocalDistXY",
-            .transverseEnergyProfileScale = 1.,
-          },
-          app   // TODO: Remove me once fixed
-        ));
-
-        app->Add(
-          new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
-             "EcalEndcapPInsertTruthClustersWithoutShapes",
-            {"EcalEndcapPInsertTruthProtoClusters", // edm4eic::ProtoClusterCollection
-#if EDM4EIC_VERSION_MAJOR >= 7
-             "EcalEndcapPInsertRawHitAssociations"}, // edm4eic::MCRecoCalorimeterHitCollection
-#else
-             "EcalEndcapPInsertHits"}, // edm4hep::SimCalorimeterHitCollection
-#endif
-            {"EcalEndcapPInsertTruthClustersWithoutShapes", // edm4eic::Cluster
-             "EcalEndcapPInsertTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
-            {
-              .energyWeight = "log",
-              .sampFrac = 1.0,
-              .logWeightBase = 6.2,
-              .enableEtaBounds = true
-            },
-            app   // TODO: Remove me once fixed
-          )
-        );
-
-        app->Add(
-          new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
-            "EcalEndcapPInsertTruthClusters",
-            {"EcalEndcapPInsertTruthClustersWithoutShapes",
-             "EcalEndcapPInsertTruthClusterAssociationsWithoutShapes"},
-            {"EcalEndcapPInsertTruthClusters",
-             "EcalEndcapPInsertTruthClusterAssociations"},
-            {
-              .energyWeight = "log",
-              .logWeightBase = 6.2
-            },
-            app
-          )
-        );
-
-        app->Add(
-          new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
-             "EcalEndcapPInsertClustersWithoutShapes",
-            {"EcalEndcapPInsertIslandProtoClusters", // edm4eic::ProtoClusterCollection
-#if EDM4EIC_VERSION_MAJOR >= 7
-             "EcalEndcapPInsertRawHitAssociations"}, // edm4eic::MCRecoCalorimeterHitCollection
-#else
-             "EcalEndcapPInsertHits"}, // edm4hep::SimCalorimeterHitCollection
-#endif
-            {"EcalEndcapPInsertClustersWithoutShapes", // edm4eic::Cluster
-             "EcalEndcapPInsertClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
-            {
-              .energyWeight = "log",
-              .sampFrac = 1.0,
-              .logWeightBase = 3.6,
-              .enableEtaBounds = false,
-            },
-            app   // TODO: Remove me once fixed
-          )
-        );
-
-        app->Add(
-          new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
-            "EcalEndcapPInsertClusters",
-            {"EcalEndcapPInsertClustersWithoutShapes",
-             "EcalEndcapPInsertClusterAssociationsWithoutShapes"},
-            {"EcalEndcapPInsertClusters",
-             "EcalEndcapPInsertClusterAssociations"},
             {
               .energyWeight = "log",
               .logWeightBase = 3.6

--- a/src/factories/calorimetry/CalorimeterHitDigi_factory.h
+++ b/src/factories/calorimetry/CalorimeterHitDigi_factory.h
@@ -34,6 +34,8 @@ private:
     ParameterRef<std::string> m_corrMeanScale {this, "scaleResponse", config().corrMeanScale};
     ParameterRef<std::vector<std::string>> m_fields {this, "signalSumFields", config().fields};
     ParameterRef<std::string> m_readout {this, "readoutClass", config().readout};
+    ParameterRef<double> m_nPhotonPerGeV {this, "numberOfPhotonPerGeV", config().nPhotonPerGeV};
+    ParameterRef<double> m_totalPixel {this, "totalNnumberOfPixel", config().totalPixel};
 
     Service<AlgorithmsInit_service> m_algorithmsInit {this};
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Following Forward EM calorimeter geometry update:
  https://github.com/eic/epic/pull/855
this provides switch between Homogeneous and ScFi geometry implementations based on xml file loaded
  - For Homogenous, we keep energy smearing as is. SF=1.0
  - For ScFi, hits from fibers are summed to a tower and no enrgy smearing applied. SF=0.03. 
  
Added an option to put SiPM saturation to CalorimeterHitDigi
  - Specify 2 new parameters : totalPixel and nPhotonPerGeV
  - default for totalPixel is 0, which case no attenuation is applied
  - For FEMC for both geometry models, SiPM saturation is ON by default
 - Use "-PFEMC:SiPMSaturation=OFF" to turn it off

See following links for some more details:
https://www.star.bnl.gov/~akio/epic/geometry/index.html
https://www.star.bnl.gov/~akio/epic/reco/index.html
https://www.star.bnl.gov/~akio/epic/hadron/index.html

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

I don't think so, unless one provides wrong config xml file (until sum check in place)

### Does this PR change default behavior?

It does apply SiPM attenuation by default for FEMC (but not other calorimeters).