### PR TITLE
feat: switch remaining reco algorithms/factories to algorithms interface

### DIFF
--- a/src/algorithms/reco/ChargedMCParticleSelector.h
+++ b/src/algorithms/reco/ChargedMCParticleSelector.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2024 Dmitry Kalinkin, Derek Anderson
+// Copyright (C) 2024 - 2025 Dmitry Kalinkin, Derek Anderson, Wouter Deconinck
 
 #pragma once
 

--- a/src/algorithms/reco/ChargedMCParticleSelector.h
+++ b/src/algorithms/reco/ChargedMCParticleSelector.h
@@ -6,7 +6,7 @@
 #include <memory>
 #include <utility>
 
-#include <algorithms/algorithm.h
+#include <algorithms/algorithm.h>
 #include <edm4hep/MCParticleCollection.h>
 #include <spdlog/logger.h>
 

--- a/src/algorithms/reco/ChargedMCParticleSelector.h
+++ b/src/algorithms/reco/ChargedMCParticleSelector.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <utility>
 
+#include <algorithms/algorithm.h
 #include <edm4hep/MCParticleCollection.h>
 #include <spdlog/logger.h>
 
@@ -13,28 +14,33 @@
 
 namespace eicrecon {
 
-class ChargedMCParticleSelector : public WithPodConfig<NoConfig> {
+using ChargedMCParticleSelectorAlgorithm =
+    algorithms::Algorithm<algorithms::Input<edm4hep::MCParticleCollection>,
+                          algorithms::Output<edm4hep::MCParticleCollection>>;
 
-private:
-  std::shared_ptr<spdlog::logger> m_log;
+class ChargedMCParticleSelector : public ChargedMCParticleSelectorAlgorithm,
+                                  public WithPodConfig<NoConfig> {
 
 public:
+  ChargedMCParticleSelector(std::string_view name)
+      : ChargedMCParticleSelectorAlgorithm{
+            name, {"inputParticles"}, {"outputParticles"}, "select charged particles"} {}
+
   // algorithm initialization
-  void init(std::shared_ptr<spdlog::logger>& logger) { m_log = logger; }
+  void init() final {}
 
   // primary algorithm call
-  std::unique_ptr<edm4hep::MCParticleCollection>
-  process(const edm4hep::MCParticleCollection* inputs) {
-    auto outputs = std::make_unique<edm4hep::MCParticleCollection>();
-    outputs->setSubsetCollection();
+  void process(const Input& input, const Output& output) const final {
+    const auto [mc_particles_in] = input;
+    auto [mc_particles_out]      = output;
 
-    for (const auto& particle : *inputs) {
+    mc_particles_out->setSubsetCollection();
+
+    for (const auto& particle : *mc_particles_in) {
       if (particle.getCharge() != 0.) {
-        outputs->push_back(particle);
+        mc_particles_out->push_back(particle);
       }
     }
-
-    return std::move(outputs);
   }
 };
 

--- a/src/algorithms/reco/ChargedReconstructedParticleSelector.h
+++ b/src/algorithms/reco/ChargedReconstructedParticleSelector.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2024 Dmitry Kalinkin, Derek Anderson
+// Copyright (C) 2024 - 2025 Dmitry Kalinkin, Derek Anderson, Wouter Deconinck
 
 #pragma once
 

--- a/src/algorithms/reco/ChargedReconstructedParticleSelector.h
+++ b/src/algorithms/reco/ChargedReconstructedParticleSelector.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <utility>
 
+#include <algorithms/algorithm.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <spdlog/logger.h>
 
@@ -13,28 +14,32 @@
 
 namespace eicrecon {
 
-class ChargedReconstructedParticleSelector : public WithPodConfig<NoConfig> {
+using ChargedReconstructedParticleSelectorAlgorithm =
+    algorithms::Algorithm<algorithms::Input<edm4eic::ReconstructedParticleCollection>,
+                          algorithms::Output<edm4eic::ReconstructedParticleCollection>>;
 
-private:
-  std::shared_ptr<spdlog::logger> m_log;
+class ChargedReconstructedParticleSelector : public ChargedReconstructedParticleSelectorAlgorithm,
+                                             public WithPodConfig<NoConfig> {
 
 public:
+  ChargedReconstructedParticleSelector(std::string_view name)
+      : ChargedReconstructedParticleSelectorAlgorithm{
+            name, {"inputParticles"}, {"outputParticles"}, "select charged particles"} {}
+
   // algorithm initialization
-  void init(std::shared_ptr<spdlog::logger>& logger) { m_log = logger; }
+  void init() final {}
 
   // primary algorithm call
-  std::unique_ptr<edm4eic::ReconstructedParticleCollection>
-  process(const edm4eic::ReconstructedParticleCollection* inputs) {
-    auto outputs = std::make_unique<edm4eic::ReconstructedParticleCollection>();
-    outputs->setSubsetCollection();
+  void process(const Input& input, const Output& output) const final {
+    const auto [rc_particles_in] = input;
+    auto [rc_particles_out]      = output;
+    rc_particles_out->setSubsetCollection();
 
-    for (const auto& particle : *inputs) {
+    for (const auto& particle : *rc_particles_in) {
       if (particle.getCharge() != 0.) {
-        outputs->push_back(particle);
+        rc_particles_out->push_back(particle);
       }
     }
-
-    return outputs;
   }
 };
 

--- a/src/algorithms/reco/ElectronReconstruction.cc
+++ b/src/algorithms/reco/ElectronReconstruction.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2023 Daniel Brandenburg
+// Copyright (C) 2023 - 2025 Daniel Brandenburg, Wouter Deconinck
 #include "ElectronReconstruction.h"
 
 #include <edm4eic/ClusterCollection.h>

--- a/src/algorithms/reco/ElectronReconstruction.cc
+++ b/src/algorithms/reco/ElectronReconstruction.cc
@@ -12,10 +12,10 @@
 
 namespace eicrecon {
 
-void ElectronReconstruction::init(std::shared_ptr<spdlog::logger> logger) { m_log = logger; }
+void ElectronReconstruction::process(const Input& input, const Output& output) const {
 
-std::unique_ptr<edm4eic::ReconstructedParticleCollection>
-ElectronReconstruction::execute(const edm4eic::ReconstructedParticleCollection* rcparts) {
+  const auto [rcparts] = input;
+  auto [out_electrons] = output;
 
   // Some obvious improvements:
   // - E/p cut from real study optimized for electron finding and hadron rejection
@@ -23,7 +23,6 @@ ElectronReconstruction::execute(const edm4eic::ReconstructedParticleCollection* 
   // - check for duplicates?
 
   // output container
-  auto out_electrons = std::make_unique<edm4eic::ReconstructedParticleCollection>();
   out_electrons
       ->setSubsetCollection(); // out_electrons is a subset of the ReconstructedParticles collection
 
@@ -39,15 +38,13 @@ ElectronReconstruction::execute(const edm4eic::ReconstructedParticleCollection* 
     double p      = edm4hep::utils::magnitude(particle.getMomentum());
     double EOverP = E / p;
 
-    m_log->trace(
-        "ReconstructedElectron: Energy={} GeV, p={} GeV, E/p = {} for PDG (from truth): {}", E, p,
-        EOverP, particle.getPDG());
+    trace("ReconstructedElectron: Energy={} GeV, p={} GeV, E/p = {} for PDG (from truth): {}", E, p,
+          EOverP, particle.getPDG());
     // Apply the E/p cut here to select electons
     if (EOverP >= m_cfg.min_energy_over_momentum && EOverP <= m_cfg.max_energy_over_momentum) {
       out_electrons->push_back(particle);
     }
   }
-  m_log->debug("Found {} electron candidates", out_electrons->size());
-  return out_electrons;
+  debug("Found {} electron candidates", out_electrons->size());
 }
 } // namespace eicrecon

--- a/src/algorithms/reco/ElectronReconstruction.cc
+++ b/src/algorithms/reco/ElectronReconstruction.cc
@@ -7,6 +7,7 @@
 #include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
 #include <podio/RelationRange.h>
+#include <gsl/pointers>
 
 #include "algorithms/reco/ElectronReconstructionConfig.h"
 

--- a/src/algorithms/reco/ElectronReconstruction.h
+++ b/src/algorithms/reco/ElectronReconstruction.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <algorithms/algorithm.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <spdlog/logger.h>
 #include <memory>
@@ -12,16 +13,22 @@
 
 namespace eicrecon {
 
-class ElectronReconstruction : public WithPodConfig<ElectronReconstructionConfig> {
+using ElectronReconstructionAlgorithm =
+    algorithms::Algorithm<algorithms::Input<edm4eic::ReconstructedParticleCollection>,
+                          algorithms::Output<edm4eic::ReconstructedParticleCollection>>;
+
+class ElectronReconstruction : public ElectronReconstructionAlgorithm,
+                               public WithPodConfig<ElectronReconstructionConfig> {
 
 public:
-  void init(std::shared_ptr<spdlog::logger> logger);
+  ElectronReconstruction(std::string_view name)
+      : ElectronReconstructionAlgorithm{name,
+                                        {"inputParticles"},
+                                        {"outputParticles"},
+                                        "selected electrons from reconstructed particles"} {}
 
-  // idea will be to overload this with other version (e.g. reco mode)
-  std::unique_ptr<edm4eic::ReconstructedParticleCollection>
-  execute(const edm4eic::ReconstructedParticleCollection* rcparts);
-
-private:
-  std::shared_ptr<spdlog::logger> m_log;
+  void init() final;
+  void process(const Input&, const Output&) const final;
 };
+
 } // namespace eicrecon

--- a/src/algorithms/reco/ElectronReconstruction.h
+++ b/src/algorithms/reco/ElectronReconstruction.h
@@ -5,8 +5,8 @@
 
 #include <algorithms/algorithm.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
-#include <spdlog/logger.h>
-#include <memory>
+#include <string>
+#include <string_view>
 
 #include "ElectronReconstructionConfig.h"
 #include "algorithms/interfaces/WithPodConfig.h"

--- a/src/algorithms/reco/ElectronReconstruction.h
+++ b/src/algorithms/reco/ElectronReconstruction.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2023 Daniel Brandenburg
+// Copyright (C) 2023 - 2025 Daniel Brandenburg, Wouter Deconinck
 
 #pragma once
 

--- a/src/algorithms/reco/ElectronReconstruction.h
+++ b/src/algorithms/reco/ElectronReconstruction.h
@@ -27,7 +27,7 @@ public:
                                         {"outputParticles"},
                                         "selected electrons from reconstructed particles"} {}
 
-  void init() final;
+  void init() final{};
   void process(const Input&, const Output&) const final;
 };
 

--- a/src/factories/reco/ChargedMCParticleSelector_factory.h
+++ b/src/factories/reco/ChargedMCParticleSelector_factory.h
@@ -10,10 +10,12 @@ namespace eicrecon {
 
 class ChargedMCParticleSelector_factory
     : public JOmniFactory<ChargedMCParticleSelector_factory, NoConfig> {
+public:
+  using AlgoT = eicrecon::ChargedMCParticleSelector;
 
 private:
   // algorithm
-  std::unique_ptr<eicrecon::ChargedMCParticleSelector> m_algo;
+  std::unique_ptr<AlgoT> m_algo;
 
   // input collection
   PodioInput<edm4hep::MCParticle> m_pars_in{this, "GeneratedParticles"};
@@ -23,7 +25,7 @@ private:
 
 public:
   void Configure() {
-    m_algo = std::make_unique<eicrecon::ChargedMCParticleSelector>(GetPrefix());
+    m_algo = std::make_unique<AlgoT>(GetPrefix());
     m_algo->init();
   }
 

--- a/src/factories/reco/ChargedMCParticleSelector_factory.h
+++ b/src/factories/reco/ChargedMCParticleSelector_factory.h
@@ -23,15 +23,15 @@ private:
 
 public:
   void Configure() {
-    m_algo = std::make_unique<eicrecon::ChargedMCParticleSelector>();
-    m_algo->init(logger());
+    m_algo = std::make_unique<eicrecon::ChargedMCParticleSelector>(GetPrefix());
+    m_algo->init();
   }
 
   void ChangeRun(int32_t /* run_number */) { /* nothing to do */
   }
 
   void Process(int32_t /* run_number */, int64_t /* event_number */) {
-    m_pars_out() = m_algo->process(m_pars_in());
+    m_algo->process({m_pars_in()}, {m_pars_out().get()});
   }
 };
 

--- a/src/factories/reco/ChargedMCParticleSelector_factory.h
+++ b/src/factories/reco/ChargedMCParticleSelector_factory.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2024 Wouter Deconinck, Dmitry Kalinkin, Derek Anderson
+// Copyright (C) 2024 - 2025 Wouter Deconinck, Dmitry Kalinkin, Derek Anderson
 
 #pragma once
 

--- a/src/factories/reco/ChargedReconstructedParticleSelector_factory.h
+++ b/src/factories/reco/ChargedReconstructedParticleSelector_factory.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2024, Derek Anderson
+// Copyright (C) 2024 - 2025 Derek Anderson, Wouter Deconinck
 
 #pragma once
 

--- a/src/factories/reco/ChargedReconstructedParticleSelector_factory.h
+++ b/src/factories/reco/ChargedReconstructedParticleSelector_factory.h
@@ -10,10 +10,12 @@ namespace eicrecon {
 
 class ChargedReconstructedParticleSelector_factory
     : public JOmniFactory<ChargedReconstructedParticleSelector_factory, NoConfig> {
+public:
+  using AlgoT = eicrecon::ChargedReconstructedParticleSelector;
 
 private:
   // algorithm
-  std::unique_ptr<eicrecon::ChargedReconstructedParticleSelector> m_algo;
+  std::unique_ptr<AlgoT> m_algo;
 
   // input collection
   PodioInput<edm4eic::ReconstructedParticle> m_pars_in{this, "GeneratedParticles"};
@@ -23,7 +25,7 @@ private:
 
 public:
   void Configure() {
-    m_algo = std::make_unique<eicrecon::ChargedReconstructedParticleSelector>(GetPrefix());
+    m_algo = std::make_unique<AlgoT>(GetPrefix());
     m_algo->init();
   }
 

--- a/src/factories/reco/ChargedReconstructedParticleSelector_factory.h
+++ b/src/factories/reco/ChargedReconstructedParticleSelector_factory.h
@@ -23,15 +23,15 @@ private:
 
 public:
   void Configure() {
-    m_algo = std::make_unique<eicrecon::ChargedReconstructedParticleSelector>();
-    m_algo->init(logger());
+    m_algo = std::make_unique<eicrecon::ChargedReconstructedParticleSelector>(GetPrefix());
+    m_algo->init();
   }
 
   void ChangeRun(int32_t /* run_number */) { /* nothing to do */
   }
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
-    m_pars_out() = m_algo->process(m_pars_in());
+    m_algo->process({m_pars_in()}, {m_pars_out().get()});
   }
 };
 

--- a/src/factories/reco/ReconstructedElectrons_factory.h
+++ b/src/factories/reco/ReconstructedElectrons_factory.h
@@ -1,5 +1,5 @@
-// Copyright (C) 2022, 2023 Daniel Brandenburg
-// Subject to the terms in the LICENSE file found in the top-level directory.
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2022 - 2025 Daniel Brandenburg, Wouter Deconinck
 
 #pragma once
 

--- a/src/factories/reco/ReconstructedElectrons_factory.h
+++ b/src/factories/reco/ReconstructedElectrons_factory.h
@@ -27,23 +27,17 @@ private:
   ParameterRef<double> m_max_energy_over_momentum{this, "maxEnergyOverMomentum",
                                                   config().max_energy_over_momentum};
 
-  // Declare services here, e.g.
-  // Service<DD4hep_service> m_geoSvc {this};
-
 public:
   void Configure() {
     // This is called when the factory is instantiated.
     // Use this callback to make sure the algorithm is configured.
     // The logger, parameters, and services have all been fetched before this is called
-    m_algo = std::make_unique<eicrecon::ElectronReconstruction>();
+    m_algo = std::make_unique<eicrecon::ElectronReconstruction>(GetPrefix());
 
     // Pass config object to algorithm
     m_algo->applyConfig(config());
 
-    // If we needed geometry, we'd obtain it like so
-    // m_algo->init(m_geoSvc().detector(), m_geoSvc().converter(), logger());
-
-    m_algo->init(logger());
+    m_algo->init();
   }
 
   void ChangeRun(int32_t /* run_number */) {
@@ -57,12 +51,9 @@ public:
     // This is called on every event.
     // Use this callback to call your Algorithm using all inputs and outputs
     // The inputs will have already been fetched for you at this point.
-    auto output = m_algo->execute(m_in_rc_particles());
+    m_algo->process({m_in_rc_particles()}, {m_out_reco_particles().get()});
 
-    logger()->debug("Found {} reconstructed electron candidates", output->size());
-
-    m_out_reco_particles() = std::move(output);
-    // JANA will take care of publishing the outputs for you.
+    logger()->debug("Found {} reconstructed electron candidates", m_out_reco_particles()->size());
   }
 };
 } // namespace eicrecon

--- a/src/factories/reco/ReconstructedElectrons_factory.h
+++ b/src/factories/reco/ReconstructedElectrons_factory.h
@@ -11,9 +11,12 @@ namespace eicrecon {
 
 class ReconstructedElectrons_factory
     : public JOmniFactory<ReconstructedElectrons_factory, ElectronReconstructionConfig> {
+public:
+  using AlgoT = eicrecon::ElectronReconstruction;
+
 private:
   // Underlying algorithm
-  std::unique_ptr<eicrecon::ElectronReconstruction> m_algo;
+  std::unique_ptr<AlgoT> m_algo;
 
   // Declare inputs
   PodioInput<edm4eic::ReconstructedParticle> m_in_rc_particles{this, "ReconstructedParticles"};
@@ -32,7 +35,7 @@ public:
     // This is called when the factory is instantiated.
     // Use this callback to make sure the algorithm is configured.
     // The logger, parameters, and services have all been fetched before this is called
-    m_algo = std::make_unique<eicrecon::ElectronReconstruction>(GetPrefix());
+    m_algo = std::make_unique<AlgoT>(GetPrefix());
 
     // Pass config object to algorithm
     m_algo->applyConfig(config());


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR switches the reco algorithms for charged MCParticle and ReconstructedParticle selection (could be a meta balgorithm) and for DIS electron selection over to the algorithms interface.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: algorithms interface consistency)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.