### PR TITLE
[Backport v1.26] Resolve missing symbols when loading plugins

### DIFF
--- a/src/algorithms/digi/CMakeLists.txt
+++ b/src/algorithms/digi/CMakeLists.txt
@@ -10,6 +10,7 @@ plugin_add(${PLUGIN_NAME} WITH_SHARED_LIBRARY WITHOUT_PLUGIN)
 plugin_glob_all(${PLUGIN_NAME})
 
 # Find dependencies
+plugin_add_algorithms(${PLUGIN_NAME})
 plugin_add_dd4hep(${PLUGIN_NAME})
 plugin_add_cern_root(${PLUGIN_NAME})
 plugin_add_event_model(${PLUGIN_NAME})

--- a/src/services/geometry/dd4hep/DD4hep_service.h
+++ b/src/services/geometry/dd4hep/DD4hep_service.h
@@ -6,7 +6,7 @@
 
 #include <DD4hep/Detector.h>
 #include <DDRec/CellIDPositionConverter.h>
-#include <JANA/JApplicationFwd.h>
+#include <JANA/JApplication.h>
 #include <JANA/JServiceFwd.h>
 #include <JANA/Services/JServiceLocator.h>
 #include <spdlog/logger.h>


### PR DESCRIPTION
# Description
Backport of #1910 to `v1.26`.