### PR TITLE
src/tests: fix for EDM4hep 00-99-02

### DIFF
--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
@@ -93,7 +93,8 @@ TEST_CASE("the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]") {
                                       edm4hep::Vector3f(), // edm4hep::Vector3f momentumAtEndpoint
                                       edm4hep::Vector3f()  // edm4hep::Vector3f spin
 #if EDM4HEP_BUILD_VERSION < EDM4HEP_VERSION(0, 99, 2)
-                                      ,edm4hep::Vector2i() // edm4hep::Vector2i colorFlow
+                                      ,
+                                      edm4hep::Vector2i() // edm4hep::Vector2i colorFlow
 #endif
   );
 
@@ -110,7 +111,8 @@ TEST_CASE("the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]") {
       edm4hep::Vector3f(),                                  // edm4hep::Vector3f momentumAtEndpoint
       edm4hep::Vector3f()                                   // edm4hep::Vector3f spin
 #if EDM4HEP_BUILD_VERSION < EDM4HEP_VERSION(0, 99, 2)
-      ,edm4hep::Vector2i()                                  // edm4hep::Vector2i colorFlow
+      ,
+      edm4hep::Vector2i() // edm4hep::Vector2i colorFlow
 #endif
   );
 
@@ -168,9 +170,10 @@ TEST_CASE("the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]") {
       edm4hep::Vector3d(),                                  // edm4hep::Vector3d endpoint
       edm4hep::Vector3f(),                                  // edm4hep::Vector3f momentum
       edm4hep::Vector3f(),                                  // edm4hep::Vector3f momentumAtEndpoint
-      edm4hep::Vector3f()                                  // edm4hep::Vector3f spin
+      edm4hep::Vector3f()                                   // edm4hep::Vector3f spin
 #if EDM4HEP_BUILD_VERSION < EDM4HEP_VERSION(0, 99, 2)
-      ,edm4hep::Vector2i()                                   // edm4hep::Vector2i colorFlow
+      ,
+      edm4hep::Vector2i() // edm4hep::Vector2i colorFlow
 #endif
   );
 

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
@@ -11,10 +11,13 @@
 #include <edm4eic/ProtoClusterCollection.h>
 #include <edm4eic/unit_system.h>
 #include <edm4hep/CaloHitContributionCollection.h>
+#include <edm4hep/EDM4hepVersion.h>
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/RawCalorimeterHitCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
+#if EDM4HEP_BUILD_VERSION < EDM4HEP_VERSION(0, 99, 2)
 #include <edm4hep/Vector2i.h>
+#endif
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
 #include <spdlog/common.h>
