### PR TITLE
fix: don't use RGB component 280 > 255

### DIFF
--- a/src/algorithms/tracking/ActsGeometryProvider.h
+++ b/src/algorithms/tracking/ActsGeometryProvider.h
@@ -107,17 +107,17 @@ private:
 
   /// Configuration for obj export
 #if Acts_VERSION_MAJOR >= 37
-  Acts::ViewConfig m_containerView{.color = {220, 220, 220}};
-  Acts::ViewConfig m_volumeView{.color = {220, 220, 0}};
-  Acts::ViewConfig m_sensitiveView{.color = {0, 180, 240}};
-  Acts::ViewConfig m_passiveView{.color = {240, 280, 0}};
-  Acts::ViewConfig m_gridView{.color = {220, 0, 0}};
+  Acts::ViewConfig m_containerView{.color = {220, 220, 220}}; // alto
+  Acts::ViewConfig m_volumeView{.color = {220, 220, 0}};      // barberry yellow
+  Acts::ViewConfig m_sensitiveView{.color = {0, 180, 240}};   // picton blue
+  Acts::ViewConfig m_passiveView{.color = {240, 180, 0}};     // lightning yellow
+  Acts::ViewConfig m_gridView{.color = {220, 0, 0}};          // scarlet red
 #else
-  Acts::ViewConfig m_containerView{{220, 220, 220}};
-  Acts::ViewConfig m_volumeView{{220, 220, 0}};
-  Acts::ViewConfig m_sensitiveView{{0, 180, 240}};
-  Acts::ViewConfig m_passiveView{{240, 280, 0}};
-  Acts::ViewConfig m_gridView{{220, 0, 0}};
+  Acts::ViewConfig m_containerView{{220, 220, 220}}; // alto
+  Acts::ViewConfig m_volumeView{{220, 220, 0}};      // barberry yellow
+  Acts::ViewConfig m_sensitiveView{{0, 180, 240}};   // picton blue
+  Acts::ViewConfig m_passiveView{{240, 180, 0}};     // lightning yellow
+  Acts::ViewConfig m_gridView{{220, 0, 0}};          // scarlet red
 #endif
   bool m_objWriteIt{false};
   bool m_plyWriteIt{false};


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes an RGB component from 280 to 180 (what was likely intended).

### What kind of change does this PR introduce?
- [x] Bug fix (issue: ultragreen)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.