### PR TITLE
fix: just require ONNX Runtime everywhere

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,11 +253,7 @@ if(NOT "cxx_std_${CMAKE_CXX_STANDARD}" IN_LIST ROOT_COMPILE_FEATURES)
 endif()
 
 # ONNX Runtime
-option(USE_ONNX "Compile with ONNX support" ON)
-if(${USE_ONNX})
-  find_package(onnxruntime ${onnxruntime_MIN_VERSION} CONFIG)
-  add_compile_definitions(USE_ONNX)
-endif()
+find_package(onnxruntime ${onnxruntime_MIN_VERSION} CONFIG)
 
 # Add CMake additional functionality:
 include(cmake/jana_plugin.cmake) # Add common settings for plugins

--- a/src/algorithms/CMakeLists.txt
+++ b/src/algorithms/CMakeLists.txt
@@ -8,7 +8,4 @@ add_subdirectory(pid_lut)
 add_subdirectory(digi)
 add_subdirectory(reco)
 add_subdirectory(fardetectors)
-
-if(USE_ONNX)
-  add_subdirectory(onnx)
-endif()
+add_subdirectory(onnx)

--- a/src/detectors/LOWQ2/CMakeLists.txt
+++ b/src/detectors/LOWQ2/CMakeLists.txt
@@ -19,7 +19,5 @@ plugin_add_onnxruntime(${PLUGIN_NAME})
 
 # Add libraries (works same as target_include_directories)
 plugin_link_libraries(${PLUGIN_NAME} algorithms_digi_library
-                      algorithms_fardetectors_library)
-if(USE_ONNX)
-  plugin_link_libraries(${PLUGIN_NAME} algorithms_onnx_library)
-endif()
+                      algorithms_fardetectors_library
+                      algorithms_onnx_library)

--- a/src/detectors/LOWQ2/CMakeLists.txt
+++ b/src/detectors/LOWQ2/CMakeLists.txt
@@ -19,5 +19,4 @@ plugin_add_onnxruntime(${PLUGIN_NAME})
 
 # Add libraries (works same as target_include_directories)
 plugin_link_libraries(${PLUGIN_NAME} algorithms_digi_library
-                      algorithms_fardetectors_library
-                      algorithms_onnx_library)
+                      algorithms_fardetectors_library algorithms_onnx_library)

--- a/src/global/reco/CMakeLists.txt
+++ b/src/global/reco/CMakeLists.txt
@@ -28,4 +28,4 @@ plugin_glob_all(${PLUGIN_NAME})
 # library)
 plugin_link_libraries(
   ${PLUGIN_NAME} algorithms_digi_library algorithms_tracking_library
-  algorithms_fardetectors_library algorithms_onnx_library)
+  algorithms_reco_library algorithms_onnx_library)

--- a/src/global/reco/CMakeLists.txt
+++ b/src/global/reco/CMakeLists.txt
@@ -27,7 +27,4 @@ plugin_glob_all(${PLUGIN_NAME})
 # Add libraries (same as target_include_directories but for both plugin and
 # library)
 plugin_link_libraries(${PLUGIN_NAME} algorithms_digi_library
-                      algorithms_tracking_library algorithms_reco_library)
-if(USE_ONNX)
-  plugin_link_libraries(${PLUGIN_NAME} algorithms_onnx_library)
-endif()
+                      algorithms_tracking_library algorithms_fardetectors_library algorithms_onnx_library)

--- a/src/global/reco/CMakeLists.txt
+++ b/src/global/reco/CMakeLists.txt
@@ -26,5 +26,6 @@ plugin_glob_all(${PLUGIN_NAME})
 
 # Add libraries (same as target_include_directories but for both plugin and
 # library)
-plugin_link_libraries(${PLUGIN_NAME} algorithms_digi_library
-                      algorithms_tracking_library algorithms_fardetectors_library algorithms_onnx_library)
+plugin_link_libraries(
+  ${PLUGIN_NAME} algorithms_digi_library algorithms_tracking_library
+  algorithms_fardetectors_library algorithms_onnx_library)

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -29,9 +29,7 @@
 #include "factories/meta/FilterMatching_factory.h"
 #include "factories/reco/FarForwardLambdaReconstruction_factory.h"
 #include "factories/reco/FarForwardNeutralsReconstruction_factory.h"
-#ifdef USE_ONNX
 #include "factories/reco/InclusiveKinematicsML_factory.h"
-#endif
 #include "factories/reco/ChargedReconstructedParticleSelector_factory.h"
 #include "factories/reco/HadronicFinalState_factory.h"
 #include "factories/reco/InclusiveKinematicsReconstructed_factory.h"
@@ -128,11 +126,9 @@ void InitPlugin(JApplication* app) {
       "InclusiveKinematicsSigma", {"MCParticles", "ScatteredElectronsTruth", "HadronicFinalState"},
       {"InclusiveKinematicsSigma"}, app));
 
-#ifdef USE_ONNX
   app->Add(new JOmniFactoryGeneratorT<InclusiveKinematicsML_factory>(
       "InclusiveKinematicsML", {"InclusiveKinematicsElectron", "InclusiveKinematicsDA"},
       {"InclusiveKinematicsML"}, app));
-#endif
 
   app->Add(new JOmniFactoryGeneratorT<ReconstructedElectrons_factory>(
       "ReconstructedElectrons", {"ReconstructedParticles"}, {"ReconstructedElectrons"}, {}, app));


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Since the EEMC doesn't use the option to turn off ONNX Runtime, we might as well not give the impression that it's supported.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: `cmake -DUSE_ONNX=OFF` fails to compile)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
ONNX Runtime required now.