### PR TITLE
[Backport v1.33] fix: don't print primary and secondary vertices for every event

### DIFF
--- a/src/algorithms/reco/SecondaryVerticesHelix.cc
+++ b/src/algorithms/reco/SecondaryVerticesHelix.cc
@@ -10,7 +10,6 @@
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/Vector4f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <fmt/core.h>
 #include <cmath>
 #include <gsl/pointers>
 #include <utility>
@@ -58,8 +57,8 @@ void SecondaryVerticesHelix::process(const SecondaryVerticesHelix::Input& input,
           pVtxPos4f.z / edm4eic::unit::mm * dd4hep::mm}); // in unit of dd4hep::tesla
   float b_field = field.z();
 
-  info("\tPrimary vertex = ({},{},{})cm \t b field = {} tesla", pVtxPos.x, pVtxPos.y, pVtxPos.z,
-       b_field / dd4hep::tesla);
+  debug("Primary vertex = ({},{},{})cm \t b field = {} tesla", pVtxPos.x, pVtxPos.y, pVtxPos.z,
+        b_field / dd4hep::tesla);
 
   std::vector<Helix> hVec;
   hVec.clear();
@@ -141,10 +140,10 @@ void SecondaryVerticesHelix::process(const SecondaryVerticesHelix::Input& input,
       v0.addToAssociatedParticles(p1);
       v0.addToAssociatedParticles(p2);
 
-      info("One secondary vertex found at (x,y,z) = ({}, {}, {}) mm.",
-           pairPos.x * edm4eic::unit::cm / edm4eic::unit::mm,
-           pairPos.y * edm4eic::unit::cm / edm4eic::unit::mm,
-           pairPos.x * edm4eic::unit::cm / edm4eic::unit::mm);
+      debug("One secondary vertex found at (x,y,z) = ({}, {}, {}) mm.",
+            pairPos.x * edm4eic::unit::cm / edm4eic::unit::mm,
+            pairPos.y * edm4eic::unit::cm / edm4eic::unit::mm,
+            pairPos.z * edm4eic::unit::cm / edm4eic::unit::mm);
 
     } // end i2
   } // end i1


### PR DESCRIPTION
# Description
Backport of #2295 to `v1.33`.