### PR TITLE
feat: use podio::LinkNavigator lookups instead of loops

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -18,6 +18,7 @@
 #include <edm4hep/SimCalorimeterHitCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
+#include <podio/LinkNavigator.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
 #include <podio/detail/Link.h>
@@ -53,11 +54,12 @@ void CalorimeterClusterRecoCoG::init() {
 
 void CalorimeterClusterRecoCoG::process(const CalorimeterClusterRecoCoG::Input& input,
                                         const CalorimeterClusterRecoCoG::Output& output) const {
-  const auto [proto, mchitassociations] = input;
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-  auto [clusters, links, associations] = output;
+  const auto [proto, mchitlinks, mchitassociations] = input;
+  auto [clusters, links, associations]              = output;
 #else
-  auto [clusters, associations] = output;
+  const auto [proto, mchitassociations] = input;
+  auto [clusters, associations]         = output;
 #endif
 
   for (const auto& pcl : *proto) {
@@ -78,14 +80,19 @@ void CalorimeterClusterRecoCoG::process(const CalorimeterClusterRecoCoG::Input& 
     clusters->push_back(cl);
 
     // If sim hits are available, associate cluster with MCParticle
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+    if (mchitlinks->empty()) {
+      debug("Provided MCRecoCalorimeterHitLink collection is empty. No truth associations "
+            "will be performed.");
+      continue;
+    }
+    associate(cl, mchitassociations, mchitlinks, links, associations);
+#else
     if (mchitassociations->empty()) {
       debug("Provided MCRecoCalorimeterHitAssociation collection is empty. No truth associations "
             "will be performed.");
       continue;
     }
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-    associate(cl, mchitassociations, links, associations);
-#else
     associate(cl, mchitassociations, associations);
 #endif
   }
@@ -175,8 +182,9 @@ CalorimeterClusterRecoCoG::reconstruct(const edm4eic::ProtoCluster& pcl) const {
 
 void CalorimeterClusterRecoCoG::associate(
     const edm4eic::Cluster& cl,
-    const edm4eic::MCRecoCalorimeterHitAssociationCollection* mchitassociations,
+    [[maybe_unused]] const edm4eic::MCRecoCalorimeterHitAssociationCollection* mchitassociations,
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+    const edm4eic::MCRecoCalorimeterHitLinkCollection* mchitlinks,
     edm4eic::MCRecoClusterParticleLinkCollection* links,
 #endif
     edm4eic::MCRecoClusterParticleAssociationCollection* assocs) const {
@@ -204,29 +212,41 @@ void CalorimeterClusterRecoCoG::associate(
   // bookkeeping maps for associated primaries
   std::map<edm4hep::MCParticle, double, decltype(compare)> mapMCParToContrib(compare);
 
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  // Build fast lookup using podio::LinkNavigator
+  podio::LinkNavigator link_nav(*mchitlinks);
+#endif
+
   // --------------------------------------------------------------------------
   // 1. get associated sim hits and sum energy
   // --------------------------------------------------------------------------
   double eSimHitSum = 0.;
   for (auto clhit : cl.getHits()) {
-    // vector to hold associated sim hits
-    std::vector<edm4hep::SimCalorimeterHit> vecAssocSimHits;
 
-    for (const auto& hitAssoc : *mchitassociations) {
-      // if found corresponding raw hit, add sim hit to vector
-      // and increment energy sum
-      if (clhit.getRawHit() == hitAssoc.getRawHit()) {
-        vecAssocSimHits.push_back(hitAssoc.getSimHit());
-        eSimHitSum += vecAssocSimHits.back().getEnergy();
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+    // Get linked sim hits using LinkNavigator
+    const auto vecAssocSimHits = link_nav.getLinked(clhit.getRawHit());
+#else
+    // Fallback: linear search through associations
+    std::vector<std::pair<edm4hep::SimCalorimeterHit, double>> vecAssocSimHits;
+    for (const auto& assoc : *mchitassociations) {
+      if (assoc.getRawHit() == clhit.getRawHit()) {
+        vecAssocSimHits.push_back(std::make_pair(assoc.getSimHit(), assoc.getWeight()));
       }
     }
+#endif
+
+    for (const auto& [simHit, weight] : vecAssocSimHits) {
+      eSimHitSum += simHit.getEnergy();
+    }
+
     debug("{} associated sim hits found for reco hit (cell ID = {})", vecAssocSimHits.size(),
           clhit.getCellID());
 
     // ------------------------------------------------------------------------
     // 2. loop through associated sim hits
     // ------------------------------------------------------------------------
-    for (const auto& simHit : vecAssocSimHits) {
+    for (const auto& [simHit, weight] : vecAssocSimHits) {
       for (const auto& contrib : simHit.getContributions()) {
         // --------------------------------------------------------------------
         // grab primary responsible for contribution & increment relevant sum
@@ -256,11 +276,13 @@ void CalorimeterClusterRecoCoG::associate(
     link.setFrom(cl);
     link.setTo(part);
 #endif
+
     // set association
     auto assoc = assocs->create();
     assoc.setWeight(weight);
     assoc.setRec(cl);
     assoc.setSim(part);
+
     debug("Associated cluster #{} to MC Particle #{} (pid = {}, status = {}, energy = {}) with "
           "weight ({})",
           cl.getObjectID().index, part.getObjectID().index, part.getPDG(),

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
@@ -16,6 +16,9 @@
 #include <edm4hep/CaloHitContribution.h>
 #include <edm4hep/MCParticle.h>
 #include <edm4eic/MCRecoCalorimeterHitAssociationCollection.h>
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoCalorimeterHitLinkCollection.h>
+#endif
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <edm4eic/ProtoClusterCollection.h>
 #include <algorithm>
@@ -56,6 +59,9 @@ using ClustersWithAssociations =
 
 using CalorimeterClusterRecoCoGAlgorithm = algorithms::Algorithm<
     algorithms::Input<edm4eic::ProtoClusterCollection,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                      std::optional<edm4eic::MCRecoCalorimeterHitLinkCollection>,
+#endif
                       std::optional<edm4eic::MCRecoCalorimeterHitAssociationCollection>>,
     algorithms::Output<edm4eic::ClusterCollection,
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
@@ -70,7 +76,11 @@ public:
   CalorimeterClusterRecoCoG(std::string_view name)
       : CalorimeterClusterRecoCoGAlgorithm{
             name,
-            {"inputProtoClusterCollection", "mcRawHitAssocations"},
+            {"inputProtoClusterCollection",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+             "mcRawHitLinks",
+#endif
+             "mcRawHitAssocations"},
             {"outputClusterCollection",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
              "outputLinks",
@@ -94,6 +104,7 @@ private:
   void associate(const edm4eic::Cluster& cl,
                  const edm4eic::MCRecoCalorimeterHitAssociationCollection* mchitassociations,
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                 const edm4eic::MCRecoCalorimeterHitLinkCollection* mchitlinks,
                  edm4eic::MCRecoClusterParticleLinkCollection* links,
 #endif
                  edm4eic::MCRecoClusterParticleAssociationCollection* assocs) const;

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
@@ -18,6 +18,7 @@
 #include <edm4eic/MCRecoCalorimeterHitAssociationCollection.h>
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
 #include <edm4eic/MCRecoCalorimeterHitLinkCollection.h>
+#include <podio/LinkNavigator.h>
 #endif
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <edm4eic/ProtoClusterCollection.h>
@@ -104,7 +105,7 @@ private:
   void associate(const edm4eic::Cluster& cl,
                  const edm4eic::MCRecoCalorimeterHitAssociationCollection* mchitassociations,
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-                 const edm4eic::MCRecoCalorimeterHitLinkCollection* mchitlinks,
+                 const podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& link_nav,
                  edm4eic::MCRecoClusterParticleLinkCollection* links,
 #endif
                  edm4eic::MCRecoClusterParticleAssociationCollection* assocs) const;

--- a/src/algorithms/calorimetry/ImagingClusterReco.cc
+++ b/src/algorithms/calorimetry/ImagingClusterReco.cc
@@ -14,6 +14,8 @@
 #include <edm4hep/SimCalorimeterHit.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
+#include <podio/detail/LinkCollectionImpl.h>
+#include <podio/LinkNavigator.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
 #include <podio/detail/Link.h>
@@ -36,10 +38,11 @@ namespace eicrecon {
 
 void ImagingClusterReco::process(const Input& input, const Output& output) const {
 
-  const auto [proto, mchitassociations] = input;
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-  auto [clusters, links, associations, layers] = output;
+  const auto [proto, mchitlinks, mchitassociations] = input;
+  auto [clusters, links, associations, layers]      = output;
 #else
+  const auto [proto, mchitassociations] = input;
   auto [clusters, associations, layers] = output;
 #endif
 
@@ -66,16 +69,21 @@ void ImagingClusterReco::process(const Input& input, const Output& output) const
     clusters->push_back(cl);
 
     // If sim hits are available, associate cluster with MCParticle
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+    if (mchitlinks->empty()) {
+      debug("Provided MCRecoCalorimeterHitLink collection is empty. No truth associations "
+            "will be performed.");
+      continue;
+    }
+    associate_mc_particles(cl, mchitassociations, mchitlinks, links, associations);
+#else
     if (mchitassociations->empty()) {
       debug("Provided MCRecoCalorimeterHitAssociation collection is empty. No truth associations "
             "will be performed.");
       continue;
     }
-    associate_mc_particles(cl, mchitassociations,
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-                           links,
+    associate_mc_particles(cl, mchitassociations, associations);
 #endif
-                           associations);
   }
 
   // debug output
@@ -232,8 +240,9 @@ ImagingClusterReco::fit_track(const std::vector<edm4eic::MutableCluster>& layers
 
 void ImagingClusterReco::associate_mc_particles(
     const edm4eic::Cluster& cl,
-    const edm4eic::MCRecoCalorimeterHitAssociationCollection* mchitassociations,
+    [[maybe_unused]] const edm4eic::MCRecoCalorimeterHitAssociationCollection* mchitassociations,
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+    const edm4eic::MCRecoCalorimeterHitLinkCollection* mchitlinks,
     edm4eic::MCRecoClusterParticleLinkCollection* links,
 #endif
     edm4eic::MCRecoClusterParticleAssociationCollection* assocs) const {
@@ -262,29 +271,40 @@ void ImagingClusterReco::associate_mc_particles(
   // bookkeeping maps for associated primaries
   std::map<edm4hep::MCParticle, double, decltype(compare)> mapMCParToContrib(compare);
 
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  // Build fast lookup using podio::LinkNavigator
+  podio::LinkNavigator link_nav(*mchitlinks);
+#endif
+
   // --------------------------------------------------------------------------
   // 1. get associated sim hits and sum energy
   // --------------------------------------------------------------------------
   double eSimHitSum = 0.;
   for (auto clhit : cl.getHits()) {
-    // vector to hold associated sim hits
-    std::vector<edm4hep::SimCalorimeterHit> vecAssocSimHits;
-
-    for (const auto& hitAssoc : *mchitassociations) {
-      // if found corresponding raw hit, add sim hit to vector
-      // and increment energy sum
-      if (clhit.getRawHit() == hitAssoc.getRawHit()) {
-        vecAssocSimHits.push_back(hitAssoc.getSimHit());
-        eSimHitSum += vecAssocSimHits.back().getEnergy();
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+    // Get linked sim hits using LinkNavigator
+    const auto vecAssocSimHits = link_nav.getLinked(clhit.getRawHit());
+#else
+    // Fallback: linear search through associations
+    std::vector<std::pair<edm4hep::SimCalorimeterHit, double>> vecAssocSimHits;
+    for (const auto& assoc : *mchitassociations) {
+      if (assoc.getRawHit() == clhit.getRawHit()) {
+        vecAssocSimHits.push_back(std::make_pair(assoc.getSimHit(), assoc.getWeight()));
       }
     }
+#endif
+
+    for (const auto& [simHit, weight] : vecAssocSimHits) {
+      eSimHitSum += simHit.getEnergy();
+    }
+
     debug("{} associated sim hits found for reco hit (cell ID = {})", vecAssocSimHits.size(),
           clhit.getCellID());
 
     // ------------------------------------------------------------------------
     // 2. loop through associated sim hits
     // ------------------------------------------------------------------------
-    for (const auto& simHit : vecAssocSimHits) {
+    for (const auto& [simHit, weight] : vecAssocSimHits) {
       for (const auto& contrib : simHit.getContributions()) {
         // --------------------------------------------------------------------
         // grab primary responsible for contribution & increment relevant sum
@@ -314,11 +334,13 @@ void ImagingClusterReco::associate_mc_particles(
     link.setFrom(cl);
     link.setTo(part);
 #endif
+
     // set association
     auto assoc = assocs->create();
     assoc.setWeight(weight);
     assoc.setRec(cl);
     assoc.setSim(part);
+
     debug("Associated cluster #{} to MC Particle #{} (pid = {}, status = {}, energy = {}) with "
           "weight ({})",
           cl.getObjectID().index, part.getObjectID().index, part.getPDG(),

--- a/src/algorithms/calorimetry/ImagingClusterReco.h
+++ b/src/algorithms/calorimetry/ImagingClusterReco.h
@@ -15,6 +15,9 @@
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/ClusterCollection.h>
 #include <edm4eic/MCRecoCalorimeterHitAssociationCollection.h>
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoCalorimeterHitLinkCollection.h>
+#endif
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <edm4eic/ProtoClusterCollection.h>
 #include <edm4hep/CaloHitContribution.h>
@@ -37,6 +40,9 @@ namespace eicrecon {
 
 using ImagingClusterRecoAlgorithm =
     algorithms::Algorithm<algorithms::Input<edm4eic::ProtoClusterCollection,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                            edm4eic::MCRecoCalorimeterHitLinkCollection,
+#endif
                                             edm4eic::MCRecoCalorimeterHitAssociationCollection>,
                           algorithms::Output<edm4eic::ClusterCollection,
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
@@ -58,7 +64,11 @@ class ImagingClusterReco : public ImagingClusterRecoAlgorithm,
 public:
   ImagingClusterReco(std::string_view name)
       : ImagingClusterRecoAlgorithm{name,
-                                    {"inputProtoClusterCollection", "mcRawHitAssocations"},
+                                    {"inputProtoClusterCollection",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                     "mcRawHitLinks",
+#endif
+                                     "mcRawHitAssocations"},
                                     {"outputClusterCollection",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
                                      "outputClusterLinks",
@@ -88,6 +98,7 @@ private:
       const edm4eic::Cluster& cl,
       const edm4eic::MCRecoCalorimeterHitAssociationCollection* mchitassociations,
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      const edm4eic::MCRecoCalorimeterHitLinkCollection* mchitlinks,
       edm4eic::MCRecoClusterParticleLinkCollection* links,
 #endif
       edm4eic::MCRecoClusterParticleAssociationCollection* assocs) const;

--- a/src/algorithms/calorimetry/ImagingClusterReco.h
+++ b/src/algorithms/calorimetry/ImagingClusterReco.h
@@ -17,6 +17,7 @@
 #include <edm4eic/MCRecoCalorimeterHitAssociationCollection.h>
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
 #include <edm4eic/MCRecoCalorimeterHitLinkCollection.h>
+#include <podio/LinkNavigator.h>
 #endif
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <edm4eic/ProtoClusterCollection.h>
@@ -98,7 +99,7 @@ private:
       const edm4eic::Cluster& cl,
       const edm4eic::MCRecoCalorimeterHitAssociationCollection* mchitassociations,
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-      const edm4eic::MCRecoCalorimeterHitLinkCollection* mchitlinks,
+      const podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& link_nav,
       edm4eic::MCRecoClusterParticleLinkCollection* links,
 #endif
       edm4eic::MCRecoClusterParticleAssociationCollection* assocs) const;

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -10,6 +10,9 @@
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoTrackParticleAssociationCollection.h>
 #include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoTrackerHitLinkCollection.h>
+#endif
 #include <edm4eic/Measurement2DCollection.h>
 #include <edm4eic/RawTrackerHit.h>
 #include <edm4eic/TrackCollection.h>
@@ -20,6 +23,7 @@
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
+#include <podio/LinkNavigator.h>
 #include <podio/RelationRange.h>
 #include <podio/detail/Link.h>
 #include <Eigen/Geometry>
@@ -30,6 +34,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <deque>
 #include <memory>
 #include <new>
 #include <unordered_map>
@@ -62,11 +67,12 @@ void FarDetectorLinearTracking::init() {
 void FarDetectorLinearTracking::process(const FarDetectorLinearTracking::Input& input,
                                         const FarDetectorLinearTracking::Output& output) const {
 
-  const auto [inputhits, assocHits] = input;
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  const auto [inputhits, hitLinks, assocHits]  = input;
   auto [outputTracks, trackLinks, assocTracks] = output;
 #else
-  auto [outputTracks, assocTracks] = output;
+  const auto [inputhits, assocHits] = input;
+  auto [outputTracks, assocTracks]  = output;
 #endif
 
   // Check the number of input collections is correct
@@ -91,7 +97,11 @@ void FarDetectorLinearTracking::process(const FarDetectorLinearTracking::Input& 
       trace("No hits in layer");
       return;
     }
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+    ConvertClusters(*layerHits, *hitLinks, *assocHits, convertedHits, assocParts);
+#else
     ConvertClusters(*layerHits, *assocHits, convertedHits, assocParts);
+#endif
   }
 
   // Create a matrix to store the hit positions
@@ -242,13 +252,21 @@ bool FarDetectorLinearTracking::checkHitPair(const Eigen::Vector3d& hit1,
 // Convert measurements into global coordinates
 void FarDetectorLinearTracking::ConvertClusters(
     const edm4eic::Measurement2DCollection& clusters,
-    const edm4eic::MCRecoTrackerHitAssociationCollection& assoc_hits,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+    const edm4eic::MCRecoTrackerHitLinkCollection& hit_links,
+#endif
+    [[maybe_unused]] const edm4eic::MCRecoTrackerHitAssociationCollection& assoc_hits,
     std::vector<std::vector<Eigen::Vector3d>>& pointPositions,
     std::vector<std::vector<edm4hep::MCParticle>>& assoc_parts) const {
 
   // Get context of first hit
   const dd4hep::VolumeManagerContext* context =
       m_cellid_converter->findContext(clusters[0].getSurface());
+
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  // Build fast lookup using podio::LinkNavigator
+  podio::LinkNavigator link_nav(hit_links);
+#endif
 
   std::vector<Eigen::Vector3d> layerPositions;
   std::vector<edm4hep::MCParticle> assocParticles;
@@ -277,14 +295,23 @@ void FarDetectorLinearTracking::ConvertClusters(
     // Get associated raw hit
     auto rawHit = maxHit.getRawHit();
 
-    // Loop over the hit associations to find the associated MCParticle
-    for (const auto& hit_assoc : assoc_hits) {
-      if (hit_assoc.getRawHit() == rawHit) {
-        auto particle = hit_assoc.getSimHit().getParticle();
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+    // Get linked sim hits using LinkNavigator
+    const auto sim_hits = link_nav.getLinked(rawHit);
+    if (!sim_hits.empty()) {
+      auto particle = sim_hits[0].o.getParticle();
+      assocParticles.push_back(particle);
+    }
+#else
+    // Fallback: linear search through associations
+    for (const auto& assoc : assoc_hits) {
+      if (assoc.getRawHit() == rawHit) {
+        auto particle = assoc.getSimHit().getParticle();
         assocParticles.push_back(particle);
         break;
       }
     }
+#endif
   }
 
   pointPositions.push_back(layerPositions);

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -34,7 +34,6 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
-#include <deque>
 #include <memory>
 #include <new>
 #include <unordered_map>

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.h
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.h
@@ -11,6 +11,7 @@
 #include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
 #include <edm4eic/MCRecoTrackerHitLinkCollection.h>
+#include <podio/LinkNavigator.h>
 #endif
 #include <edm4eic/Measurement2DCollection.h>
 #include <edm4eic/TrackCollection.h>
@@ -88,13 +89,14 @@ private:
   bool checkHitPair(const Eigen::Vector3d& hit1, const Eigen::Vector3d& hit2) const;
 
   /** Convert 2D clusters to 3D coordinates and match associated particle **/
-  void ConvertClusters(const edm4eic::Measurement2DCollection& clusters,
+  void
+  ConvertClusters(const edm4eic::Measurement2DCollection& clusters,
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-                       const edm4eic::MCRecoTrackerHitLinkCollection& hit_links,
+                  const podio::LinkNavigator<edm4eic::MCRecoTrackerHitLinkCollection>& link_nav,
 #endif
-                       const edm4eic::MCRecoTrackerHitAssociationCollection& assoc_hits,
-                       std::vector<std::vector<Eigen::Vector3d>>& pointPositions,
-                       std::vector<std::vector<edm4hep::MCParticle>>& assoc_parts) const;
+                  const edm4eic::MCRecoTrackerHitAssociationCollection& assoc_hits,
+                  std::vector<std::vector<Eigen::Vector3d>>& pointPositions,
+                  std::vector<std::vector<edm4hep::MCParticle>>& assoc_parts) const;
 };
 
 } // namespace eicrecon

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.h
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.h
@@ -9,6 +9,9 @@
 #include <edm4eic/MCRecoTrackParticleAssociationCollection.h>
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoTrackerHitLinkCollection.h>
+#endif
 #include <edm4eic/Measurement2DCollection.h>
 #include <edm4eic/TrackCollection.h>
 #include <edm4hep/MCParticle.h>
@@ -30,6 +33,9 @@ namespace eicrecon {
 
 using FarDetectorLinearTrackingAlgorithm = algorithms::Algorithm<
     algorithms::Input<std::vector<edm4eic::Measurement2DCollection>,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                      std::optional<edm4eic::MCRecoTrackerHitLinkCollection>,
+#endif
                       std::optional<edm4eic::MCRecoTrackerHitAssociationCollection>>,
     algorithms::Output<edm4eic::TrackCollection,
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
@@ -42,15 +48,18 @@ class FarDetectorLinearTracking : public FarDetectorLinearTrackingAlgorithm,
 
 public:
   FarDetectorLinearTracking(std::string_view name)
-      : FarDetectorLinearTrackingAlgorithm{
-            name,
-            {"inputHitCollections", "inputMCRecoTrackerHitAssociations"},
-            {"outputTrackCollection",
+      : FarDetectorLinearTrackingAlgorithm{name,
+                                           {"inputHitCollections",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-             "outputMCRecoTrackLinks",
+                                            "inputMCRecoTrackerHitLinks",
 #endif
-             "outputMCRecoTrackAssociations"},
-            "Fit track segments from hits in the tracker layers"} {
+                                            "inputMCRecoTrackerHitAssociations"},
+                                           {"outputTrackCollection",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                            "outputMCRecoTrackLinks",
+#endif
+                                            "outputMCRecoTrackAssociations"},
+                                           "Fit track segments from hits in the tracker layers"} {
   }
 
   /** One time initialization **/
@@ -80,6 +89,9 @@ private:
 
   /** Convert 2D clusters to 3D coordinates and match associated particle **/
   void ConvertClusters(const edm4eic::Measurement2DCollection& clusters,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                       const edm4eic::MCRecoTrackerHitLinkCollection& hit_links,
+#endif
                        const edm4eic::MCRecoTrackerHitAssociationCollection& assoc_hits,
                        std::vector<std::vector<Eigen::Vector3d>>& pointPositions,
                        std::vector<std::vector<edm4hep::MCParticle>>& assoc_parts) const;

--- a/src/detectors/B0ECAL/B0ECAL.cc
+++ b/src/detectors/B0ECAL/B0ECAL.cc
@@ -90,7 +90,10 @@ void InitPlugin(JApplication* app) {
       "B0ECalClustersWithoutShapes",
       {
           "B0ECalIslandProtoClusters", // edm4eic::ProtoClusterCollection
-          "B0ECalRawHitAssociations"   // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "B0ECalRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "B0ECalRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
       {"B0ECalClustersWithoutShapes", // edm4eic::Cluster
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
@@ -113,7 +116,10 @@ void InitPlugin(JApplication* app) {
       "B0ECalTruthClustersWithoutShapes",
       {
           "B0ECalTruthProtoClusters", // edm4eic::ProtoClusterCollection
-          "B0ECalRawHitAssociations"  // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "B0ECalRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "B0ECalRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
       {"B0ECalTruthClustersWithoutShapes", // edm4eic::Cluster
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -240,8 +240,13 @@ void InitPlugin(JApplication* app) {
       ));
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
       "EcalBarrelScFiClustersWithoutShapes",
-      {"EcalBarrelScFiProtoClusters",         // edm4eic::ProtoClusterCollection
-       "EcalBarrelScFiRawHitAssociations"},   // edm4eic::MCRecoCalorimeterHitAssociation
+      {
+          "EcalBarrelScFiProtoClusters", // edm4eic::ProtoClusterCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "EcalBarrelScFiRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "EcalBarrelScFiRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociation
+      },
       {"EcalBarrelScFiClustersWithoutShapes", // edm4eic::Cluster
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
        "EcalBarrelScFiClusterLinksWithoutShapes",
@@ -326,7 +331,11 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<ImagingClusterReco_factory>(
       "EcalBarrelImagingClustersWithoutShapes",
-      {"EcalBarrelImagingProtoClusters", "EcalBarrelImagingRawHitAssociations"},
+      {"EcalBarrelImagingProtoClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalBarrelImagingRawHitLinks",
+#endif
+       "EcalBarrelImagingRawHitAssociations"},
       {"EcalBarrelImagingClustersWithoutShapes",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
        "EcalBarrelImagingClusterLinksWithoutShapes",

--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -131,7 +131,10 @@ void InitPlugin(JApplication* app) {
       "HcalBarrelClustersWithoutShapes",
       {
           "HcalBarrelIslandProtoClusters", // edm4eic::ProtoClusterCollection
-          "HcalBarrelRawHitAssociations"   // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "HcalBarrelRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "HcalBarrelRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
       {"HcalBarrelClustersWithoutShapes",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
@@ -156,7 +159,10 @@ void InitPlugin(JApplication* app) {
       "HcalBarrelTruthClustersWithoutShapes",
       {
           "HcalBarrelTruthProtoClusters", // edm4eic::ProtoClusterCollection
-          "HcalBarrelRawHitAssociations"  // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "HcalBarrelRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "HcalBarrelRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
       {"HcalBarrelTruthClustersWithoutShapes",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
@@ -195,7 +201,10 @@ void InitPlugin(JApplication* app) {
       "HcalBarrelSplitMergeClustersWithoutShapes",
       {
           "HcalBarrelSplitMergeProtoClusters", // edm4eic::ProtoClusterCollection
-          "HcalBarrelRawHitAssociations"       // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "HcalBarrelRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "HcalBarrelRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
       {"HcalBarrelSplitMergeClustersWithoutShapes",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)

--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -232,7 +232,7 @@ void InitPlugin(JApplication* app) {
       {
           "EcalEndcapNSplitMergeProtoClusters", // edm4eic::ProtoClusterCollection
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-          "EcalEndcapNRawHitLinks",
+          "EcalEndcapNRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
 #endif
           "EcalEndcapNRawHitAssociations" // edm4hep::MCRecoCalorimeterHitAssociationCollection
       },

--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -113,7 +113,10 @@ void InitPlugin(JApplication* app) {
       "EcalEndcapNTruthClustersWithoutShapes",
       {
           "EcalEndcapNTruthProtoClusters", // edm4eic::ProtoClusterCollection
-          "EcalEndcapNRawHitAssociations"  // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "EcalEndcapNRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "EcalEndcapNRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
       {"EcalEndcapNTruthClustersWithoutShapes",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
@@ -138,7 +141,10 @@ void InitPlugin(JApplication* app) {
       "EcalEndcapNClustersWithoutPIDAndShapes",
       {
           "EcalEndcapNIslandProtoClusters", // edm4eic::ProtoClusterCollection
-          "EcalEndcapNRawHitAssociations"   // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "EcalEndcapNRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "EcalEndcapNRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
       {"EcalEndcapNClustersWithoutPIDAndShapes", // edm4eic::Cluster
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
@@ -225,6 +231,9 @@ void InitPlugin(JApplication* app) {
       "EcalEndcapNSplitMergeClustersWithoutShapes",
       {
           "EcalEndcapNSplitMergeProtoClusters", // edm4eic::ProtoClusterCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "EcalEndcapNRawHitLinks",
+#endif
           "EcalEndcapNRawHitAssociations" // edm4hep::MCRecoCalorimeterHitAssociationCollection
       },
       {"EcalEndcapNSplitMergeClustersWithoutShapes",

--- a/src/detectors/EHCAL/EHCAL.cc
+++ b/src/detectors/EHCAL/EHCAL.cc
@@ -111,7 +111,10 @@ void InitPlugin(JApplication* app) {
       "HcalEndcapNTruthClustersWithoutShapes",
       {
           "HcalEndcapNTruthProtoClusters", // edm4eic::ProtoClusterCollection
-          "HcalEndcapNRawHitAssociations"  // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "HcalEndcapNRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "HcalEndcapNRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
       {"HcalEndcapNTruthClustersWithoutShapes",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
@@ -134,7 +137,10 @@ void InitPlugin(JApplication* app) {
       "HcalEndcapNClustersWithoutShapes",
       {
           "HcalEndcapNIslandProtoClusters", // edm4eic::ProtoClusterCollection
-          "HcalEndcapNRawHitAssociations"   // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "HcalEndcapNRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "HcalEndcapNRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
       {"HcalEndcapNClustersWithoutShapes",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
@@ -175,6 +181,9 @@ void InitPlugin(JApplication* app) {
       "HcalEndcapNSplitMergeClustersWithoutShapes",
       {
           "HcalEndcapNSplitMergeProtoClusters", // edm4eic::ProtoClusterCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "HcalEndcapNRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
           "HcalEndcapNRawHitAssociations" // edm4hep::MCRecoCalorimeterHitAssociationCollection
       },
       {"HcalEndcapNSplitMergeClustersWithoutShapes",

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -251,7 +251,7 @@ void InitPlugin(JApplication* app) {
       {
           "EcalEndcapPSplitMergeProtoClusters", // edm4eic::ProtoClusterCollection
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-          "EcalEndcapPRawHitLinks",
+          "EcalEndcapPRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
 #endif
           "EcalEndcapPRawHitAssociations" // edm4hep::MCRecoCalorimeterHitAssociationCollection
       },

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -175,7 +175,10 @@ void InitPlugin(JApplication* app) {
       "EcalEndcapPTruthClustersWithoutShapes",
       {
           "EcalEndcapPTruthProtoClusters", // edm4eic::ProtoClusterCollection
-          "EcalEndcapPRawHitAssociations"  // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "EcalEndcapPRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "EcalEndcapPRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
       {"EcalEndcapPTruthClustersWithoutShapes",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
@@ -200,7 +203,10 @@ void InitPlugin(JApplication* app) {
       "EcalEndcapPClustersWithoutShapes",
       {
           "EcalEndcapPIslandProtoClusters", // edm4eic::ProtoClusterCollection
-          "EcalEndcapPRawHitAssociations"   // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "EcalEndcapPRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "EcalEndcapPRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
       {"EcalEndcapPClustersWithoutShapes",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
@@ -244,6 +250,9 @@ void InitPlugin(JApplication* app) {
       "EcalEndcapPSplitMergeClustersWithoutShapes",
       {
           "EcalEndcapPSplitMergeProtoClusters", // edm4eic::ProtoClusterCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "EcalEndcapPRawHitLinks",
+#endif
           "EcalEndcapPRawHitAssociations" // edm4hep::MCRecoCalorimeterHitAssociationCollection
       },
       {"EcalEndcapPSplitMergeClustersWithoutShapes",

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -127,6 +127,9 @@ void InitPlugin(JApplication* app) {
       "HcalEndcapPInsertTruthClustersWithoutShapes",
       {
           "HcalEndcapPInsertTruthProtoClusters", // edm4eic::ProtoClusterCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "HcalEndcapPInsertRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
           "HcalEndcapPInsertRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
       {"HcalEndcapPInsertTruthClustersWithoutShapes",
@@ -153,6 +156,9 @@ void InitPlugin(JApplication* app) {
       "HcalEndcapPInsertClustersWithoutShapes",
       {
           "HcalEndcapPInsertImagingProtoClusters", // edm4eic::ProtoClusterCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "HcalEndcapPInsertRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
           "HcalEndcapPInsertRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
       {"HcalEndcapPInsertClustersWithoutShapes",
@@ -280,7 +286,10 @@ void InitPlugin(JApplication* app) {
       "LFHCALTruthClustersWithoutShapes",
       {
           "LFHCALTruthProtoClusters", // edm4eic::ProtoClusterCollection
-          "LFHCALRawHitAssociations"  // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "LFHCALRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "LFHCALRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
       {"LFHCALTruthClustersWithoutShapes",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
@@ -305,7 +314,10 @@ void InitPlugin(JApplication* app) {
       "LFHCALClustersWithoutShapes",
       {
           "LFHCALIslandProtoClusters", // edm4eic::ProtoClusterCollection
-          "LFHCALRawHitAssociations"   // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "LFHCALRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "LFHCALRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
       {"LFHCALClustersWithoutShapes",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
@@ -347,7 +359,10 @@ void InitPlugin(JApplication* app) {
       "LFHCALSplitMergeClustersWithoutShapes",
       {
           "LFHCALSplitMergeProtoClusters", // edm4eic::ProtoClusterCollection
-          "LFHCALRawHitAssociations"       // edm4hep::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "LFHCALRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "LFHCALRawHitAssociations" // edm4hep::MCRecoCalorimeterHitAssociationCollection
       },
       {"LFHCALSplitMergeClustersWithoutShapes",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -172,6 +172,9 @@ void InitPlugin(JApplication* app) {
     std::string outputTrackAssociationTag     = outputTrackAssociationTags[i];
     std::vector<std::string> inputClusterTags = moduleClusterTags[i];
 
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+    inputClusterTags.emplace_back("TaggerTrackerRawHitLinks");
+#endif
     inputClusterTags.emplace_back("TaggerTrackerRawHitAssociations");
 
     app->Add(new JOmniFactoryGeneratorT<FarDetectorLinearTracking_factory>(

--- a/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
+++ b/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
@@ -95,7 +95,10 @@ void InitPlugin(JApplication* app) {
       "EcalLumiSpecClustersWithoutShapes",
       {
           "EcalLumiSpecIslandProtoClusters", // edm4eic::ProtoClusterCollection
-          "EcalLumiSpecRawHitAssociations"   // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "EcalLumiSpecRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "EcalLumiSpecRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
       {"EcalLumiSpecClustersWithoutShapes",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
@@ -119,7 +122,10 @@ void InitPlugin(JApplication* app) {
       "EcalLumiSpecTruthClustersWithoutShapes",
       {
           "EcalLumiSpecTruthProtoClusters", // edm4eic::ProtoClusterCollection
-          "EcalLumiSpecRawHitAssociations"  // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "EcalLumiSpecRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "EcalLumiSpecRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
       {"EcalLumiSpecTruthClustersWithoutShapes",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)

--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -128,7 +128,7 @@ void InitPlugin(JApplication* app) {
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
           "EcalFarForwardZDCRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
 #endif
-          "EcalFarForwardZDCRawHitAssociations" // edm4eic::MCRecoClusterHitAssociationCollection
+          "EcalFarForwardZDCRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociation
       },
       {"EcalFarForwardZDCClustersWithoutShapes",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)

--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -96,7 +96,10 @@ void InitPlugin(JApplication* app) {
       "EcalFarForwardZDCTruthClustersWithoutShapes",
       {
           "EcalFarForwardZDCTruthProtoClusters", // edm4eic::ProtoClusterCollection
-          "EcalFarForwardZDCRawHitAssociations"  // edm4eic::MCRecoClusterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "EcalFarForwardZDCRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "EcalFarForwardZDCRawHitAssociations" // edm4eic::MCRecoClusterHitAssociationCollection
       },
       {"EcalFarForwardZDCTruthClustersWithoutShapes",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
@@ -122,7 +125,10 @@ void InitPlugin(JApplication* app) {
       "EcalFarForwardZDCClustersWithoutShapes",
       {
           "EcalFarForwardZDCIslandProtoClusters", // edm4eic::ProtoClusterCollection
-          "EcalFarForwardZDCRawHitAssociations"   // edm4eic::MCRecoClusterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "EcalFarForwardZDCRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "EcalFarForwardZDCRawHitAssociations" // edm4eic::MCRecoClusterHitAssociationCollection
       },
       {"EcalFarForwardZDCClustersWithoutShapes",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
@@ -245,6 +251,9 @@ void InitPlugin(JApplication* app) {
       "HcalFarForwardZDCClustersWithoutShapes",
       {
           "HcalFarForwardZDCImagingProtoClusters", // edm4eic::ProtoClusterCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "HcalFarForwardZDCRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
           "HcalFarForwardZDCRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
       {"HcalFarForwardZDCClustersWithoutShapes",
@@ -308,6 +317,9 @@ void InitPlugin(JApplication* app) {
       "HcalFarForwardZDCTruthClustersWithoutShapes",
       {
           "HcalFarForwardZDCTruthProtoClusters", // edm4eic::ProtoClusterCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "HcalFarForwardZDCRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
           "HcalFarForwardZDCRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
       {"HcalFarForwardZDCTruthClustersWithoutShapes",
@@ -334,6 +346,9 @@ void InitPlugin(JApplication* app) {
       "HcalFarForwardZDCClustersBaselineWithoutShapes",
       {
           "HcalFarForwardZDCIslandProtoClustersBaseline", // edm4eic::ProtoClusterCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "HcalFarForwardZDCRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
           "HcalFarForwardZDCRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
       {"HcalFarForwardZDCClustersBaselineWithoutShapes", // edm4eic::Cluster

--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -99,7 +99,7 @@ void InitPlugin(JApplication* app) {
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
           "EcalFarForwardZDCRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
 #endif
-          "EcalFarForwardZDCRawHitAssociations" // edm4eic::MCRecoClusterHitAssociationCollection
+          "EcalFarForwardZDCRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociation
       },
       {"EcalFarForwardZDCTruthClustersWithoutShapes",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)

--- a/src/factories/calorimetry/CalorimeterClusterRecoCoG_factory.h
+++ b/src/factories/calorimetry/CalorimeterClusterRecoCoG_factory.h
@@ -20,6 +20,9 @@ private:
   std::unique_ptr<AlgoT> m_algo;
 
   PodioInput<edm4eic::ProtoCluster> m_proto_input{this};
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  PodioInput<edm4eic::MCRecoCalorimeterHitLink> m_mchitlinks_input{this};
+#endif
   PodioInput<edm4eic::MCRecoCalorimeterHitAssociation> m_mchitassocs_input{this};
 
   PodioOutput<edm4eic::Cluster> m_cluster_output{this};
@@ -48,11 +51,16 @@ public:
   }
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
-    m_algo->process({m_proto_input(), m_mchitassocs_input()}, {m_cluster_output().get(),
+    m_algo->process({m_proto_input(),
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-                                                               m_links_output().get(),
+                     m_mchitlinks_input(),
 #endif
-                                                               m_assoc_output().get()});
+                     m_mchitassocs_input()},
+                    {m_cluster_output().get(),
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                     m_links_output().get(),
+#endif
+                     m_assoc_output().get()});
   }
 };
 

--- a/src/factories/calorimetry/ImagingClusterReco_factory.h
+++ b/src/factories/calorimetry/ImagingClusterReco_factory.h
@@ -20,6 +20,9 @@ private:
   std::unique_ptr<AlgoT> m_algo;
 
   PodioInput<edm4eic::ProtoCluster> m_protos_input{this};
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  PodioInput<edm4eic::MCRecoCalorimeterHitLink> m_mchitlinks_input{this};
+#endif
   PodioInput<edm4eic::MCRecoCalorimeterHitAssociation> m_mchitassocs_input{this};
 
   PodioOutput<edm4eic::Cluster> m_clusters_output{this};
@@ -42,7 +45,11 @@ public:
   }
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
-    m_algo->process({m_protos_input(), m_mchitassocs_input()},
+    m_algo->process({m_protos_input(),
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                     m_mchitlinks_input(),
+#endif
+                     m_mchitassocs_input()},
                     {m_clusters_output().get(),
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
                      m_links_output().get(),

--- a/src/factories/fardetectors/FarDetectorLinearTracking_factory.h
+++ b/src/factories/fardetectors/FarDetectorLinearTracking_factory.h
@@ -6,11 +6,11 @@
 #include "services/geometry/dd4hep/DD4hep_service.h"
 
 // Event Model related classes
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
 #include <edm4eic/MCRecoTrackerHitLinkCollection.h>
 #endif
-#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoTrackParticleAssociationCollection.h>
 #include <edm4eic/TrackCollection.h>
 #include <edm4eic/Measurement2DCollection.h>

--- a/src/factories/fardetectors/FarDetectorLinearTracking_factory.h
+++ b/src/factories/fardetectors/FarDetectorLinearTracking_factory.h
@@ -7,6 +7,9 @@
 
 // Event Model related classes
 #include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoTrackerHitLinkCollection.h>
+#endif
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoTrackParticleAssociationCollection.h>
 #include <edm4eic/TrackCollection.h>
@@ -28,6 +31,9 @@ private:
   std::unique_ptr<AlgoT> m_algo;
 
   VariadicPodioInput<edm4eic::Measurement2D> m_hits_input{this};
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  PodioInput<edm4eic::MCRecoTrackerHitLink> m_hits_links_input{this};
+#endif
   PodioInput<edm4eic::MCRecoTrackerHitAssociation> m_hits_association_input{this};
   PodioOutput<edm4eic::Track> m_tracks_output{this};
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
@@ -57,7 +63,11 @@ public:
       }
 
       // Prepare the input tuple
-      auto input = std::make_tuple(hits, m_hits_association_input());
+      auto input = std::make_tuple(hits,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                   m_hits_links_input(),
+#endif
+                                   m_hits_association_input());
 
       m_algo->process(input, {m_tracks_output().get(),
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Needs:
- [ ] ~~https://github.com/eic/EDM4eic/pull/148~~
- [ ] ~~revert 38c3cc7~~
- [x] https://github.com/eic/EICrecon/pull/2372
- [x] convert to using [`podio::LinkNavigator`](https://key4hep.web.cern.ch/podio/links.html#the-linknavigator-utility)

This PR converts calorimetry/CalorimeterClusterRecoCoG (and ImagingClusterReco, which is essentially identical) and fardetectors/FarDetectorLinearTracking to using `podio::LinkNavigator`.

This approach removes an O(n^2) lookup strategy by looping over associations repeatedly to an O(1) lookup per search (in an O(n) loop that does other stuff).

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.