### PR TITLE
Temporarily disable omnifactory tests due to changing JANA2 internals

### DIFF
--- a/src/tests/omnifactory_test/CMakeLists.txt
+++ b/src/tests/omnifactory_test/CMakeLists.txt
@@ -1,33 +1,42 @@
-# Automatically set plugin name the same as the directory name
-get_filename_component(TEST_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
 
-# These tests can use the Catch2-provided main
-add_executable(${TEST_NAME} JOmniFactoryTests.cc)
+if (NOT JANA_VERSION VERSION_GREATER "2.4.2")
+  # Disable omnifactory tests for versions of JANA > 2.4.2.
+  # These tests use some internal JANA machinery which is going away.
+  # Tests will be re-enabled once the next version has been released.
 
-find_package(spdlog REQUIRED)
-find_package(fmt REQUIRED)
+  # Automatically set plugin name the same as the directory name
+  get_filename_component(TEST_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
 
-# Explicit linking to podio::podio is needed due to
-# https://github.com/JeffersonLab/JANA2/issues/151
-target_include_directories(
-  ${TEST_NAME}
-  PRIVATE ${PROJECT_BINARY_DIR} ${EICRECON_SOURCE_DIR}/src
-          ${PROJECT_SOURCE_DIR} ${JANA_INCLUDE_DIR} ${ROOT_INCLUDE_DIRS}
-          ${PROJECT_BINARY_DIR}/include)
-target_link_libraries(
-  ${TEST_NAME}
-  PRIVATE log_plugin
-          EDM4EIC::edm4eic
-          EDM4HEP::edm4hep
-          ${JANA_LIB}
-          podio::podio
-          podio::podioRootIO
-          ${ROOT_LIBRARIES}
-          Catch2::Catch2WithMain
-          ${CMAKE_DL_LIBS})
+  # These tests can use the Catch2-provided main
+  add_executable(${TEST_NAME} JOmniFactoryTests.cc)
 
-# Install executable
-install(TARGETS ${TEST_NAME} DESTINATION bin)
+  find_package(spdlog REQUIRED)
+  find_package(fmt REQUIRED)
 
-add_test(NAME t_${TEST_NAME} COMMAND env LLVM_PROFILE_FILE=${TEST_NAME}.profraw
-                                     $<TARGET_FILE:${TEST_NAME}>)
+  # Explicit linking to podio::podio is needed due to
+  # https://github.com/JeffersonLab/JANA2/issues/151
+  target_include_directories(
+    ${TEST_NAME}
+    PRIVATE ${PROJECT_BINARY_DIR} ${EICRECON_SOURCE_DIR}/src
+            ${PROJECT_SOURCE_DIR} ${JANA_INCLUDE_DIR} ${ROOT_INCLUDE_DIRS}
+            ${PROJECT_BINARY_DIR}/include)
+
+  target_link_libraries(
+    ${TEST_NAME}
+    PRIVATE log_plugin
+            EDM4EIC::edm4eic
+            EDM4HEP::edm4hep
+            ${JANA_LIB}
+            podio::podio
+            podio::podioRootIO
+            ${ROOT_LIBRARIES}
+            Catch2::Catch2WithMain
+            ${CMAKE_DL_LIBS})
+
+  # Install executable
+  install(TARGETS ${TEST_NAME} DESTINATION bin)
+
+  add_test(NAME t_${TEST_NAME} COMMAND env LLVM_PROFILE_FILE=${TEST_NAME}.profraw
+           $<TARGET_FILE:${TEST_NAME}>)
+
+endif()


### PR DESCRIPTION

JMultifactoryHelperT's are going away completely. Collections are accessed through JDatabundles instead, and each JDatabundle knows which JFactory populates it. JOmniFactory will ultimately inherit directly from JFactory, and pull in the same JHasInputs, JHasOutputs, JHasRunCallbacks, etc, as the other components.

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
