### PR TITLE
Update pid_lut.cc (Debugging the Issue #2143)

### DIFF
--- a/src/global/pid_lut/pid_lut.cc
+++ b/src/global/pid_lut/pid_lut.cc
@@ -233,11 +233,11 @@ void InitPlugin(JApplication* app) {
                       0.1278, 0.1412, 0.1560, 0.1724, 0.1904, 0.2103, 0.2322,
                       0.2564, 0.2830, 0.3123, 0.3445, 0.3799, 0.4188},
 
-      .azimuthal_binning        = {0., 2 * M_PI, 2 * M_PI}, // lower, upper, step
-      .momentum_bin_centers_in_lut  = true,
-      .polar_bin_centers_in_lut = true,
-      .use_radians              = true,
-      .missing_electron_prob    = true,
+      .azimuthal_binning           = {0., 2 * M_PI, 2 * M_PI}, // lower, upper, step
+      .momentum_bin_centers_in_lut = true,
+      .polar_bin_centers_in_lut    = true,
+      .use_radians                 = true,
+      .missing_electron_prob       = true,
   };
 
   app->Add(new JOmniFactoryGeneratorT<PIDLookup_factory>(


### PR DESCRIPTION
pid_lut.cc was updated via PR#2103[https://github.com/eic/EICrecon/pull/2103] to include the updated bins corresponding to drich LUT. 

It was realised that drich.lut.gz is not getting loaded. Refere to Issue#2103[https://github.com/eic/EICrecon/issues/2143].

The issue was found to be associated with missing flag indicating that the LUT file contains central values of momentum bins (similar to what was already included for the polar angle bins).

### Briefly, what does this PR introduce?
In the file pid_lut.cc, we added:

```
.momentum_bin_centers_in_lut = true, 
```

@veprbl @chchatte92 

### What kind of change does this PR introduce?
- [x] Bug fix (issue #2143)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
