### PR TITLE
feat: make Acts underlying data model a template parameter

### DIFF
--- a/src/algorithms/tracking/ActsExamplesEdm.h
+++ b/src/algorithms/tracking/ActsExamplesEdm.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2025 Wouter Deconinck
+
+#pragma once
+
+#include <ActsExamples/EventData/Track.hpp>
+#include <ActsExamples/EventData/Trajectories.hpp>
+
+namespace eicrecon {
+
+class ActsExamplesEdm {
+
+public:
+  /// (Reconstructed) track parameters e.g. close to the vertex.
+  using TrackParameters = ActsExamples::TrackParameters;
+  /// Container of reconstructed track states for multiple tracks.
+  using TrackParametersContainer = ActsExamples::TrackParametersContainer;
+
+  using TrackContainer = ActsExamples::TrackContainer;
+
+  using ConstTrackContainer = ActsExamples::ConstTrackContainer;
+
+  using TrackIndexType = ActsExamples::TrackIndexType;
+
+  using TrackProxy      = ActsExamples::TrackProxy;
+  using ConstTrackProxy = ActsExamples::ConstTrackProxy;
+
+  using TrackStateProxy      = ActsExamples::TrackStateProxy;
+  using ConstTrackStateProxy = ActsExamples::ConstTrackStateProxy;
+
+  using Trajectories          = ActsExamples::Trajectories;
+  using TrajectoriesContainer = ActsExamples::TrajectoriesContainer;
+};
+
+} // namespace eicrecon

--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -102,10 +102,9 @@ static constexpr std::array<std::pair<Acts::BoundIndices, double>, 6> edm4eic_in
      {Acts::eBoundQOverP, 1. / Acts::UnitConstants::GeV},
      {Acts::eBoundTime, Acts::UnitConstants::ns}}};
 
