### PR TITLE
Make 10x100 CI run use epic_craterlake_10x100.xml

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -443,7 +443,7 @@ jobs:
           - beam: 5x41
             detector_config: craterlake_5x41
           - beam: 10x100
-            detector_config: craterlake
+            detector_config: craterlake_10x100
           - beam: 18x275
             detector_config: craterlake_18x275
     steps:
@@ -851,7 +851,7 @@ jobs:
         - CXX: clang++
           beam: 10x100
           minq2: 0
-          detector_config: craterlake
+          detector_config: craterlake_10x100
         - CXX: clang++
           beam: 18x275
           minq2: 0


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Changes the CI run of 10x100 to use the `epic_craterlake_10x100.xml` rather than just `epic_craterlake.xml` which is actually 5x41.

I thought historically this 10x100 was correct as the default, but it isn't clear looking at the epic history it was ever anything else.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
CI run and report for 10x100 run will be corrected.