### PR TITLE
Update MatchClusters.cc/  Fix: choose best MC association by weight i…

### DIFF
--- a/src/algorithms/reco/MatchClusters.cc
+++ b/src/algorithms/reco/MatchClusters.cc
@@ -129,18 +129,18 @@ std::map<int, edm4eic::Cluster> MatchClusters::indexedClusters(
 
   // loop over clusters and pick their best MC association by weight
   for (const auto cluster : *clusters) {
-    
-    int bestMcID = -1;
+
+    int bestMcID     = -1;
     float bestWeight = -1.f;
-    
-// find best associated MC particle for this cluster (largest association weight)
+
+    // find best associated MC particle for this cluster (largest association weight)
     for (const auto assoc : *associations) {
       if (assoc.getRec() == cluster) {
         const int candMcID = assoc.getSim().getObjectID().index;
-        const float w = assoc.getWeight();
+        const float w      = assoc.getWeight();
         if (w > bestWeight) {
           bestWeight = w;
-          bestMcID = candMcID;
+          bestMcID   = candMcID;
         }
       }
     }


### PR DESCRIPTION
…n MatchClusters::indexedClusters

### Briefly, what does this PR introduce?

This PR improves the cluster-to-MC association logic in MatchClusters by selecting
the best MC particle per cluster based on association weight instead of taking
the first match found.

1.Keeps the function signature unchanged (std::map<int, edm4eic::Cluster>)
2. Prevents mismatched or low-weight associations
3. Adds debug trace output for transparency


1.Keeps the function signature unchanged (std::map<int, edm4eic::Cluster>)
2.Prevents mismatched or low-weight associations

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
