### PR TITLE
feat: speed up CI builds with unity build

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -163,7 +163,7 @@ jobs:
         platform-release: "${{ env.platform }}:${{ matrix.release }}"
         run: |
           # install this repo
-          CXX="${{ matrix.CXX }}" CXXFLAGS="${{ matrix.CXXFLAGS }}" cmake --warn-uninitialized -B build -S . -DCMAKE_INSTALL_PREFIX=install -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }} -DUSE_ASAN=${{matrix.USE_ASAN}} -DUSE_TSAN=${{matrix.USE_TSAN}} -DUSE_UBSAN=${{matrix.USE_UBSAN}} -DENABLE_LINK_WHAT_YOU_USE=ON
+          CXX="${{ matrix.CXX }}" CXXFLAGS="${{ matrix.CXXFLAGS }}" cmake --warn-uninitialized -B build -S . -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=24 -DCMAKE_INSTALL_PREFIX=install -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }} -DUSE_ASAN=${{matrix.USE_ASAN}} -DUSE_TSAN=${{matrix.USE_TSAN}} -DUSE_UBSAN=${{matrix.USE_UBSAN}} -DENABLE_LINK_WHAT_YOU_USE=ON
           cmake --build build -j $(getconf _NPROCESSORS_ONLN) --target install
           ccache --show-stats --verbose
           ccache --evict-older-than 7d

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -163,7 +163,7 @@ jobs:
         platform-release: "${{ env.platform }}:${{ matrix.release }}"
         run: |
           # install this repo
