### PR TITLE
fix: limit eicweb triggered PIPELINE_NAME to 255 characters

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -1036,6 +1036,14 @@ jobs:
     outputs:
       json: ${{ steps.trigger.outputs.json }}
     steps:
+    - uses: actions/github-script@v6
+      id: truncate_pipeline_name
+      with:
+        script: |
+          const title = github.context.payload.pull_request?.title;
+          const ref_name = github.context.ref.replace(/^refs\/heads\//, '');
+          const name = title || ref_name;
+          return name ? name.substring(0, 255) : ''
     - uses: eic/trigger-gitlab-ci@v3
       id: trigger
       with:
@@ -1048,7 +1056,7 @@ jobs:
           GITHUB_SHA=${{ github.event.pull_request.head.sha || github.sha }}
           GITHUB_PR=${{ github.event.pull_request.number }}
           EICRECON_VERSION="${{ github.event.pull_request.head.ref || github.ref_name }}"
-          PIPELINE_NAME=${{ github.repository }}: ${{ github.event.pull_request.title || github.ref_name }}
+          PIPELINE_NAME=${{ steps.truncate_pipeline_name.outputs.result }}
     - name: Post a GitHub CI status
       run: |
         gh api \


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR limits the length of `PIPELINE_NAME` to 255 characters, the maximum allowed by gitlab.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/EICrecon/actions/runs/17163709090/job/48701153137?pr=2035)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.