@@ -88,8 +91,10 @@ TEST_CASE("the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]") {
                                       edm4hep::Vector3d(), // edm4hep::Vector3d endpoint
                                       edm4hep::Vector3f(), // edm4hep::Vector3f momentum
                                       edm4hep::Vector3f(), // edm4hep::Vector3f momentumAtEndpoint
-                                      edm4hep::Vector3f(), // edm4hep::Vector3f spin
-                                      edm4hep::Vector2i()  // edm4hep::Vector2i colorFlow
+                                      edm4hep::Vector3f()  // edm4hep::Vector3f spin
+#if EDM4HEP_BUILD_VERSION < EDM4HEP_VERSION(0, 99, 2)
+                                      ,edm4hep::Vector2i() // edm4hep::Vector2i colorFlow
+#endif
   );
 
   auto mcpart12 = mcparts_coll.create(
@@ -103,8 +108,10 @@ TEST_CASE("the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]") {
       edm4hep::Vector3d(),                                  // edm4hep::Vector3d endpoint
       edm4hep::Vector3f(),                                  // edm4hep::Vector3f momentum
       edm4hep::Vector3f(),                                  // edm4hep::Vector3f momentumAtEndpoint
-      edm4hep::Vector3f(),                                  // edm4hep::Vector3f spin
-      edm4hep::Vector2i()                                   // edm4hep::Vector2i colorFlow
+      edm4hep::Vector3f()                                   // edm4hep::Vector3f spin
+#if EDM4HEP_BUILD_VERSION < EDM4HEP_VERSION(0, 99, 2)
+      ,edm4hep::Vector2i()                                  // edm4hep::Vector2i colorFlow
+#endif
   );
 
   mcpart12.addToParents(mcpart11);
@@ -161,8 +168,10 @@ TEST_CASE("the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]") {
       edm4hep::Vector3d(),                                  // edm4hep::Vector3d endpoint
       edm4hep::Vector3f(),                                  // edm4hep::Vector3f momentum
       edm4hep::Vector3f(),                                  // edm4hep::Vector3f momentumAtEndpoint
-      edm4hep::Vector3f(),                                  // edm4hep::Vector3f spin
-      edm4hep::Vector2i()                                   // edm4hep::Vector2i colorFlow
+      edm4hep::Vector3f()                                  // edm4hep::Vector3f spin
+#if EDM4HEP_BUILD_VERSION < EDM4HEP_VERSION(0, 99, 2)
+      ,edm4hep::Vector2i()                                   // edm4hep::Vector2i colorFlow
+#endif
   );
 
   auto contrib2 = contribs_coll.create(0,                        // int32_t PDG

--- a/src/tests/algorithms_test/pid_lut_PIDLookup.cc
+++ b/src/tests/algorithms_test/pid_lut_PIDLookup.cc
@@ -75,9 +75,10 @@ TEST_CASE("particles acquire PID", "[PIDLookup]") {
                     edm4hep::Vector3d(), // edm4hep::Vector3d endpoint
                     edm4hep::Vector3f(), // edm4hep::Vector3f momentum
                     edm4hep::Vector3f(), // edm4hep::Vector3f momentumAtEndpoint
-                    edm4hep::Vector3f() // edm4hep::Vector3f spin
+                    edm4hep::Vector3f()  // edm4hep::Vector3f spin
 #if EDM4HEP_BUILD_VERSION < EDM4HEP_VERSION(0, 99, 2)
-                    ,edm4hep::Vector2i()  // edm4hep::Vector2i colorFlow
+                    ,
+                    edm4hep::Vector2i() // edm4hep::Vector2i colorFlow
 #endif
     );
 

--- a/src/tests/algorithms_test/pid_lut_PIDLookup.cc
+++ b/src/tests/algorithms_test/pid_lut_PIDLookup.cc
@@ -6,10 +6,13 @@
 #include <edm4eic/Cov4f.h>
 #include <edm4eic/MCRecoParticleAssociationCollection.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
+#include <edm4hep/EDM4hepVersion.h>
 #include <edm4hep/EventHeaderCollection.h>
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/ParticleIDCollection.h>
+#if EDM4HEP_BUILD_VERSION < EDM4HEP_VERSION(0, 99, 2)
 #include <edm4hep/Vector2i.h>
+#endif
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
 #include <spdlog/common.h>
@@ -72,8 +75,10 @@ TEST_CASE("particles acquire PID", "[PIDLookup]") {
                     edm4hep::Vector3d(), // edm4hep::Vector3d endpoint
                     edm4hep::Vector3f(), // edm4hep::Vector3f momentum
                     edm4hep::Vector3f(), // edm4hep::Vector3f momentumAtEndpoint
-                    edm4hep::Vector3f(), // edm4hep::Vector3f spin
-                    edm4hep::Vector2i()  // edm4hep::Vector2i colorFlow
+                    edm4hep::Vector3f() // edm4hep::Vector3f spin
+#if EDM4HEP_BUILD_VERSION < EDM4HEP_VERSION(0, 99, 2)
+                    ,edm4hep::Vector2i()  // edm4hep::Vector2i colorFlow
+#endif
     );
 
     auto assoc_in = assocs_in->create();


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Upstream has removed colorFlow in https://github.com/key4hep/EDM4hep/pull/389, we need to account for that in creating our test objects.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No