### PR TITLE
ci: don't fail pragma once check when no headers changed

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -220,7 +220,7 @@ jobs:
     - name: Check for pragma once in changed files
       if: ${{ github.event_name == 'pull_request' }}
       run: |
-        missing_pragma_headers=$(git diff --name-only ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }} | grep "\.h$" | xargs -n 1 grep -L 'pragma once')
+        missing_pragma_headers=$(git diff --name-only ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }} | grep "\.h$" | xargs -n 1 -r grep -L 'pragma once')
         test -z "${missing_pragma_headers}"
     - name: Check for pragma once in all files
       if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes a failing CI check (for pragma once) when there are no header files in the modified file set.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/EICrecon/actions/runs/17454188303/job/49564680998?pr=2065)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.