### PR TITLE
fix: no-var-tracking during kParticleMap init in ParticleSvc.h

### DIFF
--- a/src/algorithms/interfaces/ParticleSvc.h
+++ b/src/algorithms/interfaces/ParticleSvc.h
@@ -288,7 +288,7 @@ private:
     {  1000010030, {  1000010030,   1,   2.80925       , "Tritium" }},
     {  1000020030, {  1000020030,   2,   2.80923       , "He-3" }},
     {  1000020040, {  1000020040,   2,   3.72742       , "Alpha" }},
-    // clang-format on
+      // clang-format on
   };
 #pragma GCC diagnostic pop
 };


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR hopefully speeds up the gcc builds by disabling the constantly failing variable tracking that seems to trip up over the `kParticleMap` definition in `ParticleSvc`.

- Before: 52 minutes (https://github.com/eic/EICrecon/actions/runs/16080433291/job/45384162904?pr=1948)
- After: 37 minutes (https://github.com/eic/EICrecon/actions/runs/16081076665/job/45385856004?pr=1949)

Note: not accounting for caching.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: gcc takes 40 minutes to compile...)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.