### PR TITLE
fix: improved early exit conditions in PulseGeneration

### DIFF
--- a/src/algorithms/digi/PulseGeneration.cc
+++ b/src/algorithms/digi/PulseGeneration.cc
@@ -17,6 +17,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <functional>
 #include <stdexcept>
 #include <string>

--- a/src/tests/algorithms_test/digi_PulseGeneration.cc
+++ b/src/tests/algorithms_test/digi_PulseGeneration.cc
@@ -111,3 +111,100 @@ TEST_CASE("Test the EvaluatorSvc pulse generation with a square pulse", "[PulseG
     REQUIRE(amplitude == charge); // All time bins should be zero
   }
 }
+
+TEST_CASE("Test early exit for Landau pulse never reaching threshold",
+          "[PulseGeneration][EarlyExit]") {
+
+  eicrecon::PulseGeneration<edm4hep::SimTrackerHit> algo("PulseGeneration");
+  eicrecon::PulseGenerationConfig cfg;
+
+  // Configure Landau pulse with parameters
+  cfg.pulse_shape_function = "LandauPulse";
+  cfg.pulse_shape_params   = {1.0, 1.0}; // gain=1.0, sigma_analog=1.0
+  cfg.ignore_thres         = 10.0;       // Set threshold high enough that pulse won't reach it
+  cfg.timestep             = 0.1 * edm4eic::unit::ns;
+  cfg.min_sampling_time    = 0.0 * edm4eic::unit::ns;
+  cfg.max_time_bins        = 1000;
+
+  algo.applyConfig(cfg);
+  algo.init();
+
+  // Use low charge so the pulse never reaches ignore_thres
+  // With gain=1.0, sigma=1.0, and Landau normalized, peak amplitude ~0.18 * charge
+  // So charge=20 gives peak ~3.6, well below threshold of 10.0
+  double charge = 20.0;
+  double time   = 5.0 * edm4eic::unit::ns;
+
+  edm4hep::SimTrackerHitCollection hits_coll;
+  hits_coll.create(12345, charge, time);
+
+  auto pulses = std::make_unique<PulseType::collection_type>();
+
+  auto input  = std::make_tuple(&hits_coll);
+  auto output = std::make_tuple(pulses.get());
+
+  algo.process(input, output);
+
+  // Pulse should not be generated since it never crosses threshold
+  REQUIRE(pulses->size() == 0);
+}
+
+TEST_CASE("Test Landau pulse crossing threshold is not prematurely terminated",
+          "[PulseGeneration][EarlyExit]") {
+
+  eicrecon::PulseGeneration<edm4hep::SimTrackerHit> algo("PulseGeneration");
+  eicrecon::PulseGenerationConfig cfg;
+
+  // Configure Landau pulse
+  cfg.pulse_shape_function = "LandauPulse";
+  cfg.pulse_shape_params   = {1.0, 1.0}; // gain=1.0, sigma_analog=1.0
+  cfg.ignore_thres         = 1.0;        // Set threshold low so pulse will cross it
+  cfg.timestep             = 0.1 * edm4eic::unit::ns;
+  cfg.min_sampling_time    = 2.0 * edm4eic::unit::ns; // Minimum sampling time
+  cfg.max_time_bins        = 1000;
+
+  algo.applyConfig(cfg);
+  algo.init();
+
+  // Use high enough charge that the pulse crosses threshold
+  // With gain=1.0, sigma=1.0, peak amplitude ~0.18 * charge
+  // So charge=10 gives peak ~1.8, above threshold of 1.0
+  double charge = 10.0;
+  double time   = 5.0 * edm4eic::unit::ns;
+
+  edm4hep::SimTrackerHitCollection hits_coll;
+  hits_coll.create(12345, charge, time);
+
+  auto pulses = std::make_unique<PulseType::collection_type>();
+
+  auto input  = std::make_tuple(&hits_coll);
+  auto output = std::make_tuple(pulses.get());
+
+  algo.process(input, output);
+
+  // Pulse should be generated since it crosses threshold
+  REQUIRE(pulses->size() == 1);
+  REQUIRE((*pulses)[0].getCellID() == 12345);
+
+  auto amplitudes = (*pulses)[0].getAmplitude();
+
+  // Should have non-zero amplitude samples
+  REQUIRE(amplitudes.size() > 0);
+
+  // Check that the pulse was not prematurely terminated
+  // It should sample at least until min_sampling_time after crossing threshold
+  // Derive expected minimum samples from cfg to avoid hard-coding
+  const auto expected_min_samples =
+      static_cast<std::size_t>(std::ceil(cfg.min_sampling_time / cfg.timestep));
+  REQUIRE(amplitudes.size() >= expected_min_samples);
+
+  // Verify that some amplitudes are above threshold
+  bool has_above_threshold = false;
+  for (auto amplitude : amplitudes) {
+    if (std::abs(amplitude) >= cfg.ignore_thres) {
+      has_above_threshold = true;
+      break;
+    }
+  }
+  REQUIRE(has_above_threshold);
+}


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR improves the early exist conditions for the PulseGeneration.

We were running into pathological behavior for pulses that never crossed threshold in the BEMC (causing significant performance impact): the algorithm would continue evaluating ROOT::Landua for the full 10k samples since the early exit condition was only on the time after crossing threshold.

This PR adds a new early exit condition based on the signal amplitude derivative: if have not crossed threshold, but we have a negative signal amplitude derivative, then we assume we are after the (single) pulse maximum and will never recover.

This PR imposes the condition of a falling derivative on the pulse shape (or at least a single maximum).

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.