### PR TITLE
Support JANA2 v2.4.3

### DIFF
--- a/src/detectors/DRICH/DRICH.cc
+++ b/src/detectors/DRICH/DRICH.cc
@@ -131,15 +131,14 @@ void InitPlugin(JApplication* app) {
       "DRICHGasTracks", {"CentralCKFTracks", "CentralCKFActsTrajectories", "CentralCKFActsTracks"},
       {"DRICHGasTracks"}, gas_track_cfg));
 
-#if (10000*JANA_VERSION_MAJOR + 100*JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
-    app->Add(new JOmniFactoryGeneratorT<MergeTrack_factory>(
-        "DRICHMergedTracks", {"DRICHAerogelTracks", "DRICHGasTracks"}, {"DRICHMergedTracks"}, {}));
+#if (10000 * JANA_VERSION_MAJOR + 100 * JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
+  app->Add(new JOmniFactoryGeneratorT<MergeTrack_factory>(
+      "DRICHMergedTracks", {"DRICHAerogelTracks", "DRICHGasTracks"}, {"DRICHMergedTracks"}, {}));
 #else
-    app->Add(new JOmniFactoryGeneratorT<MergeTrack_factory>( {
-        .tag = "DRICHMergedTracks",
-        .variadic_input_names = {{"DRICHAerogelTracks", "DRICHGasTracks"}}, 
-        .output_names = {"DRICHMergedTracks"} 
-    }));
+  app->Add(new JOmniFactoryGeneratorT<MergeTrack_factory>(
+      {.tag                  = "DRICHMergedTracks",
+       .variadic_input_names = {{"DRICHAerogelTracks", "DRICHGasTracks"}},
+       .output_names         = {"DRICHMergedTracks"}}));
 #endif
 
   // PID algorithm
@@ -150,18 +149,18 @@ void InitPlugin(JApplication* app) {
       {"DRICHAerogelIrtCherenkovParticleID", "DRICHGasIrtCherenkovParticleID"}, irt_cfg));
 
   // merge aerogel and gas PID results
-#if (10000*JANA_VERSION_MAJOR + 100*JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
-    app->Add(new JOmniFactoryGeneratorT<MergeCherenkovParticleID_factory>(
-        "DRICHMergedIrtCherenkovParticleID",
-        {"DRICHAerogelIrtCherenkovParticleID", "DRICHGasIrtCherenkovParticleID"},
-        {"DRICHMergedIrtCherenkovParticleID"}, merge_cfg));
+#if (10000 * JANA_VERSION_MAJOR + 100 * JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
+  app->Add(new JOmniFactoryGeneratorT<MergeCherenkovParticleID_factory>(
+      "DRICHMergedIrtCherenkovParticleID",
+      {"DRICHAerogelIrtCherenkovParticleID", "DRICHGasIrtCherenkovParticleID"},
+      {"DRICHMergedIrtCherenkovParticleID"}, merge_cfg));
 #else
-    app->Add(new JOmniFactoryGeneratorT<MergeCherenkovParticleID_factory>({
-         .tag = "DRICHMergedIrtCherenkovParticleID",
-         .variadic_input_names = {{"DRICHAerogelIrtCherenkovParticleID", "DRICHGasIrtCherenkovParticleID"}},
-         .output_names = {"DRICHMergedIrtCherenkovParticleID"}, 
-         .configs = merge_cfg
-    }));
+  app->Add(new JOmniFactoryGeneratorT<MergeCherenkovParticleID_factory>(
+      {.tag                  = "DRICHMergedIrtCherenkovParticleID",
+       .variadic_input_names = {{"DRICHAerogelIrtCherenkovParticleID",
+                                 "DRICHGasIrtCherenkovParticleID"}},
+       .output_names         = {"DRICHMergedIrtCherenkovParticleID"},
+       .configs              = merge_cfg}));
 #endif
 
   // clang-format on

--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -179,30 +179,32 @@ void InitPlugin(JApplication* app) {
           "EcalEndcapNParticleIDInput_features",
           "EcalEndcapNParticleIDTarget",
       }));
-#if (10000*JANA_VERSION_MAJOR + 100*JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
-    app->Add(new JOmniFactoryGeneratorT<ONNXInference_factory>(
-        "EcalEndcapNParticleIDInference",
+#if (10000 * JANA_VERSION_MAJOR + 100 * JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
+  app->Add(new JOmniFactoryGeneratorT<ONNXInference_factory>(
+      "EcalEndcapNParticleIDInference",
       {
-            "EcalEndcapNParticleIDInput_features",
-        },
-        {
-            "EcalEndcapNParticleIDOutput_label",
-            "EcalEndcapNParticleIDOutput_probability_tensor",
-        },
+          "EcalEndcapNParticleIDInput_features",
+      },
       {
-            .modelPath = "calibrations/onnx/EcalEndcapN_pi_rejection.onnx",
-        }));
+          "EcalEndcapNParticleIDOutput_label",
+          "EcalEndcapNParticleIDOutput_probability_tensor",
+      },
+      {
+          .modelPath = "calibrations/onnx/EcalEndcapN_pi_rejection.onnx",
+      }));
 #else
