### PR TITLE
fix: rm unused ROOT::EG

### DIFF
--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -386,7 +386,7 @@ macro(plugin_add_cern_root _name)
   endif()
 
   # Add libraries
-  plugin_link_libraries(${PLUGIN_NAME} ROOT::Core ROOT::EG)
+  plugin_link_libraries(${PLUGIN_NAME} ROOT::Core)
 
 endmacro()
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Nothing in EICrecon uses [ROOT::EG](https://root.cern/doc/master/group__eg.html) (anymore), so this PR removes ROOT::EG from plugin link libraries.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: unused link dependency)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.