### PR TITLE
Added new mode to support charge sharing sigma in the units of cell dimension

### DIFF
--- a/src/algorithms/digi/SiliconChargeSharing.cc
+++ b/src/algorithms/digi/SiliconChargeSharing.cc
@@ -171,10 +171,16 @@ dd4hep::Position SiliconChargeSharing::global2Local(const dd4hep::Position& glob
 float SiliconChargeSharing::energyAtCell(const double xDimension, const double yDimension,
                                          const dd4hep::Position localPos,
                                          const dd4hep::Position hitPos, const float edep) const {
+  auto sigma_sharingx = m_cfg.sigma_sharingx;
+  auto sigma_sharingy = m_cfg.sigma_sharingy;
+  if (m_cfg.sigma_mode == SiliconChargeSharingConfig::ESigmaMode::rel) {
+    sigma_sharingx *= xDimension;
+    sigma_sharingy *= yDimension;
+  }
   float energy = edep *
-                 integralGaus(hitPos.x(), m_cfg.sigma_sharingx, localPos.x() - 0.5 * xDimension,
+                 integralGaus(hitPos.x(), sigma_sharingx, localPos.x() - 0.5 * xDimension,
                               localPos.x() + 0.5 * xDimension) *
-                 integralGaus(hitPos.y(), m_cfg.sigma_sharingy, localPos.y() - 0.5 * yDimension,
+                 integralGaus(hitPos.y(), sigma_sharingy, localPos.y() - 0.5 * yDimension,
                               localPos.y() + 0.5 * yDimension);
   return energy;
 }

--- a/src/algorithms/digi/SiliconChargeSharingConfig.h
+++ b/src/algorithms/digi/SiliconChargeSharingConfig.h
@@ -7,10 +7,42 @@ namespace eicrecon {
 
 struct SiliconChargeSharingConfig {
   // Parameters of Silicon signal generation
+  // determines the meaning of sigma_sharingx and y.
+  // rel means relative, so charge sharing range = sigma_sharingx * cell_width_x, etc for y
+  // abs means absolute, charge sharing range = sigma_shargeingx directly
+  enum ESigmaMode { abs = 0, rel = 1 } sigma_mode = abs;
   float sigma_sharingx;
   float sigma_sharingy;
   float min_edep;
   std::string readout;
 };
+
+std::istream& operator>>(std::istream& in, SiliconChargeSharingConfig::ESigmaMode& sigmaMode) {
+  std::string s;
+  in >> s;
+  // stringifying the enums causes them to be converted to integers before conversion to strings
+  if (s == "abs" or s == "0") {
+    sigmaMode = SiliconChargeSharingConfig::ESigmaMode::abs;
+  } else if (s == "rel" or s == "1") {
+    sigmaMode = SiliconChargeSharingConfig::ESigmaMode::rel;
+  } else {
+    in.setstate(std::ios::failbit); // Set the fail bit if the input is not valid
+  }
+
+  return in;
+}
+std::ostream& operator<<(std::ostream& out, SiliconChargeSharingConfig::ESigmaMode& sigmaMode) {
+  switch (sigmaMode) {
+  case SiliconChargeSharingConfig::ESigmaMode::abs:
+    out << "abs";
+    break;
+  case SiliconChargeSharingConfig::ESigmaMode::rel:
+    out << "rel";
+    break;
+  default:
+    out.setstate(std::ios::failbit);
+  }
+  return out;
+}
 
 } // namespace eicrecon

--- a/src/detectors/BTOF/BTOF.cc
+++ b/src/detectors/BTOF/BTOF.cc
@@ -7,11 +7,14 @@
 
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JTypeInfo.h>
 #include <TMath.h>
 #include <edm4eic/unit_system.h>
-#include <memory>
+#include <cmath>
+#include <string>
+#include <vector>
 
-#include "algorithms/interfaces/WithPodConfig.h"
+#include "algorithms/digi/SiliconChargeSharingConfig.h"
 #include "extensions/jana/JOmniFactoryGeneratorT.h"
 #include "factories/digi/EICROCDigitization_factory.h"
 #include "factories/digi/PulseCombiner_factory.h"
@@ -48,8 +51,9 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<SiliconChargeSharing_factory>(
       "TOFBarrelSharedHits", {"TOFBarrelHits"}, {"TOFBarrelSharedHits"},
       {
-          .sigma_sharingx = 0.1 * dd4hep::mm,
-          .sigma_sharingy = 0.5 * dd4hep::cm,
+          .sigma_mode     = SiliconChargeSharingConfig::ESigmaMode::rel,
+          .sigma_sharingx = 1,
+          .sigma_sharingy = 0.5,
           .min_edep       = 0.0 * edm4eic::unit::GeV,
           .readout        = "TOFBarrelHits",
       },

--- a/src/factories/digi/SiliconChargeSharing_factory.h
+++ b/src/factories/digi/SiliconChargeSharing_factory.h
@@ -26,6 +26,8 @@ private:
   ParameterRef<float> m_sigma_sharingy{this, "sigmaSharingY", config().sigma_sharingy};
   ParameterRef<float> m_min_edep{this, "minEDep", config().min_edep};
   ParameterRef<std::string> m_readout{this, "readout", config().readout};
+  ParameterRef<eicrecon::SiliconChargeSharingConfig::ESigmaMode> m_sigma_mode{this, "sigmaMode",
+                                                                              config().sigma_mode};
 
 public:
   void Configure() {


### PR DESCRIPTION
### Briefly, what does this PR introduce?

I added an option in `SiliconChargeSharing `such that `sharing_sigma `can be defined relative to the cell size in the latest update, as per our agreement in the reconstruction meeting. BTOF now defaults to using this relative definition of charge sharing magnitude.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No

### Does this PR change default behavior?

No
