### PR TITLE
fix: don't create IWYU PRs for dependabot (no permissions)

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -272,7 +272,7 @@ jobs:
     - name: Create Pull Request
       id: create-pull-request
       uses: peter-evans/create-pull-request@v7
-      if: ${{ github.event_name == 'pull_request' }}
+      if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
       with:
         token: ${{ secrets.EIC_EICRECON_PULL_REQUESTS_READ_WRITE }}
         commit-message: "fix: iwyu [skip ci]"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR ensures that dependabot PRs don't fail due to insufficient permissions in the IWYU step. See https://github.com/eic/EICrecon/actions/runs/17245815142/job/48935888308?pr=2050.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/EICrecon/actions/runs/17245815142/job/48935888308?pr=2050)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.