### PR TITLE
fix: Link digi library for BEMC plugin

### DIFF
--- a/src/detectors/BEMC/CMakeLists.txt
+++ b/src/detectors/BEMC/CMakeLists.txt
@@ -17,4 +17,5 @@ plugin_add_event_model(${PLUGIN_NAME})
 plugin_add_eigen3(${PLUGIN_NAME})
 
 # Add libraries (works same as target_include_directories)
-plugin_link_libraries(${PLUGIN_NAME} algorithms_calorimetry_library algorithms_digi_library)
+plugin_link_libraries(${PLUGIN_NAME} algorithms_calorimetry_library
+                      algorithms_digi_library)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Now that BEMC uses digitization (PulseGeneration), we need to link.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: BEMC undefined symbol _ZN8eicrecon15PulseGenerationIN7edm4hep17SimCalorimeterHitEE4initEv)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.