-        app->Add(new JOmniFactoryGeneratorT<ONNXInference_factory>({
-            .tag="EcalEndcapNParticleIDInference",
-            .variadic_input_names={{ "EcalEndcapNParticleIDInput_features", }},
-            .variadic_output_names={{
-                "EcalEndcapNParticleIDOutput_label",
-                "EcalEndcapNParticleIDOutput_probability_tensor",
-            }},
-            .configs={
-                .modelPath = "calibrations/onnx/EcalEndcapN_pi_rejection.onnx",
-            }}));
+  app->Add(new JOmniFactoryGeneratorT<ONNXInference_factory>(
+      {.tag                   = "EcalEndcapNParticleIDInference",
+       .variadic_input_names  = {{
+           "EcalEndcapNParticleIDInput_features",
+       }},
+       .variadic_output_names = {{
+           "EcalEndcapNParticleIDOutput_label",
+           "EcalEndcapNParticleIDOutput_probability_tensor",
+       }},
+       .configs               = {
+                         .modelPath = "calibrations/onnx/EcalEndcapN_pi_rejection.onnx",
+       }}));
 #endif
   app->Add(new JOmniFactoryGeneratorT<CalorimeterParticleIDPostML_factory>(
       "EcalEndcapNParticleIDPostML",

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -133,44 +133,43 @@ void InitPlugin(JApplication* app) {
     }
   }
 
-#if (10000*JANA_VERSION_MAJOR + 100*JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
-    app->Add(new JOmniFactoryGeneratorT<SubDivideCollection_factory<edm4eic::TrackerHit>>(
-        "TaggerTrackerSplitHits", {"TaggerTrackerRecHits"}, geometryDivisionCollectionNames,
-        {
-            .function = GeometrySplit{geometryDivisions, readout, geometryLabels},
-        }));
+#if (10000 * JANA_VERSION_MAJOR + 100 * JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
+  app->Add(new JOmniFactoryGeneratorT<SubDivideCollection_factory<edm4eic::TrackerHit>>(
+      "TaggerTrackerSplitHits", {"TaggerTrackerRecHits"}, geometryDivisionCollectionNames,
+      {
+          .function = GeometrySplit{geometryDivisions, readout, geometryLabels},
+      }));
 #else
-    app->Add(new JOmniFactoryGeneratorT<SubDivideCollection_factory<edm4eic::TrackerHit>>({
-        .tag="TaggerTrackerSplitHits", 
-        .input_names={"TaggerTrackerRecHits"}, 
-        .variadic_output_names = {geometryDivisionCollectionNames},
-        .configs={
-            .function = GeometrySplit{geometryDivisions, readout, geometryLabels},
-        }}));
+  app->Add(new JOmniFactoryGeneratorT<SubDivideCollection_factory<edm4eic::TrackerHit>>(
+      {.tag                   = "TaggerTrackerSplitHits",
+       .input_names           = {"TaggerTrackerRecHits"},
+       .variadic_output_names = {geometryDivisionCollectionNames},
+       .configs               = {
+                         .function = GeometrySplit{geometryDivisions, readout, geometryLabels},
+       }}));
 #endif
 
-#if (10000*JANA_VERSION_MAJOR + 100*JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
-    app->Add(new JOmniFactoryGeneratorT<FarDetectorTrackerCluster_factory>(
-        "TaggerTrackerClustering", geometryDivisionCollectionNames, outputClusterCollectionNames,
-        {
-            .readout        = "TaggerTrackerHits",
-            .x_field        = "x",
-            .y_field        = "y",
-            .hit_time_limit = 10 * edm4eic::unit::ns,
-        }));
+#if (10000 * JANA_VERSION_MAJOR + 100 * JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
+  app->Add(new JOmniFactoryGeneratorT<FarDetectorTrackerCluster_factory>(
+      "TaggerTrackerClustering", geometryDivisionCollectionNames, outputClusterCollectionNames,
+      {
+          .readout        = "TaggerTrackerHits",
+          .x_field        = "x",
+          .y_field        = "y",
+          .hit_time_limit = 10 * edm4eic::unit::ns,
+      }));
 #else
-    app->Add(new JOmniFactoryGeneratorT<FarDetectorTrackerCluster_factory>({
-        .tag = "TaggerTrackerClustering", 
-        .variadic_input_names = {geometryDivisionCollectionNames}, 
-        .variadic_output_names = {outputClusterCollectionNames},
-        .configs = {
-            .readout        = "TaggerTrackerHits",
-            .x_field        = "x",
-            .y_field        = "y",
-            .hit_time_limit = 10 * edm4eic::unit::ns,
-        }}));
+  app->Add(new JOmniFactoryGeneratorT<FarDetectorTrackerCluster_factory>(
+      {.tag                   = "TaggerTrackerClustering",
+       .variadic_input_names  = {geometryDivisionCollectionNames},
+       .variadic_output_names = {outputClusterCollectionNames},
+       .configs               = {
+                         .readout        = "TaggerTrackerHits",
+                         .x_field        = "x",
+                         .y_field        = "y",
+                         .hit_time_limit = 10 * edm4eic::unit::ns,
+       }}));
 #endif
-
 
   // Linear tracking for each module, loop over modules
   for (std::size_t i = 0; i < moduleIDs.size(); i++) {
@@ -178,61 +177,60 @@ void InitPlugin(JApplication* app) {
     std::string outputTrackAssociationTag     = outputTrackAssociationTags[i];
     std::vector<std::string> inputClusterTags = moduleClusterTags[i];
 
-#if (10000*JANA_VERSION_MAJOR + 100*JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
-      inputClusterTags.emplace_back("TaggerTrackerRawHitAssociations");
-      app->Add(new JOmniFactoryGeneratorT<FarDetectorLinearTracking_factory>(
-          outputTrackTag, {inputClusterTags}, {outputTrackTag, outputTrackAssociationTag},
-          {
-              .layer_hits_max       = 200,
-              .chi2_max             = 0.001,
-              .n_layer              = 4,
-              .restrict_direction   = true,
-              .optimum_theta        = -M_PI + 0.026,
-              .optimum_phi          = 0,
-              .step_angle_tolerance = 0.05,
-          }));
+#if (10000 * JANA_VERSION_MAJOR + 100 * JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
+    inputClusterTags.emplace_back("TaggerTrackerRawHitAssociations");
+    app->Add(new JOmniFactoryGeneratorT<FarDetectorLinearTracking_factory>(
+        outputTrackTag, {inputClusterTags}, {outputTrackTag, outputTrackAssociationTag},
+        {
+            .layer_hits_max       = 200,
+            .chi2_max             = 0.001,
+            .n_layer              = 4,
+            .restrict_direction   = true,
+            .optimum_theta        = -M_PI + 0.026,
+            .optimum_phi          = 0,
+            .step_angle_tolerance = 0.05,
+        }));
 #else
-      app->Add(new JOmniFactoryGeneratorT<FarDetectorLinearTracking_factory>({
-          .tag = outputTrackTag, 
-          .input_names = {"TaggerTrackerRawHitAssociations"},
-          .variadic_input_names = {inputClusterTags},
-          .output_names = {outputTrackTag, outputTrackAssociationTag},
-          .configs = {
-              .layer_hits_max       = 200,
-              .chi2_max             = 0.001,
-              .n_layer              = 4,
-              .restrict_direction   = true,
-              .optimum_theta        = -M_PI + 0.026,
-              .optimum_phi          = 0,
-              .step_angle_tolerance = 0.05,
-          }}));
+    app->Add(new JOmniFactoryGeneratorT<FarDetectorLinearTracking_factory>(
+        {.tag                  = outputTrackTag,
+         .input_names          = {"TaggerTrackerRawHitAssociations"},
+         .variadic_input_names = {inputClusterTags},
+         .output_names         = {outputTrackTag, outputTrackAssociationTag},
+         .configs              = {
+                          .layer_hits_max       = 200,
+                          .chi2_max             = 0.001,
+                          .n_layer              = 4,
+                          .restrict_direction   = true,
+                          .optimum_theta        = -M_PI + 0.026,
+                          .optimum_phi          = 0,
+                          .step_angle_tolerance = 0.05,
+         }}));
 #endif
   }
 
-#if (10000*JANA_VERSION_MAJOR + 100*JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
-    // Combine the tracks from each module into one collection
-    app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track, true>>(
-        "TaggerTrackerLocalTracks", outputTrackTags, {"TaggerTrackerLocalTracks"}));
+#if (10000 * JANA_VERSION_MAJOR + 100 * JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
+  // Combine the tracks from each module into one collection
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track, true>>(
+      "TaggerTrackerLocalTracks", outputTrackTags, {"TaggerTrackerLocalTracks"}));
 
