### PR TITLE
JEventProcessorPODIO: remove incomplete `edm4eic::MCRecoCalorimeterHitAssociation`s from output

### DIFF
--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -5,7 +5,6 @@
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Services/JParameterManager.h>
 #include <JANA/Utils/JTypeInfo.h>
-#include <fmt/core.h>
 #include <fmt/format.h>
 #include <podio/CollectionBase.h>
 #include <podio/Frame.h>


### PR DESCRIPTION
The simHit field of the calorimetry association collections was always dangling because we can't afford to store all the related `edm4hep::CaloHitContribution`s, creating an impression that this functionality is supported in default campaigns. Using those contributions is not practical anyways, because most often relations to primary MCParticle's are desired. The functionality of finding primary particles is implemented for Clusters, which should enable majority of the meaningful studies anyway.

Resolves: #2323