### PR TITLE
1962 ep cut for epi separation

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterEoverPCut.cc
+++ b/src/algorithms/calorimetry/CalorimeterEoverPCut.cc
@@ -1,0 +1,64 @@
+#include <edm4eic/EDM4eicVersion.h>
+
+#if EDM4EIC_VERSION_MAJOR >= 8
+#include <cstddef>
+#include <services/log/Log.h>
+#include <edm4hep/MCParticle.h>
+#include <edm4hep/utils/vector_utils.h>
+#include <cmath>
+#include "CalorimeterEoverPCut.h"
+
+namespace eicrecon {
+
+void CalorimeterEoverPCut::init() {
+  // Nothing to do on init
+}
+
+void CalorimeterEoverPCut::process(const CalorimeterEoverPCut::Input&  input,
+                                   const CalorimeterEoverPCut::Output& output) const {
+
+  // Unpack inputs and outputs
+  const auto& [clusters, assoc_opt] = input;
+  auto&       [pid_coll]            = output;  // shared_ptr<ParticleIDCollection>
+
+  if (!assoc_opt) {
+    jwarn << "[E/P Cut] No MC associations provided, skipping" << jendl;
+    return;
+  }
+  const auto& assocs = *assoc_opt;
+
+  // Loop over every cluster
+  for (const auto& cluster : *clusters) {
+    // Find the MC association with highest weight
+    bool found = false;
+    edm4eic::MCRecoClusterParticleAssociation bestAssoc;
+    for (const auto& assoc : assocs) {
+      if (assoc.getRec() == cluster &&
+         (!found || assoc.getWeight() > bestAssoc.getWeight())) {
+        found     = true;
+        bestAssoc = assoc;
+      }
+    }
+    if (!found) {
+      jwarn << "[E/P Cut] Cluster without association, skipping" << jendl;
+      continue;
+    }
+
+    // Compute track momentum and E/P
+    double ptrack = edm4hep::utils::magnitude(bestAssoc.getSim().getMomentum());
+    double ep     = (ptrack > 0. ? cluster.getEnergy() / ptrack : 0.0);
+
+    // Apply the cut
+    if (ep > config().ecut) {
+      auto pid = pid_coll->create();
+      pid.setType(0);            // algorithm-specific type
+      pid.setPDG(11);            // PDG code for electron
+      pid.setAlgorithmType(0);   // user-defined algorithm tag
+      pid.setLikelihood(ep);     // store EP as likelihood
+      pid.setReference(cluster); // link back to the cluster
+    }
+  }
+}
+
+} // namespace eicrecon
+#endif

--- a/src/algorithms/calorimetry/CalorimeterEoverPCut.h
+++ b/src/algorithms/calorimetry/CalorimeterEoverPCut.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <algorithms/algorithm.h>
+#include <edm4eic/ClusterCollection.h>
+#include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
+#include <edm4hep/ParticleIDCollection.h>
+#include <algorithms/interfaces/WithPodConfig.h>
+#include "factories/calorimetry/CalorimeterEoverPCut_factory.h"
+
+namespace eicrecon {
+
+// Define base type: inputs = Clusters + optional Assocs, output = ParticleIDCollection
+using CalorimeterEoverPCutAlgorithm = algorithms::Algorithm<
+    algorithms::Input<edm4eic::ClusterCollection,
+                      std::optional<edm4eic::MCRecoClusterParticleAssociationCollection>>,
+    algorithms::Output<edm4hep::ParticleIDCollection>>;
+
+// E/P Cut algorithm implementing the base and reading config from factory
+class CalorimeterEoverPCut : public CalorimeterEoverPCutAlgorithm,
+                             public WithPodConfig<CalorimeterEoverPCutConfig> {
+public:
+  // name: factory prefix, inputs: "inputClusters","inputAssocs", outputs: "outputPIDs"
+  CalorimeterEoverPCut(std::string_view name)
+    : CalorimeterEoverPCutAlgorithm{name,
+        {"inputClusters","inputAssocs"},
+        {"outputPIDs"},
+        "E/P Cut Algorithm"},
+      WithPodConfig<CalorimeterEoverPCutConfig>{} {}
+
+  void init() final {}
+  void process(const Input&, const Output&) const final;
+};
+
+} // namespace eicrecon

