### PR TITLE
fix: abs -> std::abs

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -155,8 +155,7 @@ void CalorimeterIslandCluster::init() {
           // in the same sector
           if (h1.getSector() == h2.getSector()) {
             auto dist = hitsDist(h1, h2);
-            return (std::fabs(dist.a) <= neighbourDist[0]) &&
-                   (std::fabs(dist.b) <= neighbourDist[1]);
+            return (std::abs(dist.a) <= neighbourDist[0]) && (std::abs(dist.b) <= neighbourDist[1]);
             // different sector, local coordinates do not work, using global coordinates
           } else {
             // sector may have rotation (barrel), so z is included

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -13,6 +13,7 @@
 #include <fmt/format.h>
 #include <algorithm>
 #include <gsl/pointers>
+#include <cmath>
 #include <map>
 #include <set>
 #include <stdexcept>
@@ -154,7 +155,8 @@ void CalorimeterIslandCluster::init() {
           // in the same sector
           if (h1.getSector() == h2.getSector()) {
             auto dist = hitsDist(h1, h2);
-            return (fabs(dist.a) <= neighbourDist[0]) && (fabs(dist.b) <= neighbourDist[1]);
+            return (std::fabs(dist.a) <= neighbourDist[0]) &&
+                   (std::fabs(dist.b) <= neighbourDist[1]);
             // different sector, local coordinates do not work, using global coordinates
           } else {
             // sector may have rotation (barrel), so z is included

--- a/src/algorithms/calorimetry/EnergyPositionClusterMerger.h
+++ b/src/algorithms/calorimetry/EnergyPositionClusterMerger.h
@@ -103,7 +103,7 @@ public:
         //     where we have multiple matches. In this case take the one with the closest
         //     energies.
         // 2. best match?
-        const double delta = std::fabs(pc.getEnergy() - ec.getEnergy());
+        const double delta = std::abs(pc.getEnergy() - ec.getEnergy());
         if (delta < best_delta) {
           best_delta = delta;
           best_match = ie;

--- a/src/algorithms/calorimetry/EnergyPositionClusterMerger.h
+++ b/src/algorithms/calorimetry/EnergyPositionClusterMerger.h
@@ -103,7 +103,7 @@ public:
         //     where we have multiple matches. In this case take the one with the closest
         //     energies.
         // 2. best match?
-        const double delta = fabs(pc.getEnergy() - ec.getEnergy());
+        const double delta = std::fabs(pc.getEnergy() - ec.getEnergy());
         if (delta < best_delta) {
           best_delta = delta;
           best_match = ie;

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
@@ -116,8 +116,8 @@ void FarDetectorTrackerCluster::ClusterHits(
       auto index = clusterList[0];
 
       // Finds neighbours of cluster within time limit
-      auto filter = available * (abs(x - x[index]) <= 1) * (abs(y - y[index]) <= 1) *
-                    (abs(t - t[index]) < m_cfg.hit_time_limit);
+      auto filter = available * (std::abs(x - x[index]) <= 1) * (std::abs(y - y[index]) <= 1) *
+                    (std::abs(t - t[index]) < m_cfg.hit_time_limit);
 
       // Adds the found hits to the cluster
       clusterList = Concatenate(clusterList, indices[filter]);

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
@@ -116,8 +116,8 @@ void FarDetectorTrackerCluster::ClusterHits(
       auto index = clusterList[0];
 
       // Finds neighbours of cluster within time limit
-      auto filter = available * (std::abs(x - x[index]) <= 1) * (std::abs(y - y[index]) <= 1) *
-                    (std::abs(t - t[index]) < m_cfg.hit_time_limit);
+      auto filter = available * (abs(x - x[index]) <= 1) * (abs(y - y[index]) <= 1) *
+                    (abs(t - t[index]) < m_cfg.hit_time_limit);
 
       // Adds the found hits to the cluster
       clusterList = Concatenate(clusterList, indices[filter]);

--- a/src/algorithms/reco/Beam.h
+++ b/src/algorithms/reco/Beam.h
@@ -60,7 +60,7 @@ PxPyPzEVector round_beam_four_momentum(const Vector3& p_in, const float mass,
                                        const float crossing_angle = 0.0) {
   PxPyPzEVector p_out;
   for (const auto& pz : pz_set) {
-    if (std::fabs(p_in.z / pz - 1) < 0.1) {
+    if (std::abs(p_in.z / pz - 1) < 0.1) {
       p_out.SetPz(pz);
       break;
     }

--- a/src/algorithms/reco/Beam.h
+++ b/src/algorithms/reco/Beam.h
@@ -60,7 +60,7 @@ PxPyPzEVector round_beam_four_momentum(const Vector3& p_in, const float mass,
                                        const float crossing_angle = 0.0) {
   PxPyPzEVector p_out;
   for (const auto& pz : pz_set) {
-    if (fabs(p_in.z / pz - 1) < 0.1) {
+    if (std::fabs(p_in.z / pz - 1) < 0.1) {
       p_out.SetPz(pz);
       break;
     }

--- a/src/algorithms/reco/FarForwardLambdaReconstruction.cc
+++ b/src/algorithms/reco/FarForwardLambdaReconstruction.cc
@@ -7,7 +7,7 @@
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
-#include <math.h>
+#include <cmath>
 #include <cstddef>
 #include <gsl/pointers>
 #include <vector>
@@ -94,7 +94,7 @@ void FarForwardLambdaReconstruction::process(
         }
 
         double mass_rec = lambda.M();
-        if (abs(mass_rec - m_lambda) > m_cfg.lambdaMaxMassDev)
+        if (std::abs(mass_rec - m_lambda) > m_cfg.lambdaMaxMassDev)
           continue;
 
         // rotate everything back to the lab coordinates.

--- a/src/algorithms/reco/PrimaryVertices.cc
+++ b/src/algorithms/reco/PrimaryVertices.cc
@@ -50,7 +50,7 @@ void PrimaryVertices::process(const PrimaryVertices::Input& input,
 
     // some basic vertex selection
     if (sqrt(v.x * v.x + v.y * v.y) / edm4eic::unit::mm > m_cfg.maxVr ||
-        fabs(v.z) / edm4eic::unit::mm > m_cfg.maxVz)
+        std::fabs(v.z) / edm4eic::unit::mm > m_cfg.maxVz)
       continue;
 
     if (vtx.getChi2() > m_cfg.maxChi2)

--- a/src/algorithms/reco/PrimaryVertices.cc
+++ b/src/algorithms/reco/PrimaryVertices.cc
@@ -50,7 +50,7 @@ void PrimaryVertices::process(const PrimaryVertices::Input& input,
 
     // some basic vertex selection
     if (sqrt(v.x * v.x + v.y * v.y) / edm4eic::unit::mm > m_cfg.maxVr ||
-        std::fabs(v.z) / edm4eic::unit::mm > m_cfg.maxVz)
+        std::abs(v.z) / edm4eic::unit::mm > m_cfg.maxVz)
       continue;
 
     if (vtx.getChi2() > m_cfg.maxChi2)

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -167,10 +167,10 @@ std::unique_ptr<edm4eic::VertexCollection> eicrecon::IterativeVertexFinder::prod
           const auto& trkPars = traj.getTrackParameters();
           for (const auto& par : trkPars) {
             const double EPSILON = 1.0e-4; // mm
-            if (fabs((par.getLoc().a / edm4eic::unit::mm) - (loc_a / Acts::UnitConstants::mm)) <
-                    EPSILON &&
-                fabs((par.getLoc().b / edm4eic::unit::mm) - (loc_b / Acts::UnitConstants::mm)) <
-                    EPSILON) {
+            if (std::fabs((par.getLoc().a / edm4eic::unit::mm) -
+                          (loc_a / Acts::UnitConstants::mm)) < EPSILON &&
+                std::fabs((par.getLoc().b / edm4eic::unit::mm) -
+                          (loc_b / Acts::UnitConstants::mm)) < EPSILON) {
               m_log->trace(
                   "From ReconParticles, track local position [Loc a, Loc b] = {} mm, {} mm",
                   par.getLoc().a / edm4eic::unit::mm, par.getLoc().b / edm4eic::unit::mm);

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -167,10 +167,10 @@ std::unique_ptr<edm4eic::VertexCollection> eicrecon::IterativeVertexFinder::prod
           const auto& trkPars = traj.getTrackParameters();
           for (const auto& par : trkPars) {
             const double EPSILON = 1.0e-4; // mm
-            if (std::fabs((par.getLoc().a / edm4eic::unit::mm) -
-                          (loc_a / Acts::UnitConstants::mm)) < EPSILON &&
-                std::fabs((par.getLoc().b / edm4eic::unit::mm) -
-                          (loc_b / Acts::UnitConstants::mm)) < EPSILON) {
+            if (std::abs((par.getLoc().a / edm4eic::unit::mm) - (loc_a / Acts::UnitConstants::mm)) <
+                    EPSILON &&
+                std::abs((par.getLoc().b / edm4eic::unit::mm) - (loc_b / Acts::UnitConstants::mm)) <
+                    EPSILON) {
               m_log->trace(
                   "From ReconParticles, track local position [Loc a, Loc b] = {} mm, {} mm",
                   par.getLoc().a / edm4eic::unit::mm, par.getLoc().b / edm4eic::unit::mm);

--- a/src/algorithms/tracking/TrackParamTruthInit.cc
+++ b/src/algorithms/tracking/TrackParamTruthInit.cc
@@ -47,7 +47,8 @@ eicrecon::TrackParamTruthInit::produce(const edm4hep::MCParticleCollection* mcpa
     // require close to interaction vertex
     auto v = mcparticle.getVertex();
     if (std::abs(v.x) * dd4hep::mm > m_cfg.maxVertexX ||
-        std::abs(v.y) * dd4hep::mm > m_cfg.maxVertexY || abs(v.z) * dd4hep::mm > m_cfg.maxVertexZ) {
+        std::abs(v.y) * dd4hep::mm > m_cfg.maxVertexY ||
+        std::abs(v.z) * dd4hep::mm > m_cfg.maxVertexZ) {
       m_log->trace("ignoring particle with vs = {} [mm]", v);
       continue;
     }
@@ -75,7 +76,7 @@ eicrecon::TrackParamTruthInit::produce(const edm4hep::MCParticleCollection* mcpa
     const auto pdg      = mcparticle.getPDG();
     const auto particle = m_particleSvc.particle(pdg);
     double charge       = std::copysign(1.0, particle.charge);
-    if (abs(charge) < std::numeric_limits<double>::epsilon()) {
+    if (std::abs(charge) < std::numeric_limits<double>::epsilon()) {
       m_log->trace("ignoring neutral particle");
       continue;
     }

--- a/src/algorithms/tracking/TrackParamTruthInit.cc
+++ b/src/algorithms/tracking/TrackParamTruthInit.cc
@@ -15,7 +15,6 @@
 #include <spdlog/common.h>
 #include <Eigen/Core>
 #include <cmath>
-#include <cstdlib>
 #include <limits>
 #include <memory>
 

--- a/src/services/geometry/richgeo/IrtGeoPFRICH.cc
+++ b/src/services/geometry/richgeo/IrtGeoPFRICH.cc
@@ -17,7 +17,7 @@
 #include <TRef.h>
 #include <TVector3.h>
 #include <fmt/core.h>
-#include <math.h>
+#include <cmath>
 #include <stdint.h>
 #include <map>
 #include <string>
@@ -141,7 +141,7 @@ void richgeo::IrtGeoPFRICH::DD4hep_to_IRT() {
       auto testOrtho  = normXdir.Dot(normYdir); // should be zero, if normX and normY are orthogonal
       auto testRadial = sensorNorm.Cross(normZdir)
                             .Mag2(); // should be zero, if sensor surface normal is as expected
-      if (abs(testOrtho) > 1e-6 || abs(testRadial) > 1e-6) {
+      if (std::abs(testOrtho) > 1e-6 || std::abs(testRadial) > 1e-6) {
         m_log->error(
             "sensor normal is wrong: normX.normY = {:f}   |sensorNorm x normZdir|^2 = {:f}",
             testOrtho, testRadial);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR ensures consistent use of `std::abs` (in C++ header `<cmath>`) over `abs` (in C header `<math.h>`). Since the behavior of `abs` when included via `<math.h>` may depend on whether or not `<cmath>` is also included (possibly via another header), it is better to be explicit and required `std::abs`, which operates within the same domain for both int and float types (see https://en.cppreference.com/w/cpp/numeric/math/fabs (yes, that's for `std::abs` too)).

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/EICrecon/actions/runs/15169971236/job/42657315496#step:7:646)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.