### PR TITLE
fix: Propagate tracks from outermost surface

### DIFF
--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -244,7 +244,7 @@ TrackPropagation::propagate(const edm4eic::Track& /* track */,
   Acts::BoundTrackParameters initBoundParams(initSurface, initParams, initCov,
                                              Acts::ParticleHypothesis::pion());
 
-  // Get pathlength of last track state with respect to perigee surface 
+  // Get pathlength of last track state with respect to perigee surface
   const auto initPathLength = trackState.pathLength();
 
   m_log->trace("    TrackPropagation. Propagating to surface # {}",

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -236,12 +236,13 @@ TrackPropagation::propagate(const edm4eic::Track& /* track */,
 
   // Get track state at last measurement surface
   // For last measurement surface, filtered and smoothed results are equivalent
-  auto trackState = mj.getTrackState(trackTip);
-  auto initSurface = trackState.referenceSurface().getSharedPtr();
-  const auto& initParams  = trackState.filtered();
-  const auto& initCov     = trackState.filteredCovariance();
+  auto trackState        = mj.getTrackState(trackTip);
+  auto initSurface       = trackState.referenceSurface().getSharedPtr();
+  const auto& initParams = trackState.filtered();
+  const auto& initCov    = trackState.filteredCovariance();
 
-  Acts::BoundTrackParameters initBoundParams(initSurface,initParams,initCov,Acts::ParticleHypothesis::pion());
+  Acts::BoundTrackParameters initBoundParams(initSurface, initParams, initCov,
+                                             Acts::ParticleHypothesis::pion());
 
   m_log->trace("    TrackPropagation. Propagating to surface # {}",
                typeid(targetSurf->type()).name());

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -244,6 +244,9 @@ TrackPropagation::propagate(const edm4eic::Track& /* track */,
   Acts::BoundTrackParameters initBoundParams(initSurface, initParams, initCov,
                                              Acts::ParticleHypothesis::pion());
 
+  // Get pathlength of last track state with respect to perigee surface 
+  const auto initPathLength = trackState.pathLength();
+
   m_log->trace("    TrackPropagation. Propagating to surface # {}",
                typeid(targetSurf->type()).name());
 
@@ -277,7 +280,7 @@ TrackPropagation::propagate(const edm4eic::Track& /* track */,
   const auto& covariance = *trackStateParams.covariance();
 
   // Path length
-  const float pathLength      = (*result).pathLength;
+  const float pathLength      = initPathLength + (*result).pathLength;
   const float pathLengthError = 0;
   m_log->trace("    path len = {}", pathLength);
 
@@ -337,19 +340,6 @@ TrackPropagation::propagate(const edm4eic::Track& /* track */,
   uint64_t surface = targetSurf->geometryId().value();
   uint32_t system  = 0; // default value...will be set in TrackPropagation factory
 
-  /*
-         ::edm4hep::Vector3f position{}; ///< Position of the trajectory point [mm]
-          ::edm4eic::Cov3f positionError{}; ///< Error on the position
-          ::edm4hep::Vector3f momentum{}; ///< 3-momentum at the point [GeV]
-          ::edm4eic::Cov3f momentumError{}; ///< Error on the 3-momentum
-          float time{}; ///< Time at this point [ns]
-          float timeError{}; ///< Error on the time at this point
-          float theta{}; ///< polar direction of the track at the surface [rad]
-          float phi{}; ///< azimuthal direction of the track at the surface [rad]
-          ::edm4eic::Cov2f directionError{}; ///< Error on the polar and azimuthal angles
-          float pathlength{}; ///< Pathlength from the origin to this point
-          float pathlengthError{}; ///< Error on the pathlenght
-         */
   return std::make_unique<edm4eic::TrackPoint>(
       edm4eic::TrackPoint{surface, system, position, positionError, momentum, momentumError, time,
                           timeError, theta, phi, directionError, pathLength, pathLengthError});


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This updates the track propagation (projection) to use the track parameters determined on the outermost tracking layer.


### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, it will change the track propagation results.
