### PR TITLE
fix: change CKFTracking ACTS_ERROR to m_log->debug

### DIFF
--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -325,7 +325,8 @@ CKFTracking::process(const edm4eic::TrackParametersCollection& init_trk_params,
     auto result = (*m_trackFinderFunc)(acts_init_trk_params.at(iseed), options, acts_tracks);
 
     if (!result.ok()) {
-      m_log->debug("Track finding failed for seed {} with error {}", iseed, result.error().message());
+      m_log->debug("Track finding failed for seed {} with error {}", iseed,
+                   result.error().message());
       continue;
     }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR modifies two uses of `ACTS_ERROR` to `m_log->debug`. Failing smoothing and extrapolation are common, and not indicative of the systemic failure that an error seems to scream at the user. A few lines earlier, we have
```
      m_log->debug("Track finding failed for seed {} with error {}", iseed, result.error());
```
so it seems that failing to find a track is already at the `debug` level.

This also modifies the messages to print `error().message()` instead of just an enum key.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: too many non-actionable errors reported)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.