-    // Combine the associations from each module into one collection
-    app->Add(new JOmniFactoryGeneratorT<
-            CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation, true>>(
-        "TaggerTrackerLocalTrackAssociations", outputTrackAssociationTags,
-        {"TaggerTrackerLocalTrackAssociations"}));
+  // Combine the associations from each module into one collection
+  app->Add(new JOmniFactoryGeneratorT<
+           CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation, true>>(
+      "TaggerTrackerLocalTrackAssociations", outputTrackAssociationTags,
+      {"TaggerTrackerLocalTrackAssociations"}));
 #else
-    // Combine the tracks from each module into one collection
-    app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track, true>>({
-        .tag="TaggerTrackerLocalTracks",
-        .variadic_input_names={outputTrackTags},
-        .output_names = {"TaggerTrackerLocalTracks"}}));
+  // Combine the tracks from each module into one collection
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track, true>>(
+      {.tag                  = "TaggerTrackerLocalTracks",
+       .variadic_input_names = {outputTrackTags},
+       .output_names         = {"TaggerTrackerLocalTracks"}}));
 
-    // Combine the associations from each module into one collection
-    app->Add(new JOmniFactoryGeneratorT<
-            CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation, true>>({
-        .tag="TaggerTrackerLocalTrackAssociations", 
-        .variadic_input_names = {outputTrackAssociationTags},
-        .output_names = {"TaggerTrackerLocalTrackAssociations"}
-    }));
+  // Combine the associations from each module into one collection
+  app->Add(new JOmniFactoryGeneratorT<
+           CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation, true>>(
+      {.tag                  = "TaggerTrackerLocalTrackAssociations",
+       .variadic_input_names = {outputTrackAssociationTags},
+       .output_names         = {"TaggerTrackerLocalTrackAssociations"}}));
 #endif
 
   // Project tracks onto a plane
@@ -253,22 +251,22 @@ void InitPlugin(JApplication* app) {
       {
           .beamE = 10.0,
       }));
