### PR TITLE
fix(ci): g++: require -Werror=maybe-uninitialized again

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -91,8 +91,7 @@ jobs:
             release: nightly
         include:
           - CXX: g++
-            # -Wno-error=maybe-uninitialized for GCC only as it has issues with /usr/include/c++/12/bits/std_function.h
-            CXXFLAGS: -Werror -Wall -Wextra -Wundef -Wno-error=maybe-uninitialized
+            CXXFLAGS: -Werror -Wall -Wextra -Wundef
           - CXX: clang++
             CXXFLAGS: -Werror -Wall -Wextra -Wundef
           # include clang++ Debug with profile CXXFLAGS


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes the '-Wno-error=maybe-uninitialized' flag from the g++ CXXFLAGS again. It was added in GCC-12 days, now we're well beyond that and not affected by the STL headers that were causing issues. Instead it has started to mask legitimate issues.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: tech debt)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.