### PR TITLE
fix: handle exceptions in algorithms with JANA2 v2026.01.01

### DIFF
--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -539,11 +539,12 @@ public:
 
   void Process(const std::shared_ptr<const JEvent>& event) override {
     try {
-      for (auto* input : m_inputs) {
-        input->GetCollection(*event);
-      }
+      // Reset outputs first to create empty collections
       for (auto* output : m_outputs) {
         output->Reset();
+      }
+      for (auto* input : m_inputs) {
+        input->GetCollection(*event);
       }
 #if SPDLOG_VERSION >= 11400 && (!defined(SPDLOG_NO_TLS) || !SPDLOG_NO_TLS)
       spdlog::mdc::put("e", std::to_string(event->GetEventNumber()));
@@ -553,6 +554,15 @@ public:
         output->SetCollection(*this);
       }
     } catch (std::exception& e) {
+      // On exception, still set empty collections for any outputs that were Reset()
+      // This ensures podio frames have consistent collections across all events
+      for (auto* output : m_outputs) {
+        try {
+          output->SetCollection(*this);
+        } catch (...) {
+          // Ignore errors setting empty collections
+        }
+      }
       throw JException(e.what());
     }
   }

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -539,12 +539,11 @@ public:
 
   void Process(const std::shared_ptr<const JEvent>& event) override {
     try {
-      // Reset outputs first to create empty collections
-      for (auto* output : m_outputs) {
-        output->Reset();
-      }
       for (auto* input : m_inputs) {
         input->GetCollection(*event);
+      }
+      for (auto* output : m_outputs) {
+        output->Reset();
       }
 #if SPDLOG_VERSION >= 11400 && (!defined(SPDLOG_NO_TLS) || !SPDLOG_NO_TLS)
       spdlog::mdc::put("e", std::to_string(event->GetEventNumber()));
@@ -554,15 +553,6 @@ public:
         output->SetCollection(*this);
       }
     } catch (std::exception& e) {
-      // On exception, still set empty collections for any outputs that were Reset()
-      // This ensures podio frames have consistent collections across all events
-      for (auto* output : m_outputs) {
-        try {
-          output->SetCollection(*this);
-        } catch (...) {
-          // Ignore errors setting empty collections
-        }
-      }
       throw JException(e.what());
     }
   }

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -479,6 +479,35 @@ void JEventProcessorPODIO::FindCollectionsToWrite(const std::shared_ptr<const JE
       }
     }
   }
