### PR TITLE
fix: rm redundant `cmake_minimum_required`

### DIFF
--- a/src/algorithms/CMakeLists.txt
+++ b/src/algorithms/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
-
 add_subdirectory(interfaces)
 add_subdirectory(calorimetry)
 add_subdirectory(tracking)

--- a/src/algorithms/calorimetry/CMakeLists.txt
+++ b/src/algorithms/calorimetry/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
-
 set(PLUGIN_NAME "algorithms_calorimetry")
 
 # Function creates ${PLUGIN_NAME}_plugin and ${PLUGIN_NAME}_library targets

--- a/src/algorithms/onnx/CMakeLists.txt
+++ b/src/algorithms/onnx/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
-
 set(PLUGIN_NAME "algorithms_onnx")
 
 # Function creates ${PLUGIN_NAME}_plugin and ${PLUGIN_NAME}_library targets

--- a/src/algorithms/pid/CMakeLists.txt
+++ b/src/algorithms/pid/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
-
 set(PLUGIN_NAME "algorithms_pid")
 
 # Function creates ${PLUGIN_NAME}_plugin and ${PLUGIN_NAME}_library targets

--- a/src/algorithms/reco/CMakeLists.txt
+++ b/src/algorithms/reco/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
-
 set(PLUGIN_NAME "algorithms_reco")
 
 # Function creates ${PLUGIN_NAME}_plugin and ${PLUGIN_NAME}_library targets

--- a/src/algorithms/tracking/CMakeLists.txt
+++ b/src/algorithms/tracking/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
-
 set(PLUGIN_NAME "algorithms_tracking")
 
 # Function creates ${PLUGIN_NAME}_plugin and ${PLUGIN_NAME}_library targets

--- a/src/global/CMakeLists.txt
+++ b/src/global/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
-
 add_subdirectory(tracking)
 add_subdirectory(reco)
 add_subdirectory(pid)

--- a/src/global/pid/CMakeLists.txt
+++ b/src/global/pid/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
-
 # Automatically set plugin name the same as the directory name Don't forget
 # string(REPLACE " " "_" PLUGIN_NAME ${PLUGIN_NAME}) if this dir has spaces in
 # its name

--- a/src/global/pid_lut/CMakeLists.txt
+++ b/src/global/pid_lut/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
-
 # Automatically set plugin name the same as the directory name Don't forget
 # string(REPLACE " " "_" PLUGIN_NAME ${PLUGIN_NAME}) if this dir has spaces in
 # its name get_filename_component(PLUGIN_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)

--- a/src/global/reco/CMakeLists.txt
+++ b/src/global/reco/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
-
 get_filename_component(PLUGIN_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
 
 # Function creates ${PLUGIN_NAME}_plugin and ${PLUGIN_NAME}_library targets

--- a/src/global/tracking/CMakeLists.txt
+++ b/src/global/tracking/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
-
 get_filename_component(PLUGIN_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
 
 # Function creates ${PLUGIN_NAME}_plugin and ${PLUGIN_NAME}_library targets

--- a/src/services/algorithms_init/CMakeLists.txt
+++ b/src/services/algorithms_init/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
-
 # Automatically set plugin name the same as the directory name Don't forget
 # string(REPLACE " " "_" PLUGIN_NAME ${PLUGIN_NAME}) if this dir has spaces in
 # its name

--- a/src/services/evaluator/CMakeLists.txt
+++ b/src/services/evaluator/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
-
 # Automatically set plugin name the same as the directory name Don't forget
 # string(REPLACE " " "_" PLUGIN_NAME ${PLUGIN_NAME}) if this dir has spaces in
 # its name

--- a/src/services/geometry/acts/CMakeLists.txt
+++ b/src/services/geometry/acts/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
-
 # Automatically set plugin name the same as the directory name Don't forget
 # string(REPLACE " " "_" PLUGIN_NAME ${PLUGIN_NAME}) if this dir has spaces in
 # its name

--- a/src/services/geometry/dd4hep/CMakeLists.txt
+++ b/src/services/geometry/dd4hep/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
-
 # Automatically set plugin name the same as the directory name Don't forget
 # string(REPLACE " " "_" PLUGIN_NAME ${PLUGIN_NAME}) if this dir has spaces in
 # its name

--- a/src/services/geometry/richgeo/CMakeLists.txt
+++ b/src/services/geometry/richgeo/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
-
 # Automatically set plugin name the same as the directory name Don't forget
 # string(REPLACE " " "_" PLUGIN_NAME ${PLUGIN_NAME}) if this dir has spaces in
 # its name

--- a/src/services/log/CMakeLists.txt
+++ b/src/services/log/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
-
 # Automatically set plugin name the same as the directory name Don't forget
 # string(REPLACE " " "_" PLUGIN_NAME ${PLUGIN_NAME}) if this dir has spaces in
 # its name

--- a/src/services/rootfile/CMakeLists.txt
+++ b/src/services/rootfile/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
-
 # Automatically set plugin name the same as the directory name Don't forget
 # string(REPLACE " " "_" PLUGIN_NAME ${PLUGIN_NAME}) if this dir has spaces in
 # its name


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes redundant `cmake_minimum_required`. We should have one `cmake_minimum_required` per project (`eicrecon` is still a different project).

### What kind of change does this PR introduce?
- [x] Bug fix (issue: tech debt)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.