### PR TITLE
fix: rm unused vars in src/scripts/CMakeLists.txt

### DIFF
--- a/src/scripts/CMakeLists.txt
+++ b/src/scripts/CMakeLists.txt
@@ -1,14 +1,3 @@
-find_package(ROOT)
-find_package(podio)
-find_package(IRT)
-
-if(DEFINED ENV{DETECTOR_PATH})
-  set(DETECTOR_PATH $ENV{DETECTOR_PATH})
-endif()
-if(DEFINED ENV{BEAMLINE_PATH})
-  set(BEAMLINE_PATH $ENV{BEAMLINE_PATH})
-endif()
-
 configure_file(eicrecon-this.sh.in eicrecon-this.sh @ONLY)
 
 install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/eicrecon-this.sh DESTINATION bin)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes unused variables in src/scripts where only the EICrecon PLUGIN_OUTPUT_DIRECTORY is used in configure_file.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: unused vars)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.