### PR TITLE
hotfix: revert build-docs back to ubuntu-24.04

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -1137,7 +1137,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-docs:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     needs:
       - eicrecon-gun
       - eicrecon-dis


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR reverts the runner type for the build-docs job back to ubuntu-24.04, since ubuntu-slim leads to errors, https://github.com/eic/EICrecon/actions/runs/21202307204/job/60993524736.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.