### PR TITLE
Fix missing photon reconstruction caused by charged track overlap in MatchClusters.cc

### DIFF
--- a/src/algorithms/reco/MatchClusters.cc
+++ b/src/algorithms/reco/MatchClusters.cc
@@ -132,7 +132,7 @@ std::map<int, edm4eic::Cluster> MatchClusters::indexedClusters(
   for (const auto cluster : *clusters) {
 
     int bestMcID     = -1;
-    float bestWeight = -1.f;
+    float bestWeight = -1.F;
 
     // find best associated MC particle for this cluster (largest association weight)
     for (const auto assoc : *associations) {

--- a/src/algorithms/reco/MatchClusters.cc
+++ b/src/algorithms/reco/MatchClusters.cc
@@ -119,45 +119,64 @@ void MatchClusters::process(const MatchClusters::Input& input,
 }
 
 // get a map of mcID --> cluster
-// input: clusters --> all clusters
+// For each cluster, pick the best associated MC particle by association weight.
+// Returns a map keyed by mcID and valued with the selected cluster.
 std::map<int, edm4eic::Cluster> MatchClusters::indexedClusters(
     const edm4eic::ClusterCollection* clusters,
     const edm4eic::MCRecoClusterParticleAssociationCollection* associations) const {
 
-  std::map<int, edm4eic::Cluster> matched = {};
+  // temporary map: mcID -> (cluster, weight) so we can choose the cluster with highest weight per mcID
+  std::map<int, std::pair<edm4eic::Cluster, float>> bestForMc;
 
-  // loop over clusters
+  // loop over clusters and pick their best MC association by weight
   for (const auto cluster : *clusters) {
 
-    int mcID = -1;
+    int bestMcID = -1;
+    float bestWeight = -1.f;
 
-    // find associated particle
+     // find best associated MC particle for this cluster (largest association weight)
     for (const auto assoc : *associations) {
       if (assoc.getRec() == cluster) {
-        mcID = assoc.getSim().getObjectID().index;
-        break;
+        const int candMcID = assoc.getSim().getObjectID().index;
+        const float w = assoc.getWeight();
+        if (w > bestWeight) {
+          bestWeight = w;
+          bestMcID = candMcID;
+        }
       }
     }
 
-    trace(" --> Found cluster with mcID {} and energy {}", mcID, cluster.getEnergy());
+    trace(" --> Found cluster with best mcID {} weight {} and energy {}", bestMcID, bestWeight,
+          cluster.getEnergy());
 
-    if (mcID < 0) {
+    if (bestMcID < 0) {
       trace("   --> WARNING: no valid MC truth link found, skipping cluster...");
       continue;
     }
 
-    const bool duplicate = matched.contains(mcID);
-    if (duplicate) {
-      trace("   --> WARNING: this is a duplicate mcID, keeping the higher energy cluster");
-
-      if (cluster.getEnergy() < matched[mcID].getEnergy()) {
-        continue;
+    // For this mcID, keep the cluster with the highest association weight (tie-break by energy).
+    auto it = bestForMc.find(bestMcID);
+    if (it == bestForMc.end()) {
+      bestForMc.emplace(bestMcID, std::make_pair(cluster, bestWeight));
+    } else {
+      const float existingWeight = it->second.second;
+      if (bestWeight > existingWeight ||
+          (bestWeight == existingWeight && cluster.getEnergy() > it->second.first.getEnergy())) {
+        it->second = std::make_pair(cluster, bestWeight);
       }
     }
-    matched[mcID] = cluster;
   }
+
+  // Convert to the old API: map<int, edm4eic::Cluster>
+  std::map<int, edm4eic::Cluster> matched;
+  for (const auto& kv : bestForMc) {
+    matched.emplace(kv.first, kv.second.first);
+  }
+
   return matched;
 }
+
+    
 
 // reconstruct a neutral cluster
 // (for now assuming the vertex is at (0,0,0))

--- a/src/algorithms/reco/MatchClusters.cc
+++ b/src/algorithms/reco/MatchClusters.cc
@@ -17,7 +17,9 @@
 #include <podio/ObjectID.h>
 #include <cmath>
 #include <gsl/pointers>
+#include <iterator>
 #include <map>
+#include <utility>
 
 #include "MatchClusters.h"
 

--- a/src/algorithms/reco/MatchClusters.cc
+++ b/src/algorithms/reco/MatchClusters.cc
@@ -131,17 +131,17 @@ std::map<int, edm4eic::Cluster> MatchClusters::indexedClusters(
   // loop over clusters and pick their best MC association by weight
   for (const auto cluster : *clusters) {
 
-    int bestMcID = -1;
+    int bestMcID     = -1;
     float bestWeight = -1.f;
 
-     // find best associated MC particle for this cluster (largest association weight)
+    // find best associated MC particle for this cluster (largest association weight)
     for (const auto assoc : *associations) {
       if (assoc.getRec() == cluster) {
         const int candMcID = assoc.getSim().getObjectID().index;
-        const float w = assoc.getWeight();
+        const float w      = assoc.getWeight();
         if (w > bestWeight) {
           bestWeight = w;
-          bestMcID = candMcID;
+          bestMcID   = candMcID;
         }
       }
     }
@@ -175,8 +175,6 @@ std::map<int, edm4eic::Cluster> MatchClusters::indexedClusters(
 
   return matched;
 }
-
-    
 
 // reconstruct a neutral cluster
 // (for now assuming the vertex is at (0,0,0))


### PR DESCRIPTION
Previously, some photons that overlapped with charged tracks were being incorrectly discarded, leading to reduced reconstruction efficiency. This change adjusts the matching logic to retain valid photons without affecting charged particle suppression.


### Briefly, what does this PR introduce?
This PR improves the cluster-to-MC association logic in MatchClusters by selecting the best MC particle per cluster based on association weight, instead of taking the first match found. Default behavior is slightly changed for clusters with multiple MC associations; otherwise, results are identical. No API or function signature changes are required for users.

This code change :
1.  Builds a map keyed by cluster object index, storing the best-associated MC id and its weight.
2. When matching charged tracks, it only removes a cluster if that cluster's best association is to that charged MC particle (and chooses the best cluster for that MC by highest association weight if multiple clusters claim the same MC). Remaining clusters are treated as neutrals.


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
