### PR TITLE
fix: rm undefined collection DIRCPID

### DIFF
--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -334,7 +334,6 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
 
     // DIRC
     "DIRCRawHits",
-    "DIRCPID",
     "DIRCTruthSeededParticleIDs",
     "DIRCParticleIDs",
 

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -2,6 +2,7 @@
 #include "JEventProcessorPODIO.h"
 
 #include <JANA/JApplication.h>
+#include <JANA/JApplicationFwd.h>
 #include <JANA/Services/JParameterManager.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <edm4eic/EDM4eicVersion.h>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes the default output of `DIRCPID` which is not created by any factories. Avoids warning:
```
Warning: tProcessorPODIO] [warning] Explicitly included collection 'DIRCPID' not present in factory set, omitting.
```

### What kind of change does this PR introduce?
- [x] Bug fix (issue: warning)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.