### PR TITLE
fix: avoid duplicate definition of hash<MCParticle> in SimHitProcessor

### DIFF
--- a/src/algorithms/calorimetry/SimCalorimeterHitProcessor.cc
+++ b/src/algorithms/calorimetry/SimCalorimeterHitProcessor.cc
@@ -44,17 +44,17 @@ template <> struct hash<podio::ObjectID> {
     return h1 ^ (h2 << 1);
   }
 };
-#endif // podio version check
-#endif // defined(podio_VERSION_MAJOR) && defined(podio_VERSION_MINOR)
 
 // Necessary to make MCParticle hashable
-// @TODO maybe this could be added to podio?
 template <> struct hash<edm4hep::MCParticle> {
   size_t operator()(const edm4hep::MCParticle& p) const noexcept {
     const auto& id = p.getObjectID();
     return std::hash<podio::ObjectID>()(id);
   }
 };
+#endif // podio version check
+#endif // defined(podio_VERSION_MAJOR) && defined(podio_VERSION_MINOR)
+
 // Hash for tuple<edm4hep::MCParticle, uint64_t>
 // --> not yet supported by any compiler at the moment
 template <> struct hash<std::tuple<edm4hep::MCParticle, uint64_t>> {


### PR DESCRIPTION
### Briefly, what does this PR introduce?
With podio 1.3.0, the hash is defined for all types, https://github.com/AIDASoft/podio/commit/4522b6e05376a0f784a48a6dba6da0cba436a950. This PR ensures we don't doubly define the hash in that case.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: fails to compile with podio 1.3.0)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @mhkim-anl @sly2j 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.