### PR TITLE
fix: avoid ActsExamples::Trajectories with empty tips

### DIFF
--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -70,7 +70,6 @@
 #include <edm4eic/Measurement2DCollection.h>
 #include <edm4eic/TrackParametersCollection.h>
 #include <edm4hep/Vector2f.h>
-#include <fmt/core.h>
 #include <fmt/format.h>
 #include <Eigen/Core>
 #include <Eigen/Geometry>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR modifies the CKF tracking to avoid creating ActsExamples::Trajectories with empty tips. Those result in `Empty multiTrajectory.` warnings/errors downstream.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: avoidable warnings/errors)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.