### PR TITLE
fix: enable strongly-typed enum SiliconChargeSharingConfig::ESigmaMode

### DIFF
--- a/src/algorithms/digi/SiliconChargeSharingConfig.h
+++ b/src/algorithms/digi/SiliconChargeSharingConfig.h
@@ -31,7 +31,7 @@ std::istream& operator>>(std::istream& in, SiliconChargeSharingConfig::ESigmaMod
 
   return in;
 }
-std::ostream& operator<<(std::ostream& out, SiliconChargeSharingConfig::ESigmaMode& sigmaMode) {
+std::ostream& operator<<(std::ostream& out, const SiliconChargeSharingConfig::ESigmaMode& sigmaMode) {
   switch (sigmaMode) {
   case SiliconChargeSharingConfig::ESigmaMode::abs:
     out << "abs";

--- a/src/algorithms/digi/SiliconChargeSharingConfig.h
+++ b/src/algorithms/digi/SiliconChargeSharingConfig.h
@@ -10,7 +10,7 @@ struct SiliconChargeSharingConfig {
   // determines the meaning of sigma_sharingx and y.
   // rel means relative, so charge sharing range = sigma_sharingx * cell_width_x, etc for y
   // abs means absolute, charge sharing range = sigma_shargeingx directly
-  enum ESigmaMode { abs = 0, rel = 1 } sigma_mode = abs;
+  enum class ESigmaMode { abs = 0, rel = 1 } sigma_mode = ESigmaMode::abs;
   float sigma_sharingx;
   float sigma_sharingy;
   float min_edep;

--- a/src/algorithms/digi/SiliconChargeSharingConfig.h
+++ b/src/algorithms/digi/SiliconChargeSharingConfig.h
@@ -31,7 +31,8 @@ std::istream& operator>>(std::istream& in, SiliconChargeSharingConfig::ESigmaMod
 
   return in;
 }
-std::ostream& operator<<(std::ostream& out, const SiliconChargeSharingConfig::ESigmaMode& sigmaMode) {
+std::ostream& operator<<(std::ostream& out,
+                         const SiliconChargeSharingConfig::ESigmaMode& sigmaMode) {
   switch (sigmaMode) {
   case SiliconChargeSharingConfig::ESigmaMode::abs:
     out << "abs";


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR modifies the unscoped enum `ESigmaMode` to a scoped enum, and avoids the implicit integer conversion by correcting the `operator<<` signature. Before this fix, the output was `0` or `1` (since the incorrectly-signatured `operator<<` is not used); after this fix, the output is `abs` or `rel`.

The scoping of the enum adds a layer of safety since the symbol `abs` could previously shadow the standard function `std::abs`.

This aligns with the enabled clang-tidy check `cppcoreguidelines-use-enum-class`, https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/use-enum-class.html.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/EICrecon/pull/1999#discussion_r2255159290, but fails to compile https://github.com/eic/EICrecon/pull/1999#discussion_r2280550838)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.