### PR TITLE
Run track-cluster matching separately for each calorimeter

### DIFF
--- a/src/algorithms/reco/TrackClusterMatch.cc
+++ b/src/algorithms/reco/TrackClusterMatch.cc
@@ -29,8 +29,7 @@ void TrackClusterMatch::process(const TrackClusterMatch::Input& input,
 
   // Validate the configuration
   if (m_cfg.matching_distance <= 0) {
-    throw std::runtime_error(
-        fmt::format("Invalid matching distance: {}", m_cfg.matching_distance));
+    throw std::runtime_error(fmt::format("Invalid matching distance: {}", m_cfg.matching_distance));
   }
   if (m_cfg.calo_id.empty()) {
     throw std::runtime_error("Calorimeter ID must be set in the configuration");

--- a/src/algorithms/reco/TrackClusterMatch.cc
+++ b/src/algorithms/reco/TrackClusterMatch.cc
@@ -48,8 +48,8 @@ void TrackClusterMatch::process(const TrackClusterMatch::Input& input,
         // Check if the point is at the calorimeter
         // int id = m_detector->volumeManager().lookupDetector(cluster.getHits()[0].getCellID()).id(); // TODO: Find programmatic way to get detector cluster is from
         uint32_t calo_id = m_geo.detector()->constant<int>(m_cfg.calo_id);
-        bool is_calo            = point.system == calo_id;
-        bool is_surface         = point.surface == 1;
+        bool is_calo     = point.system == calo_id;
+        bool is_surface  = point.surface == 1;
 
         if (!is_calo || !is_surface) {
           trace("Skipping track point not at the calorimeter");

--- a/src/algorithms/reco/TrackClusterMatch.cc
+++ b/src/algorithms/reco/TrackClusterMatch.cc
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2025 Tristan Protzman
 
-#include <cstdint>
 #include <edm4eic/EDM4eicVersion.h> // Needs edm4eic::TrackClusterMatch
 #include <fmt/core.h>
+#include <podio/RelationRange.h>
+#include <cstdint>
 #include <gsl/pointers>
 #include <optional>
-#include <podio/RelationRange.h>
 #include <set>
+#include <stdexcept>
 #include <vector>
 #if EDM4EIC_VERSION_MAJOR >= 8
 

--- a/src/algorithms/reco/TrackClusterMatch.cc
+++ b/src/algorithms/reco/TrackClusterMatch.cc
@@ -27,6 +27,15 @@ void TrackClusterMatch::process(const TrackClusterMatch::Input& input,
   auto [matched_particles] = output;
   trace("We have {} tracks and {} clusters", tracks->size(), clusters->size());
 
+  // Validate the configuration
+  if (m_cfg.matching_distance <= 0) {
+    throw std::runtime_error(
+        fmt::format("Invalid matching distance: {}", m_cfg.matching_distance));
+  }
+  if (m_cfg.calo_id.empty()) {
+    throw std::runtime_error("Calorimeter ID must be set in the configuration");
+  }
+
   std::set<int> used_tracks;
   // Loop across each cluster, and find the cloeset projected track
   for (auto cluster : *clusters) {

--- a/src/algorithms/reco/TrackClusterMatch.cc
+++ b/src/algorithms/reco/TrackClusterMatch.cc
@@ -47,13 +47,11 @@ void TrackClusterMatch::process(const TrackClusterMatch::Input& input,
       for (auto point : track.getPoints()) {
         // Check if the point is at the calorimeter
         // int id = m_detector->volumeManager().lookupDetector(cluster.getHits()[0].getCellID()).id(); // TODO: Find programmatic way to get detector cluster is from
-        uint32_t ecal_barrel_id = m_geo.detector()->constant<int>("EcalBarrel_ID");
-        uint32_t hcal_barrel_id = m_geo.detector()->constant<int>("HcalBarrel_ID");
-        bool is_ecal            = point.system == ecal_barrel_id;
-        bool is_hcal            = point.system == hcal_barrel_id;
+        uint32_t calo_id = m_geo.detector()->constant<int>(m_cfg.calo_id);
+        bool is_calo            = point.system == calo_id;
         bool is_surface         = point.surface == 1;
 
-        if (!(is_ecal || is_hcal) || !is_surface) {
+        if (!is_calo || !is_surface) {
           trace("Skipping track point not at the calorimeter");
           continue;
         }

--- a/src/algorithms/reco/TrackClusterMatchConfig.h
+++ b/src/algorithms/reco/TrackClusterMatchConfig.h
@@ -9,6 +9,6 @@
 namespace eicrecon {
 struct TrackClusterMatchConfig {
   double matching_distance = 0.5;
-  std::string calo_id = ""; 
+  std::string calo_id      = "";
 };
 } // namespace eicrecon

--- a/src/algorithms/reco/TrackClusterMatchConfig.h
+++ b/src/algorithms/reco/TrackClusterMatchConfig.h
@@ -9,5 +9,6 @@
 namespace eicrecon {
 struct TrackClusterMatchConfig {
   double matching_distance = 0.5;
+  std::string calo_id = ""; 
 };
 } // namespace eicrecon

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -190,11 +190,6 @@ void InitPlugin(JApplication* app) {
       {"EcalEndcapPTrackClusterMatches"}, {.calo_id = "EcalEndcapP_ID"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(
-      "EcalEndcapPInsertTrackClusterMatcher",
-      {"CalorimeterTrackProjections", "EcalEndcapPInsertClusters"},
-      {"EcalEndcapPInsertTrackClusterMatches"}, {.calo_id = "EcalEndcapPInsert_ID"}, app));
-
-  app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(
       "LFHCALTrackClusterMatcher", {"CalorimeterTrackProjections", "LFHCALClusters"},
       {"LFHCALTrackClusterMatches"}, {.calo_id = "LFHCAL_ID"}, app));
 

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -183,18 +183,69 @@ void InitPlugin(JApplication* app) {
       },
       app));
 
-  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Cluster, true>>(
-      "BarrelClusters",
-      {
-          "HcalBarrelClusters",
-          "EcalBarrelClusters",
-      },
-      {"BarrelClusters"}, app));
 
 #if EDM4EIC_VERSION_MAJOR >= 8
+  // Forward
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(
-      "TrackClusterMatcher", {"CalorimeterTrackProjections", "BarrelClusters"},
-      {"TrackClusterMatches"}, {}, app));
+      "EcalEndcapPTrackClusterMatcher",
+      {"CalorimeterTrackProjections", "EcalEndcapPClusters"},
+      {"EcalEndcapPTrackClusterMatches"},
+      {.calo_id = "EcalEndcapP_ID"},
+      app));
+
+  app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(
+      "EcalEndcapPInsertTrackClusterMatcher",
+      {"CalorimeterTrackProjections", "EcalEndcapPInsertClusters"},
+      {"EcalEndcapPInsertTrackClusterMatches"},
+      {.calo_id = "EcalEndcapPInsert_ID"},
+      app));
+
+  app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(
+      "LFHCALTrackClusterMatcher",
+      {"CalorimeterTrackProjections", "LFHCALClusters"},
+      {"LFHCALTrackClusterMatches"},
+      {.calo_id = "LFHCAL_ID"},
+      app));
+
+  app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(
+      "HcalEndcapPInsertClusterMatcher",
+      {"CalorimeterTrackProjections", "HcalEndcapPInsertClusters"},
+      {"HcalEndcapPInsertClusterMatches"},
+      {.calo_id = "HcalEndcapPInsert_ID"},
+      app));
+
+
+  // Barrel
+  app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(
+      "EcalBarrelTrackClusterMatcher",
+      {"CalorimeterTrackProjections", "EcalBarrelClusters"},
+      {"EcalBarrelTrackClusterMatches"},
+      {.calo_id = "EcalBarrel_ID"},
+      app));
+
+  app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(
+      "HcalBarrelTrackClusterMatcher",
+      {"CalorimeterTrackProjections", "HcalBarrelClusters"},
+      {"HcalBarrelTrackClusterMatches"},
+      {.calo_id = "HcalBarrel_ID"},
+      app));
+
+  // Backward
+  app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(
+      "EcalEndcapNBarrelTrackClusterMatcher",
+      {"CalorimeterTrackProjections", "EcalEndcapNClusters"},
+      {"EcalEndcapNTrackClusterMatches"},
+      {.calo_id = "EcalEndcapN_ID"},
+      app));
+
+  app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(
+      "HcalEndcapNBarrelTrackClusterMatcher",
+      {"CalorimeterTrackProjections", "HcalEndcapNClusters"},
+      {"HcalEndcapNTrackClusterMatches"},
+      {.calo_id = "HcalEndcapN_ID"},
+      app));
+
+
 #endif // EDM4EIC_VERSION_MAJOR >= 8
 
   app->Add(new JOmniFactoryGeneratorT<TransformBreitFrame_factory>(

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -201,7 +201,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(
       "HcalEndcapPInsertClusterMatcher",
       {"CalorimeterTrackProjections", "HcalEndcapPInsertClusters"},
-      {"HcalEndcapPInsertClusterMatches"}, {.calo_id = "HcalEndcapPInsert_ID"}, app));
+      {"HcalEndcapPInsertTrackClusterMatches"}, {.calo_id = "HcalEndcapPInsert_ID"}, app));
 
   // Barrel
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -183,68 +183,45 @@ void InitPlugin(JApplication* app) {
       },
       app));
 
