### PR TITLE
fix: rename known-leaking suppressed object `edm4hep::create*Buffers`

### DIFF
--- a/.github/lsan.supp
+++ b/.github/lsan.supp
@@ -4,7 +4,7 @@ leak:dd4hep::DetElementObject::clone
 leak:dd4hep::detail::VolumeManager_Populator::scanPhysicalVolume
 leak:dd4hep::Header::Header
 leak:dd4hep::VisAttr::VisAttr
-leak:edm4hep::*::createBuffers
+leak:edm4hep::*::create*Buffers
 leak:libActsCore.so
 leak:libCling.so
 leak:libCore.so


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes a rename of the leaking object from createBuffers to create{name}Buffers, see https://github.com/AIDASoft/podio/pull/746. This applies for podio-1.3. The pattern should still match the previous name too, used in podio-1.2.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/EICrecon/actions/runs/17327690866/job/49196706907#step:7:2678)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.