### PR TITLE
Move pid_lut plugin detector constants into algorithm

### DIFF
--- a/src/algorithms/pid_lut/PIDLookup.cc
+++ b/src/algorithms/pid_lut/PIDLookup.cc
@@ -7,6 +7,7 @@
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
+#include <algorithms/geo.h>
 #include <fmt/core.h>
 #include <cmath>
 #include <gsl/pointers>
@@ -16,10 +17,13 @@
 #include "algorithms/pid_lut/PIDLookupConfig.h"
 #include "services/pid_lut/PIDLookupTableSvc.h"
 
+
 namespace eicrecon {
 
 void PIDLookup::init() {
   auto& serviceSvc = algorithms::ServiceSvc::instance();
+  auto detector    = algorithms::GeoSvc::instance().detector();
+  m_system         = detector->constant<int32_t>("BarrelTOF_ID");
   auto* lut_svc    = serviceSvc.service<PIDLookupTableSvc>("PIDLookupTableSvc");
 
   m_lut = lut_svc->load(m_cfg.filename,
@@ -89,25 +93,25 @@ void PIDLookup::process(const Input& input, const Output& output) const {
             entry->prob_kaon, entry->prob_proton);
 
       recopart.addToParticleIDs(
-          partids_out->create(m_cfg.system,                            // std::int32_t type
+          partids_out->create(m_system,                                // std::int32_t type
                               std::copysign(11, -charge),              // std::int32_t PDG
                               0,                                       // std::int32_t algorithmType
                               static_cast<float>(entry->prob_electron) // float likelihood
                               ));
       recopart.addToParticleIDs(
-          partids_out->create(m_cfg.system,                        // std::int32_t type
+          partids_out->create(m_system,                            // std::int32_t type
                               std::copysign(211, charge),          // std::int32_t PDG
                               0,                                   // std::int32_t algorithmType
                               static_cast<float>(entry->prob_pion) // float likelihood
                               ));
       recopart.addToParticleIDs(
-          partids_out->create(m_cfg.system,                        // std::int32_t type
+          partids_out->create(m_system,                            // std::int32_t type
                               std::copysign(321, charge),          // std::int32_t PDG
                               0,                                   // std::int32_t algorithmType
                               static_cast<float>(entry->prob_kaon) // float likelihood
                               ));
       recopart.addToParticleIDs(
-          partids_out->create(m_cfg.system,                          // std::int32_t type
+          partids_out->create(m_system,                              // std::int32_t type
                               std::copysign(2212, charge),           // std::int32_t PDG
                               0,                                     // std::int32_t algorithmType
                               static_cast<float>(entry->prob_proton) // float likelihood

--- a/src/algorithms/pid_lut/PIDLookup.cc
+++ b/src/algorithms/pid_lut/PIDLookup.cc
@@ -7,9 +7,9 @@
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <algorithms/geo.h>
 #include <fmt/core.h>
 #include <cmath>
+#include <exception>
 #include <gsl/pointers>
 #include <stdexcept>
 
@@ -21,9 +21,8 @@ namespace eicrecon {
 
 void PIDLookup::init() {
 
-  auto detector = algorithms::GeoSvc::instance().detector();
   try {
-    m_system = detector->constant<int32_t>(m_cfg.system);
+    m_system = m_detector->constant<int32_t>(m_cfg.system);
   } catch (const std::exception& e) {
     error("Failed to get {} from the detector: {}", m_cfg.system, e.what());
     throw std::runtime_error("Failed to get requested ID from the detector");

--- a/src/algorithms/pid_lut/PIDLookup.cc
+++ b/src/algorithms/pid_lut/PIDLookup.cc
@@ -21,9 +21,16 @@
 namespace eicrecon {
 
 void PIDLookup::init() {
+
+  auto detector = algorithms::GeoSvc::instance().detector();
+  try{
+    m_system         = detector->constant<int32_t>(m_cfg.system);
+  } catch (const std::exception& e) {
+    error("Failed to get {} from the detector: {}", m_cfg.system, e.what());
+    throw std::runtime_error("Failed to get requested ID from the detector");
+  }
+  
   auto& serviceSvc = algorithms::ServiceSvc::instance();
-  auto detector    = algorithms::GeoSvc::instance().detector();
-  m_system         = detector->constant<int32_t>("BarrelTOF_ID");
   auto* lut_svc    = serviceSvc.service<PIDLookupTableSvc>("PIDLookupTableSvc");
 
   m_lut = lut_svc->load(m_cfg.filename,

--- a/src/algorithms/pid_lut/PIDLookup.cc
+++ b/src/algorithms/pid_lut/PIDLookup.cc
@@ -17,19 +17,18 @@
 #include "algorithms/pid_lut/PIDLookupConfig.h"
 #include "services/pid_lut/PIDLookupTableSvc.h"
 
-
 namespace eicrecon {
 
 void PIDLookup::init() {
 
   auto detector = algorithms::GeoSvc::instance().detector();
-  try{
-    m_system         = detector->constant<int32_t>(m_cfg.system);
+  try {
+    m_system = detector->constant<int32_t>(m_cfg.system);
   } catch (const std::exception& e) {
     error("Failed to get {} from the detector: {}", m_cfg.system, e.what());
     throw std::runtime_error("Failed to get requested ID from the detector");
   }
-  
+
   auto& serviceSvc = algorithms::ServiceSvc::instance();
   auto* lut_svc    = serviceSvc.service<PIDLookupTableSvc>("PIDLookupTableSvc");
 

--- a/src/algorithms/pid_lut/PIDLookup.h
+++ b/src/algorithms/pid_lut/PIDLookup.h
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2024, Nathan Brei, Dmitry Kalinkin
 
+#include <DD4hep/Detector.h>
 #include <algorithms/algorithm.h>
+#include <algorithms/geo.h>
 #include <edm4eic/MCRecoParticleAssociationCollection.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/ParticleIDCollection.h>
+#include <stdint.h>
+#include <gsl/pointers>
 #include <random>
 #include <string>
 #include <string_view>
@@ -41,6 +45,7 @@ private:
   mutable std::uniform_real_distribution<double> m_dist{0, 1};
   int32_t m_system;
   const algorithms::ParticleSvc& m_particleSvc = algorithms::ParticleSvc::instance();
+  const dd4hep::Detector* m_detector{algorithms::GeoSvc::instance().detector()};
   const PIDLookupTable* m_lut;
 };
 

--- a/src/algorithms/pid_lut/PIDLookup.h
+++ b/src/algorithms/pid_lut/PIDLookup.h
@@ -39,6 +39,7 @@ public:
 private:
   mutable std::mt19937 m_gen{};
   mutable std::uniform_real_distribution<double> m_dist{0, 1};
+  int32_t m_system;
   const algorithms::ParticleSvc& m_particleSvc = algorithms::ParticleSvc::instance();
   const PIDLookupTable* m_lut;
 };

--- a/src/algorithms/pid_lut/PIDLookupConfig.h
+++ b/src/algorithms/pid_lut/PIDLookupConfig.h
@@ -9,7 +9,7 @@ namespace eicrecon {
 
 struct PIDLookupConfig {
   std::string filename;
-  int system;
+  std::string system;
   std::vector<int> pdg_values;
   std::vector<int> charge_values;
   std::vector<double> momentum_edges;

--- a/src/factories/pid_lut/PIDLookup_factory.h
+++ b/src/factories/pid_lut/PIDLookup_factory.h
@@ -29,7 +29,7 @@ private:
 
   ParameterRef<std::string> m_filename{this, "filename", config().filename,
                                        "Relative to current working directory"};
-  ParameterRef<int> m_system{this, "system", config().system, "For the ParticleID record"};
+  ParameterRef<std::string> m_system{this, "system", config().system, "For the ParticleID record"};
 
   Service<AlgorithmsInit_service> m_algorithmsInit{this};
 

--- a/src/global/pid_lut/pid_lut.cc
+++ b/src/global/pid_lut/pid_lut.cc
@@ -1,13 +1,9 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022, 2023, Christopher Dilks
 
-#include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
 #include <math.h>
-#include <algorithm>
-#include <gsl/pointers>
 #include <memory>
-#include <stdexcept>
 
 #include "algorithms/interfaces/WithPodConfig.h"
 #include "algorithms/pid_lut/PIDLookupConfig.h"

--- a/src/global/pid_lut/pid_lut.cc
+++ b/src/global/pid_lut/pid_lut.cc
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022, 2023, Christopher Dilks
 
-#include <DD4hep/Detector.h>
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
 #include <math.h>
@@ -15,7 +14,6 @@
 #include "extensions/jana/JOmniFactoryGeneratorT.h"
 // factories
 #include "factories/pid_lut/PIDLookup_factory.h"
-#include "services/geometry/dd4hep/DD4hep_service.h"
 
 extern "C" {
 void InitPlugin(JApplication* app) {
@@ -26,17 +24,9 @@ void InitPlugin(JApplication* app) {
   //-------------------------------------------------------------------------
   // PFRICH PID
   //-------------------------------------------------------------------------
-
-  int BackwardRICH_ID = 0;
-  try {
-    auto detector   = app->GetService<DD4hep_service>()->detector();
-    BackwardRICH_ID = detector->constant<int>("BackwardRICH_ID");
-  } catch (const std::runtime_error&) {
-    // Nothing
-  }
   PIDLookupConfig pfrich_pid_cfg{
       .filename       = "calibrations/pfrich.lut",
-      .system         = BackwardRICH_ID,
+      .system         = "BackwardRICH_ID",
       .pdg_values     = {11, 211, 321, 2212},
       .charge_values  = {1},
       .momentum_edges = {0.4,  0.8,  1.2,  1.6, 2,    2.4,  2.8,  3.2,  3.6, 4,    4.4,  4.8, 5.2,
@@ -81,16 +71,9 @@ void InitPlugin(JApplication* app) {
   // TOF PID
   //-------------------------------------------------------------------------
 
-  int BarrelTOF_ID = 0;
-  try {
-    auto detector = app->GetService<DD4hep_service>()->detector();
-    BarrelTOF_ID  = detector->constant<int>("BarrelTOF_ID");
-  } catch (const std::runtime_error&) {
-    // Nothing
-  }
   PIDLookupConfig tof_pid_cfg{
       .filename       = "calibrations/tof.lut",
-      .system         = BarrelTOF_ID,
+      .system         = "BarrelTOF_ID",
       .pdg_values     = {11, 211, 321, 2212},
       .charge_values  = {1},
       .momentum_edges = {0.0, 0.3, 0.6, 0.9, 1.2, 1.5, 1.8, 2.1, 2.4, 2.7, 3.0,
@@ -132,16 +115,9 @@ void InitPlugin(JApplication* app) {
   // DIRC PID
   //-------------------------------------------------------------------------
 
-  int BarrelDIRC_ID = 0;
-  try {
-    auto detector = app->GetService<DD4hep_service>()->detector();
-    BarrelDIRC_ID = detector->constant<int>("BarrelDIRC_ID");
-  } catch (const std::runtime_error&) {
-    // Nothing
-  }
   PIDLookupConfig dirc_pid_cfg{
       .filename       = "calibrations/hpdirc.lut.gz",
-      .system         = BarrelDIRC_ID,
+      .system         = "BarrelDIRC_ID",
       .pdg_values     = {11, 211, 321, 2212},
       .charge_values  = {-1, 1},
       .momentum_edges = {0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6, 1.8, 2.0, 2.2,  2.4, 2.6,
@@ -194,16 +170,9 @@ void InitPlugin(JApplication* app) {
   // DRICH PID
   //-------------------------------------------------------------------------
 
-  int ForwardRICH_ID = 0;
-  try {
-    auto detector  = app->GetService<DD4hep_service>()->detector();
-    ForwardRICH_ID = detector->constant<int>("ForwardRICH_ID");
-  } catch (const std::runtime_error&) {
-    // Nothing
-  }
   PIDLookupConfig drich_pid_cfg{
       .filename                 = "calibrations/drich.lut",
-      .system                   = ForwardRICH_ID,
+      .system                   = "ForwardRICH_ID",
       .pdg_values               = {211, 321, 2212},
       .charge_values            = {1},
       .momentum_edges           = {0.25,  0.75,  1.25,  1.75,  2.25,  2.75,  3.25,  3.75,  4.25,

--- a/src/tests/algorithms_test/algorithmsInit.cc
+++ b/src/tests/algorithms_test/algorithmsInit.cc
@@ -5,6 +5,7 @@
 #include <DD4hep/IDDescriptor.h>
 #include <DD4hep/Readout.h>
 #include <DD4hep/Segmentations.h>
+#include <DD4hep/Objects.h>
 #include <algorithms/geo.h>
 #include <algorithms/interfaces/ParticleSvc.h>
 #include <algorithms/random.h>
@@ -29,12 +30,14 @@ public:
 
   void testRunStarting(Catch::TestRunInfo const& /*testRunInfo*/) override {
     auto detector = dd4hep::Detector::make_unique("");
+    detector->addConstant(dd4hep::Constant("MockCalorimeter_ID", "1")); 
     dd4hep::Readout readout(std::string("MockCalorimeterHits"));
     dd4hep::IDDescriptor id_desc("MockCalorimeterHits", "system:8,layer:8,x:8,y:8");
     readout.setIDDescriptor(id_desc);
     detector->add(id_desc);
     detector->add(readout);
 
+    detector->addConstant(dd4hep::Constant("MockTracker_ID", "2"));
     dd4hep::Readout readoutTracker(std::string("MockTrackerHits"));
     dd4hep::IDDescriptor id_desc_tracker("MockTrackerHits", "system:8,layer:8,x:8,y:8");
     //Create segmentation with 1x1 mm pixels

--- a/src/tests/algorithms_test/algorithmsInit.cc
+++ b/src/tests/algorithms_test/algorithmsInit.cc
@@ -30,7 +30,7 @@ public:
 
   void testRunStarting(Catch::TestRunInfo const& /*testRunInfo*/) override {
     auto detector = dd4hep::Detector::make_unique("");
-    detector->addConstant(dd4hep::Constant("MockCalorimeter_ID", "1")); 
+    detector->addConstant(dd4hep::Constant("MockCalorimeter_ID", "1"));
     dd4hep::Readout readout(std::string("MockCalorimeterHits"));
     dd4hep::IDDescriptor id_desc("MockCalorimeterHits", "system:8,layer:8,x:8,y:8");
     readout.setIDDescriptor(id_desc);

--- a/src/tests/algorithms_test/pid_lut_PIDLookup.cc
+++ b/src/tests/algorithms_test/pid_lut_PIDLookup.cc
@@ -26,7 +26,7 @@ TEST_CASE("particles acquire PID", "[PIDLookup]") {
 
   PIDLookupConfig cfg{
       .filename                    = "/dev/null",
-      .system                      = 0xFF,
+      .system                      = "MockTracker_ID",
       .pdg_values                  = {11},
       .charge_values               = {1},
       .momentum_edges              = {0., 1., 2.},


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Part of #1887. Moves the geometry plugin requirements out of the pid_lut plugin and into the algorithm.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #1887)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No