### PR TITLE
fix(ci): rm unused g++ Debug build

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -73,7 +73,11 @@ jobs:
         # note that entries that overwrite matrix values require a full specification
         # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow#expanding-or-adding-matrix-configurations
         exclude:
-          # exclude clang++ Debug with default CXXFLAGS
+          # exclude g++ Debug with default CXXFLAGS since unused
+          - CXX: g++
+            CMAKE_BUILD_TYPE: Debug
+            release: nightly
+          # exclude clang++ Debug with default CXXFLAGS since overridden
           - CXX: clang++
             CMAKE_BUILD_TYPE: Debug
             release: nightly


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes the g++ debug build which is unused by any subsequent jobs, and which consumes the [largest ccache chunks](https://github.com/eic/EICrecon/actions/caches?query=sort%3Asize-desc).

### What kind of change does this PR introduce?
- [x] Bug fix (issue: )
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.