### PR TITLE
treewide: add level() or applyConfig() where missing

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterTruthClustering.h
+++ b/src/algorithms/calorimetry/CalorimeterTruthClustering.h
@@ -19,7 +19,8 @@ using CalorimeterTruthClusteringAlgorithm = algorithms::Algorithm<
     algorithms::Input<edm4eic::CalorimeterHitCollection, edm4hep::SimCalorimeterHitCollection>,
     algorithms::Output<edm4eic::ProtoClusterCollection>>;
 
-class CalorimeterTruthClustering : public CalorimeterTruthClusteringAlgorithm, public WithPodConfig<NoConfig> {
+class CalorimeterTruthClustering : public CalorimeterTruthClusteringAlgorithm,
+                                   public WithPodConfig<NoConfig> {
 
 public:
   CalorimeterTruthClustering(std::string_view name)

--- a/src/algorithms/calorimetry/CalorimeterTruthClustering.h
+++ b/src/algorithms/calorimetry/CalorimeterTruthClustering.h
@@ -11,13 +11,15 @@
 #include <string>
 #include <string_view>
 
+#include "algorithms/interfaces/WithPodConfig.h"
+
 namespace eicrecon {
 
 using CalorimeterTruthClusteringAlgorithm = algorithms::Algorithm<
     algorithms::Input<edm4eic::CalorimeterHitCollection, edm4hep::SimCalorimeterHitCollection>,
     algorithms::Output<edm4eic::ProtoClusterCollection>>;
 
-class CalorimeterTruthClustering : public CalorimeterTruthClusteringAlgorithm {
+class CalorimeterTruthClustering : public CalorimeterTruthClusteringAlgorithm, public WithPodConfig<NoConfig> {
 
 public:
   CalorimeterTruthClustering(std::string_view name)

--- a/src/algorithms/calorimetry/TruthEnergyPositionClusterMerger.h
+++ b/src/algorithms/calorimetry/TruthEnergyPositionClusterMerger.h
@@ -31,7 +31,8 @@ using TruthEnergyPositionClusterMergerAlgorithm = algorithms::Algorithm<
    *
    * \ingroup reco
    */
-class TruthEnergyPositionClusterMerger : public TruthEnergyPositionClusterMergerAlgorithm, public WithPodConfig<NoConfig> {
+class TruthEnergyPositionClusterMerger : public TruthEnergyPositionClusterMergerAlgorithm,
+                                         public WithPodConfig<NoConfig> {
 
 public:
   TruthEnergyPositionClusterMerger(std::string_view name)

--- a/src/algorithms/calorimetry/TruthEnergyPositionClusterMerger.h
+++ b/src/algorithms/calorimetry/TruthEnergyPositionClusterMerger.h
@@ -11,6 +11,8 @@
 #include <string>
 #include <string_view>
 
+#include "algorithms/interfaces/WithPodConfig.h"
+
 namespace eicrecon {
 
 using TruthEnergyPositionClusterMergerAlgorithm = algorithms::Algorithm<
@@ -29,7 +31,7 @@ using TruthEnergyPositionClusterMergerAlgorithm = algorithms::Algorithm<
    *
    * \ingroup reco
    */
-class TruthEnergyPositionClusterMerger : public TruthEnergyPositionClusterMergerAlgorithm {
+class TruthEnergyPositionClusterMerger : public TruthEnergyPositionClusterMergerAlgorithm, public WithPodConfig<NoConfig> {
 
 public:
   TruthEnergyPositionClusterMerger(std::string_view name)

--- a/src/algorithms/meta/CollectionCollector.h
+++ b/src/algorithms/meta/CollectionCollector.h
@@ -18,8 +18,8 @@ using CollectionCollectorAlgorithm =
     algorithms::Algorithm<typename algorithms::Input<std::vector<const T>>,
                           typename algorithms::Output<T>>;
 
-template <class T> class CollectionCollector : public CollectionCollectorAlgorithm<T>,
-                                               public WithPodConfig<NoConfig> {
+template <class T>
+class CollectionCollector : public CollectionCollectorAlgorithm<T>, public WithPodConfig<NoConfig> {
 
 public:
   CollectionCollector(std::string_view name)

--- a/src/algorithms/meta/CollectionCollector.h
+++ b/src/algorithms/meta/CollectionCollector.h
@@ -18,7 +18,8 @@ using CollectionCollectorAlgorithm =
     algorithms::Algorithm<typename algorithms::Input<std::vector<const T>>,
                           typename algorithms::Output<T>>;
 
-template <class T> class CollectionCollector : public CollectionCollectorAlgorithm<T> {
+template <class T> class CollectionCollector : public CollectionCollectorAlgorithm<T>,
+                                               public WithPodConfig<NoConfig> {
 
 public:
   CollectionCollector(std::string_view name)

--- a/src/algorithms/meta/FilterMatching.h
+++ b/src/algorithms/meta/FilterMatching.h
@@ -27,7 +27,8 @@ using FilterMatchingAlgorithm =
 /// These functions are envisioned to link the objectIDs of the collection/associations but could be anything
 template <typename ToFilterObjectT, auto ToFilterFunction, typename FilterByObjectT,
           auto FilterByFunction>
-class FilterMatching : public FilterMatchingAlgorithm<ToFilterObjectT, FilterByObjectT>, public WithPodConfig<NoConfig> {
+class FilterMatching : public FilterMatchingAlgorithm<ToFilterObjectT, FilterByObjectT>,
+                       public WithPodConfig<NoConfig> {
 
 public:
   FilterMatching(std::string_view name)

--- a/src/algorithms/meta/FilterMatching.h
+++ b/src/algorithms/meta/FilterMatching.h
@@ -27,7 +27,7 @@ using FilterMatchingAlgorithm =
 /// These functions are envisioned to link the objectIDs of the collection/associations but could be anything
 template <typename ToFilterObjectT, auto ToFilterFunction, typename FilterByObjectT,
           auto FilterByFunction>
-class FilterMatching : public FilterMatchingAlgorithm<ToFilterObjectT, FilterByObjectT> {
+class FilterMatching : public FilterMatchingAlgorithm<ToFilterObjectT, FilterByObjectT>, public WithPodConfig<NoConfig> {
 
 public:
   FilterMatching(std::string_view name)

--- a/src/algorithms/pid/MergeTracks.h
+++ b/src/algorithms/pid/MergeTracks.h
@@ -16,13 +16,15 @@
 #include <string_view>
 #include <vector>
 
+#include "algorithms/interfaces/WithPodConfig.h"
+
 namespace eicrecon {
 
 using MergeTracksAlgorithm =
     algorithms::Algorithm<algorithms::Input<std::vector<const edm4eic::TrackSegmentCollection>>,
                           algorithms::Output<edm4eic::TrackSegmentCollection>>;
 
-class MergeTracks : public MergeTracksAlgorithm {
+class MergeTracks : public MergeTracksAlgorithm, public WithPodConfig<NoConfig> {
 
 public:
   MergeTracks(std::string_view name)

--- a/src/algorithms/reco/HadronicFinalState.h
+++ b/src/algorithms/reco/HadronicFinalState.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <string_view>
 
+#include "algorithms/interfaces/WithPodConfig.h"
 #include "services/particle/ParticleSvc.h"
 
 namespace eicrecon {
@@ -20,7 +21,7 @@ using HadronicFinalStateAlgorithm = algorithms::Algorithm<
                       edm4eic::MCRecoParticleAssociationCollection>,
     algorithms::Output<edm4eic::HadronicFinalStateCollection>>;
 
-class HadronicFinalState : public HadronicFinalStateAlgorithm {
+class HadronicFinalState : public HadronicFinalStateAlgorithm, public WithPodConfig<NoConfig> {
 
 public:
   HadronicFinalState(std::string_view name)

--- a/src/algorithms/reco/InclusiveKinematicsDA.h
+++ b/src/algorithms/reco/InclusiveKinematicsDA.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <string_view>
 
+#include "algorithms/interfaces/WithPodConfig.h"
 #include "services/particle/ParticleSvc.h"
 
 namespace eicrecon {
@@ -20,7 +21,7 @@ using InclusiveKinematicsDAAlgorithm = algorithms::Algorithm<
                       edm4eic::HadronicFinalStateCollection>,
     algorithms::Output<edm4eic::InclusiveKinematicsCollection>>;
 
-class InclusiveKinematicsDA : public InclusiveKinematicsDAAlgorithm {
+class InclusiveKinematicsDA : public InclusiveKinematicsDAAlgorithm, public WithPodConfig<NoConfig> {
 
 public:
   InclusiveKinematicsDA(std::string_view name)

--- a/src/algorithms/reco/InclusiveKinematicsDA.h
+++ b/src/algorithms/reco/InclusiveKinematicsDA.h
@@ -21,7 +21,8 @@ using InclusiveKinematicsDAAlgorithm = algorithms::Algorithm<
                       edm4eic::HadronicFinalStateCollection>,
     algorithms::Output<edm4eic::InclusiveKinematicsCollection>>;
 
-class InclusiveKinematicsDA : public InclusiveKinematicsDAAlgorithm, public WithPodConfig<NoConfig> {
+class InclusiveKinematicsDA : public InclusiveKinematicsDAAlgorithm,
+                              public WithPodConfig<NoConfig> {
 
 public:
   InclusiveKinematicsDA(std::string_view name)

--- a/src/algorithms/reco/InclusiveKinematicsESigma.h
+++ b/src/algorithms/reco/InclusiveKinematicsESigma.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <string_view>
 
+#include "algorithms/interfaces/WithPodConfig.h"
 #include "services/particle/ParticleSvc.h"
 
 namespace eicrecon {
@@ -20,7 +21,7 @@ using InclusiveKinematicsESigmaAlgorithm = algorithms::Algorithm<
                       edm4eic::HadronicFinalStateCollection>,
     algorithms::Output<edm4eic::InclusiveKinematicsCollection>>;
 
-class InclusiveKinematicsESigma : public InclusiveKinematicsESigmaAlgorithm {
+class InclusiveKinematicsESigma : public InclusiveKinematicsESigmaAlgorithm, public WithPodConfig<NoConfig> {
 
 public:
   InclusiveKinematicsESigma(std::string_view name)

--- a/src/algorithms/reco/InclusiveKinematicsESigma.h
+++ b/src/algorithms/reco/InclusiveKinematicsESigma.h
@@ -21,7 +21,8 @@ using InclusiveKinematicsESigmaAlgorithm = algorithms::Algorithm<
                       edm4eic::HadronicFinalStateCollection>,
     algorithms::Output<edm4eic::InclusiveKinematicsCollection>>;
 
-class InclusiveKinematicsESigma : public InclusiveKinematicsESigmaAlgorithm, public WithPodConfig<NoConfig> {
+class InclusiveKinematicsESigma : public InclusiveKinematicsESigmaAlgorithm,
+                                  public WithPodConfig<NoConfig> {
 
 public:
   InclusiveKinematicsESigma(std::string_view name)

--- a/src/algorithms/reco/InclusiveKinematicsElectron.h
+++ b/src/algorithms/reco/InclusiveKinematicsElectron.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <string_view>
 
+#include "algorithms/interfaces/WithPodConfig.h"
 #include "services/particle/ParticleSvc.h"
 
 namespace eicrecon {
@@ -20,7 +21,7 @@ using InclusiveKinematicsElectronAlgorithm = algorithms::Algorithm<
                       edm4eic::HadronicFinalStateCollection>,
     algorithms::Output<edm4eic::InclusiveKinematicsCollection>>;
 
-class InclusiveKinematicsElectron : public InclusiveKinematicsElectronAlgorithm {
+class InclusiveKinematicsElectron : public InclusiveKinematicsElectronAlgorithm, public WithPodConfig<NoConfig> {
 
 public:
   InclusiveKinematicsElectron(std::string_view name)

--- a/src/algorithms/reco/InclusiveKinematicsElectron.h
+++ b/src/algorithms/reco/InclusiveKinematicsElectron.h
@@ -21,7 +21,8 @@ using InclusiveKinematicsElectronAlgorithm = algorithms::Algorithm<
                       edm4eic::HadronicFinalStateCollection>,
     algorithms::Output<edm4eic::InclusiveKinematicsCollection>>;
 
-class InclusiveKinematicsElectron : public InclusiveKinematicsElectronAlgorithm, public WithPodConfig<NoConfig> {
+class InclusiveKinematicsElectron : public InclusiveKinematicsElectronAlgorithm,
+                                    public WithPodConfig<NoConfig> {
 
 public:
   InclusiveKinematicsElectron(std::string_view name)

--- a/src/algorithms/reco/InclusiveKinematicsJB.h
+++ b/src/algorithms/reco/InclusiveKinematicsJB.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <string_view>
 
+#include "algorithms/interfaces/WithPodConfig.h"
 #include "services/particle/ParticleSvc.h"
 
 namespace eicrecon {
@@ -20,7 +21,7 @@ using InclusiveKinematicsJBAlgorithm = algorithms::Algorithm<
                       edm4eic::HadronicFinalStateCollection>,
     algorithms::Output<edm4eic::InclusiveKinematicsCollection>>;
 
-class InclusiveKinematicsJB : public InclusiveKinematicsJBAlgorithm {
+class InclusiveKinematicsJB : public InclusiveKinematicsJBAlgorithm, public WithPodConfig<NoConfig> {
 
 public:
   InclusiveKinematicsJB(std::string_view name)

--- a/src/algorithms/reco/InclusiveKinematicsJB.h
+++ b/src/algorithms/reco/InclusiveKinematicsJB.h
@@ -21,7 +21,8 @@ using InclusiveKinematicsJBAlgorithm = algorithms::Algorithm<
                       edm4eic::HadronicFinalStateCollection>,
     algorithms::Output<edm4eic::InclusiveKinematicsCollection>>;
 
-class InclusiveKinematicsJB : public InclusiveKinematicsJBAlgorithm, public WithPodConfig<NoConfig> {
+class InclusiveKinematicsJB : public InclusiveKinematicsJBAlgorithm,
+                              public WithPodConfig<NoConfig> {
 
 public:
   InclusiveKinematicsJB(std::string_view name)

--- a/src/algorithms/reco/InclusiveKinematicsSigma.h
+++ b/src/algorithms/reco/InclusiveKinematicsSigma.h
@@ -21,7 +21,8 @@ using InclusiveKinematicsSigmaAlgorithm = algorithms::Algorithm<
                       edm4eic::HadronicFinalStateCollection>,
     algorithms::Output<edm4eic::InclusiveKinematicsCollection>>;
 
-class InclusiveKinematicsSigma : public InclusiveKinematicsSigmaAlgorithm, public WithPodConfig<NoConfig> {
+class InclusiveKinematicsSigma : public InclusiveKinematicsSigmaAlgorithm,
+                                 public WithPodConfig<NoConfig> {
 
 public:
   InclusiveKinematicsSigma(std::string_view name)

--- a/src/algorithms/reco/InclusiveKinematicsSigma.h
+++ b/src/algorithms/reco/InclusiveKinematicsSigma.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <string_view>
 
+#include "algorithms/interfaces/WithPodConfig.h"
 #include "services/particle/ParticleSvc.h"
 
 namespace eicrecon {
@@ -20,7 +21,7 @@ using InclusiveKinematicsSigmaAlgorithm = algorithms::Algorithm<
                       edm4eic::HadronicFinalStateCollection>,
     algorithms::Output<edm4eic::InclusiveKinematicsCollection>>;
 
-class InclusiveKinematicsSigma : public InclusiveKinematicsSigmaAlgorithm {
+class InclusiveKinematicsSigma : public InclusiveKinematicsSigmaAlgorithm, public WithPodConfig<NoConfig> {
 
 public:
   InclusiveKinematicsSigma(std::string_view name)

--- a/src/algorithms/reco/InclusiveKinematicsTruth.h
+++ b/src/algorithms/reco/InclusiveKinematicsTruth.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <string_view>
 
+#include "algorithms/interfaces/WithPodConfig.h"
 #include "services/particle/ParticleSvc.h"
 
 namespace eicrecon {
@@ -17,7 +18,7 @@ using InclusiveKinematicsTruthAlgorithm =
     algorithms::Algorithm<algorithms::Input<edm4hep::MCParticleCollection>,
                           algorithms::Output<edm4eic::InclusiveKinematicsCollection>>;
 
-class InclusiveKinematicsTruth : public InclusiveKinematicsTruthAlgorithm {
+class InclusiveKinematicsTruth : public InclusiveKinematicsTruthAlgorithm, public WithPodConfig<NoConfig> {
 
 public:
   InclusiveKinematicsTruth(std::string_view name)

--- a/src/algorithms/reco/InclusiveKinematicsTruth.h
+++ b/src/algorithms/reco/InclusiveKinematicsTruth.h
@@ -18,7 +18,8 @@ using InclusiveKinematicsTruthAlgorithm =
     algorithms::Algorithm<algorithms::Input<edm4hep::MCParticleCollection>,
                           algorithms::Output<edm4eic::InclusiveKinematicsCollection>>;
 
-class InclusiveKinematicsTruth : public InclusiveKinematicsTruthAlgorithm, public WithPodConfig<NoConfig> {
+class InclusiveKinematicsTruth : public InclusiveKinematicsTruthAlgorithm,
+                                 public WithPodConfig<NoConfig> {
 
 public:
   InclusiveKinematicsTruth(std::string_view name)

--- a/src/algorithms/reco/MatchClusters.h
+++ b/src/algorithms/reco/MatchClusters.h
@@ -18,6 +18,8 @@
 #include <string>
 #include <string_view>
 
+#include "algorithms/interfaces/WithPodConfig.h"
+
 namespace eicrecon {
 
 using MatchClustersAlgorithm = algorithms::Algorithm<
@@ -27,7 +29,7 @@ using MatchClustersAlgorithm = algorithms::Algorithm<
     algorithms::Output<edm4eic::ReconstructedParticleCollection,
                        edm4eic::MCRecoParticleAssociationCollection>>;
 
-class MatchClusters : public MatchClustersAlgorithm {
+class MatchClusters : public MatchClustersAlgorithm, public WithPodConfig<NoConfig> {
 
 public:
   MatchClusters(std::string_view name)

--- a/src/algorithms/reco/ScatteredElectronsTruth.h
+++ b/src/algorithms/reco/ScatteredElectronsTruth.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <string_view>
 
+#include "algorithms/interfaces/WithPodConfig.h"
 #include "services/particle/ParticleSvc.h"
 
 namespace eicrecon {
@@ -19,7 +20,7 @@ using ScatteredElectronsTruthAlgorithm = algorithms::Algorithm<
                       edm4eic::MCRecoParticleAssociationCollection>,
     algorithms::Output<edm4eic::ReconstructedParticleCollection>>;
 
-class ScatteredElectronsTruth : public ScatteredElectronsTruthAlgorithm {
+class ScatteredElectronsTruth : public ScatteredElectronsTruthAlgorithm, public WithPodConfig<NoConfig> {
 
 public:
   ScatteredElectronsTruth(std::string_view name)

--- a/src/algorithms/reco/ScatteredElectronsTruth.h
+++ b/src/algorithms/reco/ScatteredElectronsTruth.h
@@ -20,7 +20,8 @@ using ScatteredElectronsTruthAlgorithm = algorithms::Algorithm<
                       edm4eic::MCRecoParticleAssociationCollection>,
     algorithms::Output<edm4eic::ReconstructedParticleCollection>>;
 
-class ScatteredElectronsTruth : public ScatteredElectronsTruthAlgorithm, public WithPodConfig<NoConfig> {
+class ScatteredElectronsTruth : public ScatteredElectronsTruthAlgorithm,
+                                public WithPodConfig<NoConfig> {
 
 public:
   ScatteredElectronsTruth(std::string_view name)

--- a/src/algorithms/tracking/ActsToTracks.h
+++ b/src/algorithms/tracking/ActsToTracks.h
@@ -16,6 +16,8 @@
 #include <string_view>
 #include <vector>
 
+#include "algorithms/interfaces/WithPodConfig.h"
+
 namespace eicrecon {
 
 using ActsToTracksAlgorithm = algorithms::Algorithm<
@@ -25,7 +27,7 @@ using ActsToTracksAlgorithm = algorithms::Algorithm<
                        edm4eic::TrackCollection,
                        std::optional<edm4eic::MCRecoTrackParticleAssociationCollection>>>;
 
-class ActsToTracks : public ActsToTracksAlgorithm {
+class ActsToTracks : public ActsToTracksAlgorithm, public WithPodConfig<NoConfig> {
 public:
   ActsToTracks(std::string_view name)
       : ActsToTracksAlgorithm{name,

--- a/src/algorithms/tracking/TrackProjector.h
+++ b/src/algorithms/tracking/TrackProjector.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "ActsGeometryProvider.h"
+#include "algorithms/interfaces/WithPodConfig.h"
 
 namespace eicrecon {
 
@@ -20,7 +21,7 @@ using TrackProjectorAlgorithm = algorithms::Algorithm<
     algorithms::Input<std::vector<ActsExamples::Trajectories>, edm4eic::TrackCollection>,
     algorithms::Output<edm4eic::TrackSegmentCollection>>;
 
-class TrackProjector : public TrackProjectorAlgorithm {
+class TrackProjector : public TrackProjectorAlgorithm, public WithPodConfig<NoConfig> {
 public:
   TrackProjector(std::string_view name)
       : TrackProjectorAlgorithm{name,

--- a/src/factories/calorimetry/CalorimeterClusterShape_factory.h
+++ b/src/factories/calorimetry/CalorimeterClusterShape_factory.h
@@ -44,6 +44,7 @@ private:
 public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>(GetPrefix());
+    m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
     m_algo->applyConfig(config());
     m_algo->init();
   }

--- a/src/factories/calorimetry/CalorimeterTruthClustering_factory.h
+++ b/src/factories/calorimetry/CalorimeterTruthClustering_factory.h
@@ -10,7 +10,8 @@
 
 namespace eicrecon {
 
-class CalorimeterTruthClustering_factory : public JOmniFactory<CalorimeterTruthClustering_factory, NoConfig> {
+class CalorimeterTruthClustering_factory
+    : public JOmniFactory<CalorimeterTruthClustering_factory, NoConfig> {
 public:
   using AlgoT = eicrecon::CalorimeterTruthClustering;
 

--- a/src/factories/calorimetry/CalorimeterTruthClustering_factory.h
+++ b/src/factories/calorimetry/CalorimeterTruthClustering_factory.h
@@ -25,6 +25,7 @@ public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>(GetPrefix());
     m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
+    m_algo->applyConfig(config());
     m_algo->init();
   }
 

--- a/src/factories/calorimetry/CalorimeterTruthClustering_factory.h
+++ b/src/factories/calorimetry/CalorimeterTruthClustering_factory.h
@@ -10,7 +10,7 @@
 
 namespace eicrecon {
 
-class CalorimeterTruthClustering_factory : public JOmniFactory<CalorimeterTruthClustering_factory> {
+class CalorimeterTruthClustering_factory : public JOmniFactory<CalorimeterTruthClustering_factory, NoConfig> {
 public:
   using AlgoT = eicrecon::CalorimeterTruthClustering;
 

--- a/src/factories/calorimetry/TrackClusterMergeSplitter_factory.h
+++ b/src/factories/calorimetry/TrackClusterMergeSplitter_factory.h
@@ -49,6 +49,7 @@ private:
 public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>(GetPrefix());
+    m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
     m_algo->applyConfig(config());
     m_algo->init();
   }

--- a/src/factories/calorimetry/TruthEnergyPositionClusterMerger_factory.h
+++ b/src/factories/calorimetry/TruthEnergyPositionClusterMerger_factory.h
@@ -32,6 +32,7 @@ public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>(GetPrefix());
     m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
+    m_algo->applyConfig(config());
     m_algo->init();
   }
 

--- a/src/factories/calorimetry/TruthEnergyPositionClusterMerger_factory.h
+++ b/src/factories/calorimetry/TruthEnergyPositionClusterMerger_factory.h
@@ -10,7 +10,7 @@
 namespace eicrecon {
 
 class TruthEnergyPositionClusterMerger_factory
-    : public JOmniFactory<TruthEnergyPositionClusterMerger_factory> {
+    : public JOmniFactory<TruthEnergyPositionClusterMerger_factory, NoConfig> {
 public:
   using AlgoT = eicrecon::TruthEnergyPositionClusterMerger;
 

--- a/src/factories/meta/CollectionCollector_factory.h
+++ b/src/factories/meta/CollectionCollector_factory.h
@@ -27,6 +27,7 @@ public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>(this->GetPrefix());
     m_algo->level(static_cast<algorithms::LogLevel>(this->logger()->level()));
+    m_algo->applyConfig(this->config());
     m_algo->init();
   }
 

--- a/src/factories/meta/CollectionCollector_factory.h
+++ b/src/factories/meta/CollectionCollector_factory.h
@@ -17,10 +17,11 @@ public:
 private:
   std::unique_ptr<AlgoT> m_algo;
 
-  typename JOmniFactory<CollectionCollector_factory<T, IsOptional>, NoConfig>::template VariadicPodioInput<
-      T, IsOptional>
+  typename JOmniFactory<CollectionCollector_factory<T, IsOptional>,
+                        NoConfig>::template VariadicPodioInput<T, IsOptional>
       m_inputs{this};
-  typename JOmniFactory<CollectionCollector_factory<T, IsOptional>, NoConfig>::template PodioOutput<T>
+  typename JOmniFactory<CollectionCollector_factory<T, IsOptional>,
+                        NoConfig>::template PodioOutput<T>
       m_output{this};
 
 public:

--- a/src/factories/meta/CollectionCollector_factory.h
+++ b/src/factories/meta/CollectionCollector_factory.h
@@ -10,17 +10,17 @@ namespace eicrecon {
 
 template <class T, bool IsOptional = false>
 class CollectionCollector_factory
-    : public JOmniFactory<CollectionCollector_factory<T, IsOptional>> {
+    : public JOmniFactory<CollectionCollector_factory<T, IsOptional>, NoConfig> {
 public:
   using AlgoT = eicrecon::CollectionCollector<typename T::collection_type>;
 
 private:
   std::unique_ptr<AlgoT> m_algo;
 
-  typename JOmniFactory<CollectionCollector_factory<T, IsOptional>>::template VariadicPodioInput<
+  typename JOmniFactory<CollectionCollector_factory<T, IsOptional>, NoConfig>::template VariadicPodioInput<
       T, IsOptional>
       m_inputs{this};
-  typename JOmniFactory<CollectionCollector_factory<T, IsOptional>>::template PodioOutput<T>
+  typename JOmniFactory<CollectionCollector_factory<T, IsOptional>, NoConfig>::template PodioOutput<T>
       m_output{this};
 
 public:

--- a/src/factories/meta/FilterMatching_factory.h
+++ b/src/factories/meta/FilterMatching_factory.h
@@ -12,13 +12,15 @@ template <typename ToFilterObjectT, auto ToFilterMemberFunctionPtr, typename Fil
           auto FilterByMemberFunctionPtr>
 class FilterMatching_factory
     : public JOmniFactory<FilterMatching_factory<ToFilterObjectT, ToFilterMemberFunctionPtr,
-                                                 FilterByObjectT, FilterByMemberFunctionPtr>, NoConfig> {
+                                                 FilterByObjectT, FilterByMemberFunctionPtr>,
+                          NoConfig> {
 
 public:
   using AlgoT    = eicrecon::FilterMatching<ToFilterObjectT, ToFilterMemberFunctionPtr,
                                             FilterByObjectT, FilterByMemberFunctionPtr>;
   using FactoryT = JOmniFactory<FilterMatching_factory<ToFilterObjectT, ToFilterMemberFunctionPtr,
-                                                       FilterByObjectT, FilterByMemberFunctionPtr>, NoConfig>;
+                                                       FilterByObjectT, FilterByMemberFunctionPtr>,
+                                NoConfig>;
 
 private:
   std::unique_ptr<AlgoT> m_algo;

--- a/src/factories/meta/FilterMatching_factory.h
+++ b/src/factories/meta/FilterMatching_factory.h
@@ -32,6 +32,7 @@ public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>(this->GetPrefix());
     m_algo->level(static_cast<algorithms::LogLevel>(this->logger()->level()));
+    m_algo->applyConfig(FactoryT::config());
     m_algo->init();
   }
 

--- a/src/factories/meta/FilterMatching_factory.h
+++ b/src/factories/meta/FilterMatching_factory.h
@@ -12,13 +12,13 @@ template <typename ToFilterObjectT, auto ToFilterMemberFunctionPtr, typename Fil
           auto FilterByMemberFunctionPtr>
 class FilterMatching_factory
     : public JOmniFactory<FilterMatching_factory<ToFilterObjectT, ToFilterMemberFunctionPtr,
-                                                 FilterByObjectT, FilterByMemberFunctionPtr>> {
+                                                 FilterByObjectT, FilterByMemberFunctionPtr>, NoConfig> {
 
 public:
   using AlgoT    = eicrecon::FilterMatching<ToFilterObjectT, ToFilterMemberFunctionPtr,
                                             FilterByObjectT, FilterByMemberFunctionPtr>;
   using FactoryT = JOmniFactory<FilterMatching_factory<ToFilterObjectT, ToFilterMemberFunctionPtr,
-                                                       FilterByObjectT, FilterByMemberFunctionPtr>>;
+                                                       FilterByObjectT, FilterByMemberFunctionPtr>, NoConfig>;
 
 private:
   std::unique_ptr<AlgoT> m_algo;

--- a/src/factories/pid/MergeTrack_factory.h
+++ b/src/factories/pid/MergeTrack_factory.h
@@ -32,6 +32,7 @@ public:
   void Configure() {
     m_algo = std::make_unique<MergeTracks>(GetPrefix());
     m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
+    m_algo->applyConfig(config());
     m_algo->init();
   }
 

--- a/src/factories/pid/MergeTrack_factory.h
+++ b/src/factories/pid/MergeTrack_factory.h
@@ -17,7 +17,7 @@
 
 namespace eicrecon {
 
-class MergeTrack_factory : public JOmniFactory<MergeTrack_factory> {
+class MergeTrack_factory : public JOmniFactory<MergeTrack_factory, NoConfig> {
 private:
   // Underlying algorithm
   std::unique_ptr<eicrecon::MergeTracks> m_algo;

--- a/src/factories/pid/RichTrack_factory.h
+++ b/src/factories/pid/RichTrack_factory.h
@@ -40,7 +40,8 @@ private:
 public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>();
-    m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
+    // TODO: convert RichTrack to inherit from algorithm::Algorithm
+    // m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
     m_algo->applyConfig(config());
 
     if (config().filter_surfaces.empty())

--- a/src/factories/pid/RichTrack_factory.h
+++ b/src/factories/pid/RichTrack_factory.h
@@ -40,6 +40,7 @@ private:
 public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>();
+    m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
     m_algo->applyConfig(config());
 
     if (config().filter_surfaces.empty())

--- a/src/factories/reco/ChargedMCParticleSelector_factory.h
+++ b/src/factories/reco/ChargedMCParticleSelector_factory.h
@@ -26,6 +26,8 @@ private:
 public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>(GetPrefix());
+    m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
+    m_algo->applyConfig(config());
     m_algo->init();
   }
 

--- a/src/factories/reco/ChargedReconstructedParticleSelector_factory.h
+++ b/src/factories/reco/ChargedReconstructedParticleSelector_factory.h
@@ -26,6 +26,8 @@ private:
 public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>(GetPrefix());
+    m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
+    m_algo->applyConfig(config());
     m_algo->init();
   }
 

--- a/src/factories/reco/HadronicFinalState_factory.h
+++ b/src/factories/reco/HadronicFinalState_factory.h
@@ -37,6 +37,7 @@ public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>(this->GetPrefix());
     m_algo->level(static_cast<algorithms::LogLevel>(this->logger()->level()));
+    m_algo->applyConfig(this->config());
     m_algo->init();
   }
 

--- a/src/factories/reco/HadronicFinalState_factory.h
+++ b/src/factories/reco/HadronicFinalState_factory.h
@@ -16,10 +16,10 @@
 namespace eicrecon {
 
 template <typename AlgoT>
-class HadronicFinalState_factory : public JOmniFactory<HadronicFinalState_factory<AlgoT>> {
+class HadronicFinalState_factory : public JOmniFactory<HadronicFinalState_factory<AlgoT>, NoConfig> {
 
 public:
-  using FactoryT = JOmniFactory<HadronicFinalState_factory<AlgoT>>;
+  using FactoryT = JOmniFactory<HadronicFinalState_factory<AlgoT>, NoConfig>;
 
 private:
   std::unique_ptr<AlgoT> m_algo;

--- a/src/factories/reco/HadronicFinalState_factory.h
+++ b/src/factories/reco/HadronicFinalState_factory.h
@@ -16,7 +16,8 @@
 namespace eicrecon {
 
 template <typename AlgoT>
-class HadronicFinalState_factory : public JOmniFactory<HadronicFinalState_factory<AlgoT>, NoConfig> {
+class HadronicFinalState_factory
+    : public JOmniFactory<HadronicFinalState_factory<AlgoT>, NoConfig> {
 
 public:
   using FactoryT = JOmniFactory<HadronicFinalState_factory<AlgoT>, NoConfig>;

--- a/src/factories/reco/InclusiveKinematicsReconstructed_factory.h
+++ b/src/factories/reco/InclusiveKinematicsReconstructed_factory.h
@@ -17,10 +17,10 @@ namespace eicrecon {
 
 template <typename AlgoT>
 class InclusiveKinematicsReconstructed_factory
-    : public JOmniFactory<InclusiveKinematicsReconstructed_factory<AlgoT>> {
+    : public JOmniFactory<InclusiveKinematicsReconstructed_factory<AlgoT>, NoConfig> {
 
 public:
-  using FactoryT = JOmniFactory<InclusiveKinematicsReconstructed_factory<AlgoT>>;
+  using FactoryT = JOmniFactory<InclusiveKinematicsReconstructed_factory<AlgoT>, NoConfig>;
 
 private:
   std::unique_ptr<AlgoT> m_algo;

--- a/src/factories/reco/InclusiveKinematicsReconstructed_factory.h
+++ b/src/factories/reco/InclusiveKinematicsReconstructed_factory.h
@@ -39,6 +39,7 @@ public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>(this->GetPrefix());
     m_algo->level(static_cast<algorithms::LogLevel>(this->logger()->level()));
+    m_algo->applyConfig(this->config());
     m_algo->init();
   }
 

--- a/src/factories/reco/InclusiveKinematicsTruth_factory.h
+++ b/src/factories/reco/InclusiveKinematicsTruth_factory.h
@@ -33,6 +33,7 @@ public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>(GetPrefix());
     m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
+    m_algo->applyConfig(config());
     m_algo->init();
   }
 

--- a/src/factories/reco/InclusiveKinematicsTruth_factory.h
+++ b/src/factories/reco/InclusiveKinematicsTruth_factory.h
@@ -16,7 +16,8 @@
 
 namespace eicrecon {
 
-class InclusiveKinematicsTruth_factory : public JOmniFactory<InclusiveKinematicsTruth_factory, NoConfig> {
+class InclusiveKinematicsTruth_factory
+    : public JOmniFactory<InclusiveKinematicsTruth_factory, NoConfig> {
 
 public:
   using AlgoT = eicrecon::InclusiveKinematicsTruth;

--- a/src/factories/reco/InclusiveKinematicsTruth_factory.h
+++ b/src/factories/reco/InclusiveKinematicsTruth_factory.h
@@ -16,7 +16,7 @@
 
 namespace eicrecon {
 
-class InclusiveKinematicsTruth_factory : public JOmniFactory<InclusiveKinematicsTruth_factory> {
+class InclusiveKinematicsTruth_factory : public JOmniFactory<InclusiveKinematicsTruth_factory, NoConfig> {
 
 public:
   using AlgoT = eicrecon::InclusiveKinematicsTruth;

--- a/src/factories/reco/MatchClusters_factory.h
+++ b/src/factories/reco/MatchClusters_factory.h
@@ -42,6 +42,7 @@ public:
   void Configure() {
     m_algo = std::make_unique<MatchClusters>(GetPrefix());
     m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
+    m_algo->applyConfig(config());
     m_algo->init();
   }
 

--- a/src/factories/reco/MatchClusters_factory.h
+++ b/src/factories/reco/MatchClusters_factory.h
@@ -20,7 +20,7 @@
 
 namespace eicrecon {
 
-class MatchClusters_factory : public JOmniFactory<MatchClusters_factory> {
+class MatchClusters_factory : public JOmniFactory<MatchClusters_factory, NoConfig> {
 private:
   // Underlying algorithm
   std::unique_ptr<eicrecon::MatchClusters> m_algo;

--- a/src/factories/reco/ReconstructedElectrons_factory.h
+++ b/src/factories/reco/ReconstructedElectrons_factory.h
@@ -36,6 +36,7 @@ public:
     // Use this callback to make sure the algorithm is configured.
     // The logger, parameters, and services have all been fetched before this is called
     m_algo = std::make_unique<AlgoT>(GetPrefix());
+    m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
 
     // Pass config object to algorithm
     m_algo->applyConfig(config());

--- a/src/factories/reco/ScatteredElectronsTruth_factory.h
+++ b/src/factories/reco/ScatteredElectronsTruth_factory.h
@@ -15,7 +15,7 @@
 
 namespace eicrecon {
 
-class ScatteredElectronsTruth_factory : public JOmniFactory<ScatteredElectronsTruth_factory> {
+class ScatteredElectronsTruth_factory : public JOmniFactory<ScatteredElectronsTruth_factory, NoConfig> {
 
 public:
   using AlgoT = eicrecon::ScatteredElectronsTruth;

--- a/src/factories/reco/ScatteredElectronsTruth_factory.h
+++ b/src/factories/reco/ScatteredElectronsTruth_factory.h
@@ -15,7 +15,8 @@
 
 namespace eicrecon {
 
-class ScatteredElectronsTruth_factory : public JOmniFactory<ScatteredElectronsTruth_factory, NoConfig> {
+class ScatteredElectronsTruth_factory
+    : public JOmniFactory<ScatteredElectronsTruth_factory, NoConfig> {
 
 public:
   using AlgoT = eicrecon::ScatteredElectronsTruth;

--- a/src/factories/reco/ScatteredElectronsTruth_factory.h
+++ b/src/factories/reco/ScatteredElectronsTruth_factory.h
@@ -36,6 +36,7 @@ public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>(GetPrefix());
     m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
+    m_algo->applyConfig(config());
     m_algo->init();
   }
 

--- a/src/factories/reco/TrackClusterMatch_factory.h
+++ b/src/factories/reco/TrackClusterMatch_factory.h
@@ -30,6 +30,7 @@ private:
 public:
   void Configure() {
     m_algo = std::make_unique<eicrecon::TrackClusterMatch>(GetPrefix());
+    m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
     m_algo->applyConfig(config());
     m_algo->init();
   }

--- a/src/factories/reco/TransformBreitFrame_factory.h
+++ b/src/factories/reco/TransformBreitFrame_factory.h
@@ -41,6 +41,7 @@ public:
   void Configure() {
     m_algo = std::make_unique<Algo>(GetPrefix());
     m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
+    m_algo->applyConfig(config());
     m_algo->init();
   }
 

--- a/src/factories/reco/TransformBreitFrame_factory.h
+++ b/src/factories/reco/TransformBreitFrame_factory.h
@@ -18,7 +18,7 @@
 
 namespace eicrecon {
 
-class TransformBreitFrame_factory : public JOmniFactory<TransformBreitFrame_factory> {
+class TransformBreitFrame_factory : public JOmniFactory<TransformBreitFrame_factory, NoConfig> {
 
 public:
   // algorithm to run

--- a/src/factories/reco/UndoAfterBurnerMCParticles_factory.h
+++ b/src/factories/reco/UndoAfterBurnerMCParticles_factory.h
@@ -41,7 +41,9 @@ private:
 public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>(GetPrefix());
+    m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
     m_algo->applyConfig(config());
+    m_algo->init();
   }
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {

--- a/src/factories/tracking/ActsToTracks_factory.h
+++ b/src/factories/tracking/ActsToTracks_factory.h
@@ -10,7 +10,7 @@
 
 namespace eicrecon {
 
-class ActsToTracks_factory : public JOmniFactory<ActsToTracks_factory> {
+class ActsToTracks_factory : public JOmniFactory<ActsToTracks_factory, NoConfig> {
 public:
   using AlgoT = eicrecon::ActsToTracks;
 

--- a/src/factories/tracking/ActsToTracks_factory.h
+++ b/src/factories/tracking/ActsToTracks_factory.h
@@ -29,6 +29,7 @@ public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>(this->GetPrefix());
     m_algo->level((algorithms::LogLevel)logger()->level());
+    m_algo->applyConfig(config());
     m_algo->init();
   };
 

--- a/src/factories/tracking/ActsTrajectoriesMerger_factory.h
+++ b/src/factories/tracking/ActsTrajectoriesMerger_factory.h
@@ -14,7 +14,7 @@
 
 namespace eicrecon {
 
-class ActsTrajectoriesMerger_factory : public JOmniFactory<ActsTrajectoriesMerger_factory> {
+class ActsTrajectoriesMerger_factory : public JOmniFactory<ActsTrajectoriesMerger_factory, NoConfig> {
 private:
   Input<ActsExamples::Trajectories> m_acts_trajectories1_input{this};
   Input<ActsExamples::Trajectories> m_acts_trajectories2_input{this};

--- a/src/factories/tracking/ActsTrajectoriesMerger_factory.h
+++ b/src/factories/tracking/ActsTrajectoriesMerger_factory.h
@@ -14,7 +14,8 @@
 
 namespace eicrecon {
 
-class ActsTrajectoriesMerger_factory : public JOmniFactory<ActsTrajectoriesMerger_factory, NoConfig> {
+class ActsTrajectoriesMerger_factory
+    : public JOmniFactory<ActsTrajectoriesMerger_factory, NoConfig> {
 private:
   Input<ActsExamples::Trajectories> m_acts_trajectories1_input{this};
   Input<ActsExamples::Trajectories> m_acts_trajectories2_input{this};

--- a/src/factories/tracking/AmbiguitySolver_factory.h
+++ b/src/factories/tracking/AmbiguitySolver_factory.h
@@ -39,7 +39,8 @@ private:
 public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>();
-    m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
+    // TODO: convert AmbiguitySolver to inherit from algorithm::Algorithm
+    // m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
     m_algo->applyConfig(config());
     m_algo->init(logger());
   }

--- a/src/factories/tracking/AmbiguitySolver_factory.h
+++ b/src/factories/tracking/AmbiguitySolver_factory.h
@@ -39,6 +39,7 @@ private:
 public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>();
+    m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
     m_algo->applyConfig(config());
     m_algo->init(logger());
   }

--- a/src/factories/tracking/CKFTracking_factory.h
+++ b/src/factories/tracking/CKFTracking_factory.h
@@ -45,6 +45,7 @@ private:
 public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>();
+    m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
     m_algo->applyConfig(config());
     m_algo->init(m_ACTSGeoSvc().actsGeoProvider(), logger());
   }

--- a/src/factories/tracking/CKFTracking_factory.h
+++ b/src/factories/tracking/CKFTracking_factory.h
@@ -45,7 +45,8 @@ private:
 public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>();
-    m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
+    // TODO: convert CKFTracking to inherit from algorithm::Algorithm
+    // m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
     m_algo->applyConfig(config());
     m_algo->init(m_ACTSGeoSvc().actsGeoProvider(), logger());
   }

--- a/src/factories/tracking/IterativeVertexFinder_factory.h
+++ b/src/factories/tracking/IterativeVertexFinder_factory.h
@@ -41,7 +41,8 @@ private:
 public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>();
-    m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
+    // TODO: convert IterativeVertexFinder to inherit from algorithm::Algorithm
+    // m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
     m_algo->applyConfig(config());
     m_algo->init(m_ACTSGeoSvc().actsGeoProvider(), logger());
   }

--- a/src/factories/tracking/IterativeVertexFinder_factory.h
+++ b/src/factories/tracking/IterativeVertexFinder_factory.h
@@ -41,6 +41,7 @@ private:
 public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>();
+    m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
     m_algo->applyConfig(config());
     m_algo->init(m_ACTSGeoSvc().actsGeoProvider(), logger());
   }

--- a/src/factories/tracking/TrackParamTruthInit_factory.h
+++ b/src/factories/tracking/TrackParamTruthInit_factory.h
@@ -54,6 +54,7 @@ private:
 public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>(GetPrefix());
+    m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
     m_algo->applyConfig(config());
     m_algo->init();
   }

--- a/src/factories/tracking/TrackProjector_factory.h
+++ b/src/factories/tracking/TrackProjector_factory.h
@@ -33,6 +33,7 @@ public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>(this->GetPrefix());
     m_algo->level((algorithms::LogLevel)logger()->level());
+    m_algo->applyConfig(config());
     m_algo->init();
   }
 

--- a/src/factories/tracking/TrackProjector_factory.h
+++ b/src/factories/tracking/TrackProjector_factory.h
@@ -16,7 +16,7 @@
 
 namespace eicrecon {
 
-class TrackProjector_factory : public JOmniFactory<TrackProjector_factory> {
+class TrackProjector_factory : public JOmniFactory<TrackProjector_factory, NoConfig> {
 
 private:
   using AlgoT = eicrecon::TrackProjector;

--- a/src/factories/tracking/TrackPropagation_factory.h
+++ b/src/factories/tracking/TrackPropagation_factory.h
@@ -38,7 +38,8 @@ private:
 public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>();
-    m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
+    // TODO: convert RichTrack to inherit from algorithm::Algorithm
+    // m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
     m_algo->applyConfig(config());
     m_algo->init(m_GeoSvc().detector(), m_ACTSGeoSvc().actsGeoProvider(), logger());
   }

--- a/src/factories/tracking/TrackPropagation_factory.h
+++ b/src/factories/tracking/TrackPropagation_factory.h
@@ -38,6 +38,7 @@ private:
 public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>();
+    m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
     m_algo->applyConfig(config());
     m_algo->init(m_GeoSvc().detector(), m_ACTSGeoSvc().actsGeoProvider(), logger());
   }

--- a/src/factories/tracking/TrackSeeding_factory.h
+++ b/src/factories/tracking/TrackSeeding_factory.h
@@ -103,6 +103,7 @@ private:
 public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>(GetPrefix());
+    m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
     m_algo->applyConfig(config());
     m_algo->init();
   }

--- a/src/factories/tracking/TrackerHitReconstruction_factory.h
+++ b/src/factories/tracking/TrackerHitReconstruction_factory.h
@@ -28,6 +28,7 @@ private:
 public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>(GetPrefix());
+    m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
     m_algo->applyConfig(config());
     m_algo->init();
   }

--- a/src/factories/tracking/TrackerMeasurementFromHits_factory.h
+++ b/src/factories/tracking/TrackerMeasurementFromHits_factory.h
@@ -34,6 +34,8 @@ private:
 public:
   void Configure() {
     m_algo = std::make_unique<AlgoT>(GetPrefix());
+    m_algo->level(static_cast<algorithms::LogLevel>(logger()->level()));
+    m_algo->applyConfig(config());
     m_algo->init();
   }
 

--- a/src/factories/tracking/TrackerMeasurementFromHits_factory.h
+++ b/src/factories/tracking/TrackerMeasurementFromHits_factory.h
@@ -19,7 +19,7 @@
 
 namespace eicrecon {
 
-class TrackerMeasurementFromHits_factory : public JOmniFactory<TrackerMeasurementFromHits_factory> {
+class TrackerMeasurementFromHits_factory : public JOmniFactory<TrackerMeasurementFromHits_factory, NoConfig> {
 
 private:
   using AlgoT = eicrecon::TrackerMeasurementFromHits;

--- a/src/factories/tracking/TrackerMeasurementFromHits_factory.h
+++ b/src/factories/tracking/TrackerMeasurementFromHits_factory.h
@@ -19,7 +19,8 @@
 
 namespace eicrecon {
 
-class TrackerMeasurementFromHits_factory : public JOmniFactory<TrackerMeasurementFromHits_factory, NoConfig> {
+class TrackerMeasurementFromHits_factory
+    : public JOmniFactory<TrackerMeasurementFromHits_factory, NoConfig> {
 
 private:
   using AlgoT = eicrecon::TrackerMeasurementFromHits;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
There are factories that don't call `level` or `applyConfig`, which prevents `LogLevel` and other configuration parameters from being passed to the algorithm. This leads to surprising behaviors when using or debugging EICrecon.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No