### PR TITLE
Adjustment of dRICH aerogel index to 1.026

### DIFF
--- a/src/detectors/DRICH/DRICH.cc
+++ b/src/detectors/DRICH/DRICH.cc
@@ -93,7 +93,7 @@ void InitPlugin(JApplication* app) {
   irt_cfg.numRIndexBins = 100;
   // - aerogel
   irt_cfg.radiators.insert({"Aerogel", RadiatorConfig{}});
-  irt_cfg.radiators.at("Aerogel").referenceRIndex = 1.0190;
+  irt_cfg.radiators.at("Aerogel").referenceRIndex = 1.0260;
   irt_cfg.radiators.at("Aerogel").attenuation     = 48; // [mm]
   irt_cfg.radiators.at("Aerogel").smearingMode    = "gaussian";
   irt_cfg.radiators.at("Aerogel").smearing        = 2e-3; // [radians]


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The refractive index for the dRICH aerogel has been adjusted.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ X] Other: __
The average index of the dRICH aerogel refractive index has been set to 1.026.

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ X] Changes have been communicated to collaborators
@kumardeepraman is aware.
### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
