### PR TITLE
Add NOLINT block to pid_lut

### DIFF
--- a/src/global/pid_lut/pid_lut.cc
+++ b/src/global/pid_lut/pid_lut.cc
@@ -68,8 +68,10 @@ void InitPlugin(JApplication* app) {
       .momentum_edges = {0.4,  0.8,  1.2,  1.6, 2,    2.4,  2.8,  3.2,  3.6, 4,    4.4,  4.8, 5.2,
                          5.6,  6,    6.4,  6.8, 7.2,  7.6,  8,    8.4,  8.8, 9.2,  9.6,  10,  10.4,
                          10.8, 11.2, 11.6, 12,  12.4, 12.8, 13.2, 13.6, 14,  14.4, 14.8, 15.2},
-      .polar_edges    = {2.65,  2.6725, 2.695, 2.7175, 2.74,  2.7625, 2.785, 2.8075, 2.83,  2.8525,
-                         2.875, 2.8975, 2.92,  2.9425, 2.965, 2.9875, 3.01,  3.0325, 3.055, 3.0775},
+      // NOLINTBEGIN(modernize-use-std-numbers)
+      .polar_edges = {2.65,  2.6725, 2.695, 2.7175, 2.74,  2.7625, 2.785, 2.8075, 2.83,  2.8525,
+                      2.875, 2.8975, 2.92,  2.9425, 2.965, 2.9875, 3.01,  3.0325, 3.055, 3.0775},
+      // NOLINTEND(modernize-use-std-numbers)
       .azimuthal_binning            = {0., 2 * M_PI, 2 * M_PI / 120.}, // lower, upper, step
       .azimuthal_bin_centers_in_lut = true,
       .momentum_bin_centers_in_lut  = true,


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Stops clang tidy suggesting replacing the value `2.7175` with `e` in the `pid_lut` plugin

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No