### PR TITLE
Speed up calculation by reducing BTOF charge sharing magnitude

### DIFF
--- a/src/detectors/BTOF/BTOF.cc
+++ b/src/detectors/BTOF/BTOF.cc
@@ -61,17 +61,17 @@ void InitPlugin(JApplication* app) {
   const double x_when_landau_min = -0.22278;
   const double landau_min        = TMath::Landau(x_when_landau_min, 0, 1, true);
   const double sigma_analog      = 0.293951 * edm4eic::unit::ns;
-  const double Vm                = 1e-4 * dd4hep::GeV;
+  const double Vm                = 3e-4 * dd4hep::GeV;
   const double adc_range         = 256;
   // gain is set such that pulse reaches a height of adc_range when EDep = Vm
   // gain is negative as LGAD voltage is always negative
-  const double gain = -adc_range / Vm / landau_min;
+  const double gain = -adc_range / Vm / landau_min * sigma_analog;
   const int offset  = 3;
   app->Add(new JOmniFactoryGeneratorT<SiliconPulseGeneration_factory>(
       "LGADPulseGeneration", {"TOFBarrelSharedHits"}, {"TOFBarrelSmoothPulses"},
       {
           .pulse_shape_function = "LandauPulse",
-          .pulse_shape_params   = {gain, sigma_analog, offset * sigma_analog},
+          .pulse_shape_params   = {gain, sigma_analog, offset},
           .ignore_thres         = 0.05 * adc_range,
           .timestep             = 0.01 * edm4eic::unit::ns,
       },


### PR DESCRIPTION
### Briefly, what does this PR introduce?

TOF pulse generation currently takes 30% of the workload (see https://github.com/eic/EICrecon/pull/1924). This can be significantly improved by reducing charge sharing sigma. Realistically speaking, charge is being shared to 1-3 neighboring cells as the prototype indicates, but the current code sharing everything to, on average, 9 cells. That's because while the grid size is reduced to an unrealistic width (see https://github.com/eic/epic/pull/883), the charge sharing sigma is not reduced along with it.

This pull request reduces sigmaX of BTOF from 0.1 cm to 0.1 mm. Here's the speed of reconstructing 1000 pi+ in the main branch on my laptop,

<img width="1831" height="315" alt="image" src="https://github.com/user-attachments/assets/b6ec017c-3b72-4caa-9449-feee28269808" />

Here's the speed in this pull request,

<img width="1764" height="321" alt="image" src="https://github.com/user-attachments/assets/5698ac3f-5427-48be-8a93-7c2f2afcf9ee" />

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No

### Does this PR change default behavior?

There would be less `TOFBarrelADCTDC` entries due to reduced charge sharing. 