### PR TITLE
fix: clear output vectors of Acts objects before process

### DIFF
--- a/src/factories/tracking/AmbiguitySolver_factory.h
+++ b/src/factories/tracking/AmbiguitySolver_factory.h
@@ -44,6 +44,11 @@ public:
   }
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
+    // FIXME clear output since it may not have been initialized or reset
+    // See https://github.com/eic/EICrecon/issues/1961
+    m_acts_tracks_output().clear();
+    m_acts_trajectories_output().clear();
+
     std::tie(m_acts_tracks_output(), m_acts_trajectories_output()) =
         m_algo->process(m_acts_tracks_input(), *m_measurements_input());
   }

--- a/src/factories/tracking/CKFTracking_factory.h
+++ b/src/factories/tracking/CKFTracking_factory.h
@@ -50,6 +50,11 @@ public:
   }
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
+    // FIXME clear output since it may not have been initialized or reset
+    // See https://github.com/eic/EICrecon/issues/1961
+    m_acts_trajectories_output().clear();
+    m_acts_tracks_output().clear();
+
     std::tie(m_acts_trajectories_output(), m_acts_tracks_output()) =
         m_algo->process(*m_parameters_input(), *m_measurements_input());
   }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR propagates the workaround in bf2857de (for issue #1961) to the two other factories that use a similar construct. Before #1959 was merged, this was done by our JOmniFactory.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.