### PR TITLE
feat: allow specifying regex for `podio:output_collections`

### DIFF
--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -455,7 +455,7 @@ void JEventProcessorPODIO::FindCollectionsToWrite(const std::shared_ptr<const JE
     std::set<std::string> all_collections_set =
         std::set<std::string>(all_collections.begin(), all_collections.end());
 
-    // Turn regexes among output collections into actual collections
+    // Turn regexes among output collections into actual collection names
     std::set<std::string> matching_collections_set;
     std::vector<std::regex> output_collections_regex(m_output_collections.size());
     std::transform(m_output_collections.begin(), m_output_collections.end(),

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -454,9 +454,10 @@ void JEventProcessorPODIO::FindCollectionsToWrite(const std::shared_ptr<const JE
         std::set<std::string>(all_collections.begin(), all_collections.end());
 
     // Turn regexes among output collections into actual collections
-    std::vector<std::string> matching_collections_set;
+    std::set<std::string> matching_collections_set;
     std::copy_if(all_collections_set.begin(), all_collections_set.end(),
-                 std::back_inserter(matching_collections_set), [&](const std::string& c) {
+                 std::inserter(matching_collections_set, matching_collections_set.end()),
+                 [&](const std::string& c) {
                    return std::any_of(
                        m_output_collections.begin(), m_output_collections.end(),
                        [&](const std::string& r) { return std::regex_match(c, std::regex(r)); });

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -10,7 +10,9 @@
 #include <podio/CollectionBase.h>
 #include <podio/Frame.h>
 #include <podio/ROOTWriter.h>
+#include <algorithm>
 #include <exception>
+#include <iterator>
 #include <ostream>
 #include <regex>
 #include <stdexcept>

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -457,12 +457,16 @@ void JEventProcessorPODIO::FindCollectionsToWrite(const std::shared_ptr<const JE
 
     // Turn regexes among output collections into actual collections
     std::set<std::string> matching_collections_set;
+    std::vector<std::regex> output_collections_regex(m_output_collections.size());
+    std::transform(m_output_collections.begin(), m_output_collections.end(),
+                   output_collections_regex.begin(),
+                   [](const std::string& r) { return std::regex(r); });
     std::copy_if(all_collections_set.begin(), all_collections_set.end(),
                  std::inserter(matching_collections_set, matching_collections_set.end()),
                  [&](const std::string& c) {
-                   return std::any_of(
-                       m_output_collections.begin(), m_output_collections.end(),
-                       [&](const std::string& r) { return std::regex_match(c, std::regex(r)); });
+                   return std::any_of(output_collections_regex.begin(),
+                                      output_collections_regex.end(),
+                                      [&](const std::regex& r) { return std::regex_match(c, r); });
                  });
 
     for (const auto& col : matching_collections_set) {


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds the functionality that allows for specifying regex patterns as `podio:output_collections`, e.g. `eicrecon -Ppodio:output_collections='EcalBarrel.*'` to select all `EcalBarrel` outputs. Note, it's a regex, not a glob.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.