### PR TITLE
fix: don't print primary and secondary vertices for every event

### DIFF
--- a/src/algorithms/reco/SecondaryVerticesHelix.cc
+++ b/src/algorithms/reco/SecondaryVerticesHelix.cc
@@ -143,7 +143,7 @@ void SecondaryVerticesHelix::process(const SecondaryVerticesHelix::Input& input,
       debug("One secondary vertex found at (x,y,z) = ({}, {}, {}) mm.",
             pairPos.x * edm4eic::unit::cm / edm4eic::unit::mm,
             pairPos.y * edm4eic::unit::cm / edm4eic::unit::mm,
-            pairPos.x * edm4eic::unit::cm / edm4eic::unit::mm);
+            pairPos.z * edm4eic::unit::cm / edm4eic::unit::mm);
 
     } // end i2
   } // end i1


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR changes the default logging level of the primary and secondary vertices from `info` to `debug`. We don't want to print everything we reconstruct to the log output.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: SecondaryVerticesHelix is too verbose)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.