### PR TITLE
fix: Update the devcontainer image to eic_ci:nightly

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "ghcr.io/eic/jug_prod:master-nightly",
+  "image": "ghcr.io/eic/eic_ci:nightly",
   "postCreateCommand": "./.devcontainer/postCreateCommand.sh",
   "customizations": {
     "vscode": {


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR updates the devcontainer image (used by GitHub codespaces) to `eic_ci:nightly`. Using the smaller eic_ci images and pulled from ghcr.io for startup speed reasons.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: jug_prod isn't updated anymore)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.