### PR TITLE
fix: explicitly convert signed run number to unsigned for bitset (ubsan fix)

### DIFF
--- a/src/algorithms/interfaces/UniqueIDGenSvc.h
+++ b/src/algorithms/interfaces/UniqueIDGenSvc.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <edm4hep/EventHeaderCollection.h>
+#include <edm4hep/EDM4hepVersion.h>
 #include <algorithms/logger.h>
 #include <algorithms/service.h>
 #include <bitset>
@@ -49,7 +50,12 @@ public:
                      const std::string_view& name) const {
     std::bitset<seed_digits> seed_bits           = m_seed.value();
     std::bitset<event_num_digits> event_num_bits = evt_num;
+#if EDM4HEP_BUILD_VERSION > EDM4HEP_VERSION(0, 99, 2)
     std::bitset<run_num_digits> run_num_bits     = run_num;
+#else
+    // FIXME until edm4hep 0.99.1, the run number is signed and defaults to -1
+    std::bitset<run_num_digits> run_num_bits     = static_cast<std::uint32_t>(run_num);
+#endif
     std::bitset<name_digits> name_bits           = std::hash<std::string_view>{}(name);
 
     std::bitset<seed_digits + event_num_digits + run_num_digits + name_digits> combined_bits;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR avoids an Undefined Behavior warning due to the default run number of -1 being used in the constructor of a bitset, which only accepts unsigned long long. Negative run numbers are static cast from -1 to 4294967295 instead of just taking abs because that would lead to -1, 0, 1 run sequences having random IDs that are identical in close proximity.
```
SUMMARY: UndefinedBehaviorSanitizer: implicit-integer-sign-change /home/wdconinc/git/EICrecon/src/algorithms/interfaces/UniqueIDGenSvc.h:52:52 
```

See also:
- https://github.com/JeffersonLab/JANA2/blob/a2c5bbeb00c545ed44fb7698bd9e7f1d74feb8b0/src/libraries/JANA/JFactory.h#L184
- https://github.com/key4hep/EDM4hep/commit/5219b52264285910c65f21d7d047fb93fafd85d2

Note: no warning is suppressed for event numbers since those are not ever -1 (and if they are, we want to know why it changed).

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.