### PR TITLE
fix(ci): prevent uncontrolled ccache growth with 7d eviction

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -136,6 +136,7 @@ jobs:
           CXX="${{ matrix.CXX }}" CXXFLAGS="${{ matrix.CXXFLAGS }}" cmake -B build -S . -DCMAKE_INSTALL_PREFIX=install -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }} -DUSE_ASAN=ON -DUSE_TSAN=OFF -DUSE_UBSAN=ON
           cmake --build build -j $(getconf _NPROCESSORS_ONLN) --target install
           ccache --show-stats --verbose
+          ccache --evict-older-than 7d
     - name: Check dynamic library loader paths
       uses: eic/run-cvmfs-osg-eic-shell@main
       with:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
It is my suspicion that the ccache is larger than needed, and it results in evictions from the github actions cache. By doing some eviction inside the ccache, we will hopefully limit this.

As an example, the incoming 1036 MB cache in https://github.com/eic/EICrecon/actions/runs/14887400044/job/41810570776?pr=1855#step:4:39 is reduced to 533 MB in https://github.com/eic/EICrecon/actions/runs/14887400044/job/41810570776?pr=1855#step:25:5.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: ccache grow too large)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.