### PR TITLE
fix: no continue-on-error for MT running

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -884,7 +884,6 @@ jobs:
     - build
     - npsim-dis
     - npsim-minbias
-    continue-on-error: ${{ matrix.nthreads > 1 }}
     strategy:
       matrix:
         include:
@@ -898,6 +897,7 @@ jobs:
           minq2: 0
           detector_config: craterlake_10x100
           sanitizer: TSAN
+          nthreads: 4
         - CXX: clang++
           beam: 18x275
           minq2: 0


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes the `continue-on-error` condition for multi-threading, and ensures that all TSAN runs are using all 4 threads available.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: tech debt from the uncertain times)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.