### PR TITLE
fix: properly ignore neutrals in TrackParamTruthInit.cc

### DIFF
--- a/src/algorithms/tracking/TrackParamTruthInit.cc
+++ b/src/algorithms/tracking/TrackParamTruthInit.cc
@@ -75,7 +75,7 @@ eicrecon::TrackParamTruthInit::produce(const edm4hep::MCParticleCollection* mcpa
     const auto pdg      = mcparticle.getPDG();
     const auto particle = m_particleSvc.particle(pdg);
     double charge       = std::copysign(1.0, particle.charge);
-    if (std::abs(charge) < std::numeric_limits<double>::epsilon()) {
+    if (std::abs(particle.charge) < std::numeric_limits<double>::epsilon()) {
       m_log->trace("ignoring neutral particle");
       continue;
     }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes an issue ([pointed out](https://github.com/eic/EICrecon/pull/1876#discussion_r2102977558) by @simonge) where neutrals are not skipped as intended in TrackParamTruthInit

### What kind of change does this PR introduce?
- [x] Bug fix (issue: neutrals not skipped)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.