### PR TITLE
fix: move empty ChangeRun up a level in inheritance

### DIFF
--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -539,6 +539,8 @@ public:
     static_cast<AlgoT*>(this)->ChangeRun(event->GetRunNumber());
   }
 
+  virtual void ChangeRun(int32_t /* run_number */) override{};
+
   virtual void Process(int32_t /* run_number */, uint64_t /* event_number */){};
 
   void Process(const std::shared_ptr<const JEvent>& event) override {

--- a/src/factories/calorimetry/CalorimeterClusterRecoCoG_factory.h
+++ b/src/factories/calorimetry/CalorimeterClusterRecoCoG_factory.h
@@ -43,8 +43,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_proto_input(), m_mchitassocs_input()},
                     {m_cluster_output().get(), m_assoc_output().get()});

--- a/src/factories/calorimetry/CalorimeterClusterShape_factory.h
+++ b/src/factories/calorimetry/CalorimeterClusterShape_factory.h
@@ -48,10 +48,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {
-    //... nothing to do ...//
-  }
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_clusters_input(), m_assocs_input()},
                     {m_clusters_output().get(), m_assocs_output().get()});

--- a/src/factories/calorimetry/CalorimeterHitDigi_factory.h
+++ b/src/factories/calorimetry/CalorimeterHitDigi_factory.h
@@ -49,8 +49,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_hits_input()}, {m_hits_output().get(), m_hit_assocs_output().get()});
   }

--- a/src/factories/calorimetry/CalorimeterHitReco_factory.h
+++ b/src/factories/calorimetry/CalorimeterHitReco_factory.h
@@ -47,8 +47,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_raw_hits_input()}, {m_rec_hits_output().get()});
   }

--- a/src/factories/calorimetry/CalorimeterHitsMerger_factory.h
+++ b/src/factories/calorimetry/CalorimeterHitsMerger_factory.h
@@ -35,8 +35,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_hits_input()}, {m_hits_output().get()});
   }

--- a/src/factories/calorimetry/CalorimeterIslandCluster_factory.h
+++ b/src/factories/calorimetry/CalorimeterIslandCluster_factory.h
@@ -54,8 +54,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_calo_hit_input()}, {m_proto_cluster_output().get()});
   }

--- a/src/factories/calorimetry/CalorimeterParticleIDPostML_factory.h
+++ b/src/factories/calorimetry/CalorimeterParticleIDPostML_factory.h
@@ -34,8 +34,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process(
         {m_cluster_input(), m_cluster_assoc_input(), m_prediction_tensor_input()},

--- a/src/factories/calorimetry/CalorimeterParticleIDPreML_factory.h
+++ b/src/factories/calorimetry/CalorimeterParticleIDPreML_factory.h
@@ -32,8 +32,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_cluster_input(), m_cluster_assoc_input()},
                     {m_feature_tensor_output().get(), m_target_tensor_output().get()});

--- a/src/factories/calorimetry/CalorimeterTruthClustering_factory.h
+++ b/src/factories/calorimetry/CalorimeterTruthClustering_factory.h
@@ -28,8 +28,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_rc_hits_input(), m_mc_hits_input()}, {m_proto_clusters_output().get()});
   }

--- a/src/factories/calorimetry/EnergyPositionClusterMerger_factory.h
+++ b/src/factories/calorimetry/EnergyPositionClusterMerger_factory.h
@@ -41,8 +41,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_energy_cluster_input(), m_energy_assoc_input(), m_position_cluster_input(),
                      m_position_assoc_input()},

--- a/src/factories/calorimetry/HEXPLIT_factory.h
+++ b/src/factories/calorimetry/HEXPLIT_factory.h
@@ -33,8 +33,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_rec_hits_input()}, {m_subcell_hits_output().get()});
   }

--- a/src/factories/calorimetry/ImagingClusterReco_factory.h
+++ b/src/factories/calorimetry/ImagingClusterReco_factory.h
@@ -37,8 +37,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_protos_input(), m_mchitassocs_input()},
                     {m_clusters_output().get(), m_assocs_output().get(), m_layers_output().get()});

