### PR TITLE
fix: BTOF uses TOFBarrelCombinedPulses

### DIFF
--- a/src/detectors/BTOF/BTOF.cc
+++ b/src/detectors/BTOF/BTOF.cc
@@ -92,7 +92,7 @@ void InitPlugin(JApplication* app) {
 
   double risetime = 0.45 * edm4eic::unit::ns;
   app->Add(new JOmniFactoryGeneratorT<SiliconPulseDiscretization_factory>(
-      "SiliconPulseDiscretization", {"TOFBarrelCombinedPulse"}, {"TOFBarrelPulse"},
+      "SiliconPulseDiscretization", {"TOFBarrelCombinedPulses"}, {"TOFBarrelPulse"},
       {
           .EICROC_period = 25 * edm4eic::unit::ns,
           .local_period  = 25 * edm4eic::unit::ns / 1024,

--- a/src/detectors/BTOF/BTOF.cc
+++ b/src/detectors/BTOF/BTOF.cc
@@ -74,7 +74,7 @@ void InitPlugin(JApplication* app) {
   const double gain = -adc_range / Vm / landau_min;
   const int offset  = 3;
   app->Add(new JOmniFactoryGeneratorT<SiliconPulseGeneration_factory>(
-      "LGADPulseGeneration", {"TOFBarrelSharedHits"}, {"TOFBarrelSmoothPulse"},
+      "LGADPulseGeneration", {"TOFBarrelSharedHits"}, {"TOFBarrelSmoothPulses"},
       {
           .pulse_shape_function = "LandauPulse",
           .pulse_shape_params   = {gain, sigma_analog, offset * sigma_analog},
@@ -92,7 +92,7 @@ void InitPlugin(JApplication* app) {
 
   double risetime = 0.45 * edm4eic::unit::ns;
   app->Add(new JOmniFactoryGeneratorT<SiliconPulseDiscretization_factory>(
-      "SiliconPulseDiscretization", {"TOFBarrelCombinedPulses"}, {"TOFBarrelPulse"},
+      "SiliconPulseDiscretization", {"TOFBarrelCombinedPulses"}, {"TOFBarrelPulses"},
       {
           .EICROC_period = 25 * edm4eic::unit::ns,
           .local_period  = 25 * edm4eic::unit::ns / 1024,
@@ -101,7 +101,7 @@ void InitPlugin(JApplication* app) {
       app));
 
   app->Add(new JOmniFactoryGeneratorT<EICROCDigitization_factory>(
-      "EICROCDigitization", {"TOFBarrelPulse"}, {"TOFBarrelADCTDC"}, {}, app));
+      "EICROCDigitization", {"TOFBarrelPulses"}, {"TOFBarrelADCTDC"}, {}, app));
 
   int BarrelTOF_ID = 0;
   try {


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes a few typos in the names of collections in the  BTOF plugin. The collection name `TOFBarrelCombinedPulses` is written, but `TOFBarrelCombinedPulse` is used. Plural is preferred for collections.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/EICrecon/actions/runs/14897644470/job/41843260550?pr=975#step:7:1379)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @ssedd1123 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.