### PR TITLE
fix: avoid duplicate factory name (CentralTrackVertices)

### DIFF
--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -353,7 +353,7 @@ void InitPlugin(JApplication* app) {
       app));
 
   app->Add(new JOmniFactoryGeneratorT<IterativeVertexFinder_factory>(
-      "CentralTrackVertices",
+      "CentralAndB0TrackVertices",
       {
           "CentralAndB0TrackerCKFActsTrajectories",
           "ReconstructedChargedParticles",

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -359,7 +359,7 @@ void InitPlugin(JApplication* app) {
           "ReconstructedChargedParticles",
       },
       {
-          "CentralAndB0TrackerVertices",
+          "CentralAndB0TrackVertices",
       },
       {}, app));
 

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -236,7 +236,7 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
     "B0TrackerCKFTracksUnfiltered",
     "B0TrackerCKFTrackUnfilteredAssociations",
 
-    "CentralAndB0TrackerVertices",
+    "CentralAndB0TrackVertices",
 
     // Inclusive kinematics
     "InclusiveKinematicsDA",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes an issue that snuck in with #1744, namely a duplicate factory name `CentralTrackVertices` which results in the warning:
```
14:47:13.866  [warn] Parameter 'tracking:CentralTrackVertices:InputTags' has conflicting defaults: 'CentralAndB0TrackerCKFActsTrajectories,ReconstructedChargedParticles' vs 'CentralCKFActsTrajectories,ReconstructedChargedParticles'
14:47:13.866  [warn] Parameter 'tracking:CentralTrackVertices:OutputTags' has conflicting defaults: 'CentralAndB0TrackerVertices' vs 'CentralTrackVertices'
```

We'll have to see how this affects the comment at https://github.com/eic/EICrecon/pull/1744#discussion_r2159507602 ...

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.