### PR TITLE
fix: remove use of JANA/CLI/JVersion.h

### DIFF
--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -10,9 +10,9 @@
  * which might be changed by user parameters.
  */
 
-#include <JANA/CLI/JVersion.h>
 #include <JANA/JMultifactory.h>
 #include <JANA/JEvent.h>
+#include <JANA/JVersion.h>
 #include <spdlog/spdlog.h>
 #include <spdlog/version.h>
 #if SPDLOG_VERSION >= 11400 && (!defined(SPDLOG_NO_TLS) || !SPDLOG_NO_TLS)

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -10,8 +10,8 @@
  * which might be changed by user parameters.
  */
 
-#include <JANA/JMultifactory.h>
 #include <JANA/JEvent.h>
+#include <JANA/JMultifactory.h>
 #include <JANA/JVersion.h>
 #include <spdlog/spdlog.h>
 #include <spdlog/version.h>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes the include of `JANA/CLI/JVersion.h`, which is removed in JANA 2.4.3, https://github.com/JeffersonLab/JANA2/commit/16a0f4d3723604eda99d4bd8ed90618156c5d48b.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: fails to compile with latest JANA release)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.