### PR TITLE
Don't forget unattenuated energy and restore discarded sim variables in SimCalorimeterHitProcessor

### DIFF
--- a/src/algorithms/calorimetry/SimCalorimeterHitProcessor.cc
+++ b/src/algorithms/calorimetry/SimCalorimeterHitProcessor.cc
@@ -87,18 +87,22 @@ edm4hep::MCParticle lookup_primary(const edm4hep::CaloHitContribution& contrib) 
 class HitContributionAccumulator {
 private:
   float m_energy{0};
+  float m_att_energy{0};
   float m_avg_time{0};
   float m_min_time{std::numeric_limits<float>::max()};
   edm4hep::Vector3f m_avg_position{0, 0, 0};
 
 public:
-  void add(const float energy, const float time, const edm4hep::Vector3f& pos) {
+  void add(const float energy, const float attFactor, const float time,
+           const edm4hep::Vector3f& pos) {
     m_energy += energy;
+    m_att_energy += energy * attFactor;
     m_avg_time += energy * time;
     m_avg_position = m_avg_position + energy * pos;
     m_min_time     = (time < m_min_time) ? time : m_min_time;
   }
   float getEnergy() const { return m_energy; }
+  float getAttEnergy() const { return m_att_energy; }
   float getAvgTime() const { return m_energy > 0 ? m_avg_time / m_energy : 0; }
   float getMinTime() const { return m_min_time; }
   edm4hep::Vector3f getAvgPosition() const {
@@ -200,7 +204,7 @@ void SimCalorimeterHitProcessor::process(const SimCalorimeterHitProcessor::Input
       const double totalTime  = contrib.getTime() + propagationTime + m_cfg.fixedTimeDelay;
       const int newhit_timeID = std::floor(totalTime / m_cfg.timeWindow);
       auto& hit_accum         = hit_map[{primary, newhit_cellID, newhit_timeID}][newcontrib_cellID];
-      hit_accum.add(contrib.getEnergy() * attFactor, totalTime, ih.getPosition());
+      hit_accum.add(contrib.getEnergy(), attFactor, totalTime, ih.getPosition());
     }
   }
 
@@ -213,18 +217,21 @@ void SimCalorimeterHitProcessor::process(const SimCalorimeterHitProcessor::Input
     const auto& [particle, cellID, timeID] = hit_idx;
     HitContributionAccumulator new_hit;
     for (const auto& [contrib_idx, contrib] : contribs) {
-      // Aggregate contributions to for the global hit
-      new_hit.add(contrib.getEnergy(), contrib.getMinTime(), contrib.getAvgPosition());
+      // Aggregate contributions to for the global hit; use effective "attenuation"
+      new_hit.add(contrib.getEnergy(), contrib.getAttEnergy() / contrib.getEnergy(),
+                  contrib.getMinTime(), contrib.getAvgPosition());
       // Now store the contribution itself
       auto out_hit_contrib = out_hit_contribs->create();
+      out_hit_contrib.setPDG(particle.getPDG());
+      out_hit_contrib.setEnergy(contrib.getEnergy()); // UNattenuated energy
       out_hit_contrib.setTime(contrib.getMinTime());
-      out_hit_contrib.setStepPosition(edm4hep::Vector3f{0, 0, contrib.getAvgPosition().z});
+      out_hit_contrib.setStepPosition(contrib.getAvgPosition());
       out_hit_contrib.setParticle(particle);
       out_hit.addToContributions(out_hit_contrib);
     }
     out_hit.setCellID(cellID);
-    out_hit.setEnergy(new_hit.getEnergy());
-    out_hit.setPosition(edm4hep::Vector3f{0, 0, new_hit.getAvgPosition().z});
+    out_hit.setEnergy(new_hit.getAttEnergy()); // sum of attenuated energies
+    out_hit.setPosition(new_hit.getAvgPosition());
   }
 }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR does addresses two issues in SimCalorimeterHitProcessor:
1. The unattenuated energy is necessary to benchmark e.g. clustering algorithm performance, or to train AI algorithms. While it was originally foreseen to be available through 2-step simulated hit processor, but was then not added once we combined both steps for performance reasons.
2. Some variables in the SimCalorimeterHit were silently removed in #2076 as they were deemed "not needed". However, this was not documented, and leaves the actual SimCalorimeterHits that we use for our digi/reco in a partially filled state with some information irretrievably lost. 
I addressed the issues as follows
1. Keep track of the unattenuated energy and store it with the contribution members of the SimCalorimeterHit so it can still be accessed. It means that SimCalorimeterHit.energy/sum(contribution.energies) equals the effective attenuation.
2. Restored the discarded PID/position.xyz/... fields

### What kind of change does this PR introduce?
- [X] Bug fix (issue #__)
- [X] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
