### PR TITLE
fix the weight calculation in raw to sim hits association

### DIFF
--- a/src/algorithms/digi/SiliconTrackerDigi.cc
+++ b/src/algorithms/digi/SiliconTrackerDigi.cc
@@ -88,13 +88,17 @@ void SiliconTrackerDigi::process(const SiliconTrackerDigi::Input& input,
   }
 
   for (auto item : cell_hit_map) {
-    raw_hits->push_back(item.second);
-
+    auto raw_hit=item.second;
+    raw_hits->push_back(raw_hit);
     for (const auto& sim_hit : *sim_hits) {
       if (item.first == sim_hit.getCellID()) {
         // set association
         auto hitassoc = associations->create();
-        hitassoc.setWeight(1.0);
+        double weight = 0.0;
+        if (raw_hit.getCharge() > 0) {
+            weight = std::round((sim_hit.getEDep() * 1e6 / raw_hit.getCharge()) * 10.0) / 10.0;
+        }
+        hitassoc.setWeight(weight);
         hitassoc.setRawHit(item.second);
         hitassoc.setSimHit(sim_hit);
       }


### PR DESCRIPTION


### Briefly, what does this PR introduce?
In Si digi, the weight between raw and sim hit was set to 1 manually regardless of how many sim hits on the same cell. This update should provide a rough but more correct weight.

### What kind of change does this PR introduce?
- [ x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