-  
-#if (10000*JANA_VERSION_MAJOR + 100*JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
-    app->Add(new JOmniFactoryGeneratorT<ONNXInference_factory>(
-        "TaggerTrackerTransportationInference", {"TaggerTrackerFeatureTensor"},
-        {"TaggerTrackerPredictionTensor"},
-        {
-            .modelPath = "calibrations/onnx/TaggerTrackerTransportation.onnx",
-        }));
+
+#if (10000 * JANA_VERSION_MAJOR + 100 * JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
+  app->Add(new JOmniFactoryGeneratorT<ONNXInference_factory>(
+      "TaggerTrackerTransportationInference", {"TaggerTrackerFeatureTensor"},
+      {"TaggerTrackerPredictionTensor"},
+      {
+          .modelPath = "calibrations/onnx/TaggerTrackerTransportation.onnx",
+      }));
 #else
-    app->Add(new JOmniFactoryGeneratorT<ONNXInference_factory>({
-        .tag= "TaggerTrackerTransportationInference", 
-        .variadic_input_names = {{"TaggerTrackerFeatureTensor"}},
-        .variadic_output_names = {{"TaggerTrackerPredictionTensor"}},
-        .configs = {
-            .modelPath = "calibrations/onnx/TaggerTrackerTransportation.onnx",
-        }}));
+  app->Add(new JOmniFactoryGeneratorT<ONNXInference_factory>(
+      {.tag                   = "TaggerTrackerTransportationInference",
+       .variadic_input_names  = {{"TaggerTrackerFeatureTensor"}},
+       .variadic_output_names = {{"TaggerTrackerPredictionTensor"}},
+       .configs               = {
+                         .modelPath = "calibrations/onnx/TaggerTrackerTransportation.onnx",
+       }}));
 #endif
   app->Add(new JOmniFactoryGeneratorT<FarDetectorTransportationPostML_factory>(
       "TaggerTrackerTransportationPostML", {"TaggerTrackerPredictionTensor", "MCBeamElectrons"},

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -41,17 +41,16 @@ private:
   std::shared_ptr<spdlog::logger> m_logger;
 
 public:
-
   // This PreInit is needed for JANA2 <= 2.4.3
   inline void PreInit(std::string tag, JEventLevel level,
                       std::vector<std::string> input_collection_names,
                       std::vector<JEventLevel> input_collection_levels,
                       std::vector<std::string> output_collection_names) {
 
-    if constexpr (JVersion::major*10000 + JVersion::minor*100 + JVersion::patch < 20403) {
-        // PreInit using the underlying JANA JOmniFactory
-        JANA_JOmniFactory::PreInit(tag, level, input_collection_names, input_collection_levels,
-                                output_collection_names);
+    if constexpr (JVersion::major * 10000 + JVersion::minor * 100 + JVersion::patch < 20403) {
+      // PreInit using the underlying JANA JOmniFactory
+      JANA_JOmniFactory::PreInit(tag, level, input_collection_names, input_collection_levels,
+                                 output_collection_names);
     }
 
     // But obtain our own logger (defines the parameter option)
@@ -60,26 +59,24 @@ public:
   }
 
   // This PreInit is needed for JANA2 >= 2.4.3
-  inline void PreInit(std::string tag,
-                      JEventLevel level,
+  inline void PreInit(std::string tag, JEventLevel level,
                       std::vector<std::string> input_collection_names,
                       std::vector<JEventLevel> input_collection_levels,
                       std::vector<std::vector<std::string>> variadic_input_collection_names,
                       std::vector<JEventLevel> variadic_input_collection_levels,
                       std::vector<std::string> output_collection_names,
-                      std::vector<std::vector<std::string>> variadic_output_collection_names
-                      ) {
-  // PreInit using the underlying JANA JOmniFactory
-  if constexpr (JVersion::major*10000 + JVersion::minor*100 + JVersion::patch >= 20403) {
-    JANA_JOmniFactory::PreInit(tag, level, input_collection_names, input_collection_levels,
-                                variadic_input_collection_names, variadic_input_collection_levels,
-                                output_collection_names, variadic_output_collection_names);
+                      std::vector<std::vector<std::string>> variadic_output_collection_names) {
+    // PreInit using the underlying JANA JOmniFactory
+    if constexpr (JVersion::major * 10000 + JVersion::minor * 100 + JVersion::patch >= 20403) {
+      JANA_JOmniFactory::PreInit(tag, level, input_collection_names, input_collection_levels,
+                                 variadic_input_collection_names, variadic_input_collection_levels,
+                                 output_collection_names, variadic_output_collection_names);
+    }
+
+    // But obtain our own logger (defines the parameter option)
+    m_logger =
+        this->GetApplication()->template GetService<Log_service>()->logger(this->GetPrefix());
   }
-
-  // But obtain our own logger (defines the parameter option)
-  m_logger = this->GetApplication()->template GetService<Log_service>()->logger(this->GetPrefix());
-}
-
 
   virtual void ChangeRun(int32_t /* run_number */) override {};
 

--- a/src/global/beam/beam.cc
+++ b/src/global/beam/beam.cc
@@ -34,35 +34,33 @@ void InitPlugin(JApplication* app) {
   std::vector<std::vector<int>> values{{4, 11}, {4, 2212}, {4, 2112},
                                        {1, 11}, {1, 2212}, {1, 2112}};
 
-#if (10000*JANA_VERSION_MAJOR + 100*JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
+#if (10000 * JANA_VERSION_MAJOR + 100 * JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
 
-    app->Add(new JOmniFactoryGeneratorT<SubDivideCollection_factory<edm4hep::MCParticle>>(
-        "BeamParticles", {"MCParticles"}, outCollections,
-        {
-            .function =
-                ValueSplit<&edm4hep::MCParticle::getGeneratorStatus, &edm4hep::MCParticle::getPDG>{
-                    values},
-        }));
+  app->Add(new JOmniFactoryGeneratorT<SubDivideCollection_factory<edm4hep::MCParticle>>(
+      "BeamParticles", {"MCParticles"}, outCollections,
+      {
+          .function =
+              ValueSplit<&edm4hep::MCParticle::getGeneratorStatus, &edm4hep::MCParticle::getPDG>{
+                  values},
+      }));
 
-    // Combine beam protons and neutrons into beam hadrons
-    app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4hep::MCParticle, true>>(
-        "MCBeamHadrons", {"MCBeamProtons", "MCBeamNeutrons"}, {"MCBeamHadrons"}));
+  // Combine beam protons and neutrons into beam hadrons
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4hep::MCParticle, true>>(
+      "MCBeamHadrons", {"MCBeamProtons", "MCBeamNeutrons"}, {"MCBeamHadrons"}));
 
 #else
 
-    app->Add(new JOmniFactoryGeneratorT<SubDivideCollection_factory<edm4hep::MCParticle>>({
-        .tag = "BeamParticles",
-        .input_names = {"MCParticles"},
-        .variadic_output_names = {outCollections},
-        .configs = {
-            .function =
-                ValueSplit<&edm4hep::MCParticle::getGeneratorStatus, &edm4hep::MCParticle::getPDG>{values}
-            }}));
+  app->Add(new JOmniFactoryGeneratorT<SubDivideCollection_factory<edm4hep::MCParticle>>(
+      {.tag                   = "BeamParticles",
+       .input_names           = {"MCParticles"},
+       .variadic_output_names = {outCollections},
+       .configs               = {.function = ValueSplit<&edm4hep::MCParticle::getGeneratorStatus,
+                                                        &edm4hep::MCParticle::getPDG>{values}}}));
 
-    app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4hep::MCParticle, true>>({
-            .tag="MCBeamHadrons", 
-            .variadic_input_names = {{"MCBeamProtons", "MCBeamNeutrons"}},
-            .output_names = {"MCBeamHadrons"}}));
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4hep::MCParticle, true>>(
+      {.tag                  = "MCBeamHadrons",
+       .variadic_input_names = {{"MCBeamProtons", "MCBeamNeutrons"}},
+       .output_names         = {"MCBeamHadrons"}}));
 #endif
 }
 }

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -70,31 +70,31 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<MC2ReconstructedParticle_factory>(
       "GeneratedParticles", {"MCParticles"}, {"GeneratedParticles"}));
 
