### PR TITLE
fix: add `share/` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ include/*
 plugins/*
 build/*
 install/*
+share/*
 
 # Artifacts
 calibrations/*


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Since we install the asan.supp etc files into `share/`, it makes sense to add that to ignore (default is to install into prefix that is the source directory).

### What kind of change does this PR introduce?
- [x] Bug fix (issue: installed files suggested for tracking)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.