### PR TITLE
Use time info from TOF and MPGD for CKF

### DIFF
--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -162,13 +162,16 @@ CKFTracking::process(const edm4eic::TrackParametersCollection& init_trk_params,
     Acts::ActsVector<2> loc = Acts::Vector2::Zero();
     loc[Acts::eBoundLoc0]   = meas2D.getLoc().a;
     loc[Acts::eBoundLoc1]   = meas2D.getLoc().b;
+   // add time info from TOF or MPGD. ACTS can handle a mix of space points, AND space points with time info
+   // if tof or mpgd: 
+   //     loc[2]   = time;
+    //    cov(2,2) = time_resol*time_resol; // 
 
     Acts::ActsSquareMatrix<2> cov = Acts::ActsSquareMatrix<2>::Zero();
     cov(0, 0)                     = meas2D.getCovariance().xx;
     cov(1, 1)                     = meas2D.getCovariance().yy;
     cov(0, 1)                     = meas2D.getCovariance().xy;
     cov(1, 0)                     = meas2D.getCovariance().xy;
-
 #if Acts_VERSION_MAJOR > 37 || (Acts_VERSION_MAJOR == 37 && Acts_VERSION_MINOR >= 1)
     std::array<Acts::BoundIndices, 2> indices{Acts::eBoundLoc0, Acts::eBoundLoc1};
     Acts::visit_measurement(

--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -162,10 +162,10 @@ CKFTracking::process(const edm4eic::TrackParametersCollection& init_trk_params,
     Acts::ActsVector<2> loc = Acts::Vector2::Zero();
     loc[Acts::eBoundLoc0]   = meas2D.getLoc().a;
     loc[Acts::eBoundLoc1]   = meas2D.getLoc().b;
-   // add time info from TOF or MPGD. ACTS can handle a mix of space points, AND space points with time info
-   // if tof or mpgd: 
-   //     loc[2]   = time;
-    //    cov(2,2) = time_resol*time_resol; // 
+    // add time info from TOF or MPGD. ACTS can handle a mix of space points, AND space points with time info
+    // if tof or mpgd:
+    //     loc[2]   = time;
+    //    cov(2,2) = time_resol*time_resol; //
 
     Acts::ActsSquareMatrix<2> cov = Acts::ActsSquareMatrix<2>::Zero();
     cov(0, 0)                     = meas2D.getCovariance().xx;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Try to use time info as an additional dimension for CKF. Only provide this with TOF and MPGD hits. 
CKF should be able to handle a combination of 2D and 3D measurements.

Work in progress. 

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
