### PR TITLE
JEventProcessorPODIO: remove handling of podio:output_include_collections

### DIFF
--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -556,6 +556,4 @@ void JEventProcessorPODIO::Process(const std::shared_ptr<const JEvent>& event) {
   }
 }
 
-void JEventProcessorPODIO::Finish() {
-  m_writer->finish();
-}
+void JEventProcessorPODIO::Finish() { m_writer->finish(); }

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -397,14 +397,6 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
 
   };
   std::vector<std::string> output_exclude_collections; // need to get as vector, then convert to set
-  std::string output_include_collections = "DEPRECATED";
-  japp->SetDefaultParameter("podio:output_include_collections", output_include_collections,
-                            "DEPRECATED. Use podio:output_collections instead.");
-  if (output_include_collections != "DEPRECATED") {
-    output_collections.clear();
-    JParameterManager::Parse(output_include_collections, output_collections);
-    m_output_include_collections_set = true;
-  }
   japp->SetDefaultParameter(
       "podio:output_collections", output_collections,
       "Comma separated list of collection names to write out. If not set, all collections will be "
@@ -427,15 +419,6 @@ void JEventProcessorPODIO::Init() {
   auto* app = GetApplication();
   m_log     = app->GetService<Log_service>()->logger("JEventProcessorPODIO");
   m_writer  = std::make_unique<podio::ROOTWriter>(m_output_file);
-  // TODO: NWB: Verify that output file is writable NOW, rather than after event processing completes.
-  //       I definitely don't trust PODIO to do this for me.
-
-  if (m_output_include_collections_set) {
-    m_log->error("The podio:output_include_collections was provided, but is deprecated. Use "
-                 "podio:output_collections instead.");
-    throw std::runtime_error("The podio:output_include_collections was provided, but is "
-                             "deprecated. Use podio:output_collections instead.");
-  }
 }
 
 void JEventProcessorPODIO::FindCollectionsToWrite(const std::shared_ptr<const JEvent>& event) {
@@ -574,12 +557,5 @@ void JEventProcessorPODIO::Process(const std::shared_ptr<const JEvent>& event) {
 }
 
 void JEventProcessorPODIO::Finish() {
-  if (m_output_include_collections_set) {
-    m_log->error("The podio:output_include_collections was provided, but is deprecated. Use "
-                 "podio:output_collections instead.");
-    throw std::runtime_error("The podio:output_include_collections was provided, but is "
-                             "deprecated. Use podio:output_collections instead.");
-  }
-
   m_writer->finish();
 }

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -16,7 +16,6 @@
 #include <iterator>
 #include <regex>
 #include <sstream>
-#include <stdexcept>
 
 #include "services/log/Log_service.h"
 

--- a/src/services/io/podio/JEventProcessorPODIO.h
+++ b/src/services/io/podio/JEventProcessorPODIO.h
@@ -27,7 +27,6 @@ public:
   std::mutex m_mutex;
   std::once_flag m_is_first_event;
   std::shared_ptr<spdlog::logger> m_log;
-  bool m_output_include_collections_set = false;
 
   std::string m_output_file          = "podio_output.root";
   std::string m_output_file_copy_dir = "";


### PR DESCRIPTION
### Briefly, what does this PR introduce?

`podio:output_include_collections` was deprecated long time ago, at this point we don't need any code that handles that. We may want to add code to add extra collections on top of the default list (should we use `podio:output_extra_collections`?).

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No