### PR TITLE
Replace 25.01.1-stable with 25.07.0-stable release in compilation CI

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -113,7 +113,7 @@ jobs:
             USE_TSAN: ON
           - CXX: clang++
             CMAKE_BUILD_TYPE: Release
-            release: 25.05.0-stable
+            release: 25.07.0-stable
           - CXX: clang++
             CMAKE_BUILD_TYPE: Release
             release: 25.11.2-stable


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Updates the containers which the CI checks the compilation works with. Removing the oldest container from January and adding a new November alternative. This brings us closer to the requirement of only supporting compilation with dependencies from the last ~6 months.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
