### PR TITLE
fix: Add ImagingTopoCluster layer mode within same layers

### DIFF
--- a/src/algorithms/calorimetry/ImagingTopoCluster.cc
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.cc
@@ -180,8 +180,6 @@ void ImagingTopoCluster::process(const Input& input, const Output& output) const
   //   debug("group {}: {} hits", i, groups[i].size());
   // }
   for (std::size_t i = 0; i < groups.size(); ++i) {
-    debug("");
-    debug("");
     debug("group {}: {} hits", i, groups[i].size());
     for (auto idx : groups[i]) {
       const auto& hit = (*hits)[idx];

--- a/src/algorithms/calorimetry/ImagingTopoCluster.cc
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.cc
@@ -63,14 +63,14 @@ void ImagingTopoCluster::init() {
   sameLayerDistXY[1]     = std::visit(_toDouble, m_cfg.sameLayerDistXY[1]) / dd4hep::mm;
   diffLayerDistXY[0]     = std::visit(_toDouble, m_cfg.diffLayerDistXY[0]) / dd4hep::mm;
   diffLayerDistXY[1]     = std::visit(_toDouble, m_cfg.diffLayerDistXY[1]) / dd4hep::mm;
-  sameLayerDistEtaPhi[0] = std::visit(_toDouble, m_cfg.sameLayerDistEtaPhi[0]);
-  sameLayerDistEtaPhi[1] = std::visit(_toDouble, m_cfg.sameLayerDistEtaPhi[1]) / dd4hep::rad;
-  diffLayerDistEtaPhi[0] = std::visit(_toDouble, m_cfg.diffLayerDistEtaPhi[0]);
-  diffLayerDistEtaPhi[1] = std::visit(_toDouble, m_cfg.diffLayerDistEtaPhi[1]) / dd4hep::rad;
-  sameLayerDistTZ[0]     = std::visit(_toDouble, m_cfg.sameLayerDistTZ[0]) / dd4hep::mm;
-  sameLayerDistTZ[1]     = std::visit(_toDouble, m_cfg.sameLayerDistTZ[1]) / dd4hep::mm;
-  diffLayerDistTZ[0]     = std::visit(_toDouble, m_cfg.diffLayerDistTZ[0]) / dd4hep::mm;
-  diffLayerDistTZ[1]     = std::visit(_toDouble, m_cfg.diffLayerDistTZ[1]) / dd4hep::mm;
+  sameLayerDistEtaPhi[0] = m_cfg.sameLayerDistEtaPhi[0];
+  sameLayerDistEtaPhi[1] = m_cfg.sameLayerDistEtaPhi[1] / dd4hep::rad;
+  diffLayerDistEtaPhi[0] = m_cfg.diffLayerDistEtaPhi[0];
+  diffLayerDistEtaPhi[1] = m_cfg.diffLayerDistEtaPhi[1] / dd4hep::rad;
+  sameLayerDistTZ[0]     = m_cfg.sameLayerDistTZ[0] / dd4hep::mm;
+  sameLayerDistTZ[1]     = m_cfg.sameLayerDistTZ[1] / dd4hep::mm;
+  diffLayerDistTZ[0]     = m_cfg.diffLayerDistTZ[0] / dd4hep::mm;
+  diffLayerDistTZ[1]     = m_cfg.diffLayerDistTZ[1] / dd4hep::mm;
 
   sectorDist           = m_cfg.sectorDist / dd4hep::mm;
   minClusterHitEdep    = m_cfg.minClusterHitEdep / dd4hep::GeV;

--- a/src/algorithms/calorimetry/ImagingTopoCluster.cc
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.cc
@@ -63,10 +63,10 @@ void ImagingTopoCluster::init() {
   sameLayerDistXY[1]     = std::visit(_toDouble, m_cfg.sameLayerDistXY[1]) / dd4hep::mm;
   diffLayerDistXY[0]     = std::visit(_toDouble, m_cfg.diffLayerDistXY[0]) / dd4hep::mm;
   diffLayerDistXY[1]     = std::visit(_toDouble, m_cfg.diffLayerDistXY[1]) / dd4hep::mm;
-  sameLayerDistEtaPhi[0] = m_cfg.sameLayerDistEtaPhi[0];
-  sameLayerDistEtaPhi[1] = m_cfg.sameLayerDistEtaPhi[1] / dd4hep::rad;
-  diffLayerDistEtaPhi[0] = m_cfg.diffLayerDistEtaPhi[0];
-  diffLayerDistEtaPhi[1] = m_cfg.diffLayerDistEtaPhi[1] / dd4hep::rad;
+  sameLayerDistEtaPhi[0] = std::visit(_toDouble, m_cfg.sameLayerDistEtaPhi[0]);
+  sameLayerDistEtaPhi[1] = std::visit(_toDouble, m_cfg.sameLayerDistEtaPhi[1]) / dd4hep::rad;
+  diffLayerDistEtaPhi[0] = std::visit(_toDouble, m_cfg.diffLayerDistEtaPhi[0]);
+  diffLayerDistEtaPhi[1] = std::visit(_toDouble, m_cfg.diffLayerDistEtaPhi[1]) / dd4hep::rad;
   sameLayerDistTZ[0]     = std::visit(_toDouble, m_cfg.sameLayerDistTZ[0]) / dd4hep::mm;
   sameLayerDistTZ[1]     = std::visit(_toDouble, m_cfg.sameLayerDistTZ[1]) / dd4hep::mm;
   diffLayerDistTZ[0]     = std::visit(_toDouble, m_cfg.diffLayerDistTZ[0]) / dd4hep::mm;

--- a/src/algorithms/calorimetry/ImagingTopoCluster.cc
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.cc
@@ -158,9 +158,9 @@ void ImagingTopoCluster::process(const Input& input, const Output& output) const
        indices.empty() ? idx = indices.end() : idx) {
 
     trace("hit {:d}: local position = ({}, {}, {}), global position = ({}, {}, {}), energy = {}",
-          *idx, (*hits)[*idx].getLocal().x, (*hits)[*idx].getLocal().y,
-          (*hits)[*idx].getLocal().z, (*hits)[*idx].getPosition().x,
-          (*hits)[*idx].getPosition().y, (*hits)[*idx].getPosition().z, (*hits)[*idx].getEnergy());
+          *idx, (*hits)[*idx].getLocal().x, (*hits)[*idx].getLocal().y, (*hits)[*idx].getLocal().z,
+          (*hits)[*idx].getPosition().x, (*hits)[*idx].getPosition().y,
+          (*hits)[*idx].getPosition().z, (*hits)[*idx].getEnergy());
 
     // not energetic enough for cluster center, but could still be cluster hit
     if ((*hits)[*idx].getEnergy() < minClusterCenterEdep) {

--- a/src/algorithms/calorimetry/ImagingTopoCluster.cc
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.cc
@@ -29,6 +29,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <gsl/pointers>
+#include <stdexcept>
 #include <utility>
 #include <variant>
 #include <vector>

--- a/src/algorithms/calorimetry/ImagingTopoCluster.cc
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.cc
@@ -54,8 +54,28 @@ void ImagingTopoCluster::init() {
     error("Expected 2 values (x_dist, y_dist) for localDistXY");
     return;
   }
-  if (m_cfg.layerDistEtaPhi.size() != 2) {
-    error("Expected 2 values (eta_dist, phi_dist) for layerDistEtaPhi");
+  if (m_cfg.sameLayerDistXY.size() != 2) {
+    error("Expected 2 values (x_dist, y_dist) for sameLayerDistXY");
+    return;
+  }
+  if (m_cfg.diffLayerDistXY.size() != 2) {
+    error("Expected 2 values (x_dist, y_dist) for diffLayerDistXY");
+    return;
+  }
+  if (m_cfg.sameLayerDistEtaPhi.size() != 2) {
+    error("Expected 2 values (eta_dist, phi_dist) for sameLayerDistEtaPhi");
+    return;
+  }
+  if (m_cfg.diffLayerDistEtaPhi.size() != 2) {
+    error("Expected 2 values (eta_dist, phi_dist) for diffLayerDistEtaPhi");
+    return;
+  }
+  if (m_cfg.sameLayerDistPhiZ.size() != 2) {
+    error("Expected 2 values (phi_dist, z_dist) for sameLayerDistPhiZ");
+    return;
+  }
+  if (m_cfg.diffLayerDistPhiZ.size() != 2) {
+    error("Expected 2 values (phi_dist, z_dist) for diffLayerDistPhiZ");
     return;
   }
   if (m_cfg.minClusterCenterEdep < m_cfg.minClusterHitEdep) {
@@ -66,10 +86,19 @@ void ImagingTopoCluster::init() {
   // using juggler internal units (GeV, dd4hep::mm, dd4hep::ns, dd4hep::rad)
   localDistXY[0]       = std::visit(_toDouble, m_cfg.localDistXY[0]) / dd4hep::mm;
   localDistXY[1]       = std::visit(_toDouble, m_cfg.localDistXY[1]) / dd4hep::mm;
-  layerDistXY[0]       = std::visit(_toDouble, m_cfg.layerDistXY[0]) / dd4hep::mm;
-  layerDistXY[1]       = std::visit(_toDouble, m_cfg.layerDistXY[1]) / dd4hep::mm;
-  layerDistEtaPhi[0]   = m_cfg.layerDistEtaPhi[0];
-  layerDistEtaPhi[1]   = m_cfg.layerDistEtaPhi[1] / dd4hep::rad;
+  sameLayerDistXY[0]       = std::visit(_toDouble, m_cfg.sameLayerDistXY[0]) / dd4hep::mm;
+  sameLayerDistXY[1]       = std::visit(_toDouble, m_cfg.sameLayerDistXY[1]) / dd4hep::mm;
+  diffLayerDistXY[0]       = std::visit(_toDouble, m_cfg.diffLayerDistXY[0]) / dd4hep::mm;
+  diffLayerDistXY[1]       = std::visit(_toDouble, m_cfg.diffLayerDistXY[1]) / dd4hep::mm;
+  sameLayerDistEtaPhi[0]   = m_cfg.sameLayerDistEtaPhi[0];
+  sameLayerDistEtaPhi[1]   = m_cfg.sameLayerDistEtaPhi[1]/ dd4hep::rad;
+  diffLayerDistEtaPhi[0]   = m_cfg.diffLayerDistEtaPhi[0];
+  diffLayerDistEtaPhi[1]   = m_cfg.diffLayerDistEtaPhi[1] / dd4hep::rad;
+  sameLayerDistPhiZ[0]   = std::visit(_toDouble,m_cfg.sameLayerDistPhiZ[0])/dd4hep::mm;
+  sameLayerDistPhiZ[1]   = std::visit(_toDouble,m_cfg.sameLayerDistPhiZ[1])/dd4hep::mm;
+  diffLayerDistPhiZ[0]   = std::visit(_toDouble,m_cfg.diffLayerDistPhiZ[0])/dd4hep::mm;
+  diffLayerDistPhiZ[1]   = std::visit(_toDouble,m_cfg.diffLayerDistPhiZ[1])/dd4hep::mm;
+  
   sectorDist           = m_cfg.sectorDist / dd4hep::mm;
   minClusterHitEdep    = m_cfg.minClusterHitEdep / dd4hep::GeV;
   minClusterCenterEdep = m_cfg.minClusterCenterEdep / dd4hep::GeV;
@@ -85,12 +114,12 @@ void ImagingTopoCluster::init() {
   case ImagingTopoClusterConfig::ELayerMode::etaphi:
     info("Same-layer clustering (same sector and same layer): "
          "Global [eta, phi] distance between hits <= [{:.4f}, {:.4f} rad].",
-         layerDistEtaPhi[0], layerDistEtaPhi[1]);
+         sameLayerDistEtaPhi[0], sameLayerDistEtaPhi[1]);
     break;
   case ImagingTopoClusterConfig::ELayerMode::phiz:
     info("Same-layer clustering (same sector and same layer): "
          "Global [phi, z] distance between hits <= [{:.4f} rad, {:.4f} mm].",
-         layerDistEtaPhi[1], layerDistXY[1]);
+         sameLayerDistPhiZ[0], sameLayerDistPhiZ[1]);
     break;
   default:
     error("Unknown same-layer mode.");
@@ -101,17 +130,17 @@ void ImagingTopoCluster::init() {
   case ImagingTopoClusterConfig::ELayerMode::etaphi:
     info("Neighbour layers clustering (same sector and layer id within +- {:d}): "
          "Global [eta, phi] distance between hits <= [{:.4f}, {:.4f} rad].",
-         m_cfg.neighbourLayersRange, layerDistEtaPhi[0], layerDistEtaPhi[1]);
+         m_cfg.neighbourLayersRange, diffLayerDistEtaPhi[0], diffLayerDistEtaPhi[1]);
     break;
   case ImagingTopoClusterConfig::ELayerMode::xy:
     info("Neighbour layers clustering (same sector and layer id within +- {:d}): "
          "Global [x, y] distance between hits <= [{:.4f} mm, {:.4f} mm].",
-         m_cfg.neighbourLayersRange, layerDistXY[0], layerDistXY[1]);
+         m_cfg.neighbourLayersRange, diffLayerDistXY[0], diffLayerDistXY[1]);
     break;
   case ImagingTopoClusterConfig::ELayerMode::phiz:
     info("Neighbour layers clustering (same sector and layer id within +- {:d}): "
-         "Global [phi, z] distance between hits <= [{:.4f} rad, {:.4f} mm].",
-         m_cfg.neighbourLayersRange, layerDistEtaPhi[1], layerDistXY[1]);
+         "Global [phi, z] distance between hits <= [{:.4f} mm, {:.4f} mm].", // The coordinate Phi is the projected Phi and thus is a distance, not an angle.
+         m_cfg.neighbourLayersRange, diffLayerDistPhiZ[0], diffLayerDistPhiZ[1]);
     break;
   default:
     error("Unknown different-layer mode.");
@@ -229,9 +258,9 @@ bool ImagingTopoCluster::is_neighbour(const edm4eic::CalorimeterHit& h1,
 
     case ImagingTopoClusterConfig::ELayerMode::etaphi:
       return (std::abs(edm4hep::utils::eta(h1.getPosition()) -
-                       edm4hep::utils::eta(h2.getPosition())) <= layerDistEtaPhi[0]) &&
+                       edm4hep::utils::eta(h2.getPosition())) <= sameLayerDistEtaPhi[0]) &&
              (std::abs(edm4hep::utils::angleAzimuthal(h1.getPosition()) -
-                       edm4hep::utils::angleAzimuthal(h2.getPosition())) <= layerDistEtaPhi[1]);
+                       edm4hep::utils::angleAzimuthal(h2.getPosition())) <= sameLayerDistEtaPhi[1]);
 
     case ImagingTopoClusterConfig::ELayerMode::phiz: {
       // Layer mode 'phiz' uses the average phi of the hits to define a rotated direction. The coordinate is a distance, not an angle.
@@ -242,7 +271,7 @@ bool ImagingTopoCluster::is_neighbour(const edm4eic::CalorimeterHit& h1,
       auto h1_z = h1.getPosition().z;
       auto h2_z = h2.getPosition().z;
 
-      return (std::abs(h1_t - h2_t) <= localDistXY[0]) && (std::abs(h1_z - h2_z) <= localDistXY[1]);
+      return (std::abs(h1_t - h2_t) <= sameLayerDistPhiZ[0]) && (std::abs(h1_z - h2_z) <= sameLayerDistPhiZ[1]);
     }
 
     default:
@@ -253,14 +282,14 @@ bool ImagingTopoCluster::is_neighbour(const edm4eic::CalorimeterHit& h1,
     switch (m_cfg.diffLayerMode) {
     case eicrecon::ImagingTopoClusterConfig::ELayerMode::etaphi:
       return (std::abs(edm4hep::utils::eta(h1.getPosition()) -
-                       edm4hep::utils::eta(h2.getPosition())) <= layerDistEtaPhi[0]) &&
+                       edm4hep::utils::eta(h2.getPosition())) <= diffLayerDistEtaPhi[0]) &&
              (std::abs(edm4hep::utils::angleAzimuthal(h1.getPosition()) -
-                       edm4hep::utils::angleAzimuthal(h2.getPosition())) <= layerDistEtaPhi[1]);
+                       edm4hep::utils::angleAzimuthal(h2.getPosition())) <= diffLayerDistEtaPhi[1]);
 
     case eicrecon::ImagingTopoClusterConfig::ELayerMode::xy:
       // Here, the xy layer mode is based on global XY positions rather than local XY positions, and thus it only works for endcap detectors.
