### PR TITLE
fix: rm deprecated RecID/SimID from associations

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -9,7 +9,6 @@
  */
 
 #include <Evaluator/DD4hepUnits.h>
-#include <algorithm>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <edm4eic/CalorimeterHitCollection.h>
@@ -18,9 +17,9 @@
 #include <edm4hep/SimCalorimeterHitCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <fmt/core.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
+#include <algorithm>
 #include <cctype>
 #include <cstddef>
 #include <gsl/pointers>

--- a/src/algorithms/calorimetry/CalorimeterClusterShape.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterShape.cc
@@ -3,20 +3,18 @@
 
 #include "CalorimeterClusterShape.h"
 
-#include <algorithm>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <edm4eic/CalorimeterHitCollection.h>
-#include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <fmt/core.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
 #include <Eigen/Core>
 #include <Eigen/Eigenvalues>
 #include <Eigen/Householder> // IWYU pragma: keep
 #include <Eigen/Jacobi>
+#include <algorithm>
 #include <cctype>
 #include <cmath>
 #include <complex>

--- a/src/algorithms/calorimetry/EnergyPositionClusterMerger.cc
+++ b/src/algorithms/calorimetry/EnergyPositionClusterMerger.cc
@@ -6,7 +6,6 @@
 #include <edm4hep/MCParticle.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <fmt/core.h>
 #include <podio/ObjectID.h>
 #include <cmath>
 #include <cstddef>

--- a/src/algorithms/calorimetry/ImagingClusterReco.cc
+++ b/src/algorithms/calorimetry/ImagingClusterReco.cc
@@ -15,7 +15,6 @@
 #include <edm4hep/SimCalorimeterHit.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <fmt/core.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
 #include <Eigen/Core>

--- a/src/algorithms/calorimetry/TruthEnergyPositionClusterMerger.cc
+++ b/src/algorithms/calorimetry/TruthEnergyPositionClusterMerger.cc
@@ -6,7 +6,6 @@
 #include <Evaluator/DD4hepUnits.h>
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <fmt/core.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
 #include <cmath>

--- a/src/algorithms/reco/MatchClusters.cc
+++ b/src/algorithms/reco/MatchClusters.cc
@@ -13,7 +13,6 @@
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <fmt/core.h>
 #include <podio/ObjectID.h>
 #include <cmath>
 #include <gsl/pointers>

--- a/src/algorithms/tracking/TracksToParticles.cc
+++ b/src/algorithms/tracking/TracksToParticles.cc
@@ -7,7 +7,6 @@
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <fmt/core.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
 #include <cmath>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
In https://github.com/eic/EDM4eic/pull/100 we made the SimID and RecID fields of associations deprecated. This PR removes them from use in EICrecon.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: tech debt)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.