--- a/src/factories/calorimetry/ImagingTopoCluster_factory.h
+++ b/src/factories/calorimetry/ImagingTopoCluster_factory.h
@@ -43,8 +43,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_hits_input()}, {m_protos_output().get()});
   }

--- a/src/factories/calorimetry/SimCalorimeterHitProcessor_factory.h
+++ b/src/factories/calorimetry/SimCalorimeterHitProcessor_factory.h
@@ -45,8 +45,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_hits_input()}, {m_hits_output().get(), m_hits_contribs_output().get()});
   }

--- a/src/factories/calorimetry/TrackClusterMergeSplitter_factory.h
+++ b/src/factories/calorimetry/TrackClusterMergeSplitter_factory.h
@@ -53,9 +53,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) { /* nothing to do here */
-  }
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_protoclusters_input(), m_track_projections_input()},
                     {m_protoclusters_output().get()});

--- a/src/factories/calorimetry/TruthEnergyPositionClusterMerger_factory.h
+++ b/src/factories/calorimetry/TruthEnergyPositionClusterMerger_factory.h
@@ -35,8 +35,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_mcparticles_input(), m_energy_clusters_input(), m_energy_assocs_input(),
                      m_position_clusters_input(), m_position_assocs_input()},

--- a/src/factories/digi/EICROCDigitization_factory.h
+++ b/src/factories/digi/EICROCDigitization_factory.h
@@ -35,8 +35,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_in_sim_track()}, {m_out_reco_particles().get()});
   }

--- a/src/factories/digi/MPGDTrackerDigi_factory.h
+++ b/src/factories/digi/MPGDTrackerDigi_factory.h
@@ -35,8 +35,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_sim_hits_input()}, {m_raw_hits_output().get(), m_assoc_output().get()});
   }

--- a/src/factories/digi/PhotoMultiplierHitDigi_factory.h
+++ b/src/factories/digi/PhotoMultiplierHitDigi_factory.h
@@ -86,8 +86,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_sim_hits_input()}, {m_raw_hits_output().get(), m_raw_assocs_output().get()});
   }

--- a/src/factories/digi/PulseCombiner_factory.h
+++ b/src/factories/digi/PulseCombiner_factory.h
@@ -39,8 +39,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_in_pulses()}, {m_out_pulses().get()});
   }

--- a/src/factories/digi/PulseNoise_factory.h
+++ b/src/factories/digi/PulseNoise_factory.h
@@ -39,8 +39,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_in_pulses()}, {m_out_pulses().get()});
   }

--- a/src/factories/digi/SiliconChargeSharing_factory.h
+++ b/src/factories/digi/SiliconChargeSharing_factory.h
@@ -35,8 +35,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_in_sim_track()}, {m_out_reco_particles().get()});
   }

--- a/src/factories/digi/SiliconPulseDiscretization_factory.h
+++ b/src/factories/digi/SiliconPulseDiscretization_factory.h
@@ -38,8 +38,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_in_pulses()}, {m_out_pulses().get()});
   }

--- a/src/factories/digi/SiliconPulseGeneration_factory.h
+++ b/src/factories/digi/SiliconPulseGeneration_factory.h
@@ -44,8 +44,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_in_sim_hits()}, {m_out_pulses().get()});
   }

--- a/src/factories/digi/SiliconTrackerDigi_factory.h
+++ b/src/factories/digi/SiliconTrackerDigi_factory.h
@@ -34,8 +34,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_sim_hits_input()}, {m_raw_hits_output().get(), m_assoc_output().get()});
   }

--- a/src/factories/fardetectors/FarDetectorLinearProjection_factory.h
+++ b/src/factories/fardetectors/FarDetectorLinearProjection_factory.h
@@ -36,8 +36,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_tracks_input()}, {m_tracks_output().get()});
   }