-      return (std::abs(h1.getPosition().x - h2.getPosition().x) <= layerDistXY[0]) &&
-             (std::abs(h1.getPosition().y - h2.getPosition().y) <= layerDistXY[1]);
+      return (std::abs(h1.getPosition().x - h2.getPosition().x) <= diffLayerDistXY[0]) &&
+             (std::abs(h1.getPosition().y - h2.getPosition().y) <= diffLayerDistXY[1]);
 
     case eicrecon::ImagingTopoClusterConfig::ELayerMode::phiz: {
       auto phi  = 0.5 * (edm4hep::utils::angleAzimuthal(h1.getPosition()) +
@@ -270,7 +299,7 @@ bool ImagingTopoCluster::is_neighbour(const edm4eic::CalorimeterHit& h1,
       auto h1_z = h1.getPosition().z;
       auto h2_z = h2.getPosition().z;
 
-      return (std::abs(h1_t - h2_t) <= layerDistXY[0]) && (std::abs(h1_z - h2_z) <= layerDistXY[1]);
+      return (std::abs(h1_t - h2_t) <= diffLayerDistPhiZ[0]) && (std::abs(h1_z - h2_z) <= diffLayerDistPhiZ[1]);
     }
 
     default:

--- a/src/algorithms/calorimetry/ImagingTopoCluster.cc
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.cc
@@ -84,21 +84,21 @@ void ImagingTopoCluster::init() {
   }
 
   // using juggler internal units (GeV, dd4hep::mm, dd4hep::ns, dd4hep::rad)
-  localDistXY[0]       = std::visit(_toDouble, m_cfg.localDistXY[0]) / dd4hep::mm;
-  localDistXY[1]       = std::visit(_toDouble, m_cfg.localDistXY[1]) / dd4hep::mm;
-  sameLayerDistXY[0]       = std::visit(_toDouble, m_cfg.sameLayerDistXY[0]) / dd4hep::mm;
-  sameLayerDistXY[1]       = std::visit(_toDouble, m_cfg.sameLayerDistXY[1]) / dd4hep::mm;
-  diffLayerDistXY[0]       = std::visit(_toDouble, m_cfg.diffLayerDistXY[0]) / dd4hep::mm;
-  diffLayerDistXY[1]       = std::visit(_toDouble, m_cfg.diffLayerDistXY[1]) / dd4hep::mm;
-  sameLayerDistEtaPhi[0]   = m_cfg.sameLayerDistEtaPhi[0];
-  sameLayerDistEtaPhi[1]   = m_cfg.sameLayerDistEtaPhi[1]/ dd4hep::rad;
-  diffLayerDistEtaPhi[0]   = m_cfg.diffLayerDistEtaPhi[0];
-  diffLayerDistEtaPhi[1]   = m_cfg.diffLayerDistEtaPhi[1] / dd4hep::rad;
-  sameLayerDistPhiZ[0]   = std::visit(_toDouble,m_cfg.sameLayerDistPhiZ[0])/dd4hep::mm;
-  sameLayerDistPhiZ[1]   = std::visit(_toDouble,m_cfg.sameLayerDistPhiZ[1])/dd4hep::mm;
-  diffLayerDistPhiZ[0]   = std::visit(_toDouble,m_cfg.diffLayerDistPhiZ[0])/dd4hep::mm;
-  diffLayerDistPhiZ[1]   = std::visit(_toDouble,m_cfg.diffLayerDistPhiZ[1])/dd4hep::mm;
-  
+  localDistXY[0]         = std::visit(_toDouble, m_cfg.localDistXY[0]) / dd4hep::mm;
+  localDistXY[1]         = std::visit(_toDouble, m_cfg.localDistXY[1]) / dd4hep::mm;
+  sameLayerDistXY[0]     = std::visit(_toDouble, m_cfg.sameLayerDistXY[0]) / dd4hep::mm;
+  sameLayerDistXY[1]     = std::visit(_toDouble, m_cfg.sameLayerDistXY[1]) / dd4hep::mm;
+  diffLayerDistXY[0]     = std::visit(_toDouble, m_cfg.diffLayerDistXY[0]) / dd4hep::mm;
+  diffLayerDistXY[1]     = std::visit(_toDouble, m_cfg.diffLayerDistXY[1]) / dd4hep::mm;
+  sameLayerDistEtaPhi[0] = m_cfg.sameLayerDistEtaPhi[0];
+  sameLayerDistEtaPhi[1] = m_cfg.sameLayerDistEtaPhi[1] / dd4hep::rad;
+  diffLayerDistEtaPhi[0] = m_cfg.diffLayerDistEtaPhi[0];
+  diffLayerDistEtaPhi[1] = m_cfg.diffLayerDistEtaPhi[1] / dd4hep::rad;
+  sameLayerDistPhiZ[0]   = std::visit(_toDouble, m_cfg.sameLayerDistPhiZ[0]) / dd4hep::mm;
+  sameLayerDistPhiZ[1]   = std::visit(_toDouble, m_cfg.sameLayerDistPhiZ[1]) / dd4hep::mm;
+  diffLayerDistPhiZ[0]   = std::visit(_toDouble, m_cfg.diffLayerDistPhiZ[0]) / dd4hep::mm;
+  diffLayerDistPhiZ[1]   = std::visit(_toDouble, m_cfg.diffLayerDistPhiZ[1]) / dd4hep::mm;
+
   sectorDist           = m_cfg.sectorDist / dd4hep::mm;
   minClusterHitEdep    = m_cfg.minClusterHitEdep / dd4hep::GeV;
   minClusterCenterEdep = m_cfg.minClusterCenterEdep / dd4hep::GeV;
@@ -138,9 +138,10 @@ void ImagingTopoCluster::init() {
          m_cfg.neighbourLayersRange, diffLayerDistXY[0], diffLayerDistXY[1]);
     break;
   case ImagingTopoClusterConfig::ELayerMode::phiz:
-    info("Neighbour layers clustering (same sector and layer id within +- {:d}): "
-         "Global [phi, z] distance between hits <= [{:.4f} mm, {:.4f} mm].", // The coordinate Phi is the projected Phi and thus is a distance, not an angle.
-         m_cfg.neighbourLayersRange, diffLayerDistPhiZ[0], diffLayerDistPhiZ[1]);
+    info(
+        "Neighbour layers clustering (same sector and layer id within +- {:d}): "
+        "Global [phi, z] distance between hits <= [{:.4f} mm, {:.4f} mm].", // The coordinate Phi is the projected Phi and thus is a distance, not an angle.
+        m_cfg.neighbourLayersRange, diffLayerDistPhiZ[0], diffLayerDistPhiZ[1]);
     break;
   default:
     error("Unknown different-layer mode.");
@@ -271,7 +272,8 @@ bool ImagingTopoCluster::is_neighbour(const edm4eic::CalorimeterHit& h1,
       auto h1_z = h1.getPosition().z;
       auto h2_z = h2.getPosition().z;
 
-      return (std::abs(h1_t - h2_t) <= sameLayerDistPhiZ[0]) && (std::abs(h1_z - h2_z) <= sameLayerDistPhiZ[1]);
+      return (std::abs(h1_t - h2_t) <= sameLayerDistPhiZ[0]) &&
+             (std::abs(h1_z - h2_z) <= sameLayerDistPhiZ[1]);
     }
 
     default:
@@ -299,7 +301,8 @@ bool ImagingTopoCluster::is_neighbour(const edm4eic::CalorimeterHit& h1,
       auto h1_z = h1.getPosition().z;
       auto h2_z = h2.getPosition().z;
 
-      return (std::abs(h1_t - h2_t) <= diffLayerDistPhiZ[0]) && (std::abs(h1_z - h2_z) <= diffLayerDistPhiZ[1]);
+      return (std::abs(h1_t - h2_t) <= diffLayerDistPhiZ[0]) &&
+             (std::abs(h1_z - h2_z) <= diffLayerDistPhiZ[1]);
     }
 
     default:

--- a/src/algorithms/calorimetry/ImagingTopoCluster.cc
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.cc
@@ -157,9 +157,9 @@ void ImagingTopoCluster::process(const Input& input, const Output& output) const
   for (auto idx = indices.begin(); idx != indices.end();
        indices.empty() ? idx = indices.end() : idx) {
 
-    debug("hit {:d}: local position = ({}, {}, {}), global position = ({}, {}, {}), energy = {}",
+    trace("hit {:d}: local position = ({}, {}, {}), global position = ({}, {}, {}), energy = {}",
           *idx, (*hits)[*idx].getLocal().x, (*hits)[*idx].getLocal().y,
-          (*hits)[*idx].getPosition().z, (*hits)[*idx].getPosition().x,
+          (*hits)[*idx].getLocal().z, (*hits)[*idx].getPosition().x,
           (*hits)[*idx].getPosition().y, (*hits)[*idx].getPosition().z, (*hits)[*idx].getEnergy());
 
     // not energetic enough for cluster center, but could still be cluster hit
@@ -176,9 +176,6 @@ void ImagingTopoCluster::process(const Input& input, const Output& output) const
     idx = indices.erase(idx); // takes role of idx++
   }
   debug("found {} potential clusters (groups of hits)", groups.size());
-  // for (std::size_t i = 0; i < groups.size(); ++i) {
-  //   debug("group {}: {} hits", i, groups[i].size());
-  // }
   for (std::size_t i = 0; i < groups.size(); ++i) {
     debug("group {}: {} hits", i, groups[i].size());
     for (auto idx : groups[i]) {
@@ -224,10 +221,6 @@ bool ImagingTopoCluster::is_neighbour(const edm4eic::CalorimeterHit& h1,
   // layer check
   int ldiff = std::abs(h1.getLayer() - h2.getLayer());
   // same layer, check local positions
-  // if (ldiff == 0) {
-  //   return (std::abs(h1.getLocal().x - h2.getLocal().x) <= localDistXY[0]) &&
-  //          (std::abs(h1.getLocal().y - h2.getLocal().y) <= localDistXY[1]);
-  // }
   if (ldiff == 0) {
     switch (m_cfg.sameLayerMode) {
     case ImagingTopoClusterConfig::ELayerMode::xy:
@@ -242,7 +235,6 @@ bool ImagingTopoCluster::is_neighbour(const edm4eic::CalorimeterHit& h1,
 
     case ImagingTopoClusterConfig::ELayerMode::phiz: {
       // Layer mode 'phiz' uses the average phi of the hits to define a rotated direction. The coordinate is a distance, not an angle.
-
       auto phi  = 0.5 * (edm4hep::utils::angleAzimuthal(h1.getPosition()) +
                         edm4hep::utils::angleAzimuthal(h2.getPosition()));
       auto h1_t = (h1.getPosition().x * sin(phi)) - (h1.getPosition().y * cos(phi));

--- a/src/algorithms/calorimetry/ImagingTopoCluster.cc
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.cc
@@ -241,7 +241,8 @@ bool ImagingTopoCluster::is_neighbour(const edm4eic::CalorimeterHit& h1,
                        edm4hep::utils::angleAzimuthal(h2.getPosition())) <= layerDistEtaPhi[1]);
 
     case ImagingTopoClusterConfig::ELayerMode::phiz: {
-      // use average phi to calculate transverse coordinate in rotated frame
+      // Layer mode 'phiz' uses the average phi of the hits to define a rotated direction. The coordinate is a distance, not an angle.
+
       auto phi  = 0.5 * (edm4hep::utils::angleAzimuthal(h1.getPosition()) +
                         edm4hep::utils::angleAzimuthal(h2.getPosition()));
       auto h1_t = (h1.getPosition().x * sin(phi)) - (h1.getPosition().y * cos(phi));

--- a/src/algorithms/calorimetry/ImagingTopoCluster.cc
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.cc
@@ -147,6 +147,7 @@ void ImagingTopoCluster::init() {
         m_cfg.neighbourLayersRange, diffLayerDistTZ[0], diffLayerDistTZ[1]);
     break;
   default:
+    error("Unknown different-layer mode.");
     throw std::runtime_error("Unknown different-layer mode.");
   }
   info("Neighbour sectors clustering (different sector): "

--- a/src/algorithms/calorimetry/ImagingTopoCluster.cc
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.cc
@@ -101,12 +101,12 @@ void ImagingTopoCluster::init() {
     break;
   case ImagingTopoClusterConfig::ELayerMode::tz:
     if (m_cfg.sameLayerDistTZ.size() != 2) {
-      const std::string msg = "Expected 2 values (phi_dist, z_dist) for sameLayerDistTZ";
+      const std::string msg = "Expected 2 values (t_dist, z_dist) for sameLayerDistTZ";
       error(msg);
       throw std::runtime_error(msg);
     }
     info("Same-layer clustering (same sector and same layer): "
-         "Global [phi, z] distance between hits <= [{:.4f} rad, {:.4f} mm].",
+         "Global [t, z] distance between hits <= [{:.4f} mm, {:.4f} mm].",
          sameLayerDistTZ[0], sameLayerDistTZ[1]);
     break;
   default:

--- a/src/algorithms/calorimetry/ImagingTopoCluster.cc
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.cc
@@ -183,7 +183,7 @@ void ImagingTopoCluster::process(const Input& input, const Output& output) const
     debug("group {}: {} hits", i, groups[i].size());
     for (auto idx : groups[i]) {
       const auto& hit = (*hits)[idx];
-      debug("  hit {} -> energy = {:.6f}, layer = {}, sector = {}, local = ({:.2f}, {:.2f}, "
+      trace("  hit {} -> energy = {:.6f}, layer = {}, sector = {}, local = ({:.2f}, {:.2f}, "
             "{:.2f}), global = ({:.2f}, {:.2f}, {:.2f})",
             idx, hit.getEnergy(), hit.getLayer(), hit.getSector(), hit.getLocal().x,
             hit.getLocal().y, hit.getLocal().z, hit.getPosition().x, hit.getPosition().y,

--- a/src/algorithms/calorimetry/ImagingTopoCluster.cc
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.cc
@@ -137,15 +137,15 @@ void ImagingTopoCluster::init() {
     break;
   case ImagingTopoClusterConfig::ELayerMode::tz:
     if (m_cfg.diffLayerDistTZ.size() != 2) {
-      const std::string msg = "Expected 2 values (phi_dist, z_dist) for diffLayerDistTZ";
+      const std::string msg = "Expected 2 values (t_dist, z_dist) for diffLayerDistTZ";
       error(msg);
       throw std::runtime_error(msg);
     }
     info(
         "Neighbour layers clustering (same sector and layer id within +- {:d}): "
-        "Global [phi, z] distance between hits <= [{:.4f} mm, {:.4f} mm].", // The coordinate Phi is the projected Phi and thus is a distance, not an angle.
+        "Global [t, z] distance between hits <= [{:.4f} mm, {:.4f} mm].",
         m_cfg.neighbourLayersRange, diffLayerDistTZ[0], diffLayerDistTZ[1]);
-    break;
+break;
   default:
     error("Unknown different-layer mode.");
     throw std::runtime_error("Unknown different-layer mode.");

--- a/src/algorithms/calorimetry/ImagingTopoCluster.cc
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.cc
@@ -135,8 +135,8 @@ void ImagingTopoCluster::init() {
          m_cfg.neighbourLayersRange, diffLayerDistXY[0], diffLayerDistXY[1]);
     break;
   case ImagingTopoClusterConfig::ELayerMode::tz:
-    if (m_cfg.diffLayerDistPhiZ.size() != 2) {
-      const std::string msg = "Expected 2 values (phi_dist, z_dist) for diffLayerDistPhiZ";
+    if (m_cfg.diffLayerDistTZ.size() != 2) {
+      const std::string msg = "Expected 2 values (phi_dist, z_dist) for diffLayerDistTZ";
       error(msg);
       throw std::runtime_error(msg);
     }

--- a/src/algorithms/calorimetry/ImagingTopoCluster.cc
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.cc
@@ -50,33 +50,10 @@ void ImagingTopoCluster::init() {
 
   // unitless conversion
   // sanity checks
-  if (m_cfg.sameLayerDistXY.size() != 2) {
-    error("Expected 2 values (x_dist, y_dist) for sameLayerDistXY");
-    return;
-  }
-  if (m_cfg.diffLayerDistXY.size() != 2) {
-    error("Expected 2 values (x_dist, y_dist) for diffLayerDistXY");
-    return;
-  }
-  if (m_cfg.sameLayerDistEtaPhi.size() != 2) {
-    error("Expected 2 values (eta_dist, phi_dist) for sameLayerDistEtaPhi");
-    return;
-  }
-  if (m_cfg.diffLayerDistEtaPhi.size() != 2) {
-    error("Expected 2 values (eta_dist, phi_dist) for diffLayerDistEtaPhi");
-    return;
-  }
-  if (m_cfg.sameLayerDistPhiZ.size() != 2) {
-    error("Expected 2 values (phi_dist, z_dist) for sameLayerDistPhiZ");
-    return;
-  }
-  if (m_cfg.diffLayerDistPhiZ.size() != 2) {
-    error("Expected 2 values (phi_dist, z_dist) for diffLayerDistPhiZ");
-    return;
-  }
   if (m_cfg.minClusterCenterEdep < m_cfg.minClusterHitEdep) {
-    error("minClusterCenterEdep must be greater than or equal to minClusterHitEdep");
-    return;
+    const std::string msg = "minClusterCenterEdep must be greater than or equal to minClusterHitEdep";
+    error(msg);
+    throw std::runtime_error(msg);
   }
 
   // using juggler internal units (GeV, dd4hep::mm, dd4hep::ns, dd4hep::rad)
@@ -88,10 +65,10 @@ void ImagingTopoCluster::init() {
   sameLayerDistEtaPhi[1] = m_cfg.sameLayerDistEtaPhi[1] / dd4hep::rad;
   diffLayerDistEtaPhi[0] = m_cfg.diffLayerDistEtaPhi[0];
   diffLayerDistEtaPhi[1] = m_cfg.diffLayerDistEtaPhi[1] / dd4hep::rad;
-  sameLayerDistPhiZ[0]   = std::visit(_toDouble, m_cfg.sameLayerDistPhiZ[0]) / dd4hep::mm;
-  sameLayerDistPhiZ[1]   = std::visit(_toDouble, m_cfg.sameLayerDistPhiZ[1]) / dd4hep::mm;
-  diffLayerDistPhiZ[0]   = std::visit(_toDouble, m_cfg.diffLayerDistPhiZ[0]) / dd4hep::mm;
-  diffLayerDistPhiZ[1]   = std::visit(_toDouble, m_cfg.diffLayerDistPhiZ[1]) / dd4hep::mm;
+  sameLayerDistTZ[0]   = std::visit(_toDouble, m_cfg.sameLayerDistTZ[0]) / dd4hep::mm;
+  sameLayerDistTZ[1]   = std::visit(_toDouble, m_cfg.sameLayerDistTZ[1]) / dd4hep::mm;
+  diffLayerDistTZ[0]   = std::visit(_toDouble, m_cfg.diffLayerDistTZ[0]) / dd4hep::mm;
+  diffLayerDistTZ[1]   = std::visit(_toDouble, m_cfg.diffLayerDistTZ[1]) / dd4hep::mm;
 
   sectorDist           = m_cfg.sectorDist / dd4hep::mm;
   minClusterHitEdep    = m_cfg.minClusterHitEdep / dd4hep::GeV;
@@ -101,44 +78,74 @@ void ImagingTopoCluster::init() {
   // same layer clustering parameters
   switch (m_cfg.sameLayerMode) {
   case ImagingTopoClusterConfig::ELayerMode::xy:
+    if (m_cfg.sameLayerDistXY.size() != 2) {
+      const std::string msg = "Expected 2 values (x_dist, y_dist) for sameLayerDistXY";
+      error(msg);
+      throw std::runtime_error(msg);
+    }
     info("Same-layer clustering (same sector and same layer): "
          "Local [x, y] distance between hits <= [{:.4f} mm, {:.4f} mm].",
          sameLayerDistXY[0], sameLayerDistXY[1]);
     break;
   case ImagingTopoClusterConfig::ELayerMode::etaphi:
+    if (m_cfg.sameLayerDistEtaPhi.size() != 2) {
+      const std::string msg = "Expected 2 values (eta_dist, phi_dist) for sameLayerDistEtaPhi";
+      error(msg);
+      throw std::runtime_error(msg);
+    }
     info("Same-layer clustering (same sector and same layer): "
          "Global [eta, phi] distance between hits <= [{:.4f}, {:.4f} rad].",
          sameLayerDistEtaPhi[0], sameLayerDistEtaPhi[1]);
     break;
-  case ImagingTopoClusterConfig::ELayerMode::phiz:
+  case ImagingTopoClusterConfig::ELayerMode::tz:
+    if (m_cfg.sameLayerDistTZ.size()!=2){
+      const std::string msg = "Expected 2 values (phi_dist, z_dist) for sameLayerDistTZ";
+      error(msg);
+      throw std::runtime_error(msg);
+    }
     info("Same-layer clustering (same sector and same layer): "
          "Global [phi, z] distance between hits <= [{:.4f} rad, {:.4f} mm].",
-         sameLayerDistPhiZ[0], sameLayerDistPhiZ[1]);
+         sameLayerDistTZ[0], sameLayerDistTZ[1]);
     break;
   default:
-    error("Unknown same-layer mode.");
+    throw std::runtime_error("Unknown same-layer mode.");
   }
 
   // different layer clustering parameters
   switch (m_cfg.diffLayerMode) {
   case ImagingTopoClusterConfig::ELayerMode::etaphi:
+    if (m_cfg.diffLayerDistEtaPhi.size() != 2) {
+      const std::string msg = "Expected 2 values (eta_dist, phi_dist) for diffLayerDistEtaPhi";
+      error(msg);
+      throw std::runtime_error(msg);
+    }
     info("Neighbour layers clustering (same sector and layer id within +- {:d}): "
          "Global [eta, phi] distance between hits <= [{:.4f}, {:.4f} rad].",
          m_cfg.neighbourLayersRange, diffLayerDistEtaPhi[0], diffLayerDistEtaPhi[1]);
     break;
   case ImagingTopoClusterConfig::ELayerMode::xy:
+    if (m_cfg.diffLayerDistXY.size() != 2) {
+      const std::string msg = "Expected 2 values (x_dist, y_dist) for diffLayerDistXY";
+      error(msg);
+      throw std::runtime_error(msg);
+    }
     info("Neighbour layers clustering (same sector and layer id within +- {:d}): "
          "Global [x, y] distance between hits <= [{:.4f} mm, {:.4f} mm].",
          m_cfg.neighbourLayersRange, diffLayerDistXY[0], diffLayerDistXY[1]);
     break;
-  case ImagingTopoClusterConfig::ELayerMode::phiz:
+  case ImagingTopoClusterConfig::ELayerMode::tz:
+    if (m_cfg.diffLayerDistPhiZ.size() != 2) {
+      const std::string msg = "Expected 2 values (phi_dist, z_dist) for diffLayerDistPhiZ";
+      error(msg);
+      throw std::runtime_error(msg);
+    }
     info(
         "Neighbour layers clustering (same sector and layer id within +- {:d}): "
         "Global [phi, z] distance between hits <= [{:.4f} mm, {:.4f} mm].", // The coordinate Phi is the projected Phi and thus is a distance, not an angle.
-        m_cfg.neighbourLayersRange, diffLayerDistPhiZ[0], diffLayerDistPhiZ[1]);
+        m_cfg.neighbourLayersRange, diffLayerDistTZ[0], diffLayerDistTZ[1]);
     break;
   default:
-    error("Unknown different-layer mode.");
+    throw std::runtime_error("Unknown different-layer mode.");
   }
   info("Neighbour sectors clustering (different sector): "
        "Global distance between hits <= {:.4f} mm.",
@@ -257,8 +264,8 @@ bool ImagingTopoCluster::is_neighbour(const edm4eic::CalorimeterHit& h1,
              (std::abs(edm4hep::utils::angleAzimuthal(h1.getPosition()) -
                        edm4hep::utils::angleAzimuthal(h2.getPosition())) <= sameLayerDistEtaPhi[1]);
 
-    case ImagingTopoClusterConfig::ELayerMode::phiz: {
-      // Layer mode 'phiz' uses the average phi of the hits to define a rotated direction. The coordinate is a distance, not an angle.
+    case ImagingTopoClusterConfig::ELayerMode::tz: {
+      // Layer mode 'tz' uses the average phi of the hits to define a rotated direction. The coordinate is a distance, not an angle.
       auto phi  = 0.5 * (edm4hep::utils::angleAzimuthal(h1.getPosition()) +
                         edm4hep::utils::angleAzimuthal(h2.getPosition()));
       auto h1_t = (h1.getPosition().x * sin(phi)) - (h1.getPosition().y * cos(phi));
@@ -266,8 +273,8 @@ bool ImagingTopoCluster::is_neighbour(const edm4eic::CalorimeterHit& h1,
       auto h1_z = h1.getPosition().z;
       auto h2_z = h2.getPosition().z;
 
-      return (std::abs(h1_t - h2_t) <= sameLayerDistPhiZ[0]) &&
-             (std::abs(h1_z - h2_z) <= sameLayerDistPhiZ[1]);
+      return (std::abs(h1_t - h2_t) <= sameLayerDistTZ[0]) &&
+             (std::abs(h1_z - h2_z) <= sameLayerDistTZ[1]);
     }
 
     default:
@@ -287,7 +294,7 @@ bool ImagingTopoCluster::is_neighbour(const edm4eic::CalorimeterHit& h1,
       return (std::abs(h1.getPosition().x - h2.getPosition().x) <= diffLayerDistXY[0]) &&
              (std::abs(h1.getPosition().y - h2.getPosition().y) <= diffLayerDistXY[1]);
 
-    case eicrecon::ImagingTopoClusterConfig::ELayerMode::phiz: {
+    case eicrecon::ImagingTopoClusterConfig::ELayerMode::tz: {
       auto phi  = 0.5 * (edm4hep::utils::angleAzimuthal(h1.getPosition()) +
                         edm4hep::utils::angleAzimuthal(h2.getPosition()));
       auto h1_t = (h1.getPosition().x * sin(phi)) - (h1.getPosition().y * cos(phi));
@@ -295,8 +302,8 @@ bool ImagingTopoCluster::is_neighbour(const edm4eic::CalorimeterHit& h1,
       auto h1_z = h1.getPosition().z;
       auto h2_z = h2.getPosition().z;
 
-      return (std::abs(h1_t - h2_t) <= diffLayerDistPhiZ[0]) &&
-             (std::abs(h1_z - h2_z) <= diffLayerDistPhiZ[1]);
+      return (std::abs(h1_t - h2_t) <= diffLayerDistTZ[0]) &&
+             (std::abs(h1_z - h2_z) <= diffLayerDistTZ[1]);
     }
 
     default:

--- a/src/algorithms/calorimetry/ImagingTopoCluster.cc
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.cc
@@ -265,6 +265,7 @@ bool ImagingTopoCluster::is_neighbour(const edm4eic::CalorimeterHit& h1,
                        edm4hep::utils::angleAzimuthal(h2.getPosition())) <= layerDistEtaPhi[1]);
 
     case eicrecon::ImagingTopoClusterConfig::ELayerMode::xy:
+      // Here, the xy layer mode is based on global XY positions rather than local XY positions, and thus it only works for endcap detectors.
       return (std::abs(h1.getPosition().x - h2.getPosition().x) <= layerDistXY[0]) &&
              (std::abs(h1.getPosition().y - h2.getPosition().y) <= layerDistXY[1]);
 

--- a/src/algorithms/calorimetry/ImagingTopoCluster.cc
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.cc
@@ -141,11 +141,10 @@ void ImagingTopoCluster::init() {
       error(msg);
       throw std::runtime_error(msg);
     }
-    info(
-        "Neighbour layers clustering (same sector and layer id within +- {:d}): "
-        "Global [t, z] distance between hits <= [{:.4f} mm, {:.4f} mm].",
-        m_cfg.neighbourLayersRange, diffLayerDistTZ[0], diffLayerDistTZ[1]);
-break;
+    info("Neighbour layers clustering (same sector and layer id within +- {:d}): "
+         "Global [t, z] distance between hits <= [{:.4f} mm, {:.4f} mm].",
+         m_cfg.neighbourLayersRange, diffLayerDistTZ[0], diffLayerDistTZ[1]);
+    break;
   default:
     error("Unknown different-layer mode.");
     throw std::runtime_error("Unknown different-layer mode.");

--- a/src/algorithms/calorimetry/ImagingTopoCluster.cc
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.cc
@@ -51,7 +51,8 @@ void ImagingTopoCluster::init() {
   // unitless conversion
   // sanity checks
   if (m_cfg.minClusterCenterEdep < m_cfg.minClusterHitEdep) {
-    const std::string msg = "minClusterCenterEdep must be greater than or equal to minClusterHitEdep";
+    const std::string msg =
+        "minClusterCenterEdep must be greater than or equal to minClusterHitEdep";
     error(msg);
     throw std::runtime_error(msg);
   }
@@ -65,10 +66,10 @@ void ImagingTopoCluster::init() {
   sameLayerDistEtaPhi[1] = m_cfg.sameLayerDistEtaPhi[1] / dd4hep::rad;
   diffLayerDistEtaPhi[0] = m_cfg.diffLayerDistEtaPhi[0];
   diffLayerDistEtaPhi[1] = m_cfg.diffLayerDistEtaPhi[1] / dd4hep::rad;
-  sameLayerDistTZ[0]   = std::visit(_toDouble, m_cfg.sameLayerDistTZ[0]) / dd4hep::mm;
-  sameLayerDistTZ[1]   = std::visit(_toDouble, m_cfg.sameLayerDistTZ[1]) / dd4hep::mm;
-  diffLayerDistTZ[0]   = std::visit(_toDouble, m_cfg.diffLayerDistTZ[0]) / dd4hep::mm;
-  diffLayerDistTZ[1]   = std::visit(_toDouble, m_cfg.diffLayerDistTZ[1]) / dd4hep::mm;
+  sameLayerDistTZ[0]     = std::visit(_toDouble, m_cfg.sameLayerDistTZ[0]) / dd4hep::mm;
+  sameLayerDistTZ[1]     = std::visit(_toDouble, m_cfg.sameLayerDistTZ[1]) / dd4hep::mm;
+  diffLayerDistTZ[0]     = std::visit(_toDouble, m_cfg.diffLayerDistTZ[0]) / dd4hep::mm;
+  diffLayerDistTZ[1]     = std::visit(_toDouble, m_cfg.diffLayerDistTZ[1]) / dd4hep::mm;
 
   sectorDist           = m_cfg.sectorDist / dd4hep::mm;
   minClusterHitEdep    = m_cfg.minClusterHitEdep / dd4hep::GeV;
@@ -98,7 +99,7 @@ void ImagingTopoCluster::init() {
          sameLayerDistEtaPhi[0], sameLayerDistEtaPhi[1]);
     break;
   case ImagingTopoClusterConfig::ELayerMode::tz:
-    if (m_cfg.sameLayerDistTZ.size()!=2){
+    if (m_cfg.sameLayerDistTZ.size() != 2) {
       const std::string msg = "Expected 2 values (phi_dist, z_dist) for sameLayerDistTZ";
       error(msg);
       throw std::runtime_error(msg);

--- a/src/algorithms/calorimetry/ImagingTopoCluster.cc
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.cc
@@ -50,10 +50,6 @@ void ImagingTopoCluster::init() {
 
   // unitless conversion
   // sanity checks
-  if (m_cfg.localDistXY.size() != 2) {
-    error("Expected 2 values (x_dist, y_dist) for localDistXY");
-    return;
-  }
   if (m_cfg.sameLayerDistXY.size() != 2) {
     error("Expected 2 values (x_dist, y_dist) for sameLayerDistXY");
     return;
@@ -84,8 +80,6 @@ void ImagingTopoCluster::init() {
   }
 
   // using juggler internal units (GeV, dd4hep::mm, dd4hep::ns, dd4hep::rad)
-  localDistXY[0]         = std::visit(_toDouble, m_cfg.localDistXY[0]) / dd4hep::mm;
-  localDistXY[1]         = std::visit(_toDouble, m_cfg.localDistXY[1]) / dd4hep::mm;
   sameLayerDistXY[0]     = std::visit(_toDouble, m_cfg.sameLayerDistXY[0]) / dd4hep::mm;
   sameLayerDistXY[1]     = std::visit(_toDouble, m_cfg.sameLayerDistXY[1]) / dd4hep::mm;
   diffLayerDistXY[0]     = std::visit(_toDouble, m_cfg.diffLayerDistXY[0]) / dd4hep::mm;
@@ -109,7 +103,7 @@ void ImagingTopoCluster::init() {
   case ImagingTopoClusterConfig::ELayerMode::xy:
     info("Same-layer clustering (same sector and same layer): "
          "Local [x, y] distance between hits <= [{:.4f} mm, {:.4f} mm].",
-         localDistXY[0], localDistXY[1]);
+         sameLayerDistXY[0], sameLayerDistXY[1]);
     break;
   case ImagingTopoClusterConfig::ELayerMode::etaphi:
     info("Same-layer clustering (same sector and same layer): "
@@ -254,8 +248,8 @@ bool ImagingTopoCluster::is_neighbour(const edm4eic::CalorimeterHit& h1,
   if (ldiff == 0) {
     switch (m_cfg.sameLayerMode) {
     case ImagingTopoClusterConfig::ELayerMode::xy:
-      return (std::abs(h1.getLocal().x - h2.getLocal().x) <= localDistXY[0]) &&
-             (std::abs(h1.getLocal().y - h2.getLocal().y) <= localDistXY[1]);
+      return (std::abs(h1.getLocal().x - h2.getLocal().x) <= sameLayerDistXY[0]) &&
+             (std::abs(h1.getLocal().y - h2.getLocal().y) <= sameLayerDistXY[1]);
 
     case ImagingTopoClusterConfig::ELayerMode::etaphi:
       return (std::abs(edm4hep::utils::eta(h1.getPosition()) -

--- a/src/algorithms/calorimetry/ImagingTopoCluster.h
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.h
@@ -53,9 +53,12 @@ public:
 
 private:
   // unitless counterparts of the input parameters
-  std::array<double, 2> localDistXY{0, 0};
-  std::array<double, 2> layerDistEtaPhi{0, 0};
-  std::array<double, 2> layerDistXY{0, 0};
+  std::array<double, 2> sameLayerDistXY{0, 0};
+  std::array<double, 2> diffLayerDistXY{0, 0};
+  std::array<double, 2> sameLayerDistEtaPhi{0, 0};
+  std::array<double, 2> diffLayerDistEtaPhi{0, 0};
+  std::array<double, 2> sameLayerDistPhiZ{0, 0};
+  std::array<double, 2> diffLayerDistPhiZ{0, 0};
   double sectorDist{0};
   double minClusterHitEdep{0};
   double minClusterCenterEdep{0};

--- a/src/algorithms/calorimetry/ImagingTopoCluster.h
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.h
@@ -57,8 +57,8 @@ private:
   std::array<double, 2> diffLayerDistXY{0, 0};
   std::array<double, 2> sameLayerDistEtaPhi{0, 0};
   std::array<double, 2> diffLayerDistEtaPhi{0, 0};
-  std::array<double, 2> sameLayerDistPhiZ{0, 0};
-  std::array<double, 2> diffLayerDistPhiZ{0, 0};
+  std::array<double, 2> sameLayerDistTZ{0, 0};
+  std::array<double, 2> diffLayerDistTZ{0, 0};
   double sectorDist{0};
   double minClusterHitEdep{0};
   double minClusterCenterEdep{0};

--- a/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
+++ b/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
@@ -15,24 +15,27 @@ struct ImagingTopoClusterConfig {
 
   // maximum difference in layer numbers that can be considered as neighbours
   int neighbourLayersRange = 1;
-  // maximum distance of local (x, y) to be considered as neighbors at the same layer
-  std::vector<std::variant<std::string, double>> localDistXY = {1.0 * dd4hep::mm, 1.0 * dd4hep::mm};
-  // maximum distance of global (x, y) to be considered as neighbors at different layers (if layerMode==xy)
+  // maximum distance of global (x, y) to be considered as neighbors at same layers (if layerMode==xy)
   std::vector<std::variant<std::string, double>> sameLayerDistXY = {1.0 * dd4hep::mm,
                                                                     1.0 * dd4hep::mm};
+  // maximum distance of global (x, y) to be considered as neighbors at different layers (if layerMode==xy)
   std::vector<std::variant<std::string, double>> diffLayerDistXY = {1.0 * dd4hep::mm,
                                                                     1.0 * dd4hep::mm};
-  // maximum distance of global (eta, phi) to be considered as neighbors at different layers (if layerMode==etaphi)
+  // maximum distance of global (eta, phi) to be considered as neighbors at same layers (if layerMode==etaphi)
   std::vector<double> sameLayerDistEtaPhi = {0.01, 0.01};
+  // maximum distance of global (eta, phi) to be considered as neighbors at different layers (if layerMode==etaphi)
   std::vector<double> diffLayerDistEtaPhi = {0.01, 0.01};
-  // maximum distance of global (x, y) to be considered as neighbors at different layers (if layerMode==phiz)
+  // maximum distance of global (x, y) to be considered as neighbors at same layers (if layerMode==phiz)
   std::vector<std::variant<std::string, double>> sameLayerDistPhiZ = {1.0 * dd4hep::mm,
                                                                       1.0 * dd4hep::mm};
+  // maximum distance of global (x, y) to be considered as neighbors at different layers (if layerMode==phiz)
   std::vector<std::variant<std::string, double>> diffLayerDistPhiZ = {1.0 * dd4hep::mm,
                                                                       1.0 * dd4hep::mm};
-  // determines how neighbors are determined for hits in different layers (using either eta and phi, or x and y)
+  // Layermodes
   enum class ELayerMode { etaphi = 0, xy = 1, phiz = 2 };
+  // determines how neighbors are determined for hits in same layers (using either eta and phi, or x and y)
   ELayerMode sameLayerMode = ELayerMode::xy; // for ldiff =0
+  // determines how neighbors are determined for hits in different layers (using either eta and phi, or x and y)
   ELayerMode diffLayerMode = ELayerMode::xy; // for ldiff <= neighbourLayersRange
 
   // maximum global distance to be considered as neighbors in different sectors

--- a/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
+++ b/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
@@ -65,7 +65,7 @@ std::istream& operator>>(std::istream& in, ImagingTopoClusterConfig::ELayerMode&
 
   return in;
 }
-std::ostream& operator<<(std::ostream& out, ImagingTopoClusterConfig::ELayerMode& layerMode) {
+std::ostream& operator<<(std::ostream& out, const ImagingTopoClusterConfig::ELayerMode& layerMode) {
   switch (layerMode) {
   case ImagingTopoClusterConfig::ELayerMode::etaphi:
     out << "etaphi";

--- a/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
+++ b/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
@@ -19,7 +19,7 @@ struct ImagingTopoClusterConfig {
   std::vector<std::variant<std::string, double>> sameLayerDistXY = {1.0 * dd4hep::mm,
                                                                     1.0 * dd4hep::mm};
   // maximum distance of global (eta, phi) to be considered as neighbors at same layers (if layerMode==etaphi)
-  std::vector<double> sameLayerDistEtaPhi = {0.01, 0.01};
+  std::vector<std::variant<std::string, double>> sameLayerDistEtaPhi = {0.01, 0.01};
   // maximum distance of global (t, z) to be considered as neighbors at same layers (if layerMode==tz)
   std::vector<std::variant<std::string, double>> sameLayerDistTZ = {1.0 * dd4hep::mm,
                                                                     1.0 * dd4hep::mm};
@@ -27,7 +27,7 @@ struct ImagingTopoClusterConfig {
   std::vector<std::variant<std::string, double>> diffLayerDistXY = {1.0 * dd4hep::mm,
                                                                     1.0 * dd4hep::mm};
   // maximum distance of global (eta, phi) to be considered as neighbors at different layers (if layerMode==etaphi)
-  std::vector<double> diffLayerDistEtaPhi = {0.01, 0.01};
+  std::vector<std::variant<std::string, double>> diffLayerDistEtaPhi = {0.01, 0.01};
   // maximum distance of global (t, z) to be considered as neighbors at different layers (if layerMode==tz)
   std::vector<std::variant<std::string, double>> diffLayerDistTZ = {1.0 * dd4hep::mm,
                                                                     1.0 * dd4hep::mm};

--- a/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
+++ b/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
@@ -22,8 +22,6 @@ struct ImagingTopoClusterConfig {
   // maximum distance of global (x, y) to be considered as neighbors at different layers (if layerMode==xy)
   std::vector<std::variant<std::string, double>> layerDistXY = {1.0 * dd4hep::mm, 1.0 * dd4hep::mm};
   // determines how neighbors are determined for hits in different layers (using either eta and phi, or x and y)
-  // enum ELayerMode { etaphi = 0, xy = 1 } layerMode = etaphi;
-
   enum ELayerMode { etaphi = 0, xy = 1, phiz = 2 };
   ELayerMode sameLayerMode = xy;     // for ldiff =0
   ELayerMode diffLayerMode = etaphi; // for ldiff <= neighbourLayersRange

--- a/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
+++ b/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
@@ -26,13 +26,8 @@ struct ImagingTopoClusterConfig {
   // maximum distance of global (x, y) to be considered as neighbors at different layers (if layerMode==xy)
   std::vector<std::variant<std::string, double>> diffLayerDistXY = {1.0 * dd4hep::mm,
                                                                     1.0 * dd4hep::mm};
-  // maximum distance of global (eta, phi) to be considered as neighbors at same layers (if layerMode==etaphi)
-  std::vector<double> sameLayerDistEtaPhi = {0.01, 0.01};
   // maximum distance of global (eta, phi) to be considered as neighbors at different layers (if layerMode==etaphi)
   std::vector<double> diffLayerDistEtaPhi = {0.01, 0.01};
-  // maximum distance of global (x, y) to be considered as neighbors at same layers (if layerMode==phiz)
-  std::vector<std::variant<std::string, double>> sameLayerDistPhiZ = {1.0 * dd4hep::mm,
-                                                                      1.0 * dd4hep::mm};
   // maximum distance of global (x, y) to be considered as neighbors at different layers (if layerMode==phiz)
   std::vector<std::variant<std::string, double>> diffLayerDistPhiZ = {1.0 * dd4hep::mm,
                                                                       1.0 * dd4hep::mm};

--- a/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
+++ b/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
@@ -63,9 +63,6 @@ std::ostream& operator<<(std::ostream& out, ImagingTopoClusterConfig::ELayerMode
   case ImagingTopoClusterConfig::ELayerMode::xy:
     out << "xy";
     break;
-  // case ImagingTopoClusterConfig::ELayerMode::xyz:
-  //   out << "xyz";
-  //   break;
   case ImagingTopoClusterConfig::ELayerMode::phiz:
     out << "phiz";
     break;

--- a/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
+++ b/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
@@ -18,14 +18,18 @@ struct ImagingTopoClusterConfig {
   // maximum distance of local (x, y) to be considered as neighbors at the same layer
   std::vector<std::variant<std::string, double>> localDistXY = {1.0 * dd4hep::mm, 1.0 * dd4hep::mm};
   // maximum distance of global (x, y) to be considered as neighbors at different layers (if layerMode==xy)
-  std::vector<std::variant<std::string, double>> sameLayerDistXY = {1.0 * dd4hep::mm, 1.0 * dd4hep::mm};
-  std::vector<std::variant<std::string, double>> diffLayerDistXY = {1.0 * dd4hep::mm, 1.0 * dd4hep::mm};
+  std::vector<std::variant<std::string, double>> sameLayerDistXY = {1.0 * dd4hep::mm,
+                                                                    1.0 * dd4hep::mm};
+  std::vector<std::variant<std::string, double>> diffLayerDistXY = {1.0 * dd4hep::mm,
+                                                                    1.0 * dd4hep::mm};
   // maximum distance of global (eta, phi) to be considered as neighbors at different layers (if layerMode==etaphi)
   std::vector<double> sameLayerDistEtaPhi = {0.01, 0.01};
   std::vector<double> diffLayerDistEtaPhi = {0.01, 0.01};
   // maximum distance of global (x, y) to be considered as neighbors at different layers (if layerMode==phiz)
-  std::vector<std::variant<std::string, double>> sameLayerDistPhiZ = {1.0 * dd4hep::mm, 1.0 * dd4hep::mm};
-  std::vector<std::variant<std::string, double>> diffLayerDistPhiZ = {1.0 * dd4hep::mm, 1.0 * dd4hep::mm};
+  std::vector<std::variant<std::string, double>> sameLayerDistPhiZ = {1.0 * dd4hep::mm,
+                                                                      1.0 * dd4hep::mm};
+  std::vector<std::variant<std::string, double>> diffLayerDistPhiZ = {1.0 * dd4hep::mm,
+                                                                      1.0 * dd4hep::mm};
   // determines how neighbors are determined for hits in different layers (using either eta and phi, or x and y)
   enum class ELayerMode { etaphi = 0, xy = 1, phiz = 2 };
   ELayerMode sameLayerMode = ELayerMode::xy; // for ldiff =0

--- a/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
+++ b/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
@@ -17,10 +17,15 @@ struct ImagingTopoClusterConfig {
   int neighbourLayersRange = 1;
   // maximum distance of local (x, y) to be considered as neighbors at the same layer
   std::vector<std::variant<std::string, double>> localDistXY = {1.0 * dd4hep::mm, 1.0 * dd4hep::mm};
-  // maximum distance of global (eta, phi) to be considered as neighbors at different layers (if layerMode==etaphi)
-  std::vector<double> layerDistEtaPhi = {0.01, 0.01};
   // maximum distance of global (x, y) to be considered as neighbors at different layers (if layerMode==xy)
-  std::vector<std::variant<std::string, double>> layerDistXY = {1.0 * dd4hep::mm, 1.0 * dd4hep::mm};
+  std::vector<std::variant<std::string, double>> sameLayerDistXY = {1.0 * dd4hep::mm, 1.0 * dd4hep::mm};
+  std::vector<std::variant<std::string, double>> diffLayerDistXY = {1.0 * dd4hep::mm, 1.0 * dd4hep::mm};
+  // maximum distance of global (eta, phi) to be considered as neighbors at different layers (if layerMode==etaphi)
+  std::vector<double> sameLayerDistEtaPhi = {0.01, 0.01};
+  std::vector<double> diffLayerDistEtaPhi = {0.01, 0.01};
+  // maximum distance of global (x, y) to be considered as neighbors at different layers (if layerMode==phiz)
+  std::vector<std::variant<std::string, double>> sameLayerDistPhiZ = {1.0 * dd4hep::mm, 1.0 * dd4hep::mm};
+  std::vector<std::variant<std::string, double>> diffLayerDistPhiZ = {1.0 * dd4hep::mm, 1.0 * dd4hep::mm};
   // determines how neighbors are determined for hits in different layers (using either eta and phi, or x and y)
   enum class ELayerMode { etaphi = 0, xy = 1, phiz = 2 };
   ELayerMode sameLayerMode = ELayerMode::xy; // for ldiff =0

--- a/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
+++ b/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
@@ -19,18 +19,16 @@ struct ImagingTopoClusterConfig {
   std::vector<std::variant<std::string, double>> sameLayerDistXY = {1.0 * dd4hep::mm,
                                                                     1.0 * dd4hep::mm};
   // maximum distance of global (eta, phi) to be considered as neighbors at same layers (if layerMode==etaphi)
-  std::vector<std::variant<std::string, double>> sameLayerDistEtaPhi = {0.01, 0.01};
+  std::vector<double> sameLayerDistEtaPhi = {0.01, 0.01};
   // maximum distance of global (t, z) to be considered as neighbors at same layers (if layerMode==tz)
-  std::vector<std::variant<std::string, double>> sameLayerDistTZ = {1.0 * dd4hep::mm,
-                                                                    1.0 * dd4hep::mm};
+  std::vector<double> sameLayerDistTZ = {1.0 * dd4hep::mm, 1.0 * dd4hep::mm};
   // maximum distance of global (x, y) to be considered as neighbors at different layers (if layerMode==xy)
   std::vector<std::variant<std::string, double>> diffLayerDistXY = {1.0 * dd4hep::mm,
                                                                     1.0 * dd4hep::mm};
   // maximum distance of global (eta, phi) to be considered as neighbors at different layers (if layerMode==etaphi)
-  std::vector<std::variant<std::string, double>> diffLayerDistEtaPhi = {0.01, 0.01};
+  std::vector<double> diffLayerDistEtaPhi = {0.01, 0.01};
   // maximum distance of global (t, z) to be considered as neighbors at different layers (if layerMode==tz)
-  std::vector<std::variant<std::string, double>> diffLayerDistTZ = {1.0 * dd4hep::mm,
-                                                                    1.0 * dd4hep::mm};
+  std::vector<double> diffLayerDistTZ = {1.0 * dd4hep::mm, 1.0 * dd4hep::mm};
   // Layermodes
   enum class ELayerMode { etaphi = 0, xy = 1, tz = 2 };
   // determines how neighbors are determined for hits in same layers (using either eta and phi, or x and y)

--- a/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
+++ b/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
@@ -23,8 +23,8 @@ struct ImagingTopoClusterConfig {
   std::vector<std::variant<std::string, double>> layerDistXY = {1.0 * dd4hep::mm, 1.0 * dd4hep::mm};
   // determines how neighbors are determined for hits in different layers (using either eta and phi, or x and y)
   enum class ELayerMode { etaphi = 0, xy = 1, phiz = 2 };
-  ELayerMode sameLayerMode = ELayerMode::xy;     // for ldiff =0
-  ELayerMode diffLayerMode = ELayerMode::xy;     // for ldiff <= neighbourLayersRange
+  ELayerMode sameLayerMode = ELayerMode::xy; // for ldiff =0
+  ELayerMode diffLayerMode = ELayerMode::xy; // for ldiff <= neighbourLayersRange
 
   // maximum global distance to be considered as neighbors in different sectors
   double sectorDist = 1.0 * dd4hep::cm;

--- a/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
+++ b/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
@@ -20,7 +20,7 @@ struct ImagingTopoClusterConfig {
                                                                     1.0 * dd4hep::mm};
   // maximum distance of global (eta, phi) to be considered as neighbors at same layers (if layerMode==etaphi)
   std::vector<double> sameLayerDistEtaPhi = {0.01, 0.01};
-  // maximum distance of global (x, y) to be considered as neighbors at same layers (if layerMode==tz)
+  // maximum distance of global (t, z) to be considered as neighbors at same layers (if layerMode==tz)
   std::vector<std::variant<std::string, double>> sameLayerDistTZ = {1.0 * dd4hep::mm,
                                                                     1.0 * dd4hep::mm};
   // maximum distance of global (x, y) to be considered as neighbors at different layers (if layerMode==xy)
@@ -28,7 +28,7 @@ struct ImagingTopoClusterConfig {
                                                                     1.0 * dd4hep::mm};
   // maximum distance of global (eta, phi) to be considered as neighbors at different layers (if layerMode==etaphi)
   std::vector<double> diffLayerDistEtaPhi = {0.01, 0.01};
-  // maximum distance of global (x, y) to be considered as neighbors at different layers (if layerMode==tz)
+  // maximum distance of global (t, z) to be considered as neighbors at different layers (if layerMode==tz)
   std::vector<std::variant<std::string, double>> diffLayerDistTZ = {1.0 * dd4hep::mm,
                                                                     1.0 * dd4hep::mm};
   // Layermodes

--- a/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
+++ b/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
@@ -20,19 +20,19 @@ struct ImagingTopoClusterConfig {
                                                                     1.0 * dd4hep::mm};
   // maximum distance of global (eta, phi) to be considered as neighbors at same layers (if layerMode==etaphi)
   std::vector<double> sameLayerDistEtaPhi = {0.01, 0.01};
-  // maximum distance of global (x, y) to be considered as neighbors at same layers (if layerMode==phiz)
-  std::vector<std::variant<std::string, double>> sameLayerDistPhiZ = {1.0 * dd4hep::mm,
+  // maximum distance of global (x, y) to be considered as neighbors at same layers (if layerMode==tz)
+  std::vector<std::variant<std::string, double>> sameLayerDistTZ = {1.0 * dd4hep::mm,
                                                                       1.0 * dd4hep::mm};
   // maximum distance of global (x, y) to be considered as neighbors at different layers (if layerMode==xy)
   std::vector<std::variant<std::string, double>> diffLayerDistXY = {1.0 * dd4hep::mm,
                                                                     1.0 * dd4hep::mm};
   // maximum distance of global (eta, phi) to be considered as neighbors at different layers (if layerMode==etaphi)
   std::vector<double> diffLayerDistEtaPhi = {0.01, 0.01};
-  // maximum distance of global (x, y) to be considered as neighbors at different layers (if layerMode==phiz)
-  std::vector<std::variant<std::string, double>> diffLayerDistPhiZ = {1.0 * dd4hep::mm,
+  // maximum distance of global (x, y) to be considered as neighbors at different layers (if layerMode==tz)
+  std::vector<std::variant<std::string, double>> diffLayerDistTZ = {1.0 * dd4hep::mm,
                                                                       1.0 * dd4hep::mm};
   // Layermodes
-  enum class ELayerMode { etaphi = 0, xy = 1, phiz = 2 };
+  enum class ELayerMode { etaphi = 0, xy = 1, tz = 2 };
   // determines how neighbors are determined for hits in same layers (using either eta and phi, or x and y)
   ELayerMode sameLayerMode = ELayerMode::xy; // for ldiff =0
   // determines how neighbors are determined for hits in different layers (using either eta and phi, or x and y)
@@ -59,8 +59,8 @@ std::istream& operator>>(std::istream& in, ImagingTopoClusterConfig::ELayerMode&
     layerMode = ImagingTopoClusterConfig::ELayerMode::etaphi;
   } else if (s == "xy" or s == "1") {
     layerMode = ImagingTopoClusterConfig::ELayerMode::xy;
-  } else if (s == "phiz" or s == "2") {
-    layerMode = ImagingTopoClusterConfig::ELayerMode::phiz;
+  } else if (s == "tz" or s == "2") {
+    layerMode = ImagingTopoClusterConfig::ELayerMode::tz;
   } else {
     in.setstate(std::ios::failbit); // Set the fail bit if the input is not valid
   }
@@ -75,8 +75,8 @@ std::ostream& operator<<(std::ostream& out, ImagingTopoClusterConfig::ELayerMode
   case ImagingTopoClusterConfig::ELayerMode::xy:
     out << "xy";
     break;
-  case ImagingTopoClusterConfig::ELayerMode::phiz:
-    out << "phiz";
+  case ImagingTopoClusterConfig::ELayerMode::tz:
+    out << "tz";
     break;
   default:
     out.setstate(std::ios::failbit);

--- a/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
+++ b/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
@@ -18,6 +18,11 @@ struct ImagingTopoClusterConfig {
   // maximum distance of global (x, y) to be considered as neighbors at same layers (if layerMode==xy)
   std::vector<std::variant<std::string, double>> sameLayerDistXY = {1.0 * dd4hep::mm,
                                                                     1.0 * dd4hep::mm};
+  // maximum distance of global (eta, phi) to be considered as neighbors at same layers (if layerMode==etaphi)
+  std::vector<double> sameLayerDistEtaPhi = {0.01, 0.01};
+  // maximum distance of global (x, y) to be considered as neighbors at same layers (if layerMode==phiz)
+  std::vector<std::variant<std::string, double>> sameLayerDistPhiZ = {1.0 * dd4hep::mm,
+                                                                      1.0 * dd4hep::mm};
   // maximum distance of global (x, y) to be considered as neighbors at different layers (if layerMode==xy)
   std::vector<std::variant<std::string, double>> diffLayerDistXY = {1.0 * dd4hep::mm,
                                                                     1.0 * dd4hep::mm};

--- a/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
+++ b/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
@@ -22,9 +22,9 @@ struct ImagingTopoClusterConfig {
   // maximum distance of global (x, y) to be considered as neighbors at different layers (if layerMode==xy)
   std::vector<std::variant<std::string, double>> layerDistXY = {1.0 * dd4hep::mm, 1.0 * dd4hep::mm};
   // determines how neighbors are determined for hits in different layers (using either eta and phi, or x and y)
-  enum ELayerMode { etaphi = 0, xy = 1, phiz = 2 };
-  ELayerMode sameLayerMode = xy;     // for ldiff =0
-  ELayerMode diffLayerMode = etaphi; // for ldiff <= neighbourLayersRange
+  enum class ELayerMode { etaphi = 0, xy = 1, phiz = 2 };
+  ELayerMode sameLayerMode = ELayerMode::xy;     // for ldiff =0
+  ELayerMode diffLayerMode = ELayerMode::xy;     // for ldiff <= neighbourLayersRange
 
   // maximum global distance to be considered as neighbors in different sectors
   double sectorDist = 1.0 * dd4hep::cm;

--- a/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
+++ b/src/algorithms/calorimetry/ImagingTopoClusterConfig.h
@@ -22,7 +22,7 @@ struct ImagingTopoClusterConfig {
   std::vector<double> sameLayerDistEtaPhi = {0.01, 0.01};
   // maximum distance of global (x, y) to be considered as neighbors at same layers (if layerMode==tz)
   std::vector<std::variant<std::string, double>> sameLayerDistTZ = {1.0 * dd4hep::mm,
-                                                                      1.0 * dd4hep::mm};
+                                                                    1.0 * dd4hep::mm};
   // maximum distance of global (x, y) to be considered as neighbors at different layers (if layerMode==xy)
   std::vector<std::variant<std::string, double>> diffLayerDistXY = {1.0 * dd4hep::mm,
                                                                     1.0 * dd4hep::mm};
@@ -30,7 +30,7 @@ struct ImagingTopoClusterConfig {
   std::vector<double> diffLayerDistEtaPhi = {0.01, 0.01};
   // maximum distance of global (x, y) to be considered as neighbors at different layers (if layerMode==tz)
   std::vector<std::variant<std::string, double>> diffLayerDistTZ = {1.0 * dd4hep::mm,
-                                                                      1.0 * dd4hep::mm};
+                                                                    1.0 * dd4hep::mm};
   // Layermodes
   enum class ELayerMode { etaphi = 0, xy = 1, tz = 2 };
   // determines how neighbors are determined for hits in same layers (using either eta and phi, or x and y)

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -203,8 +203,8 @@ void InitPlugin(JApplication* app) {
       {"EcalBarrelImagingProtoClusters"},
       {
           .neighbourLayersRange = 2, //  # id diff for adjacent layer
-          .sameLayerDistXY          = {2.0 * dd4hep::mm, 2 * dd4hep::mm},     //  # same layer
-          .diffLayerDistEtaPhi      = {10 * dd4hep::mrad, 10 * dd4hep::mrad}, //  # adjacent layer
+          .sameLayerDistXY      = {2.0 * dd4hep::mm, 2 * dd4hep::mm},     //  # same layer
+          .diffLayerDistEtaPhi  = {10 * dd4hep::mrad, 10 * dd4hep::mrad}, //  # adjacent layer
           .sameLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::
               phiz, // Layer mode 'phiz' uses the average phi of the hits to define a rotated direction. The coordinate is a distance, not an angle.
           .diffLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::etaphi,

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -204,7 +204,8 @@ void InitPlugin(JApplication* app) {
           .neighbourLayersRange = 2, //  # id diff for adjacent layer
           .localDistXY          = {2.0 * dd4hep::mm, 2 * dd4hep::mm},     //  # same layer
           .layerDistEtaPhi      = {10 * dd4hep::mrad, 10 * dd4hep::mrad}, //  # adjacent layer
-          .sameLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::phiz, // Layer mode 'phiz' uses the average phi of the hits to define a rotated direction. The coordinate is a distance, not an angle.
+          .sameLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::
+              phiz, // Layer mode 'phiz' uses the average phi of the hits to define a rotated direction. The coordinate is a distance, not an angle.
           .diffLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::etaphi,
           .sectorDist           = 3.0 * dd4hep::cm,
           .minClusterHitEdep    = 0,

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -203,8 +203,8 @@ void InitPlugin(JApplication* app) {
       {"EcalBarrelImagingProtoClusters"},
       {
           .neighbourLayersRange = 2, //  # id diff for adjacent layer
-          .localDistXY          = {2.0 * dd4hep::mm, 2 * dd4hep::mm},     //  # same layer
-          .layerDistEtaPhi      = {10 * dd4hep::mrad, 10 * dd4hep::mrad}, //  # adjacent layer
+          .sameLayerDistXY          = {2.0 * dd4hep::mm, 2 * dd4hep::mm},     //  # same layer
+          .diffLayerDistEtaPhi      = {10 * dd4hep::mrad, 10 * dd4hep::mrad}, //  # adjacent layer
           .sameLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::
               phiz, // Layer mode 'phiz' uses the average phi of the hits to define a rotated direction. The coordinate is a distance, not an angle.
           .diffLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::etaphi,

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -204,10 +204,9 @@ void InitPlugin(JApplication* app) {
           .neighbourLayersRange = 2, //  # id diff for adjacent layer
           .localDistXY          = {2.0 * dd4hep::mm, 2 * dd4hep::mm},     //  # same layer
           .layerDistEtaPhi      = {10 * dd4hep::mrad, 10 * dd4hep::mrad}, //  # adjacent layer
-          .sectorDist           = 3.0 * dd4hep::cm,
-          .sameLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::
-              phiz, // Layer mode 'phiz' uses the average phi of the hits to define a rotated direction. The coordinate is a distance, not an angle.
+          .sameLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::phiz, // Layer mode 'phiz' uses the average phi of the hits to define a rotated direction. The coordinate is a distance, not an angle.
           .diffLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::etaphi,
+          .sectorDist           = 3.0 * dd4hep::cm,
           .minClusterHitEdep    = 0,
           .minClusterCenterEdep = 0,
           .minClusterEdep       = 100 * dd4hep::MeV,

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -203,7 +203,7 @@ void InitPlugin(JApplication* app) {
       {"EcalBarrelImagingProtoClusters"},
       {
           .neighbourLayersRange = 2, //  # id diff for adjacent layer
-          .sameLayerDistPhiZ      = {2.0 * dd4hep::mm, 2 * dd4hep::mm}, //  # same layer
+          .sameLayerDistPhiZ    = {2.0 * dd4hep::mm, 2 * dd4hep::mm},     //  # same layer
           .diffLayerDistEtaPhi  = {10 * dd4hep::mrad, 10 * dd4hep::mrad}, //  # adjacent layer
           .sameLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::
               phiz, // Layer mode 'phiz' uses the average phi of the hits to define a rotated direction. The coordinate is a distance, not an angle.

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -203,9 +203,9 @@ void InitPlugin(JApplication* app) {
       {"EcalBarrelImagingProtoClusters"},
       {
           .neighbourLayersRange = 2, //  # id diff for adjacent layer
-          .sameLayerDistTZ    = {2.0 * dd4hep::mm, 2 * dd4hep::mm},     //  # same layer
+          .sameLayerDistTZ      = {2.0 * dd4hep::mm, 2 * dd4hep::mm},     //  # same layer
           .diffLayerDistEtaPhi  = {10 * dd4hep::mrad, 10 * dd4hep::mrad}, //  # adjacent layer
-          .sameLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::tz, 
+          .sameLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::tz,
           .diffLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::etaphi,
           .sectorDist           = 3.0 * dd4hep::cm,
           .minClusterHitEdep    = 0,

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -203,10 +203,9 @@ void InitPlugin(JApplication* app) {
       {"EcalBarrelImagingProtoClusters"},
       {
           .neighbourLayersRange = 2, //  # id diff for adjacent layer
-          .sameLayerDistPhiZ    = {2.0 * dd4hep::mm, 2 * dd4hep::mm},     //  # same layer
+          .sameLayerDistTZ    = {2.0 * dd4hep::mm, 2 * dd4hep::mm},     //  # same layer
           .diffLayerDistEtaPhi  = {10 * dd4hep::mrad, 10 * dd4hep::mrad}, //  # adjacent layer
-          .sameLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::
-              phiz, // Layer mode 'phiz' uses the average phi of the hits to define a rotated direction. The coordinate is a distance, not an angle.
+          .sameLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::tz, 
           .diffLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::etaphi,
           .sectorDist           = 3.0 * dd4hep::cm,
           .minClusterHitEdep    = 0,

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -203,7 +203,7 @@ void InitPlugin(JApplication* app) {
       {"EcalBarrelImagingProtoClusters"},
       {
           .neighbourLayersRange = 2, //  # id diff for adjacent layer
-          .sameLayerDistXY      = {2.0 * dd4hep::mm, 2 * dd4hep::mm},     //  # same layer
+          .sameLayerDistPhiZ      = {2.0 * dd4hep::mm, 2 * dd4hep::mm}, //  # same layer
           .diffLayerDistEtaPhi  = {10 * dd4hep::mrad, 10 * dd4hep::mrad}, //  # adjacent layer
           .sameLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::
               phiz, // Layer mode 'phiz' uses the average phi of the hits to define a rotated direction. The coordinate is a distance, not an angle.

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -205,7 +205,8 @@ void InitPlugin(JApplication* app) {
           .localDistXY          = {2.0 * dd4hep::mm, 2 * dd4hep::mm},     //  # same layer
           .layerDistEtaPhi      = {10 * dd4hep::mrad, 10 * dd4hep::mrad}, //  # adjacent layer
           .sectorDist           = 3.0 * dd4hep::cm,
-          .sameLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::phiz, // Layer mode 'phiz' uses the average phi of the hits to define a rotated direction. The coordinate is a distance, not an angle. 
+          .sameLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::
+              phiz, // Layer mode 'phiz' uses the average phi of the hits to define a rotated direction. The coordinate is a distance, not an angle.
           .diffLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::etaphi,
           .minClusterHitEdep    = 0,
           .minClusterCenterEdep = 0,

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -205,7 +205,7 @@ void InitPlugin(JApplication* app) {
           .localDistXY          = {2.0 * dd4hep::mm, 2 * dd4hep::mm},     //  # same layer
           .layerDistEtaPhi      = {10 * dd4hep::mrad, 10 * dd4hep::mrad}, //  # adjacent layer
           .sectorDist           = 3.0 * dd4hep::cm,
-          .sameLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::phiz,
+          .sameLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::phiz, // Layer mode 'phiz' uses the average phi of the hits to define a rotated direction. The coordinate is a distance, not an angle. 
           .diffLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::etaphi,
           .minClusterHitEdep    = 0,
           .minClusterCenterEdep = 0,

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "algorithms/calorimetry/CalorimeterHitDigiConfig.h"
+#include "algorithms/calorimetry/ImagingTopoClusterConfig.h"
 #include "algorithms/calorimetry/SimCalorimeterHitProcessorConfig.h"
 #include "extensions/jana/JOmniFactoryGeneratorT.h"
 #include "factories/calorimetry/CalorimeterClusterRecoCoG_factory.h"

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -107,7 +107,7 @@ void InitPlugin(JApplication* app) {
               {"0.25 * max(HcalEndcapPInsertCellSizeLGRight, HcalEndcapPInsertCellSizeLGLeft)",
                "0.25 * max(HcalEndcapPInsertCellSizeLGRight, HcalEndcapPInsertCellSizeLGLeft) * "
                "sin(pi / 3)"},
-          
+
           .sameLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::xy,
           .sectorDist           = 10.0 * dd4hep::cm,
           .minClusterHitEdep    = 5.0 * dd4hep::keV,

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -99,11 +99,11 @@ void InitPlugin(JApplication* app) {
       {"HcalEndcapPInsertImagingProtoClusters"},
       {
           .neighbourLayersRange = 1,
-          .localDistXY =
+          .sameLayerDistXY =
               {"0.5 * max(HcalEndcapPInsertCellSizeLGRight, HcalEndcapPInsertCellSizeLGLeft)",
                "0.5 * max(HcalEndcapPInsertCellSizeLGRight, HcalEndcapPInsertCellSizeLGLeft) * "
                "sin(pi / 3)"},
-          .layerDistXY =
+          .diffLayerDistXY =
               {"0.25 * max(HcalEndcapPInsertCellSizeLGRight, HcalEndcapPInsertCellSizeLGLeft)",
                "0.25 * max(HcalEndcapPInsertCellSizeLGRight, HcalEndcapPInsertCellSizeLGLeft) * "
                "sin(pi / 3)"},

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -107,7 +107,7 @@ void InitPlugin(JApplication* app) {
               {"0.25 * max(HcalEndcapPInsertCellSizeLGRight, HcalEndcapPInsertCellSizeLGLeft)",
                "0.25 * max(HcalEndcapPInsertCellSizeLGRight, HcalEndcapPInsertCellSizeLGLeft) * "
                "sin(pi / 3)"},
-          // .layerMode            = eicrecon::ImagingTopoClusterConfig::ELayerMode::xy,
+          
           .sameLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::xy,
           .sectorDist           = 10.0 * dd4hep::cm,
           .minClusterHitEdep    = 5.0 * dd4hep::keV,

--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -182,9 +182,9 @@ void InitPlugin(JApplication* app) {
       {"HcalFarForwardZDCImagingProtoClusters"},
       {
           .neighbourLayersRange = 1,
-          .sameLayerDistXY          = {"0.5 * HcalFarForwardZDC_SiPMonTile_HexSideLength",
+          .sameLayerDistXY      = {"0.5 * HcalFarForwardZDC_SiPMonTile_HexSideLength",
                                    "0.5 * HcalFarForwardZDC_SiPMonTile_HexSideLength * sin(pi / 3)"},
-          .diffLayerDistXY          = {"0.5 * HcalFarForwardZDC_SiPMonTile_HexSideLength",
+          .diffLayerDistXY      = {"0.5 * HcalFarForwardZDC_SiPMonTile_HexSideLength",
                                    "0.5 * HcalFarForwardZDC_SiPMonTile_HexSideLength * sin(pi / 3)"},
           .sameLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::xy,
           .sectorDist           = 10.0 * dd4hep::cm,

--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -186,7 +186,6 @@ void InitPlugin(JApplication* app) {
                                    "0.5 * HcalFarForwardZDC_SiPMonTile_HexSideLength * sin(pi / 3)"},
           .layerDistXY          = {"0.5 * HcalFarForwardZDC_SiPMonTile_HexSideLength",
                                    "0.5 * HcalFarForwardZDC_SiPMonTile_HexSideLength * sin(pi / 3)"},
-          // .layerMode            = eicrecon::ImagingTopoClusterConfig::ELayerMode::xy,
           .sameLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::xy,
           .sectorDist           = 10.0 * dd4hep::cm,
           .minClusterHitEdep    = 50.0 * dd4hep::keV,

--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -182,9 +182,9 @@ void InitPlugin(JApplication* app) {
       {"HcalFarForwardZDCImagingProtoClusters"},
       {
           .neighbourLayersRange = 1,
-          .localDistXY          = {"0.5 * HcalFarForwardZDC_SiPMonTile_HexSideLength",
+          .sameLayerDistXY          = {"0.5 * HcalFarForwardZDC_SiPMonTile_HexSideLength",
                                    "0.5 * HcalFarForwardZDC_SiPMonTile_HexSideLength * sin(pi / 3)"},
-          .layerDistXY          = {"0.5 * HcalFarForwardZDC_SiPMonTile_HexSideLength",
+          .diffLayerDistXY          = {"0.5 * HcalFarForwardZDC_SiPMonTile_HexSideLength",
                                    "0.5 * HcalFarForwardZDC_SiPMonTile_HexSideLength * sin(pi / 3)"},
           .sameLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::xy,
           .sectorDist           = 10.0 * dd4hep::cm,

--- a/src/factories/calorimetry/ImagingTopoCluster_factory.h
+++ b/src/factories/calorimetry/ImagingTopoCluster_factory.h
@@ -28,8 +28,8 @@ private:
                                                 config().sameLayerDistEtaPhi};
   ParameterRef<std::vector<double>> m_ldep_diff{this, "diffLayerDistEtaPhi",
                                                 config().diffLayerDistEtaPhi};
-  ParameterRef<std::vector<double>> m_ldxy_same{this, "sameLayerDistTZ", config().sameLayerDistTZ};
-  ParameterRef<std::vector<double>> m_ldxy_diff{this, "diffLayerDistTZ", config().diffLayerDistTZ};
+  ParameterRef<std::vector<double>> m_ldtz_same{this, "sameLayerDistTZ", config().sameLayerDistTZ};
+  ParameterRef<std::vector<double>> m_ldtz_diff{this, "diffLayerDistTZ", config().diffLayerDistTZ};
   // ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_sameLayerMode{
   //     this, "sameLayerMode", config().sameLayerMode};
   // ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_diffLayerMode{

--- a/src/factories/calorimetry/ImagingTopoCluster_factory.h
+++ b/src/factories/calorimetry/ImagingTopoCluster_factory.h
@@ -24,8 +24,6 @@ private:
   // ParameterRef<std::vector<double>> m_ldxy{this, "localDistXY", config().localDistXY};
   ParameterRef<std::vector<double>> m_ldep{this, "layerDistEtaPhi", config().layerDistEtaPhi};
   // ParameterRef<std::vector<double>> m_ldxy_adjacent{this, "layerDistXY", config().layerDistXY};
-  // ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_laymode{this, "layerMode",
-  //                                                                        config().layerMode};
   ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_sameLayerMode{
       this, "sameLayerMode", config().sameLayerMode};
   ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_diffLayerMode{

--- a/src/factories/calorimetry/ImagingTopoCluster_factory.h
+++ b/src/factories/calorimetry/ImagingTopoCluster_factory.h
@@ -24,10 +24,10 @@ private:
   // ParameterRef<std::vector<double>> m_ldxy{this, "localDistXY", config().localDistXY};
   ParameterRef<std::vector<double>> m_ldep{this, "layerDistEtaPhi", config().layerDistEtaPhi};
   // ParameterRef<std::vector<double>> m_ldxy_adjacent{this, "layerDistXY", config().layerDistXY};
-  ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_sameLayerMode{
-      this, "sameLayerMode", config().sameLayerMode};
-  ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_diffLayerMode{
-      this, "diffLayerMode", config().diffLayerMode};
+  // ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_sameLayerMode{
+  //     this, "sameLayerMode", config().sameLayerMode};
+  // ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_diffLayerMode{
+  //     this, "diffLayerMode", config().diffLayerMode};
 
   ParameterRef<int> m_nlr{this, "neighbourLayersRange", config().neighbourLayersRange};
   ParameterRef<double> m_sd{this, "sectorDist", config().sectorDist};

--- a/src/factories/calorimetry/ImagingTopoCluster_factory.h
+++ b/src/factories/calorimetry/ImagingTopoCluster_factory.h
@@ -31,10 +31,10 @@ private:
                                                 config().diffLayerDistEtaPhi};
   ParameterRef<std::vector<double>> m_ldtz_same{this, "sameLayerDistTZ", config().sameLayerDistTZ};
   ParameterRef<std::vector<double>> m_ldtz_diff{this, "diffLayerDistTZ", config().diffLayerDistTZ};
-  // ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_sameLayerMode{
-  //     this, "sameLayerMode", config().sameLayerMode};
-  // ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_diffLayerMode{
-  //     this, "diffLayerMode", config().diffLayerMode};
+  ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_sameLayerMode{
+      this, "sameLayerMode", config().sameLayerMode};
+  ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_diffLayerMode{
+      this, "diffLayerMode", config().diffLayerMode};
 
   ParameterRef<int> m_nlr{this, "neighbourLayersRange", config().neighbourLayersRange};
   ParameterRef<double> m_sd{this, "sectorDist", config().sectorDist};

--- a/src/factories/calorimetry/ImagingTopoCluster_factory.h
+++ b/src/factories/calorimetry/ImagingTopoCluster_factory.h
@@ -22,8 +22,12 @@ private:
   PodioOutput<edm4eic::ProtoCluster> m_protos_output{this};
 
   // ParameterRef<std::vector<double>> m_ldxy{this, "localDistXY", config().localDistXY};
-  ParameterRef<std::vector<double>> m_ldep{this, "layerDistEtaPhi", config().layerDistEtaPhi};
-  // ParameterRef<std::vector<double>> m_ldxy_adjacent{this, "layerDistXY", config().layerDistXY};
+  // ParameterRef<std::vector<double>> m_ldxy_adjacent{this, "sameLayerDistXY", config().sameLayerDistXY};
+  // ParameterRef<std::vector<double>> m_ldxy_adjacent{this, "diffLayerDistXY", config().diffLayerDistXY};
+  ParameterRef<std::vector<double>> m_ldep{this, "sameLayerDistEtaPhi", config().sameLayerDistEtaPhi};
+  ParameterRef<std::vector<double>> m_ldep{this, "diffLayerDistEtaPhi", config().diffLayerDistEtaPhi};
+  // ParameterRef<std::vector<double>> m_ldxy_adjacent{this, "sameLayerDistPhiZ", config().sameLayerDistPhiZ};
+  // ParameterRef<std::vector<double>> m_ldxy_adjacent{this, "diffLayerDistPhiZ", config().diffLayerDistPhiZ};
   // ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_sameLayerMode{
   //     this, "sameLayerMode", config().sameLayerMode};
   // ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_diffLayerMode{

--- a/src/factories/calorimetry/ImagingTopoCluster_factory.h
+++ b/src/factories/calorimetry/ImagingTopoCluster_factory.h
@@ -25,9 +25,9 @@ private:
   // ParameterRef<std::vector<double>> m_ldxy_same{this, "sameLayerDistXY", config().sameLayerDistXY};
   // ParameterRef<std::vector<double>> m_ldxy_diff{this, "diffLayerDistXY", config().diffLayerDistXY};
   ParameterRef<std::vector<double>> m_ldep_same{this, "sameLayerDistEtaPhi",
-                                           config().sameLayerDistEtaPhi};
+                                                config().sameLayerDistEtaPhi};
   ParameterRef<std::vector<double>> m_ldep_diff{this, "diffLayerDistEtaPhi",
-                                           config().diffLayerDistEtaPhi};
+                                                config().diffLayerDistEtaPhi};
   // ParameterRef<std::vector<double>> m_ldxy_same{this, "sameLayerDistPhiZ", config().sameLayerDistPhiZ};
   // ParameterRef<std::vector<double>> m_ldxy_diff{this, "diffLayerDistPhiZ", config().diffLayerDistPhiZ};
   // ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_sameLayerMode{

--- a/src/factories/calorimetry/ImagingTopoCluster_factory.h
+++ b/src/factories/calorimetry/ImagingTopoCluster_factory.h
@@ -22,14 +22,14 @@ private:
   PodioOutput<edm4eic::ProtoCluster> m_protos_output{this};
 
   // ParameterRef<std::vector<double>> m_ldxy{this, "localDistXY", config().localDistXY};
-  // ParameterRef<std::vector<double>> m_ldxy_same{this, "sameLayerDistXY", config().sameLayerDistXY};
-  // ParameterRef<std::vector<double>> m_ldxy_diff{this, "diffLayerDistXY", config().diffLayerDistXY};
+  ParameterRef<std::vector<double>> m_ldxy_same{this, "sameLayerDistXY", config().sameLayerDistXY};
+  ParameterRef<std::vector<double>> m_ldxy_diff{this, "diffLayerDistXY", config().diffLayerDistXY};
   ParameterRef<std::vector<double>> m_ldep_same{this, "sameLayerDistEtaPhi",
                                                 config().sameLayerDistEtaPhi};
   ParameterRef<std::vector<double>> m_ldep_diff{this, "diffLayerDistEtaPhi",
                                                 config().diffLayerDistEtaPhi};
-  // ParameterRef<std::vector<double>> m_ldxy_same{this, "sameLayerDistTZ", config().sameLayerDistTZ};
-  // ParameterRef<std::vector<double>> m_ldxy_diff{this, "diffLayerDistTZ", config().diffLayerDistTZ};
+  ParameterRef<std::vector<double>> m_ldxy_same{this, "sameLayerDistTZ", config().sameLayerDistTZ};
+  ParameterRef<std::vector<double>> m_ldxy_diff{this, "diffLayerDistTZ", config().diffLayerDistTZ};
   // ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_sameLayerMode{
   //     this, "sameLayerMode", config().sameLayerMode};
   // ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_diffLayerMode{

--- a/src/factories/calorimetry/ImagingTopoCluster_factory.h
+++ b/src/factories/calorimetry/ImagingTopoCluster_factory.h
@@ -21,9 +21,10 @@ private:
   PodioInput<edm4eic::CalorimeterHit> m_hits_input{this};
   PodioOutput<edm4eic::ProtoCluster> m_protos_output{this};
 
-  // ParameterRef<std::vector<double>> m_ldxy{this, "localDistXY", config().localDistXY};
-  ParameterRef<std::vector<double>> m_ldxy_same{this, "sameLayerDistXY", config().sameLayerDistXY};
-  ParameterRef<std::vector<double>> m_ldxy_diff{this, "diffLayerDistXY", config().diffLayerDistXY};
+  // ParameterRef<std::vector<double>> m_ldxy_same{this, "sameLayerDistXY",
+  //                                                    config().sameLayerDistXY};
+  // ParameterRef<std::vector<double>> m_ldxy_diff{this, "diffLayerDistXY",
+  //                                                    config().diffLayerDistXY};
   ParameterRef<std::vector<double>> m_ldep_same{this, "sameLayerDistEtaPhi",
                                                 config().sameLayerDistEtaPhi};
   ParameterRef<std::vector<double>> m_ldep_diff{this, "diffLayerDistEtaPhi",

--- a/src/factories/calorimetry/ImagingTopoCluster_factory.h
+++ b/src/factories/calorimetry/ImagingTopoCluster_factory.h
@@ -24,8 +24,10 @@ private:
   // ParameterRef<std::vector<double>> m_ldxy{this, "localDistXY", config().localDistXY};
   // ParameterRef<std::vector<double>> m_ldxy_adjacent{this, "sameLayerDistXY", config().sameLayerDistXY};
   // ParameterRef<std::vector<double>> m_ldxy_adjacent{this, "diffLayerDistXY", config().diffLayerDistXY};
-  ParameterRef<std::vector<double>> m_ldep{this, "sameLayerDistEtaPhi", config().sameLayerDistEtaPhi};
-  ParameterRef<std::vector<double>> m_ldep{this, "diffLayerDistEtaPhi", config().diffLayerDistEtaPhi};
+  ParameterRef<std::vector<double>> m_ldep{this, "sameLayerDistEtaPhi",
+                                           config().sameLayerDistEtaPhi};
+  ParameterRef<std::vector<double>> m_ldep{this, "diffLayerDistEtaPhi",
+                                           config().diffLayerDistEtaPhi};
   // ParameterRef<std::vector<double>> m_ldxy_adjacent{this, "sameLayerDistPhiZ", config().sameLayerDistPhiZ};
   // ParameterRef<std::vector<double>> m_ldxy_adjacent{this, "diffLayerDistPhiZ", config().diffLayerDistPhiZ};
   // ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_sameLayerMode{

--- a/src/factories/calorimetry/ImagingTopoCluster_factory.h
+++ b/src/factories/calorimetry/ImagingTopoCluster_factory.h
@@ -22,14 +22,14 @@ private:
   PodioOutput<edm4eic::ProtoCluster> m_protos_output{this};
 
   // ParameterRef<std::vector<double>> m_ldxy{this, "localDistXY", config().localDistXY};
-  // ParameterRef<std::vector<double>> m_ldxy_adjacent{this, "sameLayerDistXY", config().sameLayerDistXY};
-  // ParameterRef<std::vector<double>> m_ldxy_adjacent{this, "diffLayerDistXY", config().diffLayerDistXY};
-  ParameterRef<std::vector<double>> m_ldep{this, "sameLayerDistEtaPhi",
+  // ParameterRef<std::vector<double>> m_ldxy_same{this, "sameLayerDistXY", config().sameLayerDistXY};
+  // ParameterRef<std::vector<double>> m_ldxy_diff{this, "diffLayerDistXY", config().diffLayerDistXY};
+  ParameterRef<std::vector<double>> m_ldep_same{this, "sameLayerDistEtaPhi",
                                            config().sameLayerDistEtaPhi};
-  ParameterRef<std::vector<double>> m_ldep{this, "diffLayerDistEtaPhi",
+  ParameterRef<std::vector<double>> m_ldep_diff{this, "diffLayerDistEtaPhi",
                                            config().diffLayerDistEtaPhi};
-  // ParameterRef<std::vector<double>> m_ldxy_adjacent{this, "sameLayerDistPhiZ", config().sameLayerDistPhiZ};
-  // ParameterRef<std::vector<double>> m_ldxy_adjacent{this, "diffLayerDistPhiZ", config().diffLayerDistPhiZ};
+  // ParameterRef<std::vector<double>> m_ldxy_same{this, "sameLayerDistPhiZ", config().sameLayerDistPhiZ};
+  // ParameterRef<std::vector<double>> m_ldxy_diff{this, "diffLayerDistPhiZ", config().diffLayerDistPhiZ};
   // ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_sameLayerMode{
   //     this, "sameLayerMode", config().sameLayerMode};
   // ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_diffLayerMode{

--- a/src/factories/calorimetry/ImagingTopoCluster_factory.h
+++ b/src/factories/calorimetry/ImagingTopoCluster_factory.h
@@ -26,9 +26,9 @@ private:
   // ParameterRef<std::vector<double>> m_ldxy_adjacent{this, "layerDistXY", config().layerDistXY};
   // ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_laymode{this, "layerMode",
   //                                                                        config().layerMode};
-  ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_sameLayMode{
+  ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_sameLayerMode{
       this, "sameLayerMode", config().sameLayerMode};
-  ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_diffLayMode{
+  ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_diffLayerMode{
       this, "diffLayerMode", config().diffLayerMode};
 
   ParameterRef<int> m_nlr{this, "neighbourLayersRange", config().neighbourLayersRange};

--- a/src/factories/calorimetry/ImagingTopoCluster_factory.h
+++ b/src/factories/calorimetry/ImagingTopoCluster_factory.h
@@ -28,8 +28,8 @@ private:
                                                 config().sameLayerDistEtaPhi};
   ParameterRef<std::vector<double>> m_ldep_diff{this, "diffLayerDistEtaPhi",
                                                 config().diffLayerDistEtaPhi};
-  // ParameterRef<std::vector<double>> m_ldxy_same{this, "sameLayerDistPhiZ", config().sameLayerDistPhiZ};
-  // ParameterRef<std::vector<double>> m_ldxy_diff{this, "diffLayerDistPhiZ", config().diffLayerDistPhiZ};
+  // ParameterRef<std::vector<double>> m_ldxy_same{this, "sameLayerDistTZ", config().sameLayerDistTZ};
+  // ParameterRef<std::vector<double>> m_ldxy_diff{this, "diffLayerDistTZ", config().diffLayerDistTZ};
   // ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_sameLayerMode{
   //     this, "sameLayerMode", config().sameLayerMode};
   // ParameterRef<eicrecon::ImagingTopoClusterConfig::ELayerMode> m_diffLayerMode{

--- a/src/tests/algorithms_test/calorimetry_ImagingTopoCluster.cc
+++ b/src/tests/algorithms_test/calorimetry_ImagingTopoCluster.cc
@@ -36,8 +36,8 @@ TEST_CASE("the clustering algorithm runs", "[ImagingTopoCluster]") {
   cfg.sameLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::xy;
   cfg.minClusterHitEdep    = 0. * dd4hep::GeV;
   cfg.minClusterCenterEdep = 0. * dd4hep::GeV;
-  cfg.localDistXY          = {1.0 * dd4hep::mm, 1.0 * dd4hep::mm}; //mm
-  cfg.layerDistXY          = {1.0 * dd4hep::mm, 1.0 * dd4hep::mm}; //mm
+  cfg.sameLayerDistXY          = {1.0 * dd4hep::mm, 1.0 * dd4hep::mm}; //mm
+  cfg.diffLayerDistXY          = {1.0 * dd4hep::mm, 1.0 * dd4hep::mm}; //mm
   cfg.minClusterEdep       = 9 * dd4hep::MeV;
   // minimum number of hits (to save this cluster)
   cfg.minClusterNhits = 1;
@@ -147,7 +147,7 @@ TEST_CASE("the clustering algorithm runs", "[ImagingTopoCluster]") {
   SECTION("run on three cells, two of which are on the same layer, and there is a third one on "
           "another layer acting as a bridge between them") {
 
-    cfg.localDistXY = {1 * dd4hep::mm, 1 * dd4hep::mm};
+    cfg.sameLayerDistXY = {1 * dd4hep::mm, 1 * dd4hep::mm};
     algo.applyConfig(cfg);
     algo.init();
 

--- a/src/tests/algorithms_test/calorimetry_ImagingTopoCluster.cc
+++ b/src/tests/algorithms_test/calorimetry_ImagingTopoCluster.cc
@@ -36,8 +36,8 @@ TEST_CASE("the clustering algorithm runs", "[ImagingTopoCluster]") {
   cfg.sameLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::xy;
   cfg.minClusterHitEdep    = 0. * dd4hep::GeV;
   cfg.minClusterCenterEdep = 0. * dd4hep::GeV;
-  cfg.sameLayerDistXY          = {1.0 * dd4hep::mm, 1.0 * dd4hep::mm}; //mm
-  cfg.diffLayerDistXY          = {1.0 * dd4hep::mm, 1.0 * dd4hep::mm}; //mm
+  cfg.sameLayerDistXY      = {1.0 * dd4hep::mm, 1.0 * dd4hep::mm}; //mm
+  cfg.diffLayerDistXY      = {1.0 * dd4hep::mm, 1.0 * dd4hep::mm}; //mm
   cfg.minClusterEdep       = 9 * dd4hep::MeV;
   // minimum number of hits (to save this cluster)
   cfg.minClusterNhits = 1;

--- a/src/tests/algorithms_test/calorimetry_ImagingTopoCluster.cc
+++ b/src/tests/algorithms_test/calorimetry_ImagingTopoCluster.cc
@@ -33,7 +33,7 @@ TEST_CASE("the clustering algorithm runs", "[ImagingTopoCluster]") {
   logger->set_level(spdlog::level::trace);
 
   ImagingTopoClusterConfig cfg;
-  cfg.layerMode            = eicrecon::ImagingTopoClusterConfig::ELayerMode::xy;
+  cfg.sameLayerMode        = eicrecon::ImagingTopoClusterConfig::ELayerMode::xy;
   cfg.minClusterHitEdep    = 0. * dd4hep::GeV;
   cfg.minClusterCenterEdep = 0. * dd4hep::GeV;
   cfg.localDistXY          = {1.0 * dd4hep::mm, 1.0 * dd4hep::mm}; //mm


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Added Layer Modes to the helper function to group hits within the same layer for ImagingTopoCluster


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
