### PR TITLE
security: restrict workflow permissions to minimum required

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -33,6 +33,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   # inputs doesn't always exist, so we make sure env does
   platform: ${{ inputs.platform || 'eic_xl' }}
@@ -205,6 +208,9 @@ jobs:
   clang-tidy-iwyu:
     runs-on: ubuntu-24.04
     needs: build
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to push fixes
+      pull-requests: write  # for commenting and creating PRs
     steps:
     - uses: actions/checkout@v6
       with:
@@ -1046,6 +1052,8 @@ jobs:
     if: ${{ github.event_name != 'merge_group' && github.event_name != 'schedule' && github.actor != 'dependabot[bot]' && github.ref != 'refs/heads/main' }}
     needs:
     - build
+    permissions:
+      statuses: write  # for posting commit status via gh api
     outputs:
       json: ${{ steps.trigger.outputs.json }}
     steps:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Set workflow-level permissions to 'contents: read' (minimum) and grant additional permissions only to jobs that need them:

- clang-tidy-iwyu: contents: write, pull-requests: write (for creating IWYU fix PRs and posting comments)
- llvm-cov: statuses: write (for posting code coverage commit statuses)
- trigger-container: statuses: write (for posting GitLab CI status)
- deploy-docs: pages: write, id-token: write, pull-requests: write (for deploying GitHub Pages and posting comments)

This addresses code scanning security alert about overly permissive workflow permissions by applying the principle of least privilege.

Fixes: Various GitHub Code Scanning Alerts, https://github.com/eic/EICrecon/security/code-scanning

### What kind of change does this PR introduce?
- [x] Bug fix (issue: permissive securi)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.