--- a/src/factories/fardetectors/FarDetectorLinearTracking_factory.h
+++ b/src/factories/fardetectors/FarDetectorLinearTracking_factory.h
@@ -41,8 +41,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
 
     try {

--- a/src/factories/fardetectors/FarDetectorMLReconstruction_factory.h
+++ b/src/factories/fardetectors/FarDetectorMLReconstruction_factory.h
@@ -53,8 +53,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_trackparam_input(), m_beamelectrons_input(), m_fittedtracks_input(),
                      m_fittedtrackassoc_input()},

--- a/src/factories/fardetectors/FarDetectorTrackerCluster_factory.h
+++ b/src/factories/fardetectors/FarDetectorTrackerCluster_factory.h
@@ -39,8 +39,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     std::vector<gsl::not_null<edm4eic::Measurement2DCollection*>> clustered_collections;
     for (const auto& clustered : m_clustered_hits_output()) {

--- a/src/factories/fardetectors/FarDetectorTransportationPostML_factory.h
+++ b/src/factories/fardetectors/FarDetectorTransportationPostML_factory.h
@@ -35,8 +35,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_prediction_tensor_input(), m_beamelectrons_input()},
                     {m_particle_output().get()});

--- a/src/factories/fardetectors/FarDetectorTransportationPreML_factory.h
+++ b/src/factories/fardetectors/FarDetectorTransportationPreML_factory.h
@@ -37,8 +37,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_trackparam_input(), m_scatteredelectrons_input(), m_beamelectrons_input()},
                     {m_feature_tensor_output().get(), m_target_tensor_output().get()});

--- a/src/factories/fardetectors/MatrixTransferStatic_factory.h
+++ b/src/factories/fardetectors/MatrixTransferStatic_factory.h
@@ -63,8 +63,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_mcparts_input(), m_hits_input()}, {m_tracks_output().get()});
   }

--- a/src/factories/meta/CollectionCollector_factory.h
+++ b/src/factories/meta/CollectionCollector_factory.h
@@ -28,8 +28,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     std::vector<gsl::not_null<const typename T::collection_type*>> in_collections;
     for (const auto& in_collection : m_inputs()) {

--- a/src/factories/meta/FilterMatching_factory.h
+++ b/src/factories/meta/FilterMatching_factory.h
@@ -35,8 +35,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_collection_input(), m_matched_input()},
                     {m_is_matched_output().get(), m_is_not_matched_output().get()});

--- a/src/factories/meta/ONNXInference_factory.h
+++ b/src/factories/meta/ONNXInference_factory.h
@@ -33,8 +33,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     std::vector<gsl::not_null<const edm4eic::TensorCollection*>> in_collections;
     for (const auto& in_collection : m_input_tensors()) {

--- a/src/factories/meta/SubDivideCollection_factory.h
+++ b/src/factories/meta/SubDivideCollection_factory.h
@@ -33,8 +33,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
 
     std::vector<gsl::not_null<typename T::collection_type*>> split_collections;

--- a/src/factories/pid/IrtCherenkovParticleID_factory.h
+++ b/src/factories/pid/IrtCherenkovParticleID_factory.h
@@ -69,8 +69,6 @@ public:
     m_algo->init(m_RichGeoSvc().GetIrtGeo("DRICH")->GetIrtDetectorCollection());
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_aerogel_tracks_input(), m_gas_tracks_input(), m_merged_tracks_input(),
                      m_raw_hits_input(), m_raw_hit_assoc_input()},

--- a/src/factories/pid/MatchToRICHPID_factory.h
+++ b/src/factories/pid/MatchToRICHPID_factory.h
@@ -35,8 +35,6 @@ public:
     m_algo->init();
   };
 
