### PR TITLE
Update/Fix MatchClusters.cc

### DIFF
--- a/src/algorithms/reco/MatchClusters.cc
+++ b/src/algorithms/reco/MatchClusters.cc
@@ -126,22 +126,21 @@ std::map<int, edm4eic::Cluster> MatchClusters::indexedClusters(
 
   // temporary map: mcID -> (cluster, weight) so we can choose the cluster with highest weight per mcID
   std::map<int, std::pair<edm4eic::Cluster, float>> bestForMc;
-  
 
   // loop over clusters
   for (const auto cluster : *clusters) {
 
-    int bestMcID = -1;
+    int bestMcID     = -1;
     float bestWeight = -1.f;
 
     // find best associated MC particle for this cluster (largest association weight)
     for (const auto assoc : *associations) {
       if (assoc.getRec() == cluster) {
         const int candMcID = assoc.getSim().getObjectID().index;
-        const float w = assoc.getWeight();
+        const float w      = assoc.getWeight();
         if (w > bestWeight) {
           bestWeight = w;
-          bestMcID = candMcID;
+          bestMcID   = candMcID;
         }
       }
     }


### PR DESCRIPTION
Previously, some photons that overlapped with charged tracks were being incorrectly discarded, leading to reduced reconstruction efficiency. This change adjusts the matching logic to retain valid photons without affecting charged particle suppression.

### Briefly, what does this PR introduce?
This PR improves cluster-to-MC association logic by choosing the highest-weight match per cluster. 
Default behavior is slightly changed for clusters with multiple MC associations; 
otherwise, results are identical. No API or function signature changes are required for users.


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
