### PR TITLE
fix(ci): save clang-tidy fixes as yaml, and also on schedule

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -202,19 +202,19 @@ jobs:
       with:
         platform-release: "${{ env.platform }}:${{ env.release }}"
         run: |
-          git diff ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }} | clang-tidy-diff -p 1 -path build -quiet -export-fixes clang_tidy_fixes.yml -extra-arg='-std=c++20' -clang-tidy-binary run-clang-tidy
+          git diff ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }} | clang-tidy-diff -p 1 -path build -quiet -export-fixes clang_tidy_fixes.yaml -extra-arg='-std=c++20' -clang-tidy-binary run-clang-tidy
     - name: Run clang-tidy on all files
       uses: eic/run-cvmfs-osg-eic-shell@main
-      if: ${{ github.event_name == 'push' }}
+      if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
       with:
         platform-release: "${{ env.platform }}:${{ env.release }}"
         run: |
-          run-clang-tidy -p build -export-fixes clang_tidy_fixes.yml -extra-arg='-std=c++20'
+          run-clang-tidy -p build -export-fixes clang_tidy_fixes.yaml -extra-arg='-std=c++20'
     - name: Upload clang-tidy fixes as artifact
       uses: actions/upload-artifact@v4
       with:
-        name: clang-tidy-fixes.yml
-        path: clang_tidy_fixes.yml
+        name: clang-tidy-fixes.yaml
+        path: clang_tidy_fixes.yaml
         if-no-files-found: ignore
     - name: Suggest clang-tidy fixes as PR comments
       uses: platisd/clang-tidy-pr-comments@v1.7.0


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Because `clang-apply-replacements` only finds `yaml` files, not `yml` files, this PR renames them. It also ensure that full tree clang-tidy fixes are generated for every scheduled run, not just main branch pushes.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.