### PR TITLE
cmake: workaround broken ASAN with `-O0`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,7 +265,7 @@ enable_testing()
 # Address sanitizer
 option(USE_ASAN "Compile with address sanitizer" OFF)
 if(${USE_ASAN})
-  add_compile_options(-fsanitize=address -fno-omit-frame-pointer -g -O0)
+  add_compile_options(-fsanitize=address -fno-omit-frame-pointer -g -O2)
   add_link_options(-fsanitize=address)
   install(FILES .github/asan.supp .github/lsan.supp
           DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME})


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Currently, the tests are broken due to a known yet poorly understood issue:
```
==50==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x503007217b88 at pc 0x7effb94b1536 bp 0x7ffc769e3770 sp 0x7ffc769e3768
READ of size 8 at 0x503007217b88 thread T0
    #0 0x7effb94b1535 in eicrecon::FarDetectorLinearTracking::~FarDetectorLinearTracking() (/home/runner/work/EICrecon/EICrecon/install/lib/libalgorithms_fardetectors.so+0xab1535) (BuildId: eae23bd4a53fa736b90f20224840de647becf05f)
    #1 0x7effb1ff68f8 in std::default_delete<eicrecon::FarDetectorLinearTracking>::operator()(eicrecon::FarDetectorLinearTracking*) const /usr/include/c++/14/bits/unique_ptr.h:93
    #2 0x7effb1ff68f8 in std::unique_ptr<eicrecon::FarDetectorLinearTracking, std::default_delete<eicrecon::FarDetectorLinearTracking> >::~unique_ptr() /usr/include/c++/14/bits/unique_ptr.h:399
    #3 0x7effb1ff68f8 in eicrecon::FarDetectorLinearTracking_factory::~FarDetectorLinearTracking_factory() /home/runner/work/EICrecon/EICrecon/src/factories/fardetectors/FarDetectorLinearTracking_factory.h:20
```
The fixes need to be applied in the container, likely, so some measure is needed to restore CI while that is being deployed.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No