### PR TITLE
fix: rm unused privates

### DIFF
--- a/src/benchmarks/reconstruction/tracking_efficiency/TrackingEfficiency_processor.h
+++ b/src/benchmarks/reconstruction/tracking_efficiency/TrackingEfficiency_processor.h
@@ -37,11 +37,6 @@ public:
 
 private:
   TDirectory* m_dir_main{}; /// Main TDirectory for this plugin 'occupancy_ana'
-  TH1F* m_th1_prt_pz{};     /// MC Particles pz
-  TH1F* m_th1_prt_energy{}; /// MC Particles total E
-  TH1F* m_th1_prt_theta{};  /// MC Particles theta angle
-  TH1F* m_th1_prt_phi{};    /// MC Particles phi angle
-  TH2F* m_th2_prt_pxy{};    /// MC Particles px,py
 
   std::shared_ptr<spdlog::logger> m_log;
 };


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes unused private members which cause `-Werror` errors in clang-22.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: unused private members)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.