### PR TITLE
fix: suppress spurious `lgamma` data race warning

### DIFF
--- a/.github/tsan.supp
+++ b/.github/tsan.supp
@@ -1,1 +1,5 @@
 # https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
+
+# std::lgamma is not thread-safe but used in thread-safe way by std::binomial_distribution
+race:std::binomial_distribution<int>::param_type::_M_initialize
+race:std::binomial_distribution<int>::operator()


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR suppresses a spurious data race warning in TSAN for `std::lgamma` which is technically not thread-safe (see note at https://en.cppreference.com/w/cpp/numeric/math/lgamma). Since `std::binomial_distribution` only uses the return value of `std::lgamma` without subsequent calls for the `signgam` value (https://github.com/gcc-mirror/gcc/blob/releases/gcc-12.2.0/libstdc%2B%2B-v3/include/bits/random.tcc#L1475), we can safely suppress the warning inside the two functions that call `std::lgamma`.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/EICrecon/actions/runs/15948693486/job/44985972086?pr=1939#step:7:1170)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.