--- a/src/algorithms/calorimetry/CalorimeterEoverPCut.h
+++ b/src/algorithms/calorimetry/CalorimeterEoverPCut.h
@@ -1,34 +1,49 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2025 You
+
 #pragma once
 
 #include <algorithms/algorithm.h>
 #include <edm4eic/ClusterCollection.h>
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <edm4hep/ParticleIDCollection.h>
-#include <algorithms/interfaces/WithPodConfig.h>
-#include "factories/calorimetry/CalorimeterEoverPCut_factory.h"
 
 namespace eicrecon {
 
-// Define base type: inputs = Clusters + optional Assocs, output = ParticleIDCollection
-using CalorimeterEoverPCutAlgorithm = algorithms::Algorithm<
-    algorithms::Input<edm4eic::ClusterCollection,
-                      std::optional<edm4eic::MCRecoClusterParticleAssociationCollection>>,
-    algorithms::Output<edm4hep::ParticleIDCollection>>;
+// Base alias: inputs=(clusters + optional assocs), outputs=ParticleIDCollection
+using CalorimeterEoverPCutAlgorithmBase = algorithms::Algorithm<
+    algorithms::Input<
+      edm4eic::ClusterCollection,
+      std::optional<edm4eic::MCRecoClusterParticleAssociationCollection>
+    >,
+    algorithms::Output<edm4hep::ParticleIDCollection>
+>;
 
-// E/P Cut algorithm implementing the base and reading config from factory
-class CalorimeterEoverPCut : public CalorimeterEoverPCutAlgorithm,
-                             public WithPodConfig<CalorimeterEoverPCutConfig> {
+/// A simple E/P‑cut algorithm holding its own threshold and layer limit
+class CalorimeterEoverPCut : public CalorimeterEoverPCutAlgorithmBase {
 public:
-  // name: factory prefix, inputs: "inputClusters","inputAssocs", outputs: "outputPIDs"
   CalorimeterEoverPCut(std::string_view name)
-    : CalorimeterEoverPCutAlgorithm{name,
-        {"inputClusters","inputAssocs"},
+    : CalorimeterEoverPCutAlgorithmBase{
+        name,
+        {"inputClusters", "inputAssocs"},
         {"outputPIDs"},
-        "E/P Cut Algorithm"},
-      WithPodConfig<CalorimeterEoverPCutConfig>{} {}
+        "E/P Cut (manual config)"
+      }
+    , m_ecut(0.74)
+    , m_maxLayer(12)
+  {}
 
-  void init() final {}
-  void process(const Input&, const Output&) const final;
+  void init()    final {}  // nothing to do at run start
+  void process(const Input&  input,
+               const Output& output) const final;
+
+  // setters for factory to override defaults:
+  void setEcut(double e)      { m_ecut = e; }
+  void setMaxLayer(int maxL)  { m_maxLayer = maxL; }
+
+private:
+  double m_ecut;     ///< E/P threshold
+  int    m_maxLayer; ///< (unused) integration depth
 };
 
 } // namespace eicrecon

--- a/src/factories/calorimetry/CalorimeterEoverPCut_factory.h
+++ b/src/factories/calorimetry/CalorimeterEoverPCut_factory.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "extensions/jana/JOmniFactory.h"
+#include "services/log/Log.h"
+#include "algorithms/calorimetry/CalorimeterEoverPCut.h"
+
+namespace eicrecon {
+
+struct CalorimeterEoverPCutConfig {
+    int    max_layer = 8;  // how many layers to integrate (unused in this simple cut)
+    double ecut      = 0.74; // E/P threshold
+};
+
+class CalorimeterEoverPCut_factory
+  : public JOmniFactory<CalorimeterEoverPCut_factory, CalorimeterEoverPCutConfig> {
+public:
+  using AlgoT = EoverPCutAlgorithm;
+
+private:
+  std::unique_ptr<AlgoT> m_algo;
+
+  // Input ports: whole Cluster collection and its MC associations
+  PodioInput<edm4eic::Cluster> m_clusters_input{this};
+  PodioInput<edm4eic::MCRecoClusterParticleAssociation> m_assoc_input{this};
+
+  // Output port: a stream of ParticleID objects
+  PodioOutput<edm4hep::ParticleID> m_pid_output{this};
+
+public:
+  void Configure() override {
+    // instantiate & configure the algorithm
+    m_algo = std::make_unique<AlgoT>(GetPrefix());
+    m_algo->applyConfig(config());
+    m_algo->init();
+  }
+
+  void ChangeRun(int32_t /*run*/) override {}
+
+  void Process(const algorithm::InputTag&, const algorithm::ProcessingContext&) override {
+    // feed it the inputs and collect the ParticleID outputs
+    m_algo->process({ m_clusters_input(), m_assoc_input() },
+                    { m_pid_output() });
+  }
+};
+
+} // namespace eicrecon


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds a new CalorimeterEoverPCut factory and algorithm to the BEMC reconstruction plugin. It computes an event‑by‑event E/p ratio for each barrel calorimeter cluster (using the highest‑weight MC association for true momentum), applies a JANA‑configurable threshold (ecut) and optional max_layer, and emits an edm4hep::ParticleIDCollection marking clusters that pass the cut as electrons. The factory will be registered in BEMC.cc under the EDM4EIC_VERSION_MAJOR >= 8 guard, mirroring the existing PreML/PostML pattern for EEMC.cc.

### What kind of change does this PR introduce?

- [X] New feature (issue #1962-ep-cut-for-epi-separation)

### Please check if this PR fulfills the following:

- [X] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No breaking changes. Existing plugins and factories are unaffected.

### Does this PR change default behavior?

No, no existing plugins or factories have been affected