+#if (10000 * JANA_VERSION_MAJOR + 100 * JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Cluster, true>>(
+      "EcalClusters", {"EcalEndcapNClusters", "EcalBarrelScFiClusters", "EcalEndcapPClusters"},
+      {"EcalClusters"}));
 
-#if (10000*JANA_VERSION_MAJOR + 100*JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
-    app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Cluster, true>>(
-        "EcalClusters", {"EcalEndcapNClusters", "EcalBarrelScFiClusters", "EcalEndcapPClusters"},
-        {"EcalClusters"}));
-
-    app->Add(new JOmniFactoryGeneratorT<
-            CollectionCollector_factory<edm4eic::MCRecoClusterParticleAssociation, true>>(
-        "EcalClusterAssociations",
-        {"EcalEndcapNClusterAssociations", "EcalBarrelScFiClusterAssociations",
-        "EcalEndcapPClusterAssociations"},
-        {"EcalClusterAssociations"}));
+  app->Add(new JOmniFactoryGeneratorT<
+           CollectionCollector_factory<edm4eic::MCRecoClusterParticleAssociation, true>>(
+      "EcalClusterAssociations",
+      {"EcalEndcapNClusterAssociations", "EcalBarrelScFiClusterAssociations",
+       "EcalEndcapPClusterAssociations"},
+      {"EcalClusterAssociations"}));
 #else
-    app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Cluster, true>>({
-        .tag="EcalClusters", 
-        .variadic_input_names={{"EcalEndcapNClusters", "EcalBarrelScFiClusters", "EcalEndcapPClusters"}},
-        .output_names={"EcalClusters"}
-        }));
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Cluster, true>>(
+      {.tag                  = "EcalClusters",
+       .variadic_input_names = {{"EcalEndcapNClusters", "EcalBarrelScFiClusters",
+                                 "EcalEndcapPClusters"}},
+       .output_names         = {"EcalClusters"}}));
 
