### PR TITLE
feat: if a factory fails init, take it out of remaining operation

### DIFF
--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -533,7 +533,7 @@ public:
       static_cast<AlgoT*>(this)->Configure();
     } catch (std::exception& e) {
       logger()->error("Factory initialization failed: {}", e.what());
-      SetCreationStatus(JFactory::CreationStatus::NeverCreated);
+      this->SetCreationStatus(JFactory::CreationStatus::NeverCreated);
       // Don't rethrow: factory exists but never produces data
     }
   }
@@ -550,7 +550,7 @@ public:
   virtual void Process(int32_t /* run_number */, uint64_t /* event_number */) {};
 
   void Process(const std::shared_ptr<const JEvent>& event) override {
-    if (GetCreationStatus() == JFactory::CreationStatus::NeverCreated) {
+    if (this->GetCreationStatus() == JFactory::CreationStatus::NeverCreated) {
       for (auto* output : m_outputs) {
         output->Reset();
         output->SetCollection(*this);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Needs:
- [ ] JANA2, v2026.01.01

This PR ensures that failing `init()` calls in algorithms immediately lead to that algorithm being taken out of operation for the rest of the run. This prevents the failing algorithms to attempt to get re-initialized the whole time.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes.