### PR TITLE
feat: add requireMatchingMatrix option; disable for OFFM in CI

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -887,7 +887,7 @@ jobs:
           export LD_LIBRARY_PATH=$PWD/install/lib:$LD_LIBRARY_PATH
           export JANA_PLUGIN_PATH=$PWD/install/lib/EICrecon/plugins:/usr/local/plugins
           prmon --json-summary rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.prmon.json -- \
-          $PWD/install/bin/eicrecon $JANA_OPTIONS -Ppodio:output_file=rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root -Pacts:WriteObj=true -Pacts:WritePly=true -Pplugins=janadot,janatop $(<${{ github.workspace }}/.github/janadot.groups)
+          $PWD/install/bin/eicrecon ${{env.JANA_OPTIONS}} -Ppodio:output_file=rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root -Pacts:WriteObj=true -Pacts:WritePly=true -Pplugins=janadot,janatop $(<${{ github.workspace }}/.github/janadot.groups)
     - uses: actions/upload-artifact@v4
       with:
         name: rec_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4eic.root

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -40,8 +40,9 @@ env:
   detector-version: ${{ inputs.detector-version || 'main' }}
   clang-tidy-iwyu-CXX: clang++
   clang-tidy-iwyu-CMAKE_BUILD_TYPE: Debug
-  JANA_OPTIONS: -Pjana:ticker_interval=60000 -Pjana:warmup_timeout=0 -Pjana:timeout=0
-  JANA_OPTIONS_GUN: -PFOFFMTRK:ForwardOffMRecParticles:requireBeamProton=false -PFOFFMTRK:ForwardOffMRecParticles:requireMatchingMatrix=false -PRPOTS:ForwardRomanPotRecParticles:requireBeamProton=false -PLOWQ2:TaggerTrackerTrajectories:requireBeamElectron=false -PLOWQ2:TaggerTrackerTransportationPreML:requireBeamElectron=false -PLOWQ2:TaggerTrackerTransportationPostML:requireBeamElectron=false
+  # FIXME: FOFFMTRK has only 130 GeV matrix
+  JANA_OPTIONS: -PFOFFMTRK:ForwardOffMRecParticles:requireMatchingMatrix=false -Pjana:ticker_interval=60000 -Pjana:warmup_timeout=0 -Pjana:timeout=0
+  JANA_OPTIONS_GUN: -PFOFFMTRK:ForwardOffMRecParticles:requireBeamProton=false -PRPOTS:ForwardRomanPotRecParticles:requireBeamProton=false -PLOWQ2:TaggerTrackerTrajectories:requireBeamElectron=false -PLOWQ2:TaggerTrackerTransportationPreML:requireBeamElectron=false -PLOWQ2:TaggerTrackerTransportationPostML:requireBeamElectron=false
   ASAN_OPTIONS: suppressions=${{ github.workspace }}/.github/asan.supp:malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:detect_stack_use_after_return=1:detect_odr_violation=1:new_delete_type_mismatch=0:intercept_tls_get_addr=0
   LSAN_OPTIONS: suppressions=${{ github.workspace }}/.github/lsan.supp
   UBSAN_OPTIONS: suppressions=${{ github.workspace }}/.github/ubsan.supp:print_stacktrace=1:silence_unsigned_overflow=1:report_error_type=1

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -41,7 +41,7 @@ env:
   clang-tidy-iwyu-CXX: clang++
   clang-tidy-iwyu-CMAKE_BUILD_TYPE: Debug
   JANA_OPTIONS: -Pjana:ticker_interval=60000 -Pjana:warmup_timeout=0 -Pjana:timeout=0
-  JANA_OPTIONS_GUN: -PFOFFMTRK:ForwardOffMRecParticles:requireBeamProton=false -PRPOTS:ForwardRomanPotRecParticles:requireBeamProton=false -PLOWQ2:TaggerTrackerTrajectories:requireBeamElectron=false -PLOWQ2:TaggerTrackerTransportationPreML:requireBeamElectron=false -PLOWQ2:TaggerTrackerTransportationPostML:requireBeamElectron=false
+  JANA_OPTIONS_GUN: -PFOFFMTRK:ForwardOffMRecParticles:requireBeamProton=false -PFOFFMTRK:ForwardOffMRecParticles:requireMatchingMatrix=false -PRPOTS:ForwardRomanPotRecParticles:requireBeamProton=false -PLOWQ2:TaggerTrackerTrajectories:requireBeamElectron=false -PLOWQ2:TaggerTrackerTransportationPreML:requireBeamElectron=false -PLOWQ2:TaggerTrackerTransportationPostML:requireBeamElectron=false
   ASAN_OPTIONS: suppressions=${{ github.workspace }}/.github/asan.supp:malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:detect_stack_use_after_return=1:detect_odr_violation=1:new_delete_type_mismatch=0:intercept_tls_get_addr=0
   LSAN_OPTIONS: suppressions=${{ github.workspace }}/.github/lsan.supp
   UBSAN_OPTIONS: suppressions=${{ github.workspace }}/.github/ubsan.supp:print_stacktrace=1:silence_unsigned_overflow=1:report_error_type=1

--- a/src/algorithms/fardetectors/MatrixTransferStatic.cc
+++ b/src/algorithms/fardetectors/MatrixTransferStatic.cc
@@ -97,7 +97,10 @@ void eicrecon::MatrixTransferStatic::process(const MatrixTransferStatic::Input& 
     }
   }
   if (not matrix_found) {
-    error("MatrixTransferStatic:: No valid matrix found to match beam momentum!! Skipping!!");
+    if (m_cfg.requireMatchingMatrix) {
+      critical("No matrix found with matching beam momentum");
+      throw std::runtime_error("No matrix found with matching beam momentum");
+    }
     return;
   }
 

--- a/src/algorithms/fardetectors/MatrixTransferStaticConfig.h
+++ b/src/algorithms/fardetectors/MatrixTransferStaticConfig.h
@@ -34,6 +34,7 @@ struct MatrixTransferStaticConfig {
   std::string readout{""};
 
   bool requireBeamProton{true};
+  bool requireMatchingMatrix{true};
 };
 
 } // namespace eicrecon

--- a/src/factories/fardetectors/MatrixTransferStatic_factory.h
+++ b/src/factories/fardetectors/MatrixTransferStatic_factory.h
@@ -50,6 +50,7 @@ private:
   ParameterRef<std::string> readout{this, "readout", config().readout};
 
   ParameterRef<bool> requireBeamProton{this, "requireBeamProton", config().requireBeamProton};
+  ParameterRef<bool> requireMatchingMatrix{this, "requireMatchingMatrix", config().requireMatchingMatrix};
 
   Service<AlgorithmsInit_service> m_algorithmsInit{this};
 

--- a/src/factories/fardetectors/MatrixTransferStatic_factory.h
+++ b/src/factories/fardetectors/MatrixTransferStatic_factory.h
@@ -50,7 +50,8 @@ private:
   ParameterRef<std::string> readout{this, "readout", config().readout};
 
   ParameterRef<bool> requireBeamProton{this, "requireBeamProton", config().requireBeamProton};
-  ParameterRef<bool> requireMatchingMatrix{this, "requireMatchingMatrix", config().requireMatchingMatrix};
+  ParameterRef<bool> requireMatchingMatrix{this, "requireMatchingMatrix",
+                                           config().requireMatchingMatrix};
 
   Service<AlgorithmsInit_service> m_algorithmsInit{this};
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds a new option `requireMatchingMatrix` to the MatrixTransferStatic algorithm, to allow disabling the check for a valid matrix. This allows disabling (in CI) the off-momentum tracker errors for every event.

Similar to https://github.com/eic/EICrecon/pull/1716.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: hide https://github.com/eic/EICrecon/actions/runs/14933252266/job/41956082655#step:7:1197)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.