### PR TITLE
Add configuration option to output clones from subdivided and collected collections

### DIFF
--- a/src/algorithms/meta/CollectionCollector.h
+++ b/src/algorithms/meta/CollectionCollector.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2024 Simon Gardner
+// Copyright (C) 2024-2025 Simon Gardner
 
 #include <spdlog/spdlog.h>
 #include <algorithms/algorithm.h>
@@ -7,6 +7,7 @@
 #include <string_view>
 
 #include "services/log/Log_service.h"
+#include "algorithms/meta/CollectionCollectorConfig.h"
 #include "algorithms/interfaces/WithPodConfig.h"
 
 namespace eicrecon {
@@ -16,15 +17,16 @@ using CollectionCollectorAlgorithm =
     algorithms::Algorithm<typename algorithms::Input<std::vector<const T>>,
                           typename algorithms::Output<T>>;
 
-template <class T> class CollectionCollector : public CollectionCollectorAlgorithm<T> {
+template <class T> class CollectionCollector : public CollectionCollectorAlgorithm<T>,
+                                               public WithPodConfig<CollectionCollectorConfig> {
 
 public:
   CollectionCollector(std::string_view name)
       : CollectionCollectorAlgorithm<T>{name,
                                         {"inputCollections"},
                                         {"outputCollection"},
-                                        "Merge content of collections into one subset collection"} {
-  }
+                                        "Merge content of collections into one subset collection"} 
+                                      , WithPodConfig<CollectionCollectorConfig>() {};
 
   void init() final{};
 
@@ -34,15 +36,23 @@ public:
     const auto [in_collections] = input;
     auto [out_collection]       = output;
 
-    out_collection->setSubsetCollection();
+    if (!this->m_cfg.output_copies) {
+      out_collection->setSubsetCollection();
+    }
 
     for (const auto& collection : in_collections) {
-      for (const auto& hit : *collection) {
-        out_collection->push_back(hit);
+      for (const auto& entry : *collection) {
+        if (this->m_cfg.output_copies) {
+          // Create a copy of the entry and add it to the output collection
+          out_collection->push_back(entry.clone());
+        } else {
+          // Add the entry to the subcollection
+          out_collection->push_back(entry);
+        }
       }
     }
-    //Log how many hits were collected from N input collections
-    this->debug("Collected {} hits from {} input collections", out_collection->size(),
+    //Log how many entries were collected from N input collections
+    this->debug("Collected {} entries from {} input collections", out_collection->size(),
                 in_collections.size());
   }
 };

--- a/src/algorithms/meta/CollectionCollectorConfig.h
+++ b/src/algorithms/meta/CollectionCollectorConfig.h
@@ -6,7 +6,7 @@
 namespace eicrecon {
 
 struct CollectionCollectorConfig {
-  bool output_copies = true;
+  bool output_copies = false;
 };
 
 } // namespace eicrecon

--- a/src/algorithms/meta/CollectionCollectorConfig.h
+++ b/src/algorithms/meta/CollectionCollectorConfig.h
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2025 Simon Gardner
+
+#pragma once
+
+namespace eicrecon {
+
+struct CollectionCollectorConfig {
+  bool output_copies = true;
+};
+
+} // namespace eicrecon

--- a/src/algorithms/meta/SubDivideCollection.h
+++ b/src/algorithms/meta/SubDivideCollection.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2024 Simon Gardner
+// Copyright (C) 2024-2025 Simon Gardner
 
 #pragma once
 
@@ -40,8 +40,11 @@ public:
     const auto [entries]      = input;
     auto [subdivided_entries] = output;
 
-    for (auto out : subdivided_entries) {
-      out->setSubsetCollection();
+    if (!this->m_cfg.output_copies) {
+      // Output subcollections
+      for (auto out : subdivided_entries) {
+        out->setSubsetCollection();
+      }
     }
 
     for (const auto& entry : *entries) {
@@ -49,7 +52,13 @@ public:
       auto div_indices = this->m_cfg.function(entry);
 
       for (auto index : div_indices) {
-        subdivided_entries[index]->push_back(entry);
+        if (this->m_cfg.output_copies) {
+          // Create a copy of the entry and add it to the output collection
+          subdivided_entries[index]->push_back(entry.clone());
+        } else {
+          // Add the entry to the subcollection
+          subdivided_entries[index]->push_back(entry);
+        }
       }
     }
 

--- a/src/algorithms/meta/SubDivideCollectionConfig.h
+++ b/src/algorithms/meta/SubDivideCollectionConfig.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2024 Simon Gardner
+// Copyright (C) 2024-2025 Simon Gardner
 
 #pragma once
 
@@ -7,6 +7,7 @@ namespace eicrecon {
 
 template <class T> struct SubDivideCollectionConfig {
   std::function<std::vector<int>(const T&)> function;
+  bool output_copies = false;
 };
 
 } // namespace eicrecon

--- a/src/factories/meta/CollectionCollector_factory.h
+++ b/src/factories/meta/CollectionCollector_factory.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2024 Simon Gardner
+// Copyright (C) 2024-2025 Simon Gardner
 
 #include "extensions/jana/JOmniFactory.h"
 #include "algorithms/meta/CollectionCollector.h"
@@ -8,23 +8,26 @@ namespace eicrecon {
 
 template <class T, bool IsOptional = false>
 class CollectionCollector_factory
-    : public JOmniFactory<CollectionCollector_factory<T, IsOptional>> {
+    : public JOmniFactory<CollectionCollector_factory<T, IsOptional>, CollectionCollectorConfig> {
 public:
   using AlgoT = eicrecon::CollectionCollector<typename T::collection_type>;
 
 private:
   std::unique_ptr<AlgoT> m_algo;
 
-  typename JOmniFactory<CollectionCollector_factory<T, IsOptional>>::template VariadicPodioInput<
+  typename JOmniFactory<CollectionCollector_factory<T, IsOptional>, CollectionCollectorConfig>::template VariadicPodioInput<
       T, IsOptional>
       m_inputs{this};
-  typename JOmniFactory<CollectionCollector_factory<T, IsOptional>>::template PodioOutput<T>
+  typename JOmniFactory<CollectionCollector_factory<T, IsOptional>, CollectionCollectorConfig>::template PodioOutput<T>
       m_output{this};
+
+  typename JOmniFactory<CollectionCollector_factory<T, IsOptional>, CollectionCollectorConfig>::template ParameterRef<bool> output_copies{this, "outputCopies", this->config().output_copies};
 
 public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>(this->GetPrefix());
     m_algo->level(static_cast<algorithms::LogLevel>(this->logger()->level()));
+    m_algo->applyConfig(this->config());
     m_algo->init();
   }
 

--- a/src/factories/meta/SubDivideCollection_factory.h
+++ b/src/factories/meta/SubDivideCollection_factory.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2024 Simon Gardner
+// Copyright (C) 2024-2025 Simon Gardner
 
 #pragma once
 
@@ -24,6 +24,8 @@ private:
   typename FactoryT::template VariadicPodioOutput<T> m_split_output{this};
 
   typename FactoryT::template Service<AlgorithmsInit_service> m_algorithmsInit{this};
+
+  typename FactoryT::template ParameterRef<bool> output_copies{this, "outputCopies", this->config().output_copies};
 
 public:
   void Configure() {


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Adds the `output_copies` configuration to tell the CollectionCollector and SubDivideCollection algorithms to copy the data into the output rather than produce a subset collection.

This will allow, for instance, the merging of particles from the central detector and far detectors into a final collection, with the final collection being directly readable in a root tree. Or wanting to examine the contents of the collection in a root tree for debugging.

e.g. `-Pbeam:BeamParticles:outputCopies=true`

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No, but perhaps an example collection should be chosen 