-  void ChangeRun(int32_t /* run_number */){};
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process(
         {m_recoparticles_input(), m_assocs_input(), m_cherenkov_particle_ids_input()},

--- a/src/factories/pid/MergeCherenkovParticleID_factory.h
+++ b/src/factories/pid/MergeCherenkovParticleID_factory.h
@@ -44,8 +44,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     auto in1 = m_particleID_input();
     std::vector<gsl::not_null<const edm4eic::CherenkovParticleIDCollection*>> in2;

--- a/src/factories/pid/MergeTrack_factory.h
+++ b/src/factories/pid/MergeTrack_factory.h
@@ -35,8 +35,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     auto in1 = m_track_segments_input();
     std::vector<gsl::not_null<const edm4eic::TrackSegmentCollection*>> in2;

--- a/src/factories/pid/RichTrack_factory.h
+++ b/src/factories/pid/RichTrack_factory.h
@@ -48,8 +48,6 @@ public:
     m_algo->init(m_GeoSvc().detector(), m_ACTSGeoSvc().actsGeoProvider(), logger());
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->propagateToSurfaceList(
         {*m_tracks_input(), m_acts_trajectories_input(), m_acts_tracks_input()},

--- a/src/factories/pid_lut/PIDLookup_factory.h
+++ b/src/factories/pid_lut/PIDLookup_factory.h
@@ -41,8 +41,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_recoparticles_input(), m_recoparticle_assocs_input()},
                     {m_recoparticles_output().get(), m_recoparticle_assocs_output().get(),

--- a/src/factories/reco/ChargedMCParticleSelector_factory.h
+++ b/src/factories/reco/ChargedMCParticleSelector_factory.h
@@ -29,9 +29,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) { /* nothing to do */
-  }
-
   void Process(int32_t /* run_number */, int64_t /* event_number */) {
     m_algo->process({m_pars_in()}, {m_pars_out().get()});
   }

--- a/src/factories/reco/ChargedReconstructedParticleSelector_factory.h
+++ b/src/factories/reco/ChargedReconstructedParticleSelector_factory.h
@@ -29,9 +29,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) { /* nothing to do */
-  }
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_pars_in()}, {m_pars_out().get()});
   }

--- a/src/factories/reco/FarForwardLambdaReconstruction_factory.h
+++ b/src/factories/reco/FarForwardLambdaReconstruction_factory.h
@@ -39,8 +39,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_neutrals_input()},
                     {m_lambda_output().get(), m_lambda_decay_products_cm_output().get()});

--- a/src/factories/reco/FarForwardNeutralsReconstruction_factory.h
+++ b/src/factories/reco/FarForwardNeutralsReconstruction_factory.h
@@ -46,8 +46,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process(
         {

--- a/src/factories/reco/HadronicFinalState_factory.h
+++ b/src/factories/reco/HadronicFinalState_factory.h
@@ -40,8 +40,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_mc_particles_input(), m_rc_particles_input(), m_rc_particles_assoc_input()},
                     {m_hadronic_final_state_output().get()});

--- a/src/factories/reco/InclusiveKinematicsML_factory.h
+++ b/src/factories/reco/InclusiveKinematicsML_factory.h
@@ -38,8 +38,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_inclusive_kinematics_electron_input(), m_inclusive_kinematics_da_input()},
                     {m_inclusive_kinematics_output().get()});

--- a/src/factories/reco/InclusiveKinematicsReconstructed_factory.h
+++ b/src/factories/reco/InclusiveKinematicsReconstructed_factory.h
@@ -42,8 +42,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process(
         {m_mc_particles_input(), m_scattered_electron_input(), m_hadronic_final_state_input()},

--- a/src/factories/reco/InclusiveKinematicsTruth_factory.h
+++ b/src/factories/reco/InclusiveKinematicsTruth_factory.h
@@ -36,8 +36,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_mc_particles_input()}, {m_inclusive_kinematics_output().get()});
   }

--- a/src/factories/reco/JetReconstruction_factory.h
+++ b/src/factories/reco/JetReconstruction_factory.h
@@ -58,9 +58,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) { /* nothing to do */
-  }
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_input()}, {m_output().get()});
   }

--- a/src/factories/reco/MC2ReconstructedParticle_factory.h
+++ b/src/factories/reco/MC2ReconstructedParticle_factory.h
@@ -34,8 +34,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_mc_particles_input()}, {m_rc_particles_output().get()});
   }

