### PR TITLE
fix: remove unreachable code

### DIFF
--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -254,9 +254,6 @@ CKFTracking::process(const edm4eic::TrackParametersCollection& init_trk_params,
 #if Acts_VERSION_MAJOR < 39
   extensions.measurementSelector.connect<&Acts::MeasurementSelector::select<
       typename ActsExamples::TrackContainer::TrackStateContainerBackend>>(&measSel);
-#elif Acts_VERSION_MAJOR < 39
-  extensions.measurementSelector
-      .connect<&Acts::MeasurementSelector::select<Acts::VectorMultiTrajectory>>(&measSel);
 #endif
 
   ActsExamples::IndexSourceLinkAccessor slAccessor;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes unreachable code that was introduced by mistake in https://github.com/eic/EICrecon/commit/7391f6ae0338b94f905e7a62fc2f24032caecf3d when we added support for >= 36. 

The original intention was that this should look like:
```cpp
#if (Acts_VERSION_MAJOR >= 36) && (Acts_VERSION_MAJOR < 39)
  extensions.measurementSelector.connect<&Acts::MeasurementSelector::select<
      typename ActsExamples::TrackContainer::TrackStateContainerBackend>>(&measSel);
#elif Acts_VERSION_MAJOR < 36
  extensions.measurementSelector
      .connect<&Acts::MeasurementSelector::select<Acts::VectorMultiTrajectory>>(&measSel);
#endif
```
i.e. `Acts_VERSION_MAJOR < 36` in the `elif`. Since we now require v36, that branch is unreachable, even if we correct the issue.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: unreachable code)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.