### PR TITLE
feat: switch TrackerHitReconstruction algorithm/factories to algorithms interface

### DIFF
--- a/src/algorithms/tracking/TrackerHitReconstruction.cc
+++ b/src/algorithms/tracking/TrackerHitReconstruction.cc
@@ -27,21 +27,13 @@ namespace {
   }
 } // namespace
 
-void TrackerHitReconstruction::init(const dd4hep::rec::CellIDPositionConverter* converter,
-                                    std::shared_ptr<spdlog::logger>& logger) {
-
-  m_log = logger;
-
-  m_converter = converter;
-}
-
-std::unique_ptr<edm4eic::TrackerHitCollection>
-TrackerHitReconstruction::process(const edm4eic::RawTrackerHitCollection& raw_hits) {
+void TrackerHitReconstruction::process(const Input& input, const Output& output) const {
   using dd4hep::mm;
 
-  auto rec_hits{std::make_unique<edm4eic::TrackerHitCollection>()};
+  const auto [raw_hits] = input;
+  auto [rec_hits]       = output;
 
-  for (const auto& raw_hit : raw_hits) {
+  for (const auto& raw_hit : *raw_hits) {
 
     auto id = raw_hit.getCellID();
 
@@ -50,12 +42,11 @@ TrackerHitReconstruction::process(const edm4eic::RawTrackerHitCollection& raw_hi
     auto dim = m_converter->cellDimensions(id);
 
     // >oO trace
-    if (m_log->level() == spdlog::level::trace) {
-      m_log->trace("position x={:.2f} y={:.2f} z={:.2f} [mm]: ", pos.x() / mm, pos.y() / mm,
-                   pos.z() / mm);
-      m_log->trace("dimension size: {}", dim.size());
+    if (level() == algorithms::LogLevel::kTrace) {
+      trace("position x={:.2f} y={:.2f} z={:.2f} [mm]: ", pos.x() / mm, pos.y() / mm, pos.z() / mm);
+      trace("dimension size: {}", dim.size());
       for (std::size_t j = 0; j < std::size(dim); ++j) {
-        m_log->trace(" - dimension {:<5} size: {:.2}", j, dim[j]);
+        trace(" - dimension {:<5} size: {:.2}", j, dim[j]);
       }
     }
 
@@ -81,8 +72,6 @@ TrackerHitReconstruction::process(const edm4eic::RawTrackerHitCollection& raw_hi
         0.0F);                                                         // Error on the energy
     rec_hit.setRawHit(raw_hit);
   }
-
-  return rec_hits;
 }
 
 } // namespace eicrecon

--- a/src/factories/tracking/TrackerHitReconstruction_factory.h
+++ b/src/factories/tracking/TrackerHitReconstruction_factory.h
@@ -12,7 +12,11 @@ namespace eicrecon {
 class TrackerHitReconstruction_factory
     : public JOmniFactory<TrackerHitReconstruction_factory, TrackerHitReconstructionConfig> {
 
-  TrackerHitReconstruction m_algo;
+public:
+  using AlgoT = eicrecon::TrackerHitReconstruction;
+
+private:
+  std::unique_ptr<AlgoT> m_algo;
 
   PodioInput<edm4eic::RawTrackerHit> m_raw_hits_input{this};
   PodioOutput<edm4eic::TrackerHit> m_rec_hits_output{this};
@@ -23,14 +27,15 @@ class TrackerHitReconstruction_factory
 
 public:
   void Configure() {
-    m_algo.applyConfig(config());
-    m_algo.init(m_geoSvc().converter(), logger());
+    m_algo = std::make_unique<AlgoT>(GetPrefix());
+    m_algo->applyConfig(config());
+    m_algo->init();
   }
 
   void ChangeRun(int32_t /* run_number */) {}
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
-    m_rec_hits_output() = m_algo.process(*m_raw_hits_input());
+    m_algo->process({m_raw_hits_input()}, {m_rec_hits_output().get()});
   }
 };
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR switches the TrackerHitReconstruction algorithms over to the algorithms interface.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: algorithms interface consistency)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.