-
 #if EDM4EIC_VERSION_MAJOR >= 8
   // Forward
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(
-      "EcalEndcapPTrackClusterMatcher",
-      {"CalorimeterTrackProjections", "EcalEndcapPClusters"},
-      {"EcalEndcapPTrackClusterMatches"},
-      {.calo_id = "EcalEndcapP_ID"},
-      app));
+      "EcalEndcapPTrackClusterMatcher", {"CalorimeterTrackProjections", "EcalEndcapPClusters"},
+      {"EcalEndcapPTrackClusterMatches"}, {.calo_id = "EcalEndcapP_ID"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(
       "EcalEndcapPInsertTrackClusterMatcher",
       {"CalorimeterTrackProjections", "EcalEndcapPInsertClusters"},
-      {"EcalEndcapPInsertTrackClusterMatches"},
-      {.calo_id = "EcalEndcapPInsert_ID"},
-      app));
+      {"EcalEndcapPInsertTrackClusterMatches"}, {.calo_id = "EcalEndcapPInsert_ID"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(
-      "LFHCALTrackClusterMatcher",
-      {"CalorimeterTrackProjections", "LFHCALClusters"},
-      {"LFHCALTrackClusterMatches"},
-      {.calo_id = "LFHCAL_ID"},
-      app));
+      "LFHCALTrackClusterMatcher", {"CalorimeterTrackProjections", "LFHCALClusters"},
+      {"LFHCALTrackClusterMatches"}, {.calo_id = "LFHCAL_ID"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(
       "HcalEndcapPInsertClusterMatcher",
       {"CalorimeterTrackProjections", "HcalEndcapPInsertClusters"},
-      {"HcalEndcapPInsertClusterMatches"},
-      {.calo_id = "HcalEndcapPInsert_ID"},
-      app));
-
+      {"HcalEndcapPInsertClusterMatches"}, {.calo_id = "HcalEndcapPInsert_ID"}, app));
 
   // Barrel
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(
-      "EcalBarrelTrackClusterMatcher",
-      {"CalorimeterTrackProjections", "EcalBarrelClusters"},
-      {"EcalBarrelTrackClusterMatches"},
-      {.calo_id = "EcalBarrel_ID"},
-      app));
+      "EcalBarrelTrackClusterMatcher", {"CalorimeterTrackProjections", "EcalBarrelClusters"},
+      {"EcalBarrelTrackClusterMatches"}, {.calo_id = "EcalBarrel_ID"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(
-      "HcalBarrelTrackClusterMatcher",
-      {"CalorimeterTrackProjections", "HcalBarrelClusters"},
-      {"HcalBarrelTrackClusterMatches"},
-      {.calo_id = "HcalBarrel_ID"},
-      app));
+      "HcalBarrelTrackClusterMatcher", {"CalorimeterTrackProjections", "HcalBarrelClusters"},
+      {"HcalBarrelTrackClusterMatches"}, {.calo_id = "HcalBarrel_ID"}, app));
 
   // Backward
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(
       "EcalEndcapNBarrelTrackClusterMatcher",
-      {"CalorimeterTrackProjections", "EcalEndcapNClusters"},
-      {"EcalEndcapNTrackClusterMatches"},
-      {.calo_id = "EcalEndcapN_ID"},
-      app));
+      {"CalorimeterTrackProjections", "EcalEndcapNClusters"}, {"EcalEndcapNTrackClusterMatches"},
+      {.calo_id = "EcalEndcapN_ID"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(
       "HcalEndcapNBarrelTrackClusterMatcher",
-      {"CalorimeterTrackProjections", "HcalEndcapNClusters"},
-      {"HcalEndcapNTrackClusterMatches"},
-      {.calo_id = "HcalEndcapN_ID"},
-      app));
-
+      {"CalorimeterTrackProjections", "HcalEndcapNClusters"}, {"HcalEndcapNTrackClusterMatches"},
+      {.calo_id = "HcalEndcapN_ID"}, app));
 
 #endif // EDM4EIC_VERSION_MAJOR >= 8
 

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -186,35 +186,35 @@ void InitPlugin(JApplication* app) {
 #if EDM4EIC_VERSION_MAJOR >= 8
   // Forward
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(
-      "EcalEndcapPTrackClusterMatcher", {"CalorimeterTrackProjections", "EcalEndcapPClusters"},
+      "EcalEndcapPTrackClusterMatches", {"CalorimeterTrackProjections", "EcalEndcapPClusters"},
       {"EcalEndcapPTrackClusterMatches"}, {.calo_id = "EcalEndcapP_ID"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(
-      "LFHCALTrackClusterMatcher", {"CalorimeterTrackProjections", "LFHCALClusters"},
+      "LFHCALTrackClusterMatches", {"CalorimeterTrackProjections", "LFHCALClusters"},
       {"LFHCALTrackClusterMatches"}, {.calo_id = "LFHCAL_ID"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(
-      "HcalEndcapPInsertClusterMatcher",
+      "HcalEndcapPInsertClusterMatches",
       {"CalorimeterTrackProjections", "HcalEndcapPInsertClusters"},
       {"HcalEndcapPInsertTrackClusterMatches"}, {.calo_id = "HcalEndcapPInsert_ID"}, app));
 
   // Barrel
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(
-      "EcalBarrelTrackClusterMatcher", {"CalorimeterTrackProjections", "EcalBarrelClusters"},
+      "EcalBarrelTrackClusterMatches", {"CalorimeterTrackProjections", "EcalBarrelClusters"},
       {"EcalBarrelTrackClusterMatches"}, {.calo_id = "EcalBarrel_ID"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(
-      "HcalBarrelTrackClusterMatcher", {"CalorimeterTrackProjections", "HcalBarrelClusters"},
+      "HcalBarrelTrackClusterMatches", {"CalorimeterTrackProjections", "HcalBarrelClusters"},
       {"HcalBarrelTrackClusterMatches"}, {.calo_id = "HcalBarrel_ID"}, app));
 
   // Backward
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(
-      "EcalEndcapNBarrelTrackClusterMatcher",
+      "EcalEndcapNBarrelTrackClusterMatches",
       {"CalorimeterTrackProjections", "EcalEndcapNClusters"}, {"EcalEndcapNTrackClusterMatches"},
       {.calo_id = "EcalEndcapN_ID"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMatch_factory>(
-      "HcalEndcapNBarrelTrackClusterMatcher",
+      "HcalEndcapNBarrelTrackClusterMatches",
       {"CalorimeterTrackProjections", "HcalEndcapNClusters"}, {"HcalEndcapNTrackClusterMatches"},
       {.calo_id = "HcalEndcapN_ID"}, app));
 

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -380,7 +380,14 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
     "HcalFarForwardZDCRawHitAssociations",
 #endif
 #if EDM4EIC_VERSION_MAJOR >= 8
-    "TrackClusterMatches",
+    "EcalEndcapPTrackClusterMatches",
+    "EcalEndcapPInsertTrackClusterMatches",
+    "LFHCALTrackClusterMatches",
+    "HcalEndcapPInsertClusterMatches",
+    "EcalBarrelTrackClusterMatches",
+    "HcalBarrelTrackClusterMatches",
+    "EcalEndcapNTrackClusterMatches",
+    "HcalEndcapNTrackClusterMatches",
 #endif
 
   };

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -381,7 +381,6 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
 #endif
 #if EDM4EIC_VERSION_MAJOR >= 8
     "EcalEndcapPTrackClusterMatches",
-    "EcalEndcapPInsertTrackClusterMatches",
     "LFHCALTrackClusterMatches",
     "HcalEndcapPInsertClusterMatches",
     "EcalBarrelTrackClusterMatches",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
A suggested in #1885, the track-cluster matching should be done separately for each calorimeter.  Later algorithms can then manage the merging and splitting of clusters and integration across calorimeters.  This also makes it simpler to tune the matching criteria separately for each subsystem. 

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #1885 )
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
There is no longer a single TrackClusterMatches collection output, instead is is broken into separate collections for each calorimeter
```
    EcalEndcapPTrackClusterMatches
    EcalEndcapPInsertTrackClusterMatches
    LFHCALTrackClusterMatches
    HcalEndcapPInsertClusterMatches
    EcalBarrelTrackClusterMatches
    HcalBarrelTrackClusterMatches
    EcalEndcapNTrackClusterMatches
    HcalEndcapNTrackClusterMatches
```

### Does this PR change default behavior?
See above