### PR TITLE
feat: pass the seeds relation to edm4eic::Trajectory

### DIFF
--- a/src/algorithms/tracking/ActsToTracks.cc
+++ b/src/algorithms/tracking/ActsToTracks.cc
@@ -80,6 +80,9 @@ void ActsToTracks::process(const Input& input, const Output& output) const {
     unsigned int iseed = seedNumber(track);
     if (iseed < track_seeds->size()) {
       trajectory.setSeed((*track_seeds)[iseed]);
+    } else {
+      warning("ActsToTracks: seed index {} is out of bounds (track_seeds size = {}), seed will not be set for this trajectory",
+              iseed, track_seeds->size());
     }
 
     debug("trajectory state, measurement, outlier, hole: {} {} {} {}", trajectoryState.nStates,

--- a/src/algorithms/tracking/ActsToTracks.cc
+++ b/src/algorithms/tracking/ActsToTracks.cc
@@ -81,7 +81,8 @@ void ActsToTracks::process(const Input& input, const Output& output) const {
     if (iseed < track_seeds->size()) {
       trajectory.setSeed((*track_seeds)[iseed]);
     } else {
-      warning("ActsToTracks: seed index {} is out of bounds (track_seeds size = {}), seed will not be set for this trajectory",
+      warning("ActsToTracks: seed index {} is out of bounds (track_seeds size = {}), seed will not "
+              "be set for this trajectory",
               iseed, track_seeds->size());
     }
 

--- a/src/algorithms/tracking/ActsToTracks.h
+++ b/src/algorithms/tracking/ActsToTracks.h
@@ -10,6 +10,7 @@
 #include <edm4eic/Measurement2DCollection.h>
 #include <edm4eic/TrackCollection.h>
 #include <edm4eic/TrackParametersCollection.h>
+#include <edm4eic/TrackSeedCollection.h>
 #include <edm4eic/TrajectoryCollection.h>
 #include <optional>
 #include <string>
@@ -20,7 +21,8 @@
 namespace eicrecon {
 
 using ActsToTracksAlgorithm = algorithms::Algorithm<
-    algorithms::Input<edm4eic::Measurement2DCollection, ActsExamples::ConstTrackContainer,
+    algorithms::Input<edm4eic::Measurement2DCollection, edm4eic::TrackSeedCollection,
+                      ActsExamples::ConstTrackContainer,
                       std::optional<edm4eic::MCRecoTrackerHitAssociationCollection>>,
     algorithms::Output<edm4eic::TrajectoryCollection, edm4eic::TrackParametersCollection,
                        edm4eic::TrackCollection,
@@ -32,6 +34,7 @@ public:
       : ActsToTracksAlgorithm{name,
                               {
                                   "inputMeasurements",
+                                  "inputTrackSeeds",
                                   "inputActsTracks",
                                   "inputRawTrackerHitAssociations",
                               },

--- a/src/factories/tracking/ActsToTracks_factory.h
+++ b/src/factories/tracking/ActsToTracks_factory.h
@@ -19,6 +19,7 @@ private:
   std::unique_ptr<AlgoT> m_algo;
 
   PodioInput<edm4eic::Measurement2D> m_measurements_input{this};
+  PodioInput<edm4eic::TrackSeed> m_seeds_input{this};
   Input<ActsExamples::ConstTrackContainer> m_acts_tracks_input{this};
   PodioInput<edm4eic::MCRecoTrackerHitAssociation> m_raw_hit_assocs_input{this};
   PodioOutput<edm4eic::Trajectory> m_trajectories_output{this};
@@ -41,6 +42,7 @@ public:
     m_algo->process(
         {
             m_measurements_input(),
+            m_seeds_input(),
             tracks_vec.front(),
             m_raw_hit_assocs_input(),
         },

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -98,6 +98,7 @@ void InitPlugin(JApplication* app) {
       "CentralCKFTruthSeededTracksUnfiltered",
       {
           "CentralTrackerMeasurements",
+          "CentralTrackerTruthSeeds",
           "CentralCKFTruthSeededActsTracksUnfiltered",
           "CentralTrackingRawHitAssociations",
       },
@@ -121,6 +122,7 @@ void InitPlugin(JApplication* app) {
       new JOmniFactoryGeneratorT<ActsToTracks_factory>("CentralCKFTruthSeededTracks",
                                                        {
                                                            "CentralTrackerMeasurements",
+                                                           "CentralTrackerTruthSeeds",
                                                            "CentralCKFTruthSeededActsTracks",
                                                            "CentralTrackingRawHitAssociations",
                                                        },
@@ -147,6 +149,7 @@ void InitPlugin(JApplication* app) {
       new JOmniFactoryGeneratorT<ActsToTracks_factory>("CentralCKFTracksUnfiltered",
                                                        {
                                                            "CentralTrackerMeasurements",
+                                                           "CentralTrackSeeds",
                                                            "CentralCKFActsTracksUnfiltered",
                                                            "CentralTrackingRawHitAssociations",
                                                        },
@@ -168,6 +171,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<ActsToTracks_factory>("CentralCKFTracks",
                                                             {
                                                                 "CentralTrackerMeasurements",
+                                                                "CentralTrackerSeeds",
                                                                 "CentralCKFActsTracks",
                                                                 "CentralTrackingRawHitAssociations",
                                                             },
@@ -275,6 +279,7 @@ void InitPlugin(JApplication* app) {
       "B0TrackerCKFTruthSeededTracksUnfiltered",
       {
           "B0TrackerMeasurements",
+          "B0TrackerTruthSeeds",
           "B0TrackerCKFTruthSeededActsTracksUnfiltered",
           "B0TrackerRawHitAssociations",
       },
@@ -298,6 +303,7 @@ void InitPlugin(JApplication* app) {
       "B0TrackerCKFTruthSeededTracks",
       {
           "B0TrackerMeasurements",
+          "B0TrackerTruthSeeds",
           "B0TrackerCKFTruthSeededActsTracks",
           "B0TrackerRawHitAssociations",
       },
@@ -324,6 +330,7 @@ void InitPlugin(JApplication* app) {
       "B0TrackerCKFTracksUnfiltered",
       {
           "B0TrackerMeasurements",
+          "B0TrackerSeeds",
           "B0TrackerCKFActsTracksUnfiltered",
           "B0TrackerRawHitAssociations",
       },
@@ -346,6 +353,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<ActsToTracks_factory>("B0TrackerCKFTracks",
                                                             {
                                                                 "B0TrackerMeasurements",
+                                                                "B0TrackerSeeds",
                                                                 "B0TrackerCKFActsTracks",
                                                                 "B0TrackerRawHitAssociations",
                                                             },

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -171,7 +171,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<ActsToTracks_factory>("CentralCKFTracks",
                                                             {
                                                                 "CentralTrackerMeasurements",
-                                                                "CentralTrackerSeeds",
+                                                                "CentralTrackSeeds",
                                                                 "CentralCKFActsTracks",
                                                                 "CentralTrackingRawHitAssociations",
                                                             },


### PR DESCRIPTION
### Briefly, what does this PR introduce?
We added proper seed storage in #2306 but forgot to link it in the output edm4eic::Trajectory collection. This PR fixes that oversight.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: edm4eic::Trajectory has seed link)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.