### PR TITLE
fix: use std::map by CellID in PMT hit digi

### DIFF
--- a/src/algorithms/digi/PhotoMultiplierHitDigi.cc
+++ b/src/algorithms/digi/PhotoMultiplierHitDigi.cc
@@ -15,14 +15,13 @@
 #include "PhotoMultiplierHitDigi.h"
 
 #include <Evaluator/DD4hepUnits.h>
-#include <algorithm>
 #include <algorithms/logger.h>
-#include <cmath>
 #include <edm4hep/Vector3d.h>
-#include <fmt/core.h>
+#include <podio/ObjectID.h>
+#include <algorithm>
+#include <cmath>
 #include <gsl/pointers>
 #include <iterator>
-#include <podio/ObjectID.h>
 
 #include "algorithms/digi/PhotoMultiplierHitDigiConfig.h"
 

--- a/src/algorithms/digi/PhotoMultiplierHitDigi.h
+++ b/src/algorithms/digi/PhotoMultiplierHitDigi.h
@@ -31,11 +31,11 @@
 #include <functional>
 #include <gsl/pointers>
 #include <iterator>
+#include <map>
 #include <random>
 #include <stdexcept>
 #include <string>
 #include <string_view>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Merge into:
- [ ] #2289 

This PR addresses a potential cause of irreproducibility in the `thetaPhiPhotons` output of the DRICH.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.