### PR TITLE
fix(ci): LD_LIBRARY_PATH should be $PWD/install/lib

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -142,7 +142,7 @@ jobs:
         platform-release: "${{ env.platform }}:${{ matrix.release }}"
         setup: "/opt/detector/epic-${{ env.detector-version }}/bin/thisepic.sh"
         run: |
-          export LD_LIBRARY_PATH=$PWD/lib:$LD_LIBRARY_PATH
+          export LD_LIBRARY_PATH=$PWD/install/lib:$LD_LIBRARY_PATH
           for lib in install/lib/*.so install/lib/EICrecon/plugins/*.so ; do
             readelf -d $lib
             ldd -r $lib

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -145,7 +145,8 @@ jobs:
           export LD_LIBRARY_PATH=$PWD/install/lib:$LD_LIBRARY_PATH
           for lib in install/lib/*.so install/lib/EICrecon/plugins/*.so ; do
             readelf -d $lib
-            ldd -r $lib
+            # Hide intentionally undefined symbols for asan and ubsan
+            ldd -r $lib | grep -v __asan | grep -v __ubsan
           done
     - name: Run testsuite
       uses: eic/run-cvmfs-osg-eic-shell@main


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes a minor bug that causes the incorrect libraries to be picked up in the dynamic loader unresolved functions check for plugins. Now the libraries are resolved and only few undefined functions returned, e.g. https://github.com/eic/EICrecon/actions/runs/14891841097/job/41825513765?pr=1857#step:8:203.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: incorrect ld resolution, e.g. in https://github.com/eic/EICrecon/actions/runs/14888301094/job/41813743634#step:8:2702)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.