### PR TITLE
fix: disable address sanitizer in FarDetectorLinearTracking::init

### DIFF
--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -39,7 +39,9 @@
 
 namespace eicrecon {
 
-void FarDetectorLinearTracking::init() {
+// Disable ASAN for Eigen allocator operations to match non-ASAN Acts library
+// This prevents false positives from ASAN/non-ASAN library mixing
+__attribute__((no_sanitize("address"))) void FarDetectorLinearTracking::init() {
 
   // For changing how strongly each layer hit is in contributing to the fit
   m_layerWeights = Eigen::VectorXd::Constant(m_cfg.n_layer, 1);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
In order to fix the address sanitizer issues, this PR disables address sanitizer instrumentation in the offending function. This will hopefully ensure we get the same Eigen allocators as the ones Acts is using.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/EICrecon/actions/runs/20070585095/job/57589701880)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.