### PR TITLE
Speed improvement in SiliconPulseDiscretization

### DIFF
--- a/src/algorithms/digi/SiliconPulseDiscretization.cc
+++ b/src/algorithms/digi/SiliconPulseDiscretization.cc
@@ -5,11 +5,11 @@
 //
 
 #include <DDRec/CellIDPositionConverter.h>
-#include <climits>
+#include <podio/RelationRange.h>
 #include <cmath>
 #include <gsl/pointers>
-#include <podio/RelationRange.h>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "SiliconPulseDiscretization.h"
 // use TGraph for interpolation
@@ -40,6 +40,12 @@ void SiliconPulseDiscretization::process(const SiliconPulseDiscretization::Input
   auto [outPulses]      = output;
 
   std::unordered_map<dd4hep::rec::CellID, TGraph> Graph4Cells;
+  // sometimes the first hit arrives early, but the last hit arrive very late
+  // there is a lot of nothing in between
+  // If we loop through those time interval with nothing in it, the creation of outPulses will take forever
+  // Speeds things up by denoting which EICROCcycle contains pulse information
+  // And only focus on those cycles
+  std::unordered_map<dd4hep::rec::CellID, std::unordered_set<int>> ActiveCycles4Cells;
 
   for (const auto& pulse : *inPulses) {
 
@@ -49,43 +55,42 @@ void SiliconPulseDiscretization::process(const SiliconPulseDiscretization::Input
 
     // one TGraph per pulse
     // Interpolate the pulse with TGraph
-    auto& graph = Graph4Cells[cellID];
+    auto& graph        = Graph4Cells[cellID];
+    auto& activeCycles = ActiveCycles4Cells[cellID];
     for (unsigned int i = 0; i < pulse.getAmplitude().size(); i++) {
       auto currTime = time + i * interval;
+      // current EICROC cycle
+      int EICROCCycle = std::floor(currTime / m_cfg.EICROC_period);
+      activeCycles.insert(EICROCCycle);
       graph.SetPoint(graph.GetN(), currTime + m_cfg.global_offset, pulse.getAmplitude()[i]);
     }
   }
 
   // sort all pulses data points to avoid TGraph::Eval giving nan due to non-monotonic data
-  for (auto& [cellID, graph] : Graph4Cells) {
+  for (auto& [cellID, graph] : Graph4Cells)
     graph.Sort();
-  }
 
   // sum all digitized pulses
   for (const auto& [cellID, graph] : Graph4Cells) {
-    double tMin = NAN;
-    double tMax = NAN;
-    double temp = NAN; // do not use
+    const auto& activeCycle = ActiveCycles4Cells[cellID];
+    double tMin             = NAN;
+    double tMax             = NAN;
+    double temp             = NAN; // do not use
     graph.ComputeRange(tMin, temp, tMax, temp);
 
-    // time beings at an EICROC cycle
-    double currTime = std::floor(tMin / m_cfg.EICROC_period) * m_cfg.EICROC_period;
-    // ensure that the outPulse -> create is called in the first cycle
-    int iEICRocCycle = INT_MIN;
+    for (int curriEICRocCycle : activeCycle) {
+      // time beings at an EICROC cycle
+      double startTime = curriEICRocCycle * m_cfg.EICROC_period;
 
-    edm4hep::MutableRawTimeSeries outPulse;
-    for (; currTime <= tMax; currTime += m_cfg.local_period) {
-      // find current EICROC cycle NO to see if we arrive at the next cycle
-      int curriEICRocCycle = std::floor(currTime / m_cfg.EICROC_period);
-      if (curriEICRocCycle != iEICRocCycle) {
-        // new pulse for each EICROC cycle
-        iEICRocCycle = curriEICRocCycle;
-        outPulse     = outPulses->create();
-        outPulse.setCellID(cellID);
-        outPulse.setInterval(m_cfg.local_period);
-        outPulse.setTime(iEICRocCycle * m_cfg.EICROC_period);
-      }
-      outPulse.addToAdcCounts(this->_interpolateOrZero(graph, currTime, tMin, tMax));
+      auto outPulse = outPulses->create();
+      outPulse.setCellID(cellID);
+      outPulse.setInterval(m_cfg.local_period);
+      outPulse.setTime(startTime);
+
+      // stop at the next cycle
+      for (double currTime = startTime; currTime < startTime + m_cfg.EICROC_period;
+           currTime += m_cfg.local_period)
+        outPulse.addToAdcCounts(this->_interpolateOrZero(graph, currTime, tMin, tMax));
     }
   }
 } // SiliconPulseDiscretization:process


### PR DESCRIPTION
… only generate pulses for period where pulse height is non-zero.

### Briefly, what does this PR introduce?

This update improves the performance of `SiliconPulseDiscretization` by avoiding the creation of pulses for time cycles where no signal is recorded.

Previously, the class generated pulses from `tMin` to `tMax`, where `tMin` is the time of the earliest hit and `tMax` the time of the latest. However, in some events, two hits may occur, where one very early and one very late with no activity in between. Creating zero-ADC pulses for this inactive period significantly slowed down `eicrecon`. The new behavior limits pulse creation to only those EIC time periods in which hits are actually registered.

I discovered this issue while running `physics_benchmark` locally. Some events took significantly longer to reconstruct. When I terminated the job during these slow events, the traceback consistently pointed to `SiliconPulseDiscretization`, which led me to identify the bottleneck.

To reproduce the issue, try generating:

```
sim_output/epic_craterlake/pythia8NCDIS_5x41_minQ2=10_beamEffects_xAngle=-0.025_hiDiv_1.0000.eicrecon.edm4eic.root
```

for `physics_benchmark`. Retry a few times. You’ll notice that `eicrecon` drops to 0 Hz for certain events.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No

### Does this PR change default behavior?

No
