### PR TITLE
Add sign to the reference position in SimCalorimeterHitProcessor

### DIFF
--- a/src/algorithms/calorimetry/SimCalorimeterHitProcessor.cc
+++ b/src/algorithms/calorimetry/SimCalorimeterHitProcessor.cc
@@ -153,8 +153,7 @@ void SimCalorimeterHitProcessor::init() {
   if (!m_cfg.attenuationReferencePositionName.empty()) {
     m_attenuationReferencePosition =
         m_geo.detector()->constant<double>(m_cfg.attenuationReferencePositionName) *
-        (edm4eic::unit::mm / dd4hep::mm) *
-	m_cfg.attenuationReferencePositionSign;
+        (edm4eic::unit::mm / dd4hep::mm) * m_cfg.attenuationReferencePositionSign;
   }
 }
 

--- a/src/algorithms/calorimetry/SimCalorimeterHitProcessor.cc
+++ b/src/algorithms/calorimetry/SimCalorimeterHitProcessor.cc
@@ -153,7 +153,8 @@ void SimCalorimeterHitProcessor::init() {
   if (!m_cfg.attenuationReferencePositionName.empty()) {
     m_attenuationReferencePosition =
         m_geo.detector()->constant<double>(m_cfg.attenuationReferencePositionName) *
-        edm4eic::unit::mm / dd4hep::mm;
+        (edm4eic::unit::mm / dd4hep::mm) *
+	m_cfg.attenuationReferencePositionSign;
   }
 }
 

--- a/src/algorithms/calorimetry/SimCalorimeterHitProcessorConfig.h
+++ b/src/algorithms/calorimetry/SimCalorimeterHitProcessorConfig.h
@@ -18,6 +18,7 @@ struct SimCalorimeterHitProcessorConfig {
 
   std::string readout{""};
   std::string attenuationReferencePositionName{""};
+  int attenuationReferencePositionSign{1};
   // fields for merging hits
   std::vector<std::string> hitMergeFields{};
   // fields for merging contributions

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -88,6 +88,7 @@ void InitPlugin(JApplication* app) {
           .attenuationParameters            = EcalBarrelScFi_attPars,
           .readout                          = "EcalBarrelScFiHits",
           .attenuationReferencePositionName = "EcalBarrel_Readout_zmin",
+	  .attenuationReferencePositionSign = -1,
           .hitMergeFields                   = EcalBarrelScFi_hitMergeFields,
           .contributionMergeFields          = EcalBarrelScFi_contributionMergeFields,
           .inversePropagationSpeed          = EcalBarrelScFi_inversePropagationSpeed,

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -88,7 +88,7 @@ void InitPlugin(JApplication* app) {
           .attenuationParameters            = EcalBarrelScFi_attPars,
           .readout                          = "EcalBarrelScFiHits",
           .attenuationReferencePositionName = "EcalBarrel_Readout_zmin",
-	  .attenuationReferencePositionSign = -1,
+          .attenuationReferencePositionSign = -1,
           .hitMergeFields                   = EcalBarrelScFi_hitMergeFields,
           .contributionMergeFields          = EcalBarrelScFi_contributionMergeFields,
           .inversePropagationSpeed          = EcalBarrelScFi_inversePropagationSpeed,


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This PR is to add sign to the reference position in `SimCalorimeterHitProcessor`. If the reference position is `a` and the hit position is `b`, this algorithm calculates the attenuation distance by `|a-b|`. However, since there is a case where the reference position obtained via `m_geo.detector()->constant<double>(m_cfg.attenuationReferencePositionName)` is provided without a sign (i.e., as an absolute value) even though the actual reference position with respect to the collision point is negative, a sign variable is added to `SimCalorimeterHitProcessorConfig.h`

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #2091)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No