### PR TITLE
fix: initialize variables in LGADHitClustering

### DIFF
--- a/src/algorithms/tracking/LGADHitClustering.cc
+++ b/src/algorithms/tracking/LGADHitClustering.cc
@@ -21,7 +21,7 @@
 #include <edm4eic/Cov3f.h>
 #include <edm4eic/CovDiag3f.h>
 #include <edm4hep/Vector2f.h>
-#include <stddef.h>
+#include <cstddef>
 #include <Eigen/Core>
 #include <cmath>
 #include <gsl/pointers>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR initializes variables which g++ flags with maybe-uninitialized warnings (which we suppress from -Werror).

### What kind of change does this PR introduce?
- [x] Bug fix (issue: uninitialized and later relied upon in a court of law)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.