-    app->Add(new JOmniFactoryGeneratorT<
-            CollectionCollector_factory<edm4eic::MCRecoClusterParticleAssociation, true>>({
-        .tag="EcalClusterAssociations",
-        .variadic_input_names={{"EcalEndcapNClusterAssociations", "EcalBarrelScFiClusterAssociations",
-        "EcalEndcapPClusterAssociations"}},
-        .output_names={"EcalClusterAssociations"}}));
+  app->Add(new JOmniFactoryGeneratorT<
+           CollectionCollector_factory<edm4eic::MCRecoClusterParticleAssociation, true>>(
+      {.tag                  = "EcalClusterAssociations",
+       .variadic_input_names = {{"EcalEndcapNClusterAssociations",
+                                 "EcalBarrelScFiClusterAssociations",
+                                 "EcalEndcapPClusterAssociations"}},
+       .output_names         = {"EcalClusterAssociations"}}));
 #endif
 
   app->Add(new JOmniFactoryGeneratorT<MatchClusters_factory>(
@@ -135,18 +135,17 @@ void InitPlugin(JApplication* app) {
       "InclusiveKinematicsESigma", {"MCParticles", "ScatteredElectronsTruth", "HadronicFinalState"},
       {"InclusiveKinematicsESigma"}));
 
-
-#if (10000*JANA_VERSION_MAJOR + 100*JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
-    // InclusiveKinematicseSigma is deprecated and will be removed, use InclusiveKinematicsESigma instead
-    app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::InclusiveKinematics>>(
-        "InclusiveKinematicseSigma_legacy", {"InclusiveKinematicsESigma"},
-        {"InclusiveKinematicseSigma"}));
+#if (10000 * JANA_VERSION_MAJOR + 100 * JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
+  // InclusiveKinematicseSigma is deprecated and will be removed, use InclusiveKinematicsESigma instead
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::InclusiveKinematics>>(
+      "InclusiveKinematicseSigma_legacy", {"InclusiveKinematicsESigma"},
+      {"InclusiveKinematicseSigma"}));
 #else
-    // InclusiveKinematicseSigma is deprecated and will be removed, use InclusiveKinematicsESigma instead
-    app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::InclusiveKinematics>>({
-        .tag="InclusiveKinematicseSigma_legacy", 
-        .variadic_input_names={{"InclusiveKinematicsESigma"}},
-        .output_names={"InclusiveKinematicseSigma"}}));
+  // InclusiveKinematicseSigma is deprecated and will be removed, use InclusiveKinematicsESigma instead
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::InclusiveKinematics>>(
+      {.tag                  = "InclusiveKinematicseSigma_legacy",
+       .variadic_input_names = {{"InclusiveKinematicsESigma"}},
+       .output_names         = {"InclusiveKinematicseSigma"}}));
 #endif
 
   app->Add(new JOmniFactoryGeneratorT<

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -52,67 +52,69 @@ void InitPlugin(JApplication* app) {
   std::vector<std::pair<double, double>> thetaRanges{{0, 50 * dd4hep::mrad},
                                                      {50 * dd4hep::mrad, 180 * dd4hep::deg}};
 
-#if (10000*JANA_VERSION_MAJOR + 100*JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
-    app->Add(new JOmniFactoryGeneratorT<SubDivideCollection_factory<edm4eic::TrackParameters>>(
-        "CentralB0TrackTruthSeeds", {"TrackTruthSeeds"},
-        {"B0TrackerTruthSeeds", "CentralTrackerTruthSeeds"},
-        {
-            .function = RangeSplit<&edm4eic::TrackParameters::getTheta>(thetaRanges),
-        }));
+#if (10000 * JANA_VERSION_MAJOR + 100 * JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
+  app->Add(new JOmniFactoryGeneratorT<SubDivideCollection_factory<edm4eic::TrackParameters>>(
+      "CentralB0TrackTruthSeeds", {"TrackTruthSeeds"},
+      {"B0TrackerTruthSeeds", "CentralTrackerTruthSeeds"},
+      {
+          .function = RangeSplit<&edm4eic::TrackParameters::getTheta>(thetaRanges),
+      }));
 #else
-    app->Add(new JOmniFactoryGeneratorT<SubDivideCollection_factory<edm4eic::TrackParameters>>({
-        .tag="CentralB0TrackTruthSeeds", 
-        .input_names={"TrackTruthSeeds"},
-        .variadic_output_names={{"B0TrackerTruthSeeds", "CentralTrackerTruthSeeds"}},
-        .configs={
-            .function = RangeSplit<&edm4eic::TrackParameters::getTheta>(thetaRanges),
-        }}));
+  app->Add(new JOmniFactoryGeneratorT<SubDivideCollection_factory<edm4eic::TrackParameters>>(
+      {.tag                   = "CentralB0TrackTruthSeeds",
+       .input_names           = {"TrackTruthSeeds"},
+       .variadic_output_names = {{"B0TrackerTruthSeeds", "CentralTrackerTruthSeeds"}},
+       .configs               = {
+                         .function = RangeSplit<&edm4eic::TrackParameters::getTheta>(thetaRanges),
+       }}));
 #endif
 
   // CENTRAL TRACKER
 
-#if (10000*JANA_VERSION_MAJOR + 100*JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
-    // Tracker hits collector
-    app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::TrackerHit, true>>(
-        "CentralTrackingRecHits",
-        {"SiBarrelTrackerRecHits", "SiBarrelVertexRecHits", "SiEndcapTrackerRecHits",
-        "TOFBarrelRecHits", "TOFEndcapRecHits", "MPGDBarrelRecHits", "OuterMPGDBarrelRecHits",
-        "BackwardMPGDEndcapRecHits", "ForwardMPGDEndcapRecHits"},
-        {"CentralTrackingRecHits"} // Output collection name
-        ));
+#if (10000 * JANA_VERSION_MAJOR + 100 * JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
+  // Tracker hits collector
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::TrackerHit, true>>(
+      "CentralTrackingRecHits",
+      {"SiBarrelTrackerRecHits", "SiBarrelVertexRecHits", "SiEndcapTrackerRecHits",
+       "TOFBarrelRecHits", "TOFEndcapRecHits", "MPGDBarrelRecHits", "OuterMPGDBarrelRecHits",
+       "BackwardMPGDEndcapRecHits", "ForwardMPGDEndcapRecHits"},
+      {"CentralTrackingRecHits"} // Output collection name
+      ));
 