-CKFTracking::CKFTracking() = default;
-
-void CKFTracking::init(std::shared_ptr<const ActsGeometryProvider> geo_svc,
-                       std::shared_ptr<spdlog::logger> log) {
+template <typename edm_t>
+void CKFTracking<edm_t>::init(std::shared_ptr<const ActsGeometryProvider> geo_svc,
+                              std::shared_ptr<spdlog::logger> log) {
   m_log         = log;
   m_acts_logger = eicrecon::getSpdlogLogger("CKF", m_log);
 
@@ -126,10 +125,11 @@ void CKFTracking::init(std::shared_ptr<const ActsGeometryProvider> geo_svc,
       CKFTracking::makeCKFTrackingFunction(m_geoSvc->trackingGeometry(), m_BField, logger());
 }
 
-std::tuple<std::vector<ActsExamples::Trajectories*>,
-           std::vector<ActsExamples::ConstTrackContainer*>>
-CKFTracking::process(const edm4eic::TrackParametersCollection& init_trk_params,
-                     const edm4eic::Measurement2DCollection& meas2Ds) {
+template <typename edm_t>
+std::tuple<std::vector<typename edm_t::Trajectories*>,
+           std::vector<typename edm_t::ConstTrackContainer*>>
+CKFTracking<edm_t>::process(const edm4eic::TrackParametersCollection& init_trk_params,
+                            const edm4eic::Measurement2DCollection& meas2Ds) {
 
   // create sourcelink and measurement containers
   auto measurements = std::make_shared<ActsExamples::MeasurementContainer>();
@@ -209,7 +209,7 @@ CKFTracking::process(const edm4eic::TrackParametersCollection& init_trk_params,
     hit_index++;
   }
 
-  ActsExamples::TrackParametersContainer acts_init_trk_params;
+  typename edm_t::TrackParametersContainer acts_init_trk_params;
   for (const auto& track_parameter : init_trk_params) {
 
     Acts::BoundVector params;
@@ -259,7 +259,7 @@ CKFTracking::process(const edm4eic::TrackParametersCollection& init_trk_params,
   Acts::MeasurementSelector measSel{m_sourcelinkSelectorCfg};
 
 #if Acts_VERSION_MAJOR >= 36
-  Acts::CombinatorialKalmanFilterExtensions<ActsExamples::TrackContainer> extensions;
+  Acts::CombinatorialKalmanFilterExtensions<typename edm_t::TrackContainer> extensions;
 #else
   Acts::CombinatorialKalmanFilterExtensions<Acts::VectorMultiTrajectory> extensions;
 #endif
@@ -268,8 +268,8 @@ CKFTracking::process(const edm4eic::TrackParametersCollection& init_trk_params,
       &calibrator);
 #endif
 #if Acts_VERSION_MAJOR >= 36
-  extensions.updater.connect<&Acts::GainMatrixUpdater::operator()<
-      typename ActsExamples::TrackContainer::TrackStateContainerBackend>>(&kfUpdater);
+  extensions.updater.template connect<&Acts::GainMatrixUpdater::operator()<
+      typename edm_t::TrackContainer::TrackStateContainerBackend>>(&kfUpdater);
 #else
   extensions.updater.connect<&Acts::GainMatrixUpdater::operator()<Acts::VectorMultiTrajectory>>(
       &kfUpdater);
@@ -280,7 +280,7 @@ CKFTracking::process(const edm4eic::TrackParametersCollection& init_trk_params,
 #endif
 #if (Acts_VERSION_MAJOR >= 36) && (Acts_VERSION_MAJOR < 39)
   extensions.measurementSelector.connect<&Acts::MeasurementSelector::select<
-      typename ActsExamples::TrackContainer::TrackStateContainerBackend>>(&measSel);
+      typename edm_t::TrackContainer::TrackStateContainerBackend>>(&measSel);
 #elif Acts_VERSION_MAJOR < 39
   extensions.measurementSelector
       .connect<&Acts::MeasurementSelector::select<Acts::VectorMultiTrajectory>>(&measSel);
@@ -295,7 +295,7 @@ CKFTracking::process(const edm4eic::TrackParametersCollection& init_trk_params,
 #if Acts_VERSION_MAJOR >= 39
   using TrackStateCreatorType =
       Acts::TrackStateCreator<ActsExamples::IndexSourceLinkAccessor::Iterator,
-                              ActsExamples::TrackContainer>;
+                              typename edm_t::TrackContainer>;
   TrackStateCreatorType trackStateCreator;
   trackStateCreator.sourceLinkAccessor
       .template connect<&ActsExamples::IndexSourceLinkAccessor::range>(&slAccessor);
@@ -349,12 +349,13 @@ CKFTracking::process(const edm4eic::TrackParametersCollection& init_trk_params,
 #endif
 
   // Create track container
-  auto trackContainer      = std::make_shared<Acts::VectorTrackContainer>();
-  auto trackStateContainer = std::make_shared<Acts::VectorMultiTrajectory>();
-  ActsExamples::TrackContainer acts_tracks(trackContainer, trackStateContainer);
+  auto trackContainer = std::make_shared<typename edm_t::TrackContainer::TrackContainerBackend>();
+  auto trackStateContainer =
+      std::make_shared<typename edm_t::TrackContainer::TrackStateContainerBackend>();
+  typename edm_t::TrackContainer acts_tracks(trackContainer, trackStateContainer);
 
   // Add seed number column
-  acts_tracks.addColumn<unsigned int>("seed");
+  acts_tracks.template addColumn<unsigned int>("seed");
   Acts::ProxyAccessor<unsigned int> seedNumber("seed");
   std::set<Acts::TrackIndexType> passed_tracks;
 
@@ -415,26 +416,28 @@ CKFTracking::process(const edm4eic::TrackParametersCollection& init_trk_params,
   // NOTE Using the non-const containers leads to references to
   // implicitly converted temporaries inside the Trajectories.
   auto constTrackStateContainer =
-      std::make_shared<Acts::ConstVectorMultiTrajectory>(std::move(*trackStateContainer));
+      std::make_shared<typename edm_t::ConstTrackContainer::TrackStateContainerBackend>(
+          std::move(*trackStateContainer));
 
   auto constTrackContainer =
-      std::make_shared<Acts::ConstVectorTrackContainer>(std::move(*trackContainer));
+      std::make_shared<typename edm_t::ConstTrackContainer::TrackContainerBackend>(
+          std::move(*trackContainer));
 
   // FIXME JANA2 std::vector<T*> requires wrapping ConstTrackContainer, instead of:
   //ConstTrackContainer constTracks(constTrackContainer, constTrackStateContainer);
-  std::vector<ActsExamples::ConstTrackContainer*> constTracks_v;
+  std::vector<typename edm_t::ConstTrackContainer*> constTracks_v;
   constTracks_v.push_back(
-      new ActsExamples::ConstTrackContainer(constTrackContainer, constTrackStateContainer));
+      new edm_t::ConstTrackContainer(constTrackContainer, constTrackStateContainer));
   auto& constTracks = *(constTracks_v.front());
 
   // Seed number column accessor
   const Acts::ConstProxyAccessor<unsigned int> constSeedNumber("seed");
 
   // Prepare the output data with MultiTrajectory, per seed
-  std::vector<ActsExamples::Trajectories*> acts_trajectories;
+  std::vector<typename edm_t::Trajectories*> acts_trajectories;
   acts_trajectories.reserve(init_trk_params.size());
 
-  ActsExamples::Trajectories::IndexedParameters parameters;
+  typename edm_t::Trajectories::IndexedParameters parameters;
   std::vector<Acts::MultiTrajectoryTraits::IndexType> tips;
 
   std::optional<unsigned int> lastSeed;
@@ -446,7 +449,7 @@ CKFTracking::process(const edm4eic::TrackParametersCollection& init_trk_params,
     if (constSeedNumber(track) != lastSeed.value()) {
       // make copies and clear vectors
       acts_trajectories.push_back(
-          new ActsExamples::Trajectories(constTracks.trackStateContainer(), tips, parameters));
+          new edm_t::Trajectories(constTracks.trackStateContainer(), tips, parameters));
 
       tips.clear();
       parameters.clear();
@@ -455,10 +458,10 @@ CKFTracking::process(const edm4eic::TrackParametersCollection& init_trk_params,
     lastSeed = constSeedNumber(track);
 
     tips.push_back(track.tipIndex());
-    parameters.emplace(std::pair{
+    parameters.emplace(std::make_pair(
         track.tipIndex(),
-        ActsExamples::TrackParameters{track.referenceSurface().getSharedPtr(), track.parameters(),
-                                      track.covariance(), track.particleHypothesis()}});
+        edm_t::TrackParameters(track.referenceSurface().getSharedPtr(), track.parameters(),
+                               track.covariance(), track.particleHypothesis())));
   }
 
   if (tips.empty()) {
@@ -466,10 +469,12 @@ CKFTracking::process(const edm4eic::TrackParametersCollection& init_trk_params,
   }
 
   // last entry: move vectors
-  acts_trajectories.push_back(new ActsExamples::Trajectories(
-      constTracks.trackStateContainer(), std::move(tips), std::move(parameters)));
+  acts_trajectories.push_back(new edm_t::Trajectories(constTracks.trackStateContainer(),
+                                                      std::move(tips), std::move(parameters)));
 
   return std::make_tuple(std::move(acts_trajectories), std::move(constTracks_v));
 }
+
+template <> class CKFTracking<ActsExamplesEdm>;
 
 } // namespace eicrecon

--- a/src/algorithms/tracking/CKFTracking.h
+++ b/src/algorithms/tracking/CKFTracking.h
@@ -24,6 +24,8 @@
 #include <tuple>
 #include <vector>
 
+#include "ActsExamplesEdm.h"
+
 #include "CKFTrackingConfig.h"
 #include "DD4hepBField.h"
 #include "algorithms/interfaces/WithPodConfig.h"
@@ -37,22 +39,23 @@ namespace eicrecon {
  * \ingroup tracking
  */
 
+template <typename edm_t = eicrecon::ActsExamplesEdm>
 class CKFTracking : public WithPodConfig<eicrecon::CKFTrackingConfig> {
 public:
   /// Track finder function that takes input measurements, initial trackstate
   /// and track finder options and returns some track-finder-specific result.
 #if Acts_VERSION_MAJOR >= 39
-  using TrackFinderOptions = Acts::CombinatorialKalmanFilterOptions<ActsExamples::TrackContainer>;
+  using TrackFinderOptions = Acts::CombinatorialKalmanFilterOptions<typename edm_t::TrackContainer>;
 #elif Acts_VERSION_MAJOR >= 36
   using TrackFinderOptions =
       Acts::CombinatorialKalmanFilterOptions<ActsExamples::IndexSourceLinkAccessor::Iterator,
-                                             ActsExamples::TrackContainer>;
+                                             edm_t::TrackContainer>;
 #else
   using TrackFinderOptions =
       Acts::CombinatorialKalmanFilterOptions<ActsExamples::IndexSourceLinkAccessor::Iterator,
                                              Acts::VectorMultiTrajectory>;
 #endif
-  using TrackFinderResult = Acts::Result<std::vector<ActsExamples::TrackContainer::TrackProxy>>;
+  using TrackFinderResult = Acts::Result<std::vector<typename edm_t::TrackContainer::TrackProxy>>;
 
   /// Find function that takes the above parameters
   /// @note This is separated into a virtual interface to keep compilation units
@@ -61,9 +64,8 @@ public:
   public:
     virtual ~CKFTrackingFunction() = default;
 
-    virtual TrackFinderResult operator()(const ActsExamples::TrackParameters&,
-                                         const TrackFinderOptions&,
-                                         ActsExamples::TrackContainer&) const = 0;
+    virtual TrackFinderResult operator()(const edm_t::TrackParameters&, const TrackFinderOptions&,
+                                         edm_t::TrackContainer&) const = 0;
   };
 
   /// Create the track finder function implementation.
@@ -74,13 +76,13 @@ public:
                           std::shared_ptr<const Acts::MagneticFieldProvider> magneticField,
                           const Acts::Logger& logger);
 
-  CKFTracking();
+  CKFTracking() = default;
 
   void init(std::shared_ptr<const ActsGeometryProvider> geo_svc,
             std::shared_ptr<spdlog::logger> log);
 
-  std::tuple<std::vector<ActsExamples::Trajectories*>,
-             std::vector<ActsExamples::ConstTrackContainer*>>
+  std::tuple<std::vector<typename edm_t::Trajectories*>,
+             std::vector<typename edm_t::ConstTrackContainer*>>
   process(const edm4eic::TrackParametersCollection& init_trk_params,
           const edm4eic::Measurement2DCollection& meas2Ds);
 

--- a/src/algorithms/tracking/CKFTrackingFunction.cc
+++ b/src/algorithms/tracking/CKFTrackingFunction.cc
@@ -34,41 +34,35 @@ using Stepper    = Acts::EigenStepper<>;
 using Navigator  = Acts::Navigator;
 using Propagator = Acts::Propagator<Stepper, Navigator>;
 
-#if Acts_VERSION_MAJOR >= 36
-using CKF = Acts::CombinatorialKalmanFilter<Propagator, ActsExamples::TrackContainer>;
-#else
-using CKF = Acts::CombinatorialKalmanFilter<Propagator, Acts::VectorMultiTrajectory>;
-
-using TrackContainer =
-    Acts::TrackContainer<Acts::VectorTrackContainer, Acts::VectorMultiTrajectory, std::shared_ptr>;
-#endif
-
 /** Finder implementation .
    *
    * \ingroup track
    */
-struct CKFTrackingFunctionImpl : public eicrecon::CKFTracking::CKFTrackingFunction {
+template <typename edm_t>
+struct CKFTrackingFunctionImpl : public eicrecon::CKFTracking<edm_t>::CKFTrackingFunction {
+
+#if Acts_VERSION_MAJOR >= 36
+  using CKF = Acts::CombinatorialKalmanFilter<Propagator, typename edm_t::TrackContainer>;
+#else
+  using CKF = Acts::CombinatorialKalmanFilter<Propagator,
+                                              typename edm_t::TrackContainer::TrackStateBackend>;
+#endif
+
   CKF trackFinder;
 
   CKFTrackingFunctionImpl(CKF&& f) : trackFinder(std::move(f)) {}
 
-  eicrecon::CKFTracking::TrackFinderResult
-  operator()(const ActsExamples::TrackParameters& initialParameters,
-             const eicrecon::CKFTracking::TrackFinderOptions& options,
-#if Acts_VERSION_MAJOR >= 36
-             ActsExamples::TrackContainer& tracks) const override {
-#else
-             TrackContainer& tracks) const override {
-#endif
+  eicrecon::CKFTracking<edm_t>::TrackFinderResult
+  operator()(const edm_t::TrackParameters& initialParameters,
+             const eicrecon::CKFTracking<edm_t>::TrackFinderOptions& options,
+             edm_t::TrackContainer& tracks) const override {
     return trackFinder.findTracks(initialParameters, options, tracks);
   };
 };
 
-} // namespace eicrecon
-
-namespace eicrecon {
-
-std::shared_ptr<CKFTracking::CKFTrackingFunction> CKFTracking::makeCKFTrackingFunction(
+template <typename edm_t>
+std::shared_ptr<typename CKFTracking<edm_t>::CKFTrackingFunction>
+CKFTracking<edm_t>::makeCKFTrackingFunction(
     std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry,
     std::shared_ptr<const Acts::MagneticFieldProvider> magneticField, const Acts::Logger& logger) {
   Stepper stepper(std::move(magneticField));
@@ -79,10 +73,13 @@ std::shared_ptr<CKFTracking::CKFTrackingFunction> CKFTracking::makeCKFTrackingFu
   Navigator navigator(cfg);
 
   Propagator propagator(std::move(stepper), std::move(navigator));
-  CKF trackFinder(std::move(propagator), logger.cloneWithSuffix("CKF"));
+  typename CKFTracking<edm_t>::CKFTrackingFunctionImpl::CKF trackFinder(
+      std::move(propagator), logger.cloneWithSuffix("CKF"));
 
   // build the track finder functions. owns the track finder object.
   return std::make_shared<CKFTrackingFunctionImpl>(std::move(trackFinder));
 }
+
+template <> class CKFTrackingFunctionImpl<ActsExamplesEdm>;
 
 } // namespace eicrecon

--- a/src/factories/tracking/CKFTracking_factory.h
+++ b/src/factories/tracking/CKFTracking_factory.h
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include "ActsExamples/EventData/Trajectories.hpp"
+#include "algorithms/tracking/ActsExamplesEdm.h"
 #include "algorithms/tracking/CKFTracking.h"
 #include "algorithms/tracking/CKFTrackingConfig.h"
 #include "extensions/jana/JOmniFactory.h"
@@ -21,32 +21,42 @@
 
 namespace eicrecon {
 
-class CKFTracking_factory : public JOmniFactory<CKFTracking_factory, CKFTrackingConfig> {
+template <typename edm_t = eicrecon::ActsExamplesEdm>
+class CKFTracking_factory : public JOmniFactory<CKFTracking_factory<edm_t>, CKFTrackingConfig> {
 
 private:
-  using AlgoT = eicrecon::CKFTracking;
+  using AlgoT    = eicrecon::CKFTracking<edm_t>;
+  using FactoryT = JOmniFactory<CKFTracking_factory<edm_t>, CKFTrackingConfig>;
+
   std::unique_ptr<AlgoT> m_algo;
+
+  template <typename T> using PodioInput = typename FactoryT::template PodioInput<T>;
+  template <typename T> using Output     = typename FactoryT::template Output<T>;
 
   PodioInput<edm4eic::TrackParameters> m_parameters_input{this};
   PodioInput<edm4eic::Measurement2D> m_measurements_input{this};
-  Output<ActsExamples::Trajectories> m_acts_trajectories_output{this};
-  Output<ActsExamples::ConstTrackContainer> m_acts_tracks_output{this};
+  Output<typename edm_t::Trajectories> m_acts_trajectories_output{this};
+  Output<typename edm_t::ConstTrackContainer> m_acts_tracks_output{this};
 
-  ParameterRef<std::vector<double>> m_etaBins{this, "EtaBins", config().etaBins,
+  template <typename T> using ParameterRef = typename FactoryT::template ParameterRef<T>;
+
+  ParameterRef<std::vector<double>> m_etaBins{this, "EtaBins", this->config().etaBins,
                                               "Eta Bins for ACTS CKF tracking reco"};
-  ParameterRef<std::vector<double>> m_chi2CutOff{this, "Chi2CutOff", config().chi2CutOff,
+  ParameterRef<std::vector<double>> m_chi2CutOff{this, "Chi2CutOff", this->config().chi2CutOff,
                                                  "Chi2 Cut Off for ACTS CKF tracking"};
   ParameterRef<std::vector<std::size_t>> m_numMeasurementsCutOff{
-      this, "NumMeasurementsCutOff", config().numMeasurementsCutOff,
+      this, "NumMeasurementsCutOff", this->config().numMeasurementsCutOff,
       "Number of measurements Cut Off for ACTS CKF tracking"};
+
+  template <typename T> using Service = typename FactoryT::template Service<T>;
 
   Service<ACTSGeo_service> m_ACTSGeoSvc{this};
 
 public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>();
-    m_algo->applyConfig(config());
-    m_algo->init(m_ACTSGeoSvc().actsGeoProvider(), logger());
+    m_algo->applyConfig(this->config());
+    m_algo->init(m_ACTSGeoSvc().actsGeoProvider(), this->logger());
   }
 
   void ChangeRun(int32_t /* run_number */) {}

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -79,7 +79,7 @@ void InitPlugin(JApplication* app) {
       "CentralTrackerMeasurements", {"CentralTrackingRecHits"}, {"CentralTrackerMeasurements"},
       app));
 
-  app->Add(new JOmniFactoryGeneratorT<CKFTracking_factory>(
+  app->Add(new JOmniFactoryGeneratorT<CKFTracking_factory<eicrecon::ActsExamplesEdm>>(
       "CentralCKFTruthSeededTrajectories",
       {"CentralTrackerTruthSeeds", "CentralTrackerMeasurements"},
       {
@@ -131,7 +131,7 @@ void InitPlugin(JApplication* app) {
       "CentralTrackSeedingResults", {"CentralTrackingRecHits"}, {"CentralTrackSeedingResults"}, {},
       app));
 
-  app->Add(new JOmniFactoryGeneratorT<CKFTracking_factory>(
+  app->Add(new JOmniFactoryGeneratorT<CKFTracking_factory<eicrecon::ActsExamplesEdm>>(
       "CentralCKFTrajectories", {"CentralTrackSeedingResults", "CentralTrackerMeasurements"},
       {
           "CentralCKFActsTrajectoriesUnfiltered",
@@ -242,7 +242,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<TrackerMeasurementFromHits_factory>(
       "B0TrackerMeasurements", {"B0TrackerRecHits"}, {"B0TrackerMeasurements"}, app));
 
-  app->Add(new JOmniFactoryGeneratorT<CKFTracking_factory>(
+  app->Add(new JOmniFactoryGeneratorT<CKFTracking_factory<eicrecon::ActsExamplesEdm>>(
       "B0TrackerCKFTruthSeededTrajectories", {"B0TrackerTruthSeeds", "B0TrackerMeasurements"},
       {
           "B0TrackerCKFTruthSeededActsTrajectoriesUnfiltered",
@@ -292,7 +292,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<TrackSeeding_factory>(
       "B0TrackerTrackSeedingResults", {"B0TrackerRecHits"}, {"B0TrackerSeedingResults"}, {}, app));
 
-  app->Add(new JOmniFactoryGeneratorT<CKFTracking_factory>(
+  app->Add(new JOmniFactoryGeneratorT<CKFTracking_factory<eicrecon::ActsExamplesEdm>>(
       "B0TrackerCKFTrajectories", {"B0TrackerSeedingResults", "B0TrackerMeasurements"},
       {
           "B0TrackerCKFActsTrajectoriesUnfiltered",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR abstracts the Acts underlying data model to allow for easier swapping out with the podio data model.

The strategy here is to put all the support in place, but not make a change to the underlying data model itself. Then a separate PR can be used to make the actual switch.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: use podio-based data model for Acts and store in output files)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.