### PR TITLE
fix: iwyu: map fmt/base.h to fmt/format.h

### DIFF
--- a/.github/iwyu.imp
+++ b/.github/iwyu.imp
@@ -5,6 +5,10 @@
   { ref: '/opt/local/share/include-what-you-use/boost-all.imp' },
   { include: ['@<boost/histogram/.*\.hpp>', private, '<boost/histogram.hpp>', public] },
 
+  # Avoid fmt/base.h which only exists as of fmt-11
+  # FIXME this can be removed when all test systems have fmt-11
+  { include: ['<fmt/base.h>', private, '<fmt/format.h>', public] },
+
   # libc++
   { ref: '/opt/local/share/include-what-you-use/libcxx.imp' },
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes the mapping to ensure that both fmt-10 and fmt-11 headers are supported simultaneously.