-    // Tracker hit associations collector
-    app->Add(new JOmniFactoryGeneratorT<
-            CollectionCollector_factory<edm4eic::MCRecoTrackerHitAssociation, true>>(
-        "CentralTrackingRawHitAssociations",
-        {"SiBarrelRawHitAssociations", "SiBarrelVertexRawHitAssociations",
-        "SiEndcapTrackerRawHitAssociations", "TOFBarrelRawHitAssociations",
-        "TOFEndcapRawHitAssociations", "MPGDBarrelRawHitAssociations",
-        "OuterMPGDBarrelRawHitAssociations", "BackwardMPGDEndcapRawHitAssociations",
-        "ForwardMPGDEndcapRawHitAssociations"},
-        {"CentralTrackingRawHitAssociations"} // Output collection name
-        ));
+  // Tracker hit associations collector
+  app->Add(new JOmniFactoryGeneratorT<
+           CollectionCollector_factory<edm4eic::MCRecoTrackerHitAssociation, true>>(
+      "CentralTrackingRawHitAssociations",
+      {"SiBarrelRawHitAssociations", "SiBarrelVertexRawHitAssociations",
+       "SiEndcapTrackerRawHitAssociations", "TOFBarrelRawHitAssociations",
+       "TOFEndcapRawHitAssociations", "MPGDBarrelRawHitAssociations",
+       "OuterMPGDBarrelRawHitAssociations", "BackwardMPGDEndcapRawHitAssociations",
+       "ForwardMPGDEndcapRawHitAssociations"},
+      {"CentralTrackingRawHitAssociations"} // Output collection name
+      ));
 #else
-    // Tracker hits collector
-    app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::TrackerHit, true>>({
-        .tag="CentralTrackingRecHits",
-        .variadic_input_names={{"SiBarrelTrackerRecHits", "SiBarrelVertexRecHits", "SiEndcapTrackerRecHits",
-        "TOFBarrelRecHits", "TOFEndcapRecHits", "MPGDBarrelRecHits", "OuterMPGDBarrelRecHits",
-        "BackwardMPGDEndcapRecHits", "ForwardMPGDEndcapRecHits"}},
-        .output_names={"CentralTrackingRecHits"} // Output collection name
-      }));
+  // Tracker hits collector
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::TrackerHit, true>>({
+      .tag                  = "CentralTrackingRecHits",
+      .variadic_input_names = {{"SiBarrelTrackerRecHits", "SiBarrelVertexRecHits",
+                                "SiEndcapTrackerRecHits", "TOFBarrelRecHits", "TOFEndcapRecHits",
+                                "MPGDBarrelRecHits", "OuterMPGDBarrelRecHits",
+                                "BackwardMPGDEndcapRecHits", "ForwardMPGDEndcapRecHits"}},
+      .output_names         = {"CentralTrackingRecHits"} // Output collection name
+  }));
 
-    // Tracker hit associations collector
-    app->Add(new JOmniFactoryGeneratorT<
-            CollectionCollector_factory<edm4eic::MCRecoTrackerHitAssociation, true>>({
-        .tag="CentralTrackingRawHitAssociations",
-        .variadic_input_names={{"SiBarrelRawHitAssociations", "SiBarrelVertexRawHitAssociations",
-        "SiEndcapTrackerRawHitAssociations", "TOFBarrelRawHitAssociations",
-        "TOFEndcapRawHitAssociations", "MPGDBarrelRawHitAssociations",
-        "OuterMPGDBarrelRawHitAssociations", "BackwardMPGDEndcapRawHitAssociations",
-        "ForwardMPGDEndcapRawHitAssociations"}},
-        .output_names={"CentralTrackingRawHitAssociations"} // Output collection name
-      }));
+  // Tracker hit associations collector
+  app->Add(new JOmniFactoryGeneratorT<
+           CollectionCollector_factory<edm4eic::MCRecoTrackerHitAssociation, true>>({
+      .tag                  = "CentralTrackingRawHitAssociations",
+      .variadic_input_names = {{"SiBarrelRawHitAssociations", "SiBarrelVertexRawHitAssociations",
+                                "SiEndcapTrackerRawHitAssociations", "TOFBarrelRawHitAssociations",
+                                "TOFEndcapRawHitAssociations", "MPGDBarrelRawHitAssociations",
+                                "OuterMPGDBarrelRawHitAssociations",
+                                "BackwardMPGDEndcapRawHitAssociations",
+                                "ForwardMPGDEndcapRawHitAssociations"}},
+      .output_names         = {"CentralTrackingRawHitAssociations"} // Output collection name
+  }));
 #endif
 
   app->Add(new JOmniFactoryGeneratorT<TrackerMeasurementFromHits_factory>(
@@ -383,57 +385,58 @@ void InitPlugin(JApplication* app) {
       },
       {}));
 
+#if (10000 * JANA_VERSION_MAJOR + 100 * JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
 
-#if (10000*JANA_VERSION_MAJOR + 100*JANA_VERSION_MINOR + JANA_VERSION_PATCH) < 20403
+  // Add Low-Q2, central and B0 tracks
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track, true>>(
+      "CombinedTracks", {"CentralCKFTracks", "B0TrackerCKFTracks", "TaggerTrackerTracks"},
+      {"CombinedTracks"}));
 