--- a/src/factories/reco/MatchClusters_factory.h
+++ b/src/factories/reco/MatchClusters_factory.h
@@ -45,8 +45,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process(
         {

--- a/src/factories/reco/PrimaryVertices_factory.h
+++ b/src/factories/reco/PrimaryVertices_factory.h
@@ -41,8 +41,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_rc_vertices_input()}, {m_primary_vertices_output().get()});
   }

--- a/src/factories/reco/ReconstructedElectrons_factory.h
+++ b/src/factories/reco/ReconstructedElectrons_factory.h
@@ -43,13 +43,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {
-    // This is called whenever the run number is changed.
-    // Use this callback to retrieve state that is keyed off of run number.
-    // This state should usually be managed by a Service.
-    // Note: You usually don't need this, because you can declare a Resource instead.
-  }
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     // This is called on every event.
     // Use this callback to call your Algorithm using all inputs and outputs

--- a/src/factories/reco/ScatteredElectronsEMinusPz_factory.h
+++ b/src/factories/reco/ScatteredElectronsEMinusPz_factory.h
@@ -39,8 +39,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_rc_particles_input(), m_rc_electrons_input()},
                     {m_out_reco_particles().get()});

--- a/src/factories/reco/ScatteredElectronsTruth_factory.h
+++ b/src/factories/reco/ScatteredElectronsTruth_factory.h
@@ -39,8 +39,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_mc_particles_input(), m_rc_particles_input(), m_rc_particles_assoc_input()},
                     {m_out_reco_particles().get()});

--- a/src/factories/reco/TrackClusterMatch_factory.h
+++ b/src/factories/reco/TrackClusterMatch_factory.h
@@ -34,8 +34,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_tracks(), m_clusters()}, {m_matched_particles().get()});
   }

--- a/src/factories/reco/TransformBreitFrame_factory.h
+++ b/src/factories/reco/TransformBreitFrame_factory.h
@@ -44,9 +44,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) { /* nothing to do */
-  }
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_in_mcpart(), m_in_kine(), m_in_part()}, {m_out_part().get()});
   }

--- a/src/factories/reco/UndoAfterBurnerMCParticles_factory.h
+++ b/src/factories/reco/UndoAfterBurnerMCParticles_factory.h
@@ -39,8 +39,6 @@ public:
     m_algo->applyConfig(config());
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_mcparts_input()}, {m_postburn_output().get()});
   }

--- a/src/factories/tracking/ActsToTracks_factory.h
+++ b/src/factories/tracking/ActsToTracks_factory.h
@@ -32,8 +32,6 @@ public:
     m_algo->init();
   };
 
-  void ChangeRun(int32_t /* run_number */){};
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     std::vector<gsl::not_null<const ActsExamples::Trajectories*>> acts_trajectories_input;
     for (auto acts_traj : m_acts_trajectories_input()) {

--- a/src/factories/tracking/ActsTrajectoriesMerger_factory.h
+++ b/src/factories/tracking/ActsTrajectoriesMerger_factory.h
@@ -23,8 +23,6 @@ private:
 public:
   void Configure() {}
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     for (const auto& traj : m_acts_trajectories1_input()) {
       ActsExamples::Trajectories::IndexedParameters trackParameters;

--- a/src/factories/tracking/AmbiguitySolver_factory.h
+++ b/src/factories/tracking/AmbiguitySolver_factory.h
@@ -43,8 +43,6 @@ public:
     m_algo->init(logger());
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     std::tie(m_acts_tracks_output(), m_acts_trajectories_output()) =
         m_algo->process(m_acts_tracks_input(), *m_measurements_input());

--- a/src/factories/tracking/CKFTracking_factory.h
+++ b/src/factories/tracking/CKFTracking_factory.h
@@ -49,8 +49,6 @@ public:
     m_algo->init(m_ACTSGeoSvc().actsGeoProvider(), logger());
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     std::tie(m_acts_trajectories_output(), m_acts_tracks_output()) =
         m_algo->process(*m_parameters_input(), *m_measurements_input());

--- a/src/factories/tracking/IterativeVertexFinder_factory.h
+++ b/src/factories/tracking/IterativeVertexFinder_factory.h
@@ -45,8 +45,6 @@ public:
     m_algo->init(m_ACTSGeoSvc().actsGeoProvider(), logger());
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_vertices_output() =
         m_algo->produce(m_acts_trajectories_input(), m_edm4eic_reconParticles_input());

--- a/src/factories/tracking/TrackParamTruthInit_factory.h
+++ b/src/factories/tracking/TrackParamTruthInit_factory.h
@@ -57,8 +57,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_particles_input()}, {m_parameters_output().get()});
   }

