### PR TITLE
linux-eic-shell.yml: use clang for ASAN builds

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -539,7 +539,7 @@ jobs:
     - npsim-gun
     strategy:
       matrix:
-        CXX: [g++]
+        CXX: [clang++]
         particle: [e]
         detector_config: [craterlake]
     steps:
@@ -599,7 +599,7 @@ jobs:
     - npsim-gun
     strategy:
       matrix:
-        CXX: [g++]
+        CXX: [clang++]
         particle: [e]
         detector_config: [craterlake]
         test_plugins:
@@ -644,7 +644,7 @@ jobs:
     - npsim-gun
     strategy:
       matrix:
-        CXX: [g++]
+        CXX: [clang++]
         particle: [e]
         detector_config: [craterlake]
         benchmark_plugins:


### PR DESCRIPTION
The CI has false positive failures with ASAN/Eigen. We probably can overcome those with correct setting of `EIGEN_MALLOC_ALREADY_ALIGNED` once #2223 is ready. This should allow to unblock meanwhile.

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No