### PR TITLE
Use EcalBarrelClusters and associations (i.e. not just ScFi) in MatchClusters

### DIFF
--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -79,13 +79,13 @@ void InitPlugin(JApplication* app) {
       "GeneratedParticles", {"MCParticles"}, {"GeneratedParticles"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Cluster, true>>(
-      "EcalClusters", {"EcalEndcapNClusters", "EcalBarrelScFiClusters", "EcalEndcapPClusters"},
+      "EcalClusters", {"EcalEndcapNClusters", "EcalBarrelClusters", "EcalEndcapPClusters"},
       {"EcalClusters"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<
            CollectionCollector_factory<edm4eic::MCRecoClusterParticleAssociation, true>>(
       "EcalClusterAssociations",
-      {"EcalEndcapNClusterAssociations", "EcalBarrelScFiClusterAssociations",
+      {"EcalEndcapNClusterAssociations", "EcalBarrelClusterAssociations",
        "EcalEndcapPClusterAssociations"},
       {"EcalClusterAssociations"}, app));
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR modifies the MatchClusters algorithm to use the merged EcalBarrelClusters, i.e. EcalBarrelScFiClusters and EcalBarrelImagingClusters. Since the EcalBarrelImagingClusters are what brings position information, this would be the more sensible thing to do (if we didn't just have truth matching).

### What kind of change does this PR introduce?
- [x] Bug fix (issue: EcalBarrelImagingClusters ignore in MatchClusters)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes.