### PR TITLE
Add configuration for weighting hits in FarDetectorLinearTracking

### DIFF
--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -44,11 +44,7 @@ void FarDetectorLinearTracking::init() {
   // For changing how strongly each layer hit is in contributing to the fit
   m_layerWeights = Eigen::VectorXd::Constant(m_cfg.n_layer, 1);
 
-  for (std::size_t i = 0; i < m_cfg.layer_weights.size(); i++) {
-    //Check we don't go out of bounds
-    if (i >= m_cfg.n_layer) {
-      break;
-    }
+  for (std::size_t i = 0; i < std::min(m_cfg.layer_weights.size(), m_cfg.n_layer); i++) {
     m_layerWeights(i) = m_cfg.layer_weights[i];
   }
 

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -44,6 +44,14 @@ void FarDetectorLinearTracking::init() {
   // For changing how strongly each layer hit is in contributing to the fit
   m_layerWeights = Eigen::VectorXd::Constant(m_cfg.n_layer, 1);
 
+  for (std::size_t i = 0; i < m_cfg.layer_weights.size(); i++) {
+    //Check we don't go out of bounds
+    if (i >= m_cfg.n_layer) {
+      break;
+    }
+    m_layerWeights(i) = m_cfg.layer_weights[i];
+  }
+
   // For checking the direction of the track from theta and phi angles
   m_optimumDirection = Eigen::Vector3d::UnitZ();
   m_optimumDirection =

--- a/src/algorithms/fardetectors/FarDetectorLinearTrackingConfig.h
+++ b/src/algorithms/fardetectors/FarDetectorLinearTrackingConfig.h
@@ -9,6 +9,7 @@ struct FarDetectorLinearTrackingConfig {
   std::size_t layer_hits_max{10};
   float chi2_max{0.001};
   std::size_t n_layer{4};
+  std::vector<double> layer_weights{1.0, 1.0, 1.0, 1.0};
 
   // Restrict hit direction
   bool restrict_direction{true};

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -162,6 +162,7 @@ void InitPlugin(JApplication* app) {
             .layer_hits_max       = 200,
             .chi2_max             = 0.001,
             .n_layer              = 4,
+            .layer_weights        = {1.0, 1.0, 1.0, 1.0},
             .restrict_direction   = true,
             .optimum_theta        = -M_PI + 0.026,
             .optimum_phi          = 0,

--- a/src/factories/fardetectors/FarDetectorLinearTracking_factory.h
+++ b/src/factories/fardetectors/FarDetectorLinearTracking_factory.h
@@ -32,6 +32,7 @@ private:
   PodioOutput<edm4eic::MCRecoTrackParticleAssociation> m_tracks_association_output{this};
 
   ParameterRef<std::size_t> n_layer{this, "numLayers", config().n_layer};
+  ParameterRef<std::vector<double>> layer_weights{this, "layerWeights", config().layer_weights};
   ParameterRef<std::size_t> layer_hits_max{this, "layerHitsMax", config().layer_hits_max};
   ParameterRef<float> chi2_max{this, "chi2Max", config().chi2_max};
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Allows configuration via the command line and factory construction of how to weight the hits in different layers of the low-Q2 tracker when fitting the track.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No