### PR TITLE
fix: skip IRT1 hypotheses with nan weight

### DIFF
--- a/src/algorithms/pid/IrtCherenkovParticleID.cc
+++ b/src/algorithms/pid/IrtCherenkovParticleID.cc
@@ -18,8 +18,8 @@
 #include <edm4hep/Vector2f.h>
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
-#include <fmt/core.h>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
 #include <algorithm>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR should fix (suppress) a source of nan in the output file (e.g.https://github.com/eic/EICrecon/actions/runs/20682954160/job/59380495878?pr=2289#step:7:28). Technically the KS test p-value of nan doesn't necessarily mean that the data was nan, but that's what investigation reveals.

I'm not adding any debugging output since this is being rewritten anyway and nobody is going to fix IRT1. If there are nan in IRT2 they can get caught separately.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: output has nan)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.