### PR TITLE
linux-eic-shell: update llvm-cov from 15 to 18

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -301,7 +301,7 @@ jobs:
       run: |
         cd build
         COV_OPTIONS=('--ignore-filename-regex=usr/local/include/eigen3.+')
-        llvm-profdata-15 merge -sparse src/tests/algorithms_test/algorithms_test.profraw \
+        llvm-profdata-18 merge -sparse src/tests/algorithms_test/algorithms_test.profraw \
           -o src/tests/algorithms_test/algorithms_test.profdata
         LIB_PATHS=()
         for LIB_PATH in $(find src/ -type f -name "libalgorithms_*.so"); do

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -296,7 +296,7 @@ jobs:
     - name: Uncompress build artifact
       run: tar -xaf build.tar.zst
     - run: sudo apt-get update
-    - run: sudo apt-get install -y llvm-15 jq
+    - run: sudo apt-get install -y llvm-18 jq
     - name: llvm-cov
       run: |
         cd build
@@ -308,10 +308,10 @@ jobs:
           LIB_NAME="$(basename ${LIB_PATH%%.so})"
           LIB_NAME="${LIB_NAME##lib}"
           LIB_PATHS+=("$LIB_PATH")
-          llvm-cov-15 report $LIB_PATH \
+          llvm-cov-18 report $LIB_PATH \
             -instr-profile=src/tests/algorithms_test/algorithms_test.profdata \
             "${COV_OPTIONS[@]}"
-          COV_PERCENT=$(llvm-cov-15 export $LIB_PATH \
+          COV_PERCENT=$(llvm-cov-18 export $LIB_PATH \
             -instr-profile=src/tests/algorithms_test/algorithms_test.profdata \
             "${COV_OPTIONS[@]}" | jq '.data | map(.totals.regions.percent) | .[]' | xargs printf "%.1f\n")
           if [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ]; then
@@ -329,7 +329,7 @@ jobs:
             echo 'PR submitted from a fork. Skipping posting the "Code coverage ('$LIB_NAME') - '$COV_PERCENT'%" status.'
           fi
         done
-        llvm-cov-15 show "${LIB_PATHS[@]/#/--object=}" \
+        llvm-cov-18 show "${LIB_PATHS[@]/#/--object=}" \
           -instr-profile=src/tests/algorithms_test/algorithms_test.profdata \
           -output-dir=codecov_report -format=html \
           "${COV_OPTIONS[@]}"


### PR DESCRIPTION
eic-shell now ships with llvm/clang 18, so we started running into:
```
warning: src/tests/algorithms_test/algorithms_test.profraw: unsupported instrumentation profile format version
error: no profile can be merged
```