### PR TITLE
fix: lock to avoid potential data race in IrtCherenkovParticleID

### DIFF
--- a/src/algorithms/pid/IrtCherenkovParticleID.cc
+++ b/src/algorithms/pid/IrtCherenkovParticleID.cc
@@ -98,6 +98,7 @@ void IrtCherenkovParticleID::init(CherenkovDetectorCollection* irt_det_coll) {
 
   // check radiators' configuration, and pass it to `m_irt_det`'s radiators
   for (auto [rad_name, irt_rad] : m_pid_radiators) {
+    std::lock_guard<std::mutex> lock(m_irt_det_mutex);
     // find `cfg_rad`, the associated `IrtCherenkovParticleIDConfig` radiator
     auto cfg_rad_it = m_cfg.radiators.find(rad_name);
     if (cfg_rad_it != m_cfg.radiators.end()) {

--- a/src/algorithms/pid/IrtCherenkovParticleID.cc
+++ b/src/algorithms/pid/IrtCherenkovParticleID.cc
@@ -83,7 +83,8 @@ void IrtCherenkovParticleID::init(CherenkovDetectorCollection* irt_det_coll) {
     auto ri_lookup_table_orig = irt_rad->m_ri_lookup_table;
     if (ri_lookup_table_orig.size() != m_cfg.numRIndexBins) {
       irt_rad->m_ri_lookup_table.clear();
-      irt_rad->m_ri_lookup_table = Tools::ApplyFineBinning(ri_lookup_table_orig, m_cfg.numRIndexBins);
+      irt_rad->m_ri_lookup_table =
+          Tools::ApplyFineBinning(ri_lookup_table_orig, m_cfg.numRIndexBins);
     }
   }
 

--- a/src/algorithms/pid/IrtCherenkovParticleID.cc
+++ b/src/algorithms/pid/IrtCherenkovParticleID.cc
@@ -180,7 +180,7 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
     // loop over radiators
     // note: this must run exclusively since irt_rad points to shared IRT objects that are
     // owned by the RichGeo_service; it holds state (e.g. irt_rad->ResetLocation())
-    std::lock_guard<std::mutex> lock(m_pid_radiators_mutex);
+    std::lock_guard<std::mutex> lock(m_irt_det_mutex);
     for (auto [rad_name, irt_rad] : m_pid_radiators) {
 
       // get the `charged_particle` for this radiator

--- a/src/algorithms/pid/IrtCherenkovParticleID.cc
+++ b/src/algorithms/pid/IrtCherenkovParticleID.cc
@@ -57,7 +57,7 @@ void IrtCherenkovParticleID::init(CherenkovDetectorCollection* irt_det_coll) {
               "use MC photon vertex, wavelength, refractive index");
   print_cheat("cheatTrueRadiator", m_cfg.cheatTrueRadiator, "use MC truth to obtain true radiator");
 
-  // extract the the relevant `CherenkovDetector`, set to `m_irt_det`
+  // extract the relevant `CherenkovDetector`, set to `m_irt_det`
   const auto& detectors = m_irt_det_coll->GetDetectors();
   if (detectors.empty()) {
     throw std::runtime_error("No CherenkovDetectors found in input collection `irt_det_coll`");

--- a/src/algorithms/pid/IrtCherenkovParticleID.h
+++ b/src/algorithms/pid/IrtCherenkovParticleID.h
@@ -60,7 +60,7 @@ public:
 
 private:
   // any access (R or W) to m_irt_det_coll, m_irt_det, m_pid_radiators must be locked
-  mutable std::mutex m_irt_det_mutex;
+  inline static std::mutex m_irt_det_mutex;
   CherenkovDetectorCollection* m_irt_det_coll;
   CherenkovDetector* m_irt_det;
   std::map<std::string, CherenkovRadiator*> m_pid_radiators;

--- a/src/algorithms/pid/IrtCherenkovParticleID.h
+++ b/src/algorithms/pid/IrtCherenkovParticleID.h
@@ -59,8 +59,10 @@ public:
   void process(const Input&, const Output&) const;
 
 private:
+  // any access (R or W) to m_irt_det_coll, m_irt_det, m_pid_radiators must be locked
   CherenkovDetectorCollection* m_irt_det_coll;
   CherenkovDetector* m_irt_det;
+  std::map<std::string, CherenkovRadiator*> m_pid_radiators;
 
   const algorithms::ParticleSvc& m_particleSvc = algorithms::ParticleSvc::instance();
 
@@ -69,7 +71,6 @@ private:
   std::unordered_map<int, double> m_pdg_mass;
 
   inline static std::mutex m_pid_radiators_mutex;
-  std::map<std::string, CherenkovRadiator*> m_pid_radiators;
 };
 
 } // namespace eicrecon

--- a/src/algorithms/pid/IrtCherenkovParticleID.h
+++ b/src/algorithms/pid/IrtCherenkovParticleID.h
@@ -60,6 +60,7 @@ public:
 
 private:
   // any access (R or W) to m_irt_det_coll, m_irt_det, m_pid_radiators must be locked
+  mutable std::mutex m_irt_det_mutex;
   CherenkovDetectorCollection* m_irt_det_coll;
   CherenkovDetector* m_irt_det;
   std::map<std::string, CherenkovRadiator*> m_pid_radiators;
@@ -69,8 +70,6 @@ private:
   uint64_t m_cell_mask;
   std::string m_det_name;
   std::unordered_map<int, double> m_pdg_mass;
-
-  inline static std::mutex m_pid_radiators_mutex;
 };
 
 } // namespace eicrecon


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes #1937 by adding more scoped lock_guards.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #1937)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.