### PR TITLE
fix(ci): cancel eicweb pipeline if workflow canceled or failed

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -968,7 +968,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event_name != 'merge_group' && github.event_name != 'schedule' && github.actor != 'dependabot[bot]' }}
     needs:
-    - eicrecon-gun
+    - build
     outputs:
       json: ${{ steps.trigger.outputs.json }}
     steps:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR cancels the triggered eicweb pipeline when a GitHub workflow later fails or is canceled (for example by a new commit). This reduces the load on eicweb when multiple commits are submitted in relatively quick succession.

Note that canceling the container pipeline on eicweb does not cancel any benchmark pipelines it may have triggered. That's a problem for eicweb to solve, not here (arguably).

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No .

### Does this PR change default behavior?
No.