-    // Add Low-Q2, central and B0 tracks
-    app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track, true>>(
-        "CombinedTracks", {"CentralCKFTracks", "B0TrackerCKFTracks", "TaggerTrackerTracks"},
-        {"CombinedTracks"}));
+  app->Add(new JOmniFactoryGeneratorT<
+           CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation, true>>(
+      "CombinedTrackAssociations",
+      {"CentralCKFTrackAssociations", "B0TrackerCKFTrackAssociations",
+       "TaggerTrackerTrackAssociations"},
+      {"CombinedTrackAssociations"}));
 
-    app->Add(new JOmniFactoryGeneratorT<
-            CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation, true>>(
-        "CombinedTrackAssociations",
-        {"CentralCKFTrackAssociations", "B0TrackerCKFTrackAssociations",
-        "TaggerTrackerTrackAssociations"},
-        {"CombinedTrackAssociations"}));
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track, true>>(
+      "CombinedTruthSeededTracks",
+      {"CentralCKFTruthSeededTracks", "B0TrackerCKFTruthSeededTracks", "TaggerTrackerTracks"},
+      {"CombinedTruthSeededTracks"}));
 
-    app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track, true>>(
-        "CombinedTruthSeededTracks",
-        {"CentralCKFTruthSeededTracks", "B0TrackerCKFTruthSeededTracks", "TaggerTrackerTracks"},
-        {"CombinedTruthSeededTracks"}));
-
-    app->Add(new JOmniFactoryGeneratorT<
-            CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation, true>>(
-        "CombinedTruthSeededTrackAssociations",
-        {"CentralCKFTruthSeededTrackAssociations", "B0TrackerCKFTruthSeededTrackAssociations",
-        "TaggerTrackerTrackAssociations"},
-        {"CombinedTruthSeededTrackAssociations"}));
+  app->Add(new JOmniFactoryGeneratorT<
+           CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation, true>>(
+      "CombinedTruthSeededTrackAssociations",
+      {"CentralCKFTruthSeededTrackAssociations", "B0TrackerCKFTruthSeededTrackAssociations",
+       "TaggerTrackerTrackAssociations"},
+      {"CombinedTruthSeededTrackAssociations"}));
 #else
-    // Add Low-Q2, central and B0 tracks
-    app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track, true>>({
-        .tag="CombinedTracks", 
-        .variadic_input_names={{"CentralCKFTracks", "B0TrackerCKFTracks", "TaggerTrackerTracks"}},
-        .output_names={"CombinedTracks"}}));
+  // Add Low-Q2, central and B0 tracks
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track, true>>(
+      {.tag                  = "CombinedTracks",
+       .variadic_input_names = {{"CentralCKFTracks", "B0TrackerCKFTracks", "TaggerTrackerTracks"}},
+       .output_names         = {"CombinedTracks"}}));
 
-    app->Add(new JOmniFactoryGeneratorT<
-            CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation, true>>({
-        .tag="CombinedTrackAssociations",
-        .variadic_input_names={{"CentralCKFTrackAssociations", "B0TrackerCKFTrackAssociations",
-        "TaggerTrackerTrackAssociations"}},
-        .output_names={"CombinedTrackAssociations"}}));
+  app->Add(new JOmniFactoryGeneratorT<
+           CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation, true>>(
+      {.tag                  = "CombinedTrackAssociations",
+       .variadic_input_names = {{"CentralCKFTrackAssociations", "B0TrackerCKFTrackAssociations",
+                                 "TaggerTrackerTrackAssociations"}},
+       .output_names         = {"CombinedTrackAssociations"}}));
 
-    app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track, true>>({
-        .tag="CombinedTruthSeededTracks",
-        .variadic_input_names={{"CentralCKFTruthSeededTracks", "B0TrackerCKFTruthSeededTracks", "TaggerTrackerTracks"}},
-        .output_names={"CombinedTruthSeededTracks"}}));
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track, true>>(
+      {.tag                  = "CombinedTruthSeededTracks",
+       .variadic_input_names = {{"CentralCKFTruthSeededTracks", "B0TrackerCKFTruthSeededTracks",
+                                 "TaggerTrackerTracks"}},
+       .output_names         = {"CombinedTruthSeededTracks"}}));
 
-    app->Add(new JOmniFactoryGeneratorT<
-            CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation, true>>({
-        .tag="CombinedTruthSeededTrackAssociations",
-        .variadic_input_names={{"CentralCKFTruthSeededTrackAssociations", "B0TrackerCKFTruthSeededTrackAssociations",
-        "TaggerTrackerTrackAssociations"}},
-        .output_names={"CombinedTruthSeededTrackAssociations"}}));
+  app->Add(new JOmniFactoryGeneratorT<
+           CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation, true>>(
+      {.tag                  = "CombinedTruthSeededTrackAssociations",
+       .variadic_input_names = {{"CentralCKFTruthSeededTrackAssociations",
+                                 "B0TrackerCKFTruthSeededTrackAssociations",
+                                 "TaggerTrackerTrackAssociations"}},
+       .output_names         = {"CombinedTruthSeededTrackAssociations"}}));
 #endif
 
   app->Add(new JOmniFactoryGeneratorT<TracksToParticles_factory>(


### PR DESCRIPTION
PR #1959 pulled in JANA2 v2.4.2's JOmniFactory and JOmniFactoryGenerator after JANA2 v2.4.3 was already released. The new release includes backwards incompatible changes to JOmniFactory{Generator}. They add support for multiple variadic inputs and outputs with arbitrary arity, which is needed for timeframe splitting.
