### PR TITLE
fix: use Navigator with MaterialInteractor action for track propagation

### DIFF
--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -283,8 +283,7 @@ TrackPropagation::propagate(const edm4eic::Track& /* track */,
 #if Acts_VERSION_MAJOR >= 36
   using Propagator = Acts::Propagator<Acts::EigenStepper<>, Acts::Navigator>;
 #if Acts_VERSION_MAJOR >= 37
-  using PropagatorOptions = Propagator::template Options<
-      Acts::ActorList<Acts::MaterialInteractor>>;
+  using PropagatorOptions = Propagator::template Options<Acts::ActorList<Acts::MaterialInteractor>>;
 #else
   using PropagatorOptions =
       Propagator::template Options<Acts::ActionList<Acts::MaterialInteractor>>;

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -25,7 +25,6 @@
 #endif
 #include <Acts/Propagator/Propagator.hpp>
 #if Acts_VERSION_MAJOR >= 36
-#include <Acts/Propagator/PropagatorOptions.hpp>
 #include <Acts/Propagator/PropagatorResult.hpp>
 #endif
 #if Acts_VERSION_MAJOR >= 34

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -16,6 +16,7 @@
 #if Acts_VERSION_MAJOR >= 37
 #include <Acts/Propagator/ActorList.hpp>
 #else
+#include <Acts/Propagator/AbortList.hpp>
 #include <Acts/Propagator/ActionList.hpp>
 #endif
 #include <Acts/Propagator/EigenStepper.hpp>

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -16,7 +16,6 @@
 #if Acts_VERSION_MAJOR >= 37
 #include <Acts/Propagator/ActorList.hpp>
 #else
-#include <Acts/Propagator/AbortList.hpp>
 #include <Acts/Propagator/ActionList.hpp>
 #endif
 #include <Acts/Propagator/EigenStepper.hpp>
@@ -26,9 +25,6 @@
 #include <Acts/Propagator/Propagator.hpp>
 #if Acts_VERSION_MAJOR >= 36
 #include <Acts/Propagator/PropagatorResult.hpp>
-#endif
-#if Acts_VERSION_MAJOR >= 34
-#include <Acts/Propagator/StandardAborters.hpp>
 #endif
 #include <Acts/Surfaces/CylinderBounds.hpp>
 #include <Acts/Surfaces/CylinderSurface.hpp>
@@ -289,8 +285,8 @@ TrackPropagation::propagate(const edm4eic::Track& /* track */,
   using PropagatorOptions = Propagator::template Options<
       Acts::ActorList<Acts::MaterialInteractor, Acts::EndOfWorldReached>>;
 #else
-  using PropagatorOptions = Propagator::template Options<Acts::ActionList<Acts::MaterialInteractor>,
-                                                         Acts::AbortList<Acts::EndOfWorldReached>>;
+  using PropagatorOptions =
+      Propagator::template Options<Acts::ActionList<Acts::MaterialInteractor>>;
 #endif
   Propagator propagator(
       Acts::EigenStepper<>(magneticField),
@@ -302,9 +298,8 @@ TrackPropagation::propagate(const edm4eic::Track& /* track */,
       Acts::EigenStepper<>(magneticField),
       Acts::Navigator({m_geoSvc->trackingGeometry()}, logger().cloneWithSuffix("Navigator")),
       logger().cloneWithSuffix("Propagator"));
-  Acts::PropagatorOptions<Acts::ActionList<Acts::MaterialInteractor>,
-                          Acts::AbortList<Acts::EndOfWorldReached>>
-      propagationOptions(m_geoContext, m_fieldContext);
+  Acts::PropagatorOptions<Acts::ActionList<Acts::MaterialInteractor>> propagationOptions(
+      m_geoContext, m_fieldContext);
 #endif
 
   auto result = propagator.propagate(initBoundParams, *targetSurf, propagationOptions);

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -2,6 +2,7 @@
 // Copyright (C) 2022, 2023 Wenqing Fan, Barak Schmookler, Whitney Armstrong, Sylvester Joosten, Dmitry Romanov, Christopher Dilks, Wouter Deconinck
 
 #include <Acts/Definitions/Algebra.hpp>
+#include <Acts/Definitions/Common.hpp>
 #include <Acts/Definitions/Direction.hpp>
 #include <Acts/Definitions/TrackParametrization.hpp>
 #include <Acts/Definitions/Units.hpp>
@@ -9,9 +10,9 @@
 #include <Acts/EventData/MultiTrajectoryHelpers.hpp>
 #include <Acts/EventData/ParticleHypothesis.hpp>
 #include <Acts/Geometry/GeometryIdentifier.hpp>
-#include <Acts/Geometry/Layer.hpp>
 #include <Acts/Geometry/TrackingGeometry.hpp>
 #include <Acts/MagneticField/MagneticFieldProvider.hpp>
+#include <Acts/Material/MaterialInteraction.hpp>
 #if Acts_VERSION_MAJOR >= 34
 #if Acts_VERSION_MAJOR >= 37
 #include <Acts/Propagator/ActorList.hpp>
@@ -35,7 +36,8 @@
 #include <ActsExamples/EventData/Trajectories.hpp>
 #include <DD4hep/Handle.h>
 #include <Evaluator/DD4hepUnits.h>
-#include <boost/container/vector.hpp>
+#include <edm4eic/Cov2f.h>
+#include <edm4eic/Cov3f.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
@@ -52,6 +54,7 @@
 #include <string>
 #include <tuple>
 #include <typeinfo>
+#include <utility>
 #include <variant>
 
 #include "algorithms/tracking/ActsGeometryProvider.h"

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -284,7 +284,7 @@ TrackPropagation::propagate(const edm4eic::Track& /* track */,
   using Propagator = Acts::Propagator<Acts::EigenStepper<>, Acts::Navigator>;
 #if Acts_VERSION_MAJOR >= 37
   using PropagatorOptions = Propagator::template Options<
-      Acts::ActorList<Acts::MaterialInteractor, Acts::EndOfWorldReached>>;
+      Acts::ActorList<Acts::MaterialInteractor>>;
 #else
   using PropagatorOptions =
       Propagator::template Options<Acts::ActionList<Acts::MaterialInteractor>>;

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -44,6 +44,7 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <algorithm>
+#include <any>
 #include <cmath>
 #include <cstdint>
 #include <functional>

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -9,6 +9,7 @@
 #include <Acts/EventData/MultiTrajectoryHelpers.hpp>
 #include <Acts/EventData/ParticleHypothesis.hpp>
 #include <Acts/Geometry/GeometryIdentifier.hpp>
+#include <Acts/Geometry/Layer.hpp>
 #include <Acts/Geometry/TrackingGeometry.hpp>
 #include <Acts/MagneticField/MagneticFieldProvider.hpp>
 #if Acts_VERSION_MAJOR >= 34
@@ -23,6 +24,13 @@
 #include <Acts/Propagator/Navigator.hpp>
 #endif
 #include <Acts/Propagator/Propagator.hpp>
+#if Acts_VERSION_MAJOR >= 36
+#include <Acts/Propagator/PropagatorOptions.hpp>
+#include <Acts/Propagator/PropagatorResult.hpp>
+#endif
+#if Acts_VERSION_MAJOR >= 34
+#include <Acts/Propagator/StandardAborters.hpp>
+#endif
 #include <Acts/Surfaces/CylinderBounds.hpp>
 #include <Acts/Surfaces/CylinderSurface.hpp>
 #include <Acts/Surfaces/DiscSurface.hpp>
@@ -30,16 +38,16 @@
 #include <Acts/Utilities/Logger.hpp>
 #include <ActsExamples/EventData/Trajectories.hpp>
 #include <DD4hep/Handle.h>
-#include <Eigen/Core>
-#include <Eigen/Geometry>
 #include <Evaluator/DD4hepUnits.h>
-#include <algorithm>
 #include <boost/container/vector.hpp>
-#include <cmath>
-#include <cstdint>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
 #include <functional>
 #include <iterator>
 #include <map>

--- a/src/algorithms/tracking/TrackPropagation.h
+++ b/src/algorithms/tracking/TrackPropagation.h
@@ -16,10 +16,12 @@
 #include <edm4eic/TrackPoint.h>
 #include <edm4eic/TrackSegmentCollection.h>
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <spdlog/logger.h>
 #include <cstddef>
 #include <memory>
 #include <tuple>
+#include <variant>
 #include <vector>
 
 #include "algorithms/interfaces/WithPodConfig.h"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds an explicit Navigator with MaterialInteractor action for track propagation. This may impact how the material map is taken into account during propagation.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: material map no explicitly included in track propagation)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.