--- a/src/factories/tracking/TrackProjector_factory.h
+++ b/src/factories/tracking/TrackProjector_factory.h
@@ -36,8 +36,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     std::vector<gsl::not_null<const ActsExamples::Trajectories*>> acts_trajectories_input;
     for (auto acts_traj : m_acts_trajectories_input()) {

--- a/src/factories/tracking/TrackPropagation_factory.h
+++ b/src/factories/tracking/TrackPropagation_factory.h
@@ -42,8 +42,6 @@ public:
     m_algo->init(m_GeoSvc().detector(), m_ACTSGeoSvc().actsGeoProvider(), logger());
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({*m_tracks_input(), m_acts_trajectories_input(), m_acts_tracks_input()},
                     {m_track_segments_output().get()});

--- a/src/factories/tracking/TrackSeeding_factory.h
+++ b/src/factories/tracking/TrackSeeding_factory.h
@@ -107,8 +107,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_hits_input()}, {m_parameters_output().get()});
   }

--- a/src/factories/tracking/TrackerHitReconstruction_factory.h
+++ b/src/factories/tracking/TrackerHitReconstruction_factory.h
@@ -32,8 +32,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_raw_hits_input()}, {m_rec_hits_output().get()});
   }

--- a/src/factories/tracking/TrackerMeasurementFromHits_factory.h
+++ b/src/factories/tracking/TrackerMeasurementFromHits_factory.h
@@ -37,8 +37,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_hits_input()}, {m_measurements_output().get()});
   }

--- a/src/factories/tracking/TracksToParticles_factory.h
+++ b/src/factories/tracking/TracksToParticles_factory.h
@@ -33,8 +33,6 @@ public:
     m_algo->init();
   };
 
-  void ChangeRun(int32_t /* run_number */){};
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_tracks_input(), m_trackassocs_input()},
                     {m_recoparticles_output().get(), m_recoassocs_output().get()});

--- a/src/tests/omnifactory_test/JOmniFactoryTests.cc
+++ b/src/tests/omnifactory_test/JOmniFactoryTests.cc
@@ -324,8 +324,6 @@ struct SubsetTestAlg : public JOmniFactory<SubsetTestAlg, BasicTestAlgConfig> {
 
   void Configure() {}
 
-  void ChangeRun(int32_t /* run_number */) override {}
-
   // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
   void Process(int32_t /* run_number */, uint64_t /* event_number */) override {
 
@@ -390,7 +388,6 @@ struct VariadicOutputTestAlg : public JOmniFactory<VariadicOutputTestAlg, BasicT
   VariadicPodioOutput<edm4hep::SimCalorimeterHit> m_hits_out{this};
 
   void Configure() {}
-  void ChangeRun(int32_t /* run_number */) override {}
 
   // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
   void Process(int32_t /* run_number */, uint64_t /* event_number */) override {
@@ -443,8 +440,6 @@ struct OptionalPodioInputTestAlg
   PodioOutput<edm4hep::SimCalorimeterHit> m_right_hits_out{this};
 
   void Configure() {}
-
-  void ChangeRun(int32_t /* run_number */) override {}
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) override {
 
@@ -527,8 +522,6 @@ struct OptionalVariadicPodioInputTestAlg
   PodioOutput<edm4hep::SimCalorimeterHit> m_hits_out{this};
 
   void Configure() {}
-
-  void ChangeRun(int32_t /* run_number */) override {}
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) override {
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR moves the (typically) empty factory `ChangeRun` up a level in inheritance to avoid empty boilerplate.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: reduce boilerplate)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.