### PR TITLE
updated the matrices for the OMD 130 GeV/n deuteron beams

### DIFF
--- a/src/detectors/FOFFMTRK/FOFFMTRK.cc
+++ b/src/detectors/FOFFMTRK/FOFFMTRK.cc
@@ -44,27 +44,27 @@ void InitPlugin(JApplication* app) {
 
               .aX =
                   {
-                      {1.61591, 12.6786},
-                      {0.184206, -2.907},
+                      {2.08344, 5.37571},
+                      {0.188756, -2.90941},
                   },
 
               .aY =
                   {
-                      {-0.789385, -28.5578},
-                      {-0.0721796, -2.8763},
+                      {-0.977013, -35.7785},
+                      {-0.0812252, -2.86315},
                   },
 
-              .local_x_offset       = -881.631,
-              .local_y_offset       = -0.00552173,
-              .local_x_slope_offset = -59.7386,
-              .local_y_slope_offset = -0.00360656,
+              .local_x_offset       = -1032.2,
+              .local_y_offset       = 0.00462829,
+              .local_x_slope_offset = -59.7363,
+              .local_y_slope_offset = -0.0030213,
 
           }},
 
-          .hit1minZ = 22490.0,
-          .hit1maxZ = 22512.0,
-          .hit2minZ = 24512.0,
-          .hit2maxZ = 24535.0,
+          .hit1minZ = 25490.0,
+          .hit1maxZ = 25512.0,
+          .hit2minZ = 27012.0,
+          .hit2maxZ = 27035.0,
 
           .readout = "ForwardOffMTrackerRecHits",
       },


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This PR introduces the update OMD matrices to account for changes in the cryostat (PR: https://github.com/eic/epic/pull/893) that forced the OMD to move further from the IP.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No, this will allow PR https://github.com/eic/epic/pull/893 to be merged (at the same time as this one) without breaking the reconstruction.

### Does this PR change default behavior?

When both PRs are merged, no, it returns things to default behavior.
