### PR TITLE
Re-add EcalBarrelScFiRawHits and associations

### DIFF
--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -295,6 +295,7 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       "EcalBarrelScFiPAttenuatedHitContributions",
       "EcalBarrelScFiNAttenuatedHits",
       "EcalBarrelScFiNAttenuatedHitContributions",
+      "EcalBarrelScFiRawHits",
       "EcalBarrelScFiPPulses",
       "EcalBarrelScFiNPulses",
       "EcalBarrelScFiPCombinedPulses",
@@ -372,6 +373,7 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       "DIRCParticleIDs",
 
       "B0ECalRawHitAssociations",
+      "EcalBarrelScFiRawHitAssociations",
       "EcalBarrelImagingRawHitAssociations",
       "HcalBarrelRawHitAssociations",
       "EcalEndcapNRawHitAssociations",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR re-adds the EcalBarrelScFiRawHits and associations to the output, after they were removed in #2076.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: regression when used outputs were removed)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Restore outputs.