+
+  // Now trigger all factories to see which ones actually create collections.
+  std::vector<std::string> candidate_collections = m_collections_to_write;
+  for (const std::string& coll : candidate_collections) {
+    try {
+      m_log->trace("Triggering factory for collection '{}'", coll);
+      event->GetCollectionBase(coll);
+    } catch (...) {
+      // Exception expected for factories with missing dependencies
+      // The JOmniFactory fix should have created empty collections
+    }
+  }
+
+  // Check which collections actually made it into the frame
+  const auto* frame         = event->GetSingle<podio::Frame>();
+  auto collections_in_frame = frame->getAvailableCollections();
+
+  std::vector<std::string> final_collections;
+  for (const std::string& coll : candidate_collections) {
+    if (std::find(collections_in_frame.begin(), collections_in_frame.end(), coll) !=
+        collections_in_frame.end()) {
+      final_collections.push_back(coll);
+    } else {
+      m_log->warn("Collection '{}' not in frame after factory trigger, omitting from output", coll);
+    }
+  }
+
+  m_collections_to_write = final_collections;
+  m_log->info("Will write {} collections", m_collections_to_write.size());
 }
 
 void JEventProcessorPODIO::Process(const std::shared_ptr<const JEvent>& event) {
@@ -487,11 +516,9 @@ void JEventProcessorPODIO::Process(const std::shared_ptr<const JEvent>& event) {
   std::call_once(m_is_first_event, &JEventProcessorPODIO::FindCollectionsToWrite, this, event);
 
   // Print the contents of some collections, just for debugging purposes
-  // Do this before writing just in case writing crashes
   if (!m_collections_to_print.empty()) {
     m_log->info("========================================");
     m_log->info("JEventProcessorPODIO: Event {}", event->GetEventNumber());
-    ;
   }
   for (const auto& coll_name : m_collections_to_print) {
     m_log->info("------------------------------");
@@ -509,55 +536,19 @@ void JEventProcessorPODIO::Process(const std::shared_ptr<const JEvent>& event) {
       m_log->info("missing");
     }
   }
-
   m_log->trace("==================================");
   m_log->trace("Event #{}", event->GetEventNumber());
 
-  // Make sure that all factories get called that need to be written into the frame.
-  // We need to do this for _all_ factories unless we've constrained it by using includes/excludes.
-  // Note that all collections need to be present in the first event, as podio::RootFrameWriter constrains us to write one event at a time, so there
-  // is no way to add a new branch after the first event.
-
-  // If we get an exception below while trying to add a factory for any
-  // reason then mark that factory as bad and don't try running it again.
-  // This is motivated by trying to write EcalBarrelSciGlass objects for
-  // data simulated using the imaging calorimeter. In that case, it will
-  // always throw an exception, but DD4hep also prints its own error message.
-  // Thus, to prevent that error message every event, we must avoid calling
-  // it.
-
-  // Activate factories.
-  std::vector<std::string> successful_collections;
-  std::set<std::string> failed_collections;
+  // Activate factories
   for (const std::string& coll : m_collections_to_write) {
     try {
-      m_log->trace("Ensuring factory for collection '{}' has been called.", coll);
-      const auto* coll_ptr = event->GetCollectionBase(coll);
-      if (coll_ptr == nullptr) {
-        // If a collection is missing from the frame, the podio root writer will segfault.
-        // To avoid this, we treat this as a failing collection and omit from this point onwards.
-        // However, this code path is expected to be unreachable because any missing collection will be
-        // replaced with an empty collection in JFactoryPodioTFixed::Create.
-        if (!failed_collections.contains(coll)) {
-          m_log->error("Omitting PODIO collection '{}' because it is null", coll);
-          failed_collections.insert(coll);
-        }
-      } else {
-        m_log->trace("Including PODIO collection '{}'", coll);
-        successful_collections.push_back(coll);
-      }
-    } catch (std::exception& e) {
-      // Limit printing warning to just once per factory
-      if (!failed_collections.contains(coll)) {
-        m_log->error("Omitting PODIO collection '{}' due to exception: {}.", coll, e.what());
-        failed_collections.insert(coll);
-      }
+      event->GetCollectionBase(coll);
+    } catch (...) {
+      // Exception expected - factory created empty collection before rethrowing
     }
   }
 
-  // Frame will contain data from all Podio factories that have been triggered,
-  // including by the `event->GetCollectionBase(coll);` above.
-  // Note that collections MUST be present in frame. If a collection is null, the writer will segfault.
+  // Write frame
   const auto* frame = event->GetSingle<podio::Frame>();
   {
     std::lock_guard<std::mutex> lock(m_mutex);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes the issues observed with JANA2 2026.01.01 (e.g. https://github.com/eic/EICrecon/actions/runs/21097316331/job/60676579118).

Until JANA2 v2.4.3, an exception in an algorithm was handled by creating an empty collection. As of JANA2 v2026.01.01 that's not the case anymore (https://github.com/JeffersonLab/JANA2/commit/c0d07c26806e80be5cceee931a33f29c12b8c502). It is therefore up to us, in `JOmniFactory.h` to make sure the collections are properly empty.

This PR consists of one change:
- we more robustly handle the first event, by triggering all requested collections and also (newly) verifying what made it into the frame.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: JANA2 v2026.01.01 support)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.