### PR TITLE
EcalBarrelScFiProtoClusters: use localDistXY instead of localDistXZ

### DIFF
--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -162,7 +162,7 @@ void InitPlugin(JApplication* app) {
           .adjacencyMatrix{},
           .peakNeighbourhoodMatrix{},
           .readout{},
-          .sectorDist = 50. * dd4hep::mm,
+          .sectorDist  = 50. * dd4hep::mm,
           .localDistXY = {80 * dd4hep::mm, 80 * dd4hep::mm},
           .localDistXZ{},
           .localDistYZ{},


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The island clustering in the BEMC EcalBarrelScFiProtoClusters should happen in the XY plane, not the XZ plane. This should remove the unreasonable effectiveness of the island clustering for two gammas in the same sector. We only gain Z information when we add timing analysis, and we don't lose the Y information at that point but combine it all in topological clustering.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: EcalBarrelScFiProtoClusters unreasonably effective)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, makes EcalBarrelScFiProtoClusters worse.