### PR TITLE
refactor: use std::map with comparator for deterministic ordering in SimCalorimeterHitProcessor

### DIFF
--- a/src/algorithms/calorimetry/SimCalorimeterHitProcessor.cc
+++ b/src/algorithms/calorimetry/SimCalorimeterHitProcessor.cc
@@ -199,8 +199,8 @@ void SimCalorimeterHitProcessor::process(const SimCalorimeterHitProcessor::Input
   auto [out_hits, out_hit_contribs] = output;
 
   // Map for staging output information. We have 2 levels of structure:
-  //   - top level: (MCParticle, Merged Hit CellID, TimeID)
-  //   - second level: (Merged Contributions)
+  //   - top level: (MCParticle, Merged Hit CellID, TimeID) -> contributions map
+  //   - second level: maps from contribution cellID to HitContributionAccumulator
   // We use std::map with a custom comparator to ensure deterministic ordering
   // and reproducible results between single-threaded and multi-threaded execution.
   // The custom comparator uses ObjectID instead of podio's default memory-address-based


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR aims to remove the non-deterministic behavior between single- and multi-threading observed in e.g. `_EcalBarrelScFiPPulses_calorimeterHits` and brethren. Compared to unordered_map, we get
- slower insertion with map (O(log n) instead of O(1)),
- technically* slower lookup (O(log n) instead of O(1)), and 
- the same iteration complexity (O(n)).

In the map we define an explicit comparator since the default OrderKey in podio is memory-address based.

At this point (and maybe always), deterministic output outweighs performance consideration.

(*Technically since we don't do random lookups.)

### What kind of change does this PR introduce?
- [x] Bug fix (issue: non-deterministic behavior)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, we might have slightly slower performance and better determinism.