### PR TITLE
MatchClusters: do not assign PDG code to trackless EM clusters

### DIFF
--- a/src/algorithms/reco/MatchClusters.cc
+++ b/src/algorithms/reco/MatchClusters.cc
@@ -89,8 +89,8 @@ void MatchClusters::process(const MatchClusters::Input& input,
 
     // get mass/PDG from mcparticles, 0 (unidentified) in case the matched particle is charged.
     const auto mc     = (*mcparticles)[mcID];
-    const double mass = (mc.getCharge() == 0.0F) ? mc.getMass() : 0;
-    const int32_t pdg = (mc.getCharge() == 0.0F) ? mc.getPDG() : 0;
+    const double mass = 0.;
+    const int32_t pdg = 0;
     if (level() <= algorithms::LogLevel::kDebug) {
       if (mc.getCharge() != 0.0F) {
         debug("   --> associated mcparticle is not a neutral (PDG: {}), "

--- a/src/algorithms/reco/MatchClusters.cc
+++ b/src/algorithms/reco/MatchClusters.cc
@@ -89,8 +89,19 @@ void MatchClusters::process(const MatchClusters::Input& input,
 
     // get mass/PDG from mcparticles, 0 (unidentified) in case the matched particle is charged.
     const auto mc     = (*mcparticles)[mcID];
-    const double mass = (mc.getCharge() == 0.0F) ? mc.getMass() : 0;
-    const int32_t pdg = (mc.getCharge() == 0.0F) ? mc.getPDG() : 0;
+    edm4hep::ParticleID likely_pid;
+    for (auto it = clus.particleIDs_begin(); it != clus.particleIDs_end(); it++) {
+      edm4hep::ParticleID pid = *it;
+      if ((!likely_pid.isAvailable()) || (pid.getLikelihood() > likely_pid.getLikelihood())) {
+        likely_pid = pid;
+      }
+    }
+    double mass = 0.;
+    int32_t pdg = 0;
+    if (likely_pid.isAvailable()) {
+      pdg = likely_pid.getPDG();
+      mass = m_particleSvc.particle(pdg).mass;
+    }
     if (level() <= algorithms::LogLevel::kDebug) {
       if (mc.getCharge() != 0.0F) {
         debug("   --> associated mcparticle is not a neutral (PDG: {}), "

--- a/src/algorithms/reco/MatchClusters.cc
+++ b/src/algorithms/reco/MatchClusters.cc
@@ -89,19 +89,8 @@ void MatchClusters::process(const MatchClusters::Input& input,
 
     // get mass/PDG from mcparticles, 0 (unidentified) in case the matched particle is charged.
     const auto mc     = (*mcparticles)[mcID];
-    edm4hep::ParticleID likely_pid;
-    for (auto it = clus.particleIDs_begin(); it != clus.particleIDs_end(); it++) {
-      edm4hep::ParticleID pid = *it;
-      if ((!likely_pid.isAvailable()) || (pid.getLikelihood() > likely_pid.getLikelihood())) {
-        likely_pid = pid;
-      }
-    }
-    double mass = 0.;
-    int32_t pdg = 0;
-    if (likely_pid.isAvailable()) {
-      pdg = likely_pid.getPDG();
-      mass = m_particleSvc.particle(pdg).mass;
-    }
+    const double mass = (mc.getCharge() == 0.0F) ? mc.getMass() : 0;
+    const int32_t pdg = (mc.getCharge() == 0.0F) ? mc.getPDG() : 0;
     if (level() <= algorithms::LogLevel::kDebug) {
       if (mc.getCharge() != 0.0F) {
         debug("   --> associated mcparticle is not a neutral (PDG: {}), "

--- a/src/algorithms/reco/MatchClusters.h
+++ b/src/algorithms/reco/MatchClusters.h
@@ -18,8 +18,6 @@
 #include <string>
 #include <string_view>
 
-#include "algorithms/interfaces/ParticleSvc.h"
-
 namespace eicrecon {
 
 using MatchClustersAlgorithm = algorithms::Algorithm<
@@ -53,8 +51,6 @@ private:
   // (for now assuming the vertex is at (0,0,0))
   static edm4eic::MutableReconstructedParticle
   reconstruct_neutral(const edm4eic::Cluster* cluster, const double mass, const int32_t pdg);
-
-  const algorithms::ParticleSvc& m_particleSvc = algorithms::ParticleSvc::instance();
 };
 
 } // namespace eicrecon

--- a/src/algorithms/reco/MatchClusters.h
+++ b/src/algorithms/reco/MatchClusters.h
@@ -18,6 +18,8 @@
 #include <string>
 #include <string_view>
 
+#include "algorithms/interfaces/ParticleSvc.h"
+
 namespace eicrecon {
 
 using MatchClustersAlgorithm = algorithms::Algorithm<
@@ -51,6 +53,8 @@ private:
   // (for now assuming the vertex is at (0,0,0))
   static edm4eic::MutableReconstructedParticle
   reconstruct_neutral(const edm4eic::Cluster* cluster, const double mass, const int32_t pdg);
+
+  const algorithms::ParticleSvc& m_particleSvc = algorithms::ParticleSvc::instance();
 };
 
 } // namespace eicrecon


### PR DESCRIPTION
### Briefly, what does this PR introduce?
There were reports of ReconstructedParticle containing PDG=130 (K0L), which we don't identify. Convention is that we use PID information in Reconstructed* branches. That is already the case for tracks (ChargedParticles), but was never addressed for when we add in clusters in `MatchClusters`. For now the only clusters with PID are from EEEMCal, and only electron/pion separation is implemented which requires a track and does not belong in this branch, so we can't take that. So solution, for now, is to keep zero values.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
Yes, users may observe missing PDG for neutral particles reconstructed.

### Does this PR change default behavior?
Yes