### PR TITLE
fix: make capybara summary "Last updated" line just small, not sub-sup

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -1252,7 +1252,8 @@ jobs:
           echo "### Capybara summary for PR ${{ github.event.pull_request.number }}" >> capybara_${{ github.event.pull_request.number }}.md
           find publishing_docs/pr/${{ github.event.pull_request.number }}/capybara/ -mindepth 1 -maxdepth 1 -type d -printf \
             "- [%f](https://eicrecon.epic-eic.org/pr/${{ github.event.pull_request.number }}/capybara/%f/index.html)\n" | sort >> capybara_${{ github.event.pull_request.number }}.md
-          echo "<sup><sub>Last updated $(TZ=America/New_York date -Iminutes) ${{github.event.pull_request.head.sha}}</sub></sup>" >> capybara_${{ github.event.pull_request.number }}.md
+          echo >> capybara_${{ github.event.pull_request.number }}.md
+          echo "<small>Last updated $(TZ=America/New_York date -Iminutes) ${{github.event.pull_request.head.sha}}</small>" >> capybara_${{ github.event.pull_request.number }}.md
       - name: Create capybara step summary
         if: ${{ github.event_name == 'pull_request' }}
         run: |


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR updates the teeny tiny text <sub><sup>Last updated</sup></sub> in the capybara summary comment to be just small: <small>Last updated</small>. My eyes will thank me.

Note: It doesn't seem like GitHub's style currently makes small any smaller than normal text. But it is semantically sensible and even at normal font it's actually fine. Anything but the squinting text.

### What kind of change does this PR introduce?
- [x] Bug fix (issue :eyes:)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.