-          CXX="${{ matrix.CXX }}" CXXFLAGS="${{ matrix.CXXFLAGS }}" cmake --warn-uninitialized -B build -S . -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=24 -DCMAKE_INSTALL_PREFIX=install -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }} -DUSE_ASAN=${{matrix.USE_ASAN}} -DUSE_TSAN=${{matrix.USE_TSAN}} -DUSE_UBSAN=${{matrix.USE_UBSAN}} -DENABLE_LINK_WHAT_YOU_USE=ON
+          CXX="${{ matrix.CXX }}" CXXFLAGS="${{ matrix.CXXFLAGS }}" cmake --warn-uninitialized -B build -S . -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=24 -DCMAKE_UNITY_BUILD_UNIQUE_ID=UNITY_BUILD_UNIQUE_ID -DCMAKE_INSTALL_PREFIX=install -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }} -DUSE_ASAN=${{matrix.USE_ASAN}} -DUSE_TSAN=${{matrix.USE_TSAN}} -DUSE_UBSAN=${{matrix.USE_UBSAN}} -DENABLE_LINK_WHAT_YOU_USE=ON
           cmake --build build -j $(getconf _NPROCESSORS_ONLN) --target install
           ccache --show-stats --verbose
           ccache --evict-older-than 7d

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -35,10 +35,6 @@
 using namespace edm4eic;
 
 namespace eicrecon {
-template <typename... L> struct multilambda : L... {
-  using L::operator()...;
-  constexpr multilambda(L... lambda) : L(std::move(lambda))... {}
-};
 
 static double Phi_mpi_pi(double phi) { return std::remainder(phi, 2 * M_PI); }
 

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.h
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.h
@@ -70,6 +70,11 @@ public:
   dd4hep::IDDescriptor m_idSpec;
 
 private:
+  template <typename... L> struct multilambda : L... {
+    using L::operator()...;
+    constexpr multilambda(L... lambda) : L(std::move(lambda))... {}
+  };
+
   // grouping function with Breadth-First Search
   void bfs_group(const edm4eic::CalorimeterHitCollection& hits, std::set<std::size_t>& group,
                  std::size_t idx, std::vector<bool>& visits) const;

--- a/src/algorithms/calorimetry/ImagingTopoCluster.cc
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.cc
@@ -36,10 +36,6 @@
 #include "algorithms/calorimetry/ImagingTopoClusterConfig.h"
 
 namespace eicrecon {
-template <typename... L> struct multilambda : L... {
-  using L::operator()...;
-  constexpr multilambda(L... lambda) : L(std::move(lambda))... {}
-};
 
 void ImagingTopoCluster::init() {
 

--- a/src/algorithms/calorimetry/ImagingTopoCluster.h
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.h
@@ -71,6 +71,11 @@ public:
   void process(const Input& input, const Output& output) const final;
 
 private:
+  template <typename... L> struct multilambda : L... {
+    using L::operator()...;
+    constexpr multilambda(L... lambda) : L(std::move(lambda))... {}
+  };
+
   // helper function to group hits
   bool is_neighbour(const edm4eic::CalorimeterHit& h1, const edm4eic::CalorimeterHit& h2) const;
 

--- a/src/algorithms/onnx/InclusiveKinematicsML.cc
+++ b/src/algorithms/onnx/InclusiveKinematicsML.cc
@@ -15,25 +15,37 @@
 
 namespace eicrecon {
 
-static std::string print_shape(const std::vector<std::int64_t>& v) {
-  std::stringstream ss("");
-  for (std::size_t i = 0; i < v.size() - 1; i++) {
-    ss << v[i] << "x";
-  }
-  ss << v[v.size() - 1];
-  return ss.str();
-}
+#ifndef UNITY_BUILD_UNIQUE_ID
+#define UNITY_BUILD_UNIQUE_ID
+#endif
 
-template <typename T>
-Ort::Value vec_to_tensor(std::vector<T>& data, const std::vector<std::int64_t>& shape) {
-  Ort::MemoryInfo mem_info = Ort::MemoryInfo::CreateCpu(OrtAllocatorType::OrtArenaAllocator,
-                                                        OrtMemType::OrtMemTypeDefault);
-  auto tensor =
-      Ort::Value::CreateTensor<T>(mem_info, data.data(), data.size(), shape.data(), shape.size());
-  return tensor;
-}
+namespace {
+  namespace UNITY_BUILD_UNIQUE_ID {
+
+    static std::string print_shape(const std::vector<std::int64_t>& v) {
+      std::stringstream ss("");
+      for (std::size_t i = 0; i < v.size() - 1; i++) {
+        ss << v[i] << "x";
+      }
+      ss << v[v.size() - 1];
+      return ss.str();
+    }
+
+    template <typename T>
+    Ort::Value vec_to_tensor(std::vector<T>& data, const std::vector<std::int64_t>& shape) {
+      Ort::MemoryInfo mem_info = Ort::MemoryInfo::CreateCpu(OrtAllocatorType::OrtArenaAllocator,
+                                                            OrtMemType::OrtMemTypeDefault);
+      auto tensor = Ort::Value::CreateTensor<T>(mem_info, data.data(), data.size(), shape.data(),
+                                                shape.size());
+      return tensor;
+    }
+
+  } // namespace UNITY_BUILD_UNIQUE_ID
+} // namespace
 
 void InclusiveKinematicsML::init() {
+  using namespace UNITY_BUILD_UNIQUE_ID;
+
   // onnxruntime setup
   m_env = Ort::Env(ORT_LOGGING_LEVEL_WARNING, "inclusive-kinematics-ml");
   Ort::SessionOptions session_options;
@@ -86,6 +98,8 @@ void InclusiveKinematicsML::init() {
 
 void InclusiveKinematicsML::process(const InclusiveKinematicsML::Input& input,
                                     const InclusiveKinematicsML::Output& output) const {
+
+  using namespace UNITY_BUILD_UNIQUE_ID;
 
   const auto [electron, da] = input;
   auto [ml]                 = output;

--- a/src/algorithms/onnx/ONNXInference.cc
+++ b/src/algorithms/onnx/ONNXInference.cc
@@ -15,42 +15,54 @@
 
 namespace eicrecon {
 
-static std::string print_shape(const std::vector<std::int64_t>& v) {
-  std::stringstream ss("");
-  for (std::size_t i = 0; i < v.size() - 1; i++) {
-    ss << v[i] << " x ";
-  }
-  ss << v[v.size() - 1];
-  return ss.str();
-}
+#ifndef UNITY_BUILD_UNIQUE_ID
+#define UNITY_BUILD_UNIQUE_ID
+#endif
 
-static bool check_shape_consistency(const std::vector<std::int64_t>& shape1,
-                                    const std::vector<std::int64_t>& shape2) {
-  if (shape2.size() != shape1.size()) {
-    return false;
-  }
-  for (std::size_t ix = 0; ix < shape1.size(); ix++) {
-    if ((shape1[ix] != -1) && (shape2[ix] != -1) && (shape1[ix] != shape2[ix])) {
-      return false;
+namespace {
+  namespace UNITY_BUILD_UNIQUE_ID {
+
+    static std::string print_shape(const std::vector<std::int64_t>& v) {
+      std::stringstream ss("");
+      for (std::size_t i = 0; i < v.size() - 1; i++) {
+        ss << v[i] << " x ";
+      }
+      ss << v[v.size() - 1];
+      return ss.str();
     }
-  }
-  return true;
-}
 
-template <typename T>
-static Ort::Value iters_to_tensor(typename std::vector<T>::const_iterator data_begin,
-                                  typename std::vector<T>::const_iterator data_end,
-                                  std::vector<int64_t>::const_iterator shape_begin,
-                                  std::vector<int64_t>::const_iterator shape_end) {
-  Ort::MemoryInfo mem_info = Ort::MemoryInfo::CreateCpu(OrtAllocatorType::OrtArenaAllocator,
-                                                        OrtMemType::OrtMemTypeDefault);
-  auto tensor =
-      Ort::Value::CreateTensor<T>(mem_info, const_cast<T*>(&*data_begin), data_end - data_begin,
-                                  &*shape_begin, shape_end - shape_begin);
-  return tensor;
-}
+    static bool check_shape_consistency(const std::vector<std::int64_t>& shape1,
+                                        const std::vector<std::int64_t>& shape2) {
+      if (shape2.size() != shape1.size()) {
+        return false;
+      }
+      for (std::size_t ix = 0; ix < shape1.size(); ix++) {
+        if ((shape1[ix] != -1) && (shape2[ix] != -1) && (shape1[ix] != shape2[ix])) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    template <typename T>
+    static Ort::Value iters_to_tensor(typename std::vector<T>::const_iterator data_begin,
+                                      typename std::vector<T>::const_iterator data_end,
+                                      std::vector<int64_t>::const_iterator shape_begin,
+                                      std::vector<int64_t>::const_iterator shape_end) {
+      Ort::MemoryInfo mem_info = Ort::MemoryInfo::CreateCpu(OrtAllocatorType::OrtArenaAllocator,
+                                                            OrtMemType::OrtMemTypeDefault);
+      auto tensor =
+          Ort::Value::CreateTensor<T>(mem_info, const_cast<T*>(&*data_begin), data_end - data_begin,
+                                      &*shape_begin, shape_end - shape_begin);
+      return tensor;
+    }
+
+  } // namespace UNITY_BUILD_UNIQUE_ID
+} // namespace
 
 void ONNXInference::init() {
+  using namespace UNITY_BUILD_UNIQUE_ID;
+
   // onnxruntime setup
   m_env = Ort::Env(ORT_LOGGING_LEVEL_WARNING, name().data());
   Ort::SessionOptions session_options;
@@ -100,6 +112,8 @@ void ONNXInference::init() {
 
 void ONNXInference::process(const ONNXInference::Input& input,
                             const ONNXInference::Output& output) const {
+
+  using namespace UNITY_BUILD_UNIQUE_ID;
 
   const auto [in_tensors] = input;
   auto [out_tensors]      = output;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
To speed up CI builds, we can use [unity builds](https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html), essentially bundling multiple source files in a single source file per library, and compiling in one go. This speeds up a non-ccache compilation locally from
```
        Elapsed (wall clock) time (h:mm:ss or m:ss): 6:37.68
```
to
```
        Elapsed (wall clock) time (h:mm:ss or m:ss): 4:15.68
```
(Methodology: `rm -rf build && cmake -Bbuild -S. -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=24 --fresh && /usr/bin/time -v make -Cbuild -j8 install`)

Unity builds are not without their drawbacks. It requires that the different source files can coexist in a single source file. They cannot define functions with the same name in the same namespace. It is in general a good practice to avoid these conflicts (by defining them once), so in addition to the benefit of faster compilation, this is a useful for the code base quality.

Needs:
- [x] #2058 
- [x] #2059 
- [x] #2060 
- [x] #2062 
- [ ] #2904

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.