### PR TITLE
fix: Add debug logs for time cap exceedance in hits; don't skip them

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -178,7 +178,7 @@ void CalorimeterHitDigi::process(const CalorimeterHitDigi::Input& input,
         }
       }
       if (timeC > m_cfg.capTime) {
-        continue;
+        debug("retaining hit, even though time %f ns > %f ns", timeC / dd4hep::ns, m_cfg.capTime / dd4hep::ns);
       }
       edep += hit.getEnergy();
       trace("adding {} \t total: {}", hit.getEnergy(), edep);
@@ -199,7 +199,7 @@ void CalorimeterHitDigi::process(const CalorimeterHitDigi::Input& input,
       rawassocs_staging.push_back(assoc);
     }
     if (time > m_cfg.capTime) {
-      continue;
+      debug("retaining hit, even though time %f ns > %f ns", time / dd4hep::ns, m_cfg.capTime / dd4hep::ns);
     }
 
     // safety check

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -178,7 +178,8 @@ void CalorimeterHitDigi::process(const CalorimeterHitDigi::Input& input,
         }
       }
       if (timeC > m_cfg.capTime) {
-        debug("retaining hit, even though time %f ns > %f ns", timeC / dd4hep::ns, m_cfg.capTime / dd4hep::ns);
+        debug("retaining hit, even though time %f ns > %f ns", timeC / dd4hep::ns,
+              m_cfg.capTime / dd4hep::ns);
       }
       edep += hit.getEnergy();
       trace("adding {} \t total: {}", hit.getEnergy(), edep);
@@ -199,7 +200,8 @@ void CalorimeterHitDigi::process(const CalorimeterHitDigi::Input& input,
       rawassocs_staging.push_back(assoc);
     }
     if (time > m_cfg.capTime) {
-      debug("retaining hit, even though time %f ns > %f ns", time / dd4hep::ns, m_cfg.capTime / dd4hep::ns);
+      debug("retaining hit, even though time %f ns > %f ns", time / dd4hep::ns,
+            m_cfg.capTime / dd4hep::ns);
     }
 
     // safety check


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Added debug logging for hits retained despite exceeding `capTime`.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #2080)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, multiple hits at different times inside a single calorimeter channel will be retained.