### PR TITLE
fix: remove use of `operator->` for podio collection objects

### DIFF
--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -181,8 +181,8 @@ void FarDetectorLinearTracking::checkHitCombination(
 
   // Create the track
   auto track = (*outputTracks)
-                   ->create(type, position, momentum, positionMomentumCovariance, time, timeError,
-                            charge, chi2, ndf, pdg);
+                   .create(type, position, momentum, positionMomentumCovariance, time, timeError,
+                           charge, chi2, ndf, pdg);
 
   // Add Measurement2D relations and count occurrence of particles contributing to the track
   std::unordered_map<const edm4hep::MCParticle*, int> particleCount;

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
@@ -108,7 +108,7 @@ void FarDetectorTrackerCluster::ClusterHits(
     ROOT::VecOps::RVec<float> clusterW;
 
     // Create cluster
-    auto cluster = outputClusters->create();
+    auto cluster = outputClusters.create();
 
     // Loop over hits, adding neighbouring hits as relevant
     while (!clusterList.empty()) {

--- a/src/algorithms/pid/MatchToRICHPID.cc
+++ b/src/algorithms/pid/MatchToRICHPID.cc
@@ -143,7 +143,7 @@ bool MatchToRICHPID::linkCherenkovPID(edm4eic::MutableReconstructedParticle& in_
 
   // relate matched ParticleID objects to output particle
   for (const auto& [out_pids_index, out_pids_id] : out_pid_index_map) {
-    const auto& out_pid = out_pids->at(out_pids_index);
+    const auto& out_pid = out_pids.at(out_pids_index);
     if (out_pid.getObjectID().index != static_cast<int>(out_pids_id)) { // sanity check
       error("indexing error in `edm4eic::ParticleID` collection");
       return false;

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
@@ -130,7 +130,7 @@ TEST_CASE("the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]") {
   simhit1.addToContributions(contrib11);
   simhit1.addToContributions(contrib12);
 
-  auto hitassoc1 = hitassocs_coll->create();
+  auto hitassoc1 = hitassocs_coll.create();
   hitassoc1.setRawHit(rawhit1);
   hitassoc1.setSimHit(simhit1);
 
@@ -178,7 +178,7 @@ TEST_CASE("the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]") {
   simhit2.setPosition(hit2.getPosition());
   simhit2.addToContributions(contrib2);
 
-  auto hitassoc2 = hitassocs_coll->create();
+  auto hitassoc2 = hitassocs_coll.create();
   hitassoc2.setRawHit(rawhit2);
   hitassoc2.setSimHit(simhit2);
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes the deprecated use of `operator->` for podio collection objects, which is deprecated as of https://github.com/AIDASoft/podio/commit/66ad12a900fca2561e12d00c0ca04616b92c955e.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: semantically dubious choices)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.