### PR TITLE
feat: write *Links for all *Associations when EDM4EIC >= 8.7.0

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -12,14 +12,15 @@
 #include <boost/algorithm/string/join.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <edm4eic/CalorimeterHitCollection.h>
-#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/Cov3f.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4hep/RawCalorimeterHit.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
+#include <podio/detail/Link.h>
 #include <algorithm>
 #include <cctype>
 #include <cstddef>

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
@@ -12,6 +12,7 @@
 
 #include <algorithms/algorithm.h>
 #include <edm4eic/ClusterCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4hep/CaloHitContribution.h>
 #include <edm4hep/MCParticle.h>
 #include <edm4eic/MCRecoCalorimeterHitAssociationCollection.h>
@@ -29,6 +30,10 @@
 
 #include "CalorimeterClusterRecoCoGConfig.h"
 #include "algorithms/interfaces/WithPodConfig.h"
+
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoClusterParticleLinkCollection.h>
+#endif
 
 static double constWeight(double /*E*/, double /*tE*/, double /*p*/, int /*type*/) { return 1.0; }
 static double linearWeight(double E, double /*tE*/, double /*p*/, int /*type*/) { return E; }
@@ -53,6 +58,9 @@ using CalorimeterClusterRecoCoGAlgorithm = algorithms::Algorithm<
     algorithms::Input<edm4eic::ProtoClusterCollection,
                       std::optional<edm4eic::MCRecoCalorimeterHitAssociationCollection>>,
     algorithms::Output<edm4eic::ClusterCollection,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                       std::optional<edm4eic::MCRecoClusterParticleLinkCollection>,
+#endif
                        std::optional<edm4eic::MCRecoClusterParticleAssociationCollection>>>;
 
 class CalorimeterClusterRecoCoG : public CalorimeterClusterRecoCoGAlgorithm,
@@ -63,10 +71,15 @@ public:
       : CalorimeterClusterRecoCoGAlgorithm{
             name,
             {"inputProtoClusterCollection", "mcRawHitAssocations"},
-            {"outputClusterCollection", "outputAssociations"},
+            {"outputClusterCollection",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+             "outputLinks",
+#endif
+             "outputAssociations"},
             "Reconstruct a cluster with the Center of Gravity method. For "
             "simulation results it optionally creates a Cluster <-> MCParticle "
-            "association provided both optional arguments are provided."} {}
+            "association provided both optional arguments are provided."} {
+  }
 
 public:
   void init() final;
@@ -80,6 +93,9 @@ private:
   std::optional<edm4eic::MutableCluster> reconstruct(const edm4eic::ProtoCluster& pcl) const;
   void associate(const edm4eic::Cluster& cl,
                  const edm4eic::MCRecoCalorimeterHitAssociationCollection* mchitassociations,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                 edm4eic::MCRecoClusterParticleLinkCollection* links,
+#endif
                  edm4eic::MCRecoClusterParticleAssociationCollection* assocs) const;
   static edm4hep::MCParticle get_primary(const edm4hep::CaloHitContribution& contrib);
 };

--- a/src/algorithms/calorimetry/CalorimeterClusterShape.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterShape.cc
@@ -6,6 +6,7 @@
 #include <boost/algorithm/string/join.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <edm4eic/CalorimeterHitCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <podio/ObjectID.h>
@@ -61,7 +62,11 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
 
   // grab inputs/outputs
   const auto [in_clusters, in_associations] = input;
-  auto [out_clusters, out_associations]     = output;
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  auto [out_clusters, out_links, out_associations] = output;
+#else
+  auto [out_clusters, out_associations] = output;
+#endif
 
   // exit if no clusters in collection
   if (in_clusters->empty()) {
@@ -204,7 +209,13 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
     // ----------------------------------------------------------------------
     for (auto in_assoc : *in_associations) {
       if (in_assoc.getRec() == in_clust) {
-        auto mc_par    = in_assoc.getSim();
+        auto mc_par = in_assoc.getSim();
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+        auto out_link = out_links->create();
+        out_link.setFrom(out_clust);
+        out_link.setTo(mc_par);
+        out_link.setWeight(in_assoc.getWeight());
+#endif
         auto out_assoc = out_associations->create();
         out_assoc.setRec(out_clust);
         out_assoc.setSim(mc_par);

--- a/src/algorithms/calorimetry/CalorimeterClusterShape.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterShape.cc
@@ -7,10 +7,13 @@
 #include <boost/range/adaptor/map.hpp>
 #include <edm4eic/CalorimeterHitCollection.h>
 #include <edm4eic/EDM4eicVersion.h>
+#include <edm4hep/MCParticle.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
+#include <podio/detail/Link.h>
+#include <podio/detail/LinkCollectionImpl.h>
 #include <Eigen/Core>
 #include <Eigen/Eigenvalues>
 #include <Eigen/Householder> // IWYU pragma: keep
@@ -22,6 +25,7 @@
 #include <cstddef>
 #include <gsl/pointers>
 #include <iterator>
+#include <memory>
 #include <utility>
 #include <vector>
 

--- a/src/algorithms/calorimetry/CalorimeterClusterShape.h
+++ b/src/algorithms/calorimetry/CalorimeterClusterShape.h
@@ -5,6 +5,7 @@
 
 #include <algorithms/algorithm.h>
 #include <edm4eic/ClusterCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <algorithm>
 #include <cmath>
@@ -18,6 +19,10 @@
 #include "CalorimeterClusterShapeConfig.h"
 #include "algorithms/interfaces/WithPodConfig.h"
 
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoClusterParticleLinkCollection.h>
+#endif
+
 namespace eicrecon {
 
 // --------------------------------------------------------------------------
@@ -27,6 +32,9 @@ using CalorimeterClusterShapeAlgorithm = algorithms::Algorithm<
     algorithms::Input<edm4eic::ClusterCollection,
                       std::optional<edm4eic::MCRecoClusterParticleAssociationCollection>>,
     algorithms::Output<edm4eic::ClusterCollection,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                       std::optional<edm4eic::MCRecoClusterParticleLinkCollection>,
+#endif
                        std::optional<edm4eic::MCRecoClusterParticleAssociationCollection>>>;
 
 // --------------------------------------------------------------------------
@@ -44,8 +52,13 @@ public:
   CalorimeterClusterShape(std::string_view name)
       : CalorimeterClusterShapeAlgorithm{name,
                                          {"inputClusters", "inputMCClusterAssociations"},
-                                         {"outputClusters", "outputMCClusterAssociations"},
-                                         "Computes cluster shape parameters"} {}
+                                         {"outputClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                          "outputMCClusterLinks",
+#endif
+                                          "outputMCClusterAssociations"},
+                                         "Computes cluster shape parameters"} {
+  }
 
   // public methods
   void init() final;

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -23,12 +23,15 @@
 #include <edm4hep/CaloHitContributionCollection.h>
 #include <fmt/format.h>
 #include <podio/RelationRange.h>
+#include <podio/detail/Link.h>
+#include <podio/detail/LinkCollectionImpl.h>
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
 #include <gsl/pointers>
 #include <limits>
 #include <map>
+#include <memory>
 #include <random>
 #include <stdexcept>
 #include <string>

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -18,10 +18,10 @@
 #include <DDSegmentation/BitFieldCoder.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <algorithms/service.h>
-#include <edm4eic/MCRecoCalorimeterHitAssociationCollection.h>
 #include <edm4eic/EDM4eicVersion.h>
+#include <edm4eic/MCRecoCalorimeterHitAssociationCollection.h>
 #include <edm4hep/CaloHitContributionCollection.h>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <podio/RelationRange.h>
 #include <algorithm>
 #include <cmath>

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.h
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.h
@@ -16,6 +16,7 @@
 #include <algorithms/algorithm.h>
 #include <algorithms/geo.h>
 #include <edm4eic/MCRecoCalorimeterHitAssociationCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4hep/EventHeaderCollection.h>
 #include <edm4hep/RawCalorimeterHitCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
@@ -28,11 +29,18 @@
 #include "algorithms/interfaces/UniqueIDGenSvc.h"
 #include "algorithms/interfaces/WithPodConfig.h"
 
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoCalorimeterHitLinkCollection.h>
+#endif
+
 namespace eicrecon {
 
 using CalorimeterHitDigiAlgorithm = algorithms::Algorithm<
     algorithms::Input<edm4hep::EventHeaderCollection, edm4hep::SimCalorimeterHitCollection>,
     algorithms::Output<edm4hep::RawCalorimeterHitCollection,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                       edm4eic::MCRecoCalorimeterHitLinkCollection,
+#endif
                        edm4eic::MCRecoCalorimeterHitAssociationCollection>>;
 
 class CalorimeterHitDigi : public CalorimeterHitDigiAlgorithm,
@@ -43,9 +51,14 @@ public:
       : CalorimeterHitDigiAlgorithm{
             name,
             {"eventHeader", "inputHitCollection"},
-            {"outputRawHitCollection", "outputRawHitAssociationCollection"},
+            {"outputRawHitCollection",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+             "outputHitLinks",
+#endif
+             "outputRawHitAssociationCollection"},
             "Smear energy deposit, digitize within ADC range, add pedestal, "
-            "convert time with smearing resolution, and sum signals."} {}
+            "convert time with smearing resolution, and sum signals."} {
+  }
 
   void init() final;
   void process(const Input&, const Output&) const final;

--- a/src/algorithms/calorimetry/EnergyPositionClusterMerger.cc
+++ b/src/algorithms/calorimetry/EnergyPositionClusterMerger.cc
@@ -2,18 +2,20 @@
 // Copyright (C) 2022 Sylvester Joosten
 
 #include <edm4eic/EDM4eicVersion.h>
-#include "algorithms/calorimetry/EnergyPositionClusterMerger.h"
-
 #include <edm4hep/MCParticle.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <podio/ObjectID.h>
+#include <podio/detail/Link.h>
+#include <podio/detail/LinkCollectionImpl.h>
 #include <cmath>
 #include <cstddef>
 #include <gsl/pointers>
 #include <limits>
+#include <memory>
 #include <vector>
 
+#include "algorithms/calorimetry/EnergyPositionClusterMerger.h"
 #include "algorithms/calorimetry/EnergyPositionClusterMergerConfig.h"
 
 namespace eicrecon {

--- a/src/algorithms/calorimetry/EnergyPositionClusterMerger.h
+++ b/src/algorithms/calorimetry/EnergyPositionClusterMerger.h
@@ -5,12 +5,17 @@
 
 #include <algorithms/algorithm.h>
 #include <edm4eic/ClusterCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <string>
 #include <string_view>
 
 #include "EnergyPositionClusterMergerConfig.h"
 #include "algorithms/interfaces/WithPodConfig.h"
+
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoClusterParticleLinkCollection.h>
+#endif
 
 namespace eicrecon {
 
@@ -19,6 +24,9 @@ using EnergyPositionClusterMergerAlgorithm = algorithms::Algorithm<
         edm4eic::ClusterCollection, edm4eic::MCRecoClusterParticleAssociationCollection,
         edm4eic::ClusterCollection, edm4eic::MCRecoClusterParticleAssociationCollection>,
     algorithms::Output<edm4eic::ClusterCollection,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                       edm4eic::MCRecoClusterParticleLinkCollection,
+#endif
                        edm4eic::MCRecoClusterParticleAssociationCollection>>;
 
 /** Simple algorithm to merge the energy measurement from cluster1 with the position
@@ -42,8 +50,13 @@ public:
             name,
             {"energyClusterCollection", "energyClusterAssociations", "positionClusterCollection",
              "positionClusterAssociations"},
-            {"outputClusterCollection", "outputClusterAssociations"},
-            "Merge energy and position clusters if matching."} {}
+            {"outputClusterCollection",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+             "outputClusterLinks",
+#endif
+             "outputClusterAssociations"},
+            "Merge energy and position clusters if matching."} {
+  }
 
 public:
   void init() {}

--- a/src/algorithms/calorimetry/ImagingClusterReco.cc
+++ b/src/algorithms/calorimetry/ImagingClusterReco.cc
@@ -8,6 +8,7 @@
  *  Author: Chao Peng (ANL), 06/02/2021
  */
 
+#include <edm4eic/EDM4eicVersion.h>
 #include "algorithms/calorimetry/ImagingClusterReco.h"
 
 #include <Evaluator/DD4hepUnits.h>
@@ -35,7 +36,11 @@ namespace eicrecon {
 void ImagingClusterReco::process(const Input& input, const Output& output) const {
 
   const auto [proto, mchitassociations] = input;
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  auto [clusters, links, associations, layers] = output;
+#else
   auto [clusters, associations, layers] = output;
+#endif
 
   for (const auto& pcl : *proto) {
     if (!pcl.getHits().empty() && !pcl.getHits(0).isAvailable()) {
@@ -65,7 +70,11 @@ void ImagingClusterReco::process(const Input& input, const Output& output) const
             "will be performed.");
       continue;
     }
-    associate_mc_particles(cl, mchitassociations, associations);
+    associate_mc_particles(cl, mchitassociations,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                           links,
+#endif
+                           associations);
   }
 
   // debug output
@@ -223,6 +232,9 @@ ImagingClusterReco::fit_track(const std::vector<edm4eic::MutableCluster>& layers
 void ImagingClusterReco::associate_mc_particles(
     const edm4eic::Cluster& cl,
     const edm4eic::MCRecoCalorimeterHitAssociationCollection* mchitassociations,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+    edm4eic::MCRecoClusterParticleLinkCollection* links,
+#endif
     edm4eic::MCRecoClusterParticleAssociationCollection* assocs) const {
   // --------------------------------------------------------------------------
   // Association Logic
@@ -294,6 +306,13 @@ void ImagingClusterReco::associate_mc_particles(
     // calculate weight
     const double weight = contribution / eSimHitSum;
 
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+    // create link
+    auto link = links->create();
+    link.setWeight(weight);
+    link.setFrom(cl);
+    link.setTo(part);
+#endif
     // set association
     auto assoc = assocs->create();
     assoc.setWeight(weight);

--- a/src/algorithms/calorimetry/ImagingClusterReco.cc
+++ b/src/algorithms/calorimetry/ImagingClusterReco.cc
@@ -8,16 +8,15 @@
  *  Author: Chao Peng (ANL), 06/02/2021
  */
 
-#include <edm4eic/EDM4eicVersion.h>
-#include "algorithms/calorimetry/ImagingClusterReco.h"
-
 #include <Evaluator/DD4hepUnits.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4hep/RawCalorimeterHit.h>
 #include <edm4hep/SimCalorimeterHit.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
+#include <podio/detail/Link.h>
 #include <Eigen/Core>
 #include <Eigen/Householder> // IWYU pragma: keep
 #include <Eigen/Jacobi>
@@ -26,9 +25,11 @@
 #include <cmath>
 #include <gsl/pointers>
 #include <map>
+#include <memory>
 #include <new>
 
 #include "algorithms/calorimetry/ClusterTypes.h"
+#include "algorithms/calorimetry/ImagingClusterReco.h"
 #include "algorithms/calorimetry/ImagingClusterRecoConfig.h"
 
 namespace eicrecon {

--- a/src/algorithms/calorimetry/ImagingClusterReco.h
+++ b/src/algorithms/calorimetry/ImagingClusterReco.h
@@ -12,6 +12,7 @@
 
 #include <algorithms/algorithm.h>
 #include <edm4eic/CalorimeterHitCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/ClusterCollection.h>
 #include <edm4eic/MCRecoCalorimeterHitAssociationCollection.h>
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
@@ -28,12 +29,19 @@
 #include "ImagingClusterRecoConfig.h"
 #include "algorithms/interfaces/WithPodConfig.h"
 
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoClusterParticleLinkCollection.h>
+#endif
+
 namespace eicrecon {
 
 using ImagingClusterRecoAlgorithm =
     algorithms::Algorithm<algorithms::Input<edm4eic::ProtoClusterCollection,
                                             edm4eic::MCRecoCalorimeterHitAssociationCollection>,
                           algorithms::Output<edm4eic::ClusterCollection,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                             edm4eic::MCRecoClusterParticleLinkCollection,
+#endif
                                              edm4eic::MCRecoClusterParticleAssociationCollection,
                                              edm4eic::ClusterCollection>>;
 
@@ -49,11 +57,15 @@ class ImagingClusterReco : public ImagingClusterRecoAlgorithm,
 
 public:
   ImagingClusterReco(std::string_view name)
-      : ImagingClusterRecoAlgorithm{
-            name,
-            {"inputProtoClusterCollection", "mcRawHitAssocations"},
-            {"outputClusterCollection", "outputClusterAssociations", "outputLayerCollection"},
-            "Reconstruct the cluster/layer info for imaging calorimeter."} {}
+      : ImagingClusterRecoAlgorithm{name,
+                                    {"inputProtoClusterCollection", "mcRawHitAssocations"},
+                                    {"outputClusterCollection",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                     "outputClusterLinks",
+#endif
+                                     "outputClusterAssociations", "outputLayerCollection"},
+                                    "Reconstruct the cluster/layer info for imaging calorimeter."} {
+  }
 
 public:
   void init() {}
@@ -75,6 +87,9 @@ private:
   void associate_mc_particles(
       const edm4eic::Cluster& cl,
       const edm4eic::MCRecoCalorimeterHitAssociationCollection* mchitassociations,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      edm4eic::MCRecoClusterParticleLinkCollection* links,
+#endif
       edm4eic::MCRecoClusterParticleAssociationCollection* assocs) const;
 
   edm4hep::MCParticle get_primary(const edm4hep::CaloHitContribution& contrib) const;

--- a/src/algorithms/calorimetry/TruthEnergyPositionClusterMerger.cc
+++ b/src/algorithms/calorimetry/TruthEnergyPositionClusterMerger.cc
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022 Sylvester Joosten
 
+#include <edm4eic/EDM4eicVersion.h>
 #include "algorithms/calorimetry/TruthEnergyPositionClusterMerger.h"
 
 #include <Evaluator/DD4hepUnits.h>
@@ -18,7 +19,11 @@ namespace eicrecon {
 void TruthEnergyPositionClusterMerger::process(const Input& input, const Output& output) const {
 
   const auto [mcparticles, energy_clus, energy_assoc, pos_clus, pos_assoc] = input;
-  auto [merged_clus, merged_assoc]                                         = output;
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  auto [merged_clus, merged_links, merged_assoc] = output;
+#else
+  auto [merged_clus, merged_assoc] = output;
+#endif
 
   debug("Merging energy and position clusters for new event");
 
@@ -79,6 +84,12 @@ void TruthEnergyPositionClusterMerger::process(const Input& input, const Output&
             new_clus.getEnergy());
 
       // set association
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      auto clusterlink = merged_links->create();
+      clusterlink.setWeight(1.0);
+      clusterlink.setFrom(new_clus);
+      clusterlink.setTo((*mcparticles)[mcID]);
+#endif
       auto clusterassoc = merged_assoc->create();
       clusterassoc.setWeight(1.0);
       clusterassoc.setRec(new_clus);
@@ -94,6 +105,12 @@ void TruthEnergyPositionClusterMerger::process(const Input& input, const Output&
       merged_clus->push_back(new_clus);
 
       // set association
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      auto clusterlink = merged_links->create();
+      clusterlink.setWeight(1.0);
+      clusterlink.setFrom(new_clus);
+      clusterlink.setTo((*mcparticles)[mcID]);
+#endif
       auto clusterassoc = merged_assoc->create();
       clusterassoc.setWeight(1.0);
       clusterassoc.setRec(new_clus);
@@ -126,6 +143,12 @@ void TruthEnergyPositionClusterMerger::process(const Input& input, const Output&
           new_clus.getEnergy());
 
     // set association
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+    auto clusterlink = merged_links->create();
+    clusterlink.setWeight(1.0);
+    clusterlink.setFrom(new_clus);
+    clusterlink.setTo(mc);
+#endif
     auto clusterassoc = merged_assoc->create();
     clusterassoc.setWeight(1.0);
     clusterassoc.setRec(new_clus);

--- a/src/algorithms/calorimetry/TruthEnergyPositionClusterMerger.cc
+++ b/src/algorithms/calorimetry/TruthEnergyPositionClusterMerger.cc
@@ -1,18 +1,21 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022 Sylvester Joosten
 
-#include <edm4eic/EDM4eicVersion.h>
-#include "algorithms/calorimetry/TruthEnergyPositionClusterMerger.h"
-
 #include <Evaluator/DD4hepUnits.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
+#include <podio/detail/Link.h>
+#include <podio/detail/LinkCollectionImpl.h>
 #include <cmath>
 #include <gsl/pointers>
 #include <initializer_list>
+#include <memory>
 #include <vector>
+
+#include "algorithms/calorimetry/TruthEnergyPositionClusterMerger.h"
 
 namespace eicrecon {
 

--- a/src/algorithms/calorimetry/TruthEnergyPositionClusterMerger.h
+++ b/src/algorithms/calorimetry/TruthEnergyPositionClusterMerger.h
@@ -5,6 +5,7 @@
 
 #include <algorithms/algorithm.h>
 #include <edm4eic/ClusterCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <edm4hep/MCParticleCollection.h>
 #include <map>
@@ -12,6 +13,10 @@
 #include <string_view>
 
 #include "algorithms/interfaces/WithPodConfig.h"
+
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoClusterParticleLinkCollection.h>
+#endif
 
 namespace eicrecon {
 
@@ -21,6 +26,9 @@ using TruthEnergyPositionClusterMergerAlgorithm = algorithms::Algorithm<
                       edm4eic::ClusterCollection,
                       edm4eic::MCRecoClusterParticleAssociationCollection>,
     algorithms::Output<edm4eic::ClusterCollection,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                       edm4eic::MCRecoClusterParticleLinkCollection,
+#endif
                        edm4eic::MCRecoClusterParticleAssociationCollection>>;
 
 /** Simple algorithm to merge the energy measurement from cluster1 with the position
@@ -40,8 +48,13 @@ public:
             name,
             {"mcParticles", "energyClusterCollection", "energyClusterAssociations",
              "positionClusterCollection", "positionClusterAssociations"},
-            {"outputClusterCollection", "outputClusterAssociations"},
-            "Merge energy and position clusters based on truth."} {}
+            {"outputClusterCollection",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+             "outputClusterLinks",
+#endif
+             "outputClusterAssociations"},
+            "Merge energy and position clusters based on truth."} {
+  }
 
 public:
   void init() {}

--- a/src/algorithms/digi/MPGDTrackerDigi.cc
+++ b/src/algorithms/digi/MPGDTrackerDigi.cc
@@ -42,12 +42,15 @@
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
 #include <fmt/format.h>
+#include <podio/detail/Link.h>
+#include <podio/detail/LinkCollectionImpl.h>
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <gsl/pointers>
 #include <initializer_list>
 #include <iterator>
+#include <memory>
 #include <random>
 #include <stdexcept>
 #include <unordered_map>

--- a/src/algorithms/digi/MPGDTrackerDigi.cc
+++ b/src/algorithms/digi/MPGDTrackerDigi.cc
@@ -37,6 +37,7 @@
 // Access "algorithms:GeoSvc"
 #include <algorithms/geo.h>
 #include <algorithms/logger.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
@@ -103,7 +104,11 @@ void MPGDTrackerDigi::process(const MPGDTrackerDigi::Input& input,
   // - The simulation is simplistic: single-hit cluster per coordinate.
 
   const auto [headers, sim_hits] = input;
-  auto [raw_hits, associations]  = output;
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  auto [raw_hits, links, associations] = output;
+#else
+  auto [raw_hits, associations] = output;
+#endif
 
   // local random generator
   auto seed = m_uid.getUniqueID(*headers, name());
@@ -220,6 +225,13 @@ void MPGDTrackerDigi::process(const MPGDTrackerDigi::Input& input,
       CellIDs cIDs = *sim_it++;
       for (CellID cID : {cIDs.first, cIDs.second}) {
         if (item.first == cID) {
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          // create link
+          auto link = links->create();
+          link.setFrom(item.second);
+          link.setTo(sim_hit);
+          link.setWeight(1.0);
+#endif
           // set association
           auto hitassoc = associations->create();
           hitassoc.setWeight(1.0);

--- a/src/algorithms/digi/MPGDTrackerDigi.h
+++ b/src/algorithms/digi/MPGDTrackerDigi.h
@@ -7,6 +7,7 @@
 #include <DD4hep/Segmentations.h>
 #include <algorithms/algorithm.h>
 #include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/RawTrackerHitCollection.h>
 #include <edm4hep/EventHeaderCollection.h>
 #include <edm4hep/SimTrackerHitCollection.h>
@@ -17,11 +18,18 @@
 #include "algorithms/interfaces/UniqueIDGenSvc.h"
 #include "algorithms/interfaces/WithPodConfig.h"
 
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoTrackerHitLinkCollection.h>
+#endif
+
 namespace eicrecon {
 
 using MPGDTrackerDigiAlgorithm = algorithms::Algorithm<
     algorithms::Input<edm4hep::EventHeaderCollection, edm4hep::SimTrackerHitCollection>,
     algorithms::Output<edm4eic::RawTrackerHitCollection,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                       edm4eic::MCRecoTrackerHitLinkCollection,
+#endif
                        edm4eic::MCRecoTrackerHitAssociationCollection>>;
 
 class MPGDTrackerDigi : public MPGDTrackerDigiAlgorithm,
@@ -32,9 +40,14 @@ public:
       : MPGDTrackerDigiAlgorithm{
             name,
             {"eventHeaderCollection", "inputHitCollection"},
-            {"outputRawHitCollection", "outputHitAssociations"},
+            {"outputRawHitCollection",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+             "outputHitLinks",
+#endif
+             "outputHitAssociations"},
             "2D-strip segmentation, apply threshold, digitize within ADC range, "
-            "convert time with smearing resolution."} {}
+            "convert time with smearing resolution."} {
+  }
 
   void init() final;
   void process(const Input&, const Output&) const final;

--- a/src/algorithms/digi/PhotoMultiplierHitDigi.cc
+++ b/src/algorithms/digi/PhotoMultiplierHitDigi.cc
@@ -15,15 +15,14 @@
 #include "PhotoMultiplierHitDigi.h"
 
 #include <Evaluator/DD4hepUnits.h>
-#include <algorithm>
 #include <algorithms/logger.h>
-#include <cmath>
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4hep/Vector3d.h>
-#include <fmt/core.h>
+#include <podio/ObjectID.h>
+#include <algorithm>
+#include <cmath>
 #include <gsl/pointers>
 #include <iterator>
-#include <podio/ObjectID.h>
 
 #include "algorithms/digi/PhotoMultiplierHitDigiConfig.h"
 

--- a/src/algorithms/digi/PhotoMultiplierHitDigi.cc
+++ b/src/algorithms/digi/PhotoMultiplierHitDigi.cc
@@ -19,10 +19,13 @@
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4hep/Vector3d.h>
 #include <podio/ObjectID.h>
+#include <podio/detail/Link.h>
+#include <podio/detail/LinkCollectionImpl.h>
 #include <algorithm>
 #include <cmath>
 #include <gsl/pointers>
 #include <iterator>
+#include <memory>
 
 #include "algorithms/digi/PhotoMultiplierHitDigiConfig.h"
 

--- a/src/algorithms/digi/PhotoMultiplierHitDigi.h
+++ b/src/algorithms/digi/PhotoMultiplierHitDigi.h
@@ -21,6 +21,7 @@
 #include <Math/GenVector/DisplacementVector3D.h>
 #include <algorithms/algorithm.h>
 #include <algorithms/geo.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
 #include <edm4eic/RawTrackerHitCollection.h>
 #include <edm4hep/EventHeaderCollection.h>
@@ -43,11 +44,18 @@
 #include "algorithms/interfaces/UniqueIDGenSvc.h"
 #include "algorithms/interfaces/WithPodConfig.h"
 
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoTrackerHitLinkCollection.h>
+#endif
+
 namespace eicrecon {
 
 using PhotoMultiplierHitDigiAlgorithm = algorithms::Algorithm<
     algorithms::Input<edm4hep::EventHeaderCollection, edm4hep::SimTrackerHitCollection>,
     algorithms::Output<edm4eic::RawTrackerHitCollection,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                       edm4eic::MCRecoTrackerHitLinkCollection,
+#endif
                        edm4eic::MCRecoTrackerHitAssociationCollection>>;
 
 class PhotoMultiplierHitDigi : public PhotoMultiplierHitDigiAlgorithm,
@@ -57,9 +65,14 @@ public:
   PhotoMultiplierHitDigi(std::string_view name)
       : PhotoMultiplierHitDigiAlgorithm{name,
                                         {"eventHeaderCollection", "inputHitCollection"},
-                                        {"outputRawHitCollection", "outputRawHitAssociations"},
+                                        {"outputRawHitCollection",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                         "outputHitLinks",
+#endif
+                                         "outputRawHitAssociations"},
                                         "Digitize within ADC range, add pedestal, convert time "
-                                        "with smearing resolution."} {}
+                                        "with smearing resolution."} {
+  }
 
   void init() final;
   void process(const Input&, const Output&) const final;

--- a/src/algorithms/digi/PulseCombiner.cc
+++ b/src/algorithms/digi/PulseCombiner.cc
@@ -3,6 +3,7 @@
 //
 // Combine pulses into a larger pulse if they are within a certain time of each other
 
+#include <edm4eic/EDM4eicVersion.h>
 #include <DD4hep/Detector.h>
 #include <DD4hep/IDDescriptor.h>
 #include <DD4hep/Readout.h>

--- a/src/algorithms/digi/PulseCombiner.cc
+++ b/src/algorithms/digi/PulseCombiner.cc
@@ -3,17 +3,16 @@
 //
 // Combine pulses into a larger pulse if they are within a certain time of each other
 
-#include <edm4eic/EDM4eicVersion.h>
 #include <DD4hep/Detector.h>
 #include <DD4hep/IDDescriptor.h>
 #include <DD4hep/Readout.h>
 #include <DDSegmentation/BitFieldCoder.h>
 #include <algorithms/geo.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4hep/MCParticle.h>
 #include <edm4hep/SimCalorimeterHit.h>
 #include <edm4hep/SimTrackerHit.h>
 #include <edm4hep/Vector3f.h>
-#include <fmt/core.h>
 #include <podio/RelationRange.h>
 #include <algorithm>
 #include <cmath>

--- a/src/algorithms/digi/PulseGeneration.cc
+++ b/src/algorithms/digi/PulseGeneration.cc
@@ -5,6 +5,7 @@
 // Convert energy deposition into ADC pulses
 // ADC pulses are assumed to follow the shape of landau function
 
+#include <edm4eic/EDM4eicVersion.h>
 #include "PulseGeneration.h"
 
 #include <RtypesCore.h>

--- a/src/algorithms/digi/PulseNoise.cc
+++ b/src/algorithms/digi/PulseNoise.cc
@@ -4,6 +4,7 @@
 // Adds noise to a time series pulse
 //
 
+#include <edm4eic/EDM4eicVersion.h>
 #include <DDDigi/noise/FalphaNoise.h>
 #include <edm4hep/MCParticle.h>
 #include <edm4hep/SimCalorimeterHit.h>

--- a/src/algorithms/digi/SiliconTrackerDigi.cc
+++ b/src/algorithms/digi/SiliconTrackerDigi.cc
@@ -6,10 +6,13 @@
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
+#include <podio/detail/Link.h>
+#include <podio/detail/LinkCollectionImpl.h>
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <gsl/pointers>
+#include <memory>
 #include <random>
 #include <unordered_map>
 #include <utility>

--- a/src/algorithms/digi/SiliconTrackerDigi.cc
+++ b/src/algorithms/digi/SiliconTrackerDigi.cc
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022 Whitney Armstrong, Wouter Deconinck, Sylvester Joosten, Dmitry Romanov
 
+#include <edm4eic/EDM4eicVersion.h>
 #include "SiliconTrackerDigi.h"
 
 #include <Evaluator/DD4hepUnits.h>
@@ -25,7 +26,11 @@ void SiliconTrackerDigi::process(const SiliconTrackerDigi::Input& input,
                                  const SiliconTrackerDigi::Output& output) const {
 
   const auto [headers, sim_hits] = input;
-  auto [raw_hits, associations]  = output;
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  auto [raw_hits, links, associations] = output;
+#else
+  auto [raw_hits, associations] = output;
+#endif
 
   // local random generator
   auto seed = m_uid.getUniqueID(*headers, name());
@@ -87,6 +92,13 @@ void SiliconTrackerDigi::process(const SiliconTrackerDigi::Input& input,
 
     for (const auto& sim_hit : *sim_hits) {
       if (item.first == sim_hit.getCellID()) {
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+        // create link
+        auto link = links->create();
+        link.setFrom(item.second);
+        link.setTo(sim_hit);
+        link.setWeight(1.0);
+#endif
         // set association
         auto hitassoc = associations->create();
         hitassoc.setWeight(1.0);

--- a/src/algorithms/digi/SiliconTrackerDigi.cc
+++ b/src/algorithms/digi/SiliconTrackerDigi.cc
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022 Whitney Armstrong, Wouter Deconinck, Sylvester Joosten, Dmitry Romanov
 
-#include <edm4eic/EDM4eicVersion.h>
-#include "SiliconTrackerDigi.h"
-
 #include <Evaluator/DD4hepUnits.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
@@ -16,6 +14,7 @@
 #include <unordered_map>
 #include <utility>
 
+#include "SiliconTrackerDigi.h"
 #include "algorithms/digi/SiliconTrackerDigiConfig.h"
 
 namespace eicrecon {

--- a/src/algorithms/digi/SiliconTrackerDigi.h
+++ b/src/algorithms/digi/SiliconTrackerDigi.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <algorithms/algorithm.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
 #include <edm4eic/RawTrackerHitCollection.h>
 #include <edm4hep/EventHeaderCollection.h>
@@ -15,11 +16,18 @@
 #include "algorithms/interfaces/UniqueIDGenSvc.h"
 #include "algorithms/interfaces/WithPodConfig.h"
 
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoTrackerHitLinkCollection.h>
+#endif
+
 namespace eicrecon {
 
 using SiliconTrackerDigiAlgorithm = algorithms::Algorithm<
     algorithms::Input<edm4hep::EventHeaderCollection, edm4hep::SimTrackerHitCollection>,
     algorithms::Output<edm4eic::RawTrackerHitCollection,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                       edm4eic::MCRecoTrackerHitLinkCollection,
+#endif
                        edm4eic::MCRecoTrackerHitAssociationCollection>>;
 
 class SiliconTrackerDigi : public SiliconTrackerDigiAlgorithm,
@@ -29,9 +37,14 @@ public:
   SiliconTrackerDigi(std::string_view name)
       : SiliconTrackerDigiAlgorithm{name,
                                     {"eventHeaderCollection", "inputHitCollection"},
-                                    {"outputRawHitCollection", "outputHitAssociations"},
+                                    {"outputRawHitCollection",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                     "outputHitLinks",
+#endif
+                                     "outputHitAssociations"},
                                     "Apply threshold, digitize within ADC range, "
-                                    "convert time with smearing resolution."} {}
+                                    "convert time with smearing resolution."} {
+  }
 
   void init() final;
   void process(const Input&, const Output&) const final;

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -21,6 +21,7 @@
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <podio/RelationRange.h>
+#include <podio/detail/Link.h>
 #include <Eigen/Geometry>
 #include <Eigen/Householder>
 #include <Eigen/Jacobi>
@@ -29,6 +30,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <new>
 #include <unordered_map>
 #include <utility>

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -7,6 +7,7 @@
 #include <Math/GenVector/DisplacementVector3D.h>
 #include <algorithms/geo.h>
 #include <edm4eic/Cov6f.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoTrackParticleAssociationCollection.h>
 #include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
 #include <edm4eic/Measurement2DCollection.h>
@@ -61,7 +62,11 @@ void FarDetectorLinearTracking::process(const FarDetectorLinearTracking::Input& 
                                         const FarDetectorLinearTracking::Output& output) const {
 
   const auto [inputhits, assocHits] = input;
-  auto [outputTracks, assocTracks]  = output;
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  auto [outputTracks, trackLinks, assocTracks] = output;
+#else
+  auto [outputTracks, assocTracks] = output;
+#endif
 
   // Check the number of input collections is correct
   std::size_t nCollections = inputhits.size();
@@ -110,8 +115,11 @@ void FarDetectorLinearTracking::process(const FarDetectorLinearTracking::Input& 
     if (isValid) {
       if (layer == static_cast<long>(m_cfg.n_layer) - 1) {
         // Check the combination, if chi2 limit is passed, add the track to the output
-        checkHitCombination(&hitMatrix, outputTracks, assocTracks, inputhits, assocParts,
-                            layerHitIndex);
+        checkHitCombination(&hitMatrix, outputTracks,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                            trackLinks,
+#endif
+                            assocTracks, inputhits, assocParts, layerHitIndex);
       } else {
         layer++;
         continue;
@@ -141,6 +149,9 @@ void FarDetectorLinearTracking::process(const FarDetectorLinearTracking::Input& 
 
 void FarDetectorLinearTracking::checkHitCombination(
     Eigen::MatrixXd* hitMatrix, edm4eic::TrackCollection* outputTracks,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+    edm4eic::MCRecoTrackParticleLinkCollection* trackLinks,
+#endif
     edm4eic::MCRecoTrackParticleAssociationCollection* assocTracks,
     const std::vector<gsl::not_null<const edm4eic::Measurement2DCollection*>>& inputHits,
     const std::vector<std::vector<edm4hep::MCParticle>>& assocParts,
@@ -197,6 +208,12 @@ void FarDetectorLinearTracking::checkHitCombination(
 
   // Create track associations for each particle
   for (const auto& [particle, count] : particleCount) {
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+    auto trackLink = trackLinks->create();
+    trackLink.setFrom(track);
+    trackLink.setTo(*particle);
+    trackLink.setWeight(count / static_cast<double>(m_cfg.n_layer));
+#endif
     auto trackAssoc = assocTracks->create();
     trackAssoc.setRec(track);
     trackAssoc.setSim(*particle);

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -20,7 +20,6 @@
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <fmt/core.h>
 #include <podio/RelationRange.h>
 #include <Eigen/Geometry>
 #include <Eigen/Householder>

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.h
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.h
@@ -7,6 +7,7 @@
 #include <algorithms/algorithm.h>
 #include <algorithms/interfaces/WithPodConfig.h>
 #include <edm4eic/MCRecoTrackParticleAssociationCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
 #include <edm4eic/Measurement2DCollection.h>
 #include <edm4eic/TrackCollection.h>
@@ -21,12 +22,19 @@
 
 #include "FarDetectorLinearTrackingConfig.h"
 
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoTrackParticleLinkCollection.h>
+#endif
+
 namespace eicrecon {
 
 using FarDetectorLinearTrackingAlgorithm = algorithms::Algorithm<
     algorithms::Input<std::vector<edm4eic::Measurement2DCollection>,
                       std::optional<edm4eic::MCRecoTrackerHitAssociationCollection>>,
     algorithms::Output<edm4eic::TrackCollection,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                       std::optional<edm4eic::MCRecoTrackParticleLinkCollection>,
+#endif
                        std::optional<edm4eic::MCRecoTrackParticleAssociationCollection>>>;
 
 class FarDetectorLinearTracking : public FarDetectorLinearTrackingAlgorithm,
@@ -37,8 +45,13 @@ public:
       : FarDetectorLinearTrackingAlgorithm{
             name,
             {"inputHitCollections", "inputMCRecoTrackerHitAssociations"},
-            {"outputTrackCollection", "outputMCRecoTrackAssociations"},
-            "Fit track segments from hits in the tracker layers"} {}
+            {"outputTrackCollection",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+             "outputMCRecoTrackLinks",
+#endif
+             "outputMCRecoTrackAssociations"},
+            "Fit track segments from hits in the tracker layers"} {
+  }
 
   /** One time initialization **/
   void init() final;
@@ -54,6 +67,9 @@ private:
 
   void checkHitCombination(
       Eigen::MatrixXd* hitMatrix, edm4eic::TrackCollection* outputTracks,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      edm4eic::MCRecoTrackParticleLinkCollection* trackLinks,
+#endif
       edm4eic::MCRecoTrackParticleAssociationCollection* assocTracks,
       const std::vector<gsl::not_null<const edm4eic::Measurement2DCollection*>>& inputHits,
       const std::vector<std::vector<edm4hep::MCParticle>>& assocParts,

--- a/src/algorithms/fardetectors/FarDetectorTransportationPostML.cc
+++ b/src/algorithms/fardetectors/FarDetectorTransportationPostML.cc
@@ -3,7 +3,7 @@
 
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4hep/Vector3f.h>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <podio/RelationRange.h>
 #include <cmath>
 #include <cstddef>

--- a/src/algorithms/fardetectors/FarDetectorTransportationPostML.cc
+++ b/src/algorithms/fardetectors/FarDetectorTransportationPostML.cc
@@ -5,9 +5,12 @@
 #include <edm4hep/Vector3f.h>
 #include <fmt/format.h>
 #include <podio/RelationRange.h>
+#include <podio/detail/Link.h>
+#include <podio/detail/LinkCollectionImpl.h>
 #include <cmath>
 #include <cstddef>
 #include <gsl/pointers>
+#include <memory>
 #include <stdexcept>
 
 #include "FarDetectorTransportationPostML.h"

--- a/src/algorithms/fardetectors/FarDetectorTransportationPostML.h
+++ b/src/algorithms/fardetectors/FarDetectorTransportationPostML.h
@@ -5,6 +5,7 @@
 
 #include <algorithms/algorithm.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoParticleAssociationCollection.h>
 #include <edm4eic/MCRecoTrackParticleAssociationCollection.h>
 #include <edm4eic/TensorCollection.h>
@@ -17,6 +18,10 @@
 #include "algorithms/fardetectors/FarDetectorTransportationPostMLConfig.h"
 #include "algorithms/interfaces/WithPodConfig.h"
 
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoParticleLinkCollection.h>
+#endif
+
 namespace eicrecon {
 
 using FarDetectorTransportationPostMLAlgorithm = algorithms::Algorithm<
@@ -24,6 +29,9 @@ using FarDetectorTransportationPostMLAlgorithm = algorithms::Algorithm<
                       std::optional<edm4eic::MCRecoTrackParticleAssociationCollection>,
                       std::optional<edm4hep::MCParticleCollection>>,
     algorithms::Output<edm4eic::ReconstructedParticleCollection,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                       edm4eic::MCRecoParticleLinkCollection,
+#endif
                        edm4eic::MCRecoParticleAssociationCollection>>;
 
 class FarDetectorTransportationPostML
@@ -35,8 +43,13 @@ public:
       : FarDetectorTransportationPostMLAlgorithm{
             name,
             {"inputPredictionsTensor", "trackAssociations", "beamElectrons"},
-            {"outputParticles", "outputAssociations"},
-            "Convert ML output tensor into reconstructed electron"} {}
+            {"outputParticles",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+             "outputLinks",
+#endif
+             "outputAssociations"},
+            "Convert ML output tensor into reconstructed electron"} {
+  }
 
   void init() final;
   void process(const Input&, const Output&) const final;

--- a/src/algorithms/onnx/CalorimeterParticleIDPostML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPostML.cc
@@ -2,8 +2,8 @@
 // Copyright (C) 2024 Dmitry Kalinkin
 
 #include <edm4eic/EDM4eicVersion.h>
+#include <fmt/format.h>
 #include <cstddef>
-#include <fmt/core.h>
 #include <gsl/pointers>
 #include <stdexcept>
 

--- a/src/algorithms/onnx/CalorimeterParticleIDPostML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPostML.cc
@@ -2,9 +2,13 @@
 // Copyright (C) 2024 Dmitry Kalinkin
 
 #include <edm4eic/EDM4eicVersion.h>
+#include <edm4hep/MCParticle.h>
 #include <fmt/format.h>
+#include <podio/detail/Link.h>
+#include <podio/detail/LinkCollectionImpl.h>
 #include <cstddef>
 #include <gsl/pointers>
+#include <memory>
 #include <stdexcept>
 
 #include "CalorimeterParticleIDPostML.h"

--- a/src/algorithms/onnx/CalorimeterParticleIDPostML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPostML.cc
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2024 Dmitry Kalinkin
 
+#include <edm4eic/EDM4eicVersion.h>
 #include <cstddef>
 #include <fmt/core.h>
 #include <gsl/pointers>
@@ -18,7 +19,11 @@ void CalorimeterParticleIDPostML::process(const CalorimeterParticleIDPostML::Inp
                                           const CalorimeterParticleIDPostML::Output& output) const {
 
   const auto [in_clusters, in_assocs, prediction_tensors] = input;
-  auto [out_clusters, out_assocs, out_particle_ids]       = output;
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  auto [out_clusters, out_links, out_assocs, out_particle_ids] = output;
+#else
+  auto [out_clusters, out_assocs, out_particle_ids] = output;
+#endif
 
   if (prediction_tensors->size() != 1) {
     error("Expected to find a single tensor, found {}", prediction_tensors->size());
@@ -79,6 +84,12 @@ void CalorimeterParticleIDPostML::process(const CalorimeterParticleIDPostML::Inp
     // propagate associations
     for (auto in_assoc : *in_assocs) {
       if (in_assoc.getRec() == in_cluster) {
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+        auto out_link = out_links->create();
+        out_link.setFrom(out_cluster);
+        out_link.setTo(in_assoc.getSim());
+        out_link.setWeight(in_assoc.getWeight());
+#endif
         auto out_assoc = in_assoc.clone();
         out_assoc.setRec(out_cluster);
         out_assocs->push_back(out_assoc);

--- a/src/algorithms/onnx/CalorimeterParticleIDPostML.h
+++ b/src/algorithms/onnx/CalorimeterParticleIDPostML.h
@@ -5,6 +5,7 @@
 
 #include <algorithms/algorithm.h>
 #include <edm4eic/ClusterCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <edm4eic/TensorCollection.h>
 #include <edm4hep/ParticleIDCollection.h>
@@ -14,6 +15,10 @@
 
 #include "algorithms/interfaces/WithPodConfig.h"
 
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoClusterParticleLinkCollection.h>
+#endif
+
 namespace eicrecon {
 
 using CalorimeterParticleIDPostMLAlgorithm = algorithms::Algorithm<
@@ -21,6 +26,9 @@ using CalorimeterParticleIDPostMLAlgorithm = algorithms::Algorithm<
                       std::optional<edm4eic::MCRecoClusterParticleAssociationCollection>,
                       edm4eic::TensorCollection>,
     algorithms::Output<edm4eic::ClusterCollection,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                       std::optional<edm4eic::MCRecoClusterParticleLinkCollection>,
+#endif
                        std::optional<edm4eic::MCRecoClusterParticleAssociationCollection>,
                        edm4hep::ParticleIDCollection>>;
 
@@ -32,8 +40,13 @@ public:
       : CalorimeterParticleIDPostMLAlgorithm{
             name,
             {"inputClusters", "inputClusterAssociations", "inputPredictionsTensor"},
-            {"outputClusters", "outputClusterAssociations", "outputParticleIDs"},
-            ""} {}
+            {"outputClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+             "outputClusterLinks",
+#endif
+             "outputClusterAssociations", "outputParticleIDs"},
+            ""} {
+  }
 
   void init() final;
   void process(const Input&, const Output&) const final;

--- a/src/algorithms/pid/MatchToRICHPID.cc
+++ b/src/algorithms/pid/MatchToRICHPID.cc
@@ -3,12 +3,11 @@
 
 #include "MatchToRICHPID.h"
 
-#include <edm4eic/TrackPoint.h>
 #include <edm4eic/EDM4eicVersion.h>
+#include <edm4eic/TrackPoint.h>
 #include <edm4eic/TrackSegmentCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <fmt/core.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
 #include <algorithm>

--- a/src/algorithms/pid/MatchToRICHPID.cc
+++ b/src/algorithms/pid/MatchToRICHPID.cc
@@ -6,15 +6,19 @@
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/TrackPoint.h>
 #include <edm4eic/TrackSegmentCollection.h>
+#include <edm4hep/MCParticle.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
+#include <podio/detail/Link.h>
+#include <podio/detail/LinkCollectionImpl.h>
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
 #include <gsl/pointers>
 #include <map>
+#include <memory>
 #include <vector>
 
 #include "algorithms/pid/ConvertParticleID.h"

--- a/src/algorithms/pid/MatchToRICHPID.cc
+++ b/src/algorithms/pid/MatchToRICHPID.cc
@@ -4,6 +4,7 @@
 #include "MatchToRICHPID.h"
 
 #include <edm4eic/TrackPoint.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/TrackSegmentCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
@@ -27,7 +28,11 @@ void MatchToRICHPID::init() {}
 void MatchToRICHPID::process(const MatchToRICHPID::Input& input,
                              const MatchToRICHPID::Output& output) const {
   const auto [parts_in, assocs_in, drich_cherenkov_pid] = input;
-  auto [parts_out, assocs_out, pids]                    = output;
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  auto [parts_out, links_out, assocs_out, pids] = output;
+#else
+  auto [parts_out, assocs_out, pids] = output;
+#endif
 
   for (auto part_in : *parts_in) {
     auto part_out = part_in.clone();
@@ -41,6 +46,12 @@ void MatchToRICHPID::process(const MatchToRICHPID::Input& input,
 
     for (auto assoc_in : *assocs_in) {
       if (assoc_in.getRec() == part_in) {
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+        auto link_out = links_out->create();
+        link_out.setFrom(part_out);
+        link_out.setTo(assoc_in.getSim());
+        link_out.setWeight(assoc_in.getWeight());
+#endif
         auto assoc_out = assoc_in.clone();
         assoc_out.setRec(part_out);
         assocs_out->push_back(assoc_out);

--- a/src/algorithms/pid/MatchToRICHPID.h
+++ b/src/algorithms/pid/MatchToRICHPID.h
@@ -5,6 +5,7 @@
 
 #include <algorithms/algorithm.h>
 #include <edm4eic/CherenkovParticleIDCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoParticleAssociationCollection.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/ParticleIDCollection.h>
@@ -14,6 +15,10 @@
 #include "MatchToRICHPIDConfig.h"
 #include "algorithms/interfaces/WithPodConfig.h"
 
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoParticleLinkCollection.h>
+#endif
+
 namespace eicrecon {
 
 using MatchToRICHPIDAlgorithm =
@@ -21,18 +26,25 @@ using MatchToRICHPIDAlgorithm =
                                             edm4eic::MCRecoParticleAssociationCollection,
                                             edm4eic::CherenkovParticleIDCollection>,
                           algorithms::Output<edm4eic::ReconstructedParticleCollection,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                             edm4eic::MCRecoParticleLinkCollection,
+#endif
                                              edm4eic::MCRecoParticleAssociationCollection,
                                              edm4hep::ParticleIDCollection>>;
 
 class MatchToRICHPID : public MatchToRICHPIDAlgorithm, public WithPodConfig<MatchToRICHPIDConfig> {
 public:
   MatchToRICHPID(std::string_view name)
-      : MatchToRICHPIDAlgorithm{
-            name,
-            {"inputReconstructedParticlesCollection", "inputAssociationsCollection",
-             "inputCherenkovParticleIDCollection"},
-            {"outputReconstructedParticlesCollection", "outputAssociationsCollection"},
-            "Matches tracks to Cherenkov PIDs"} {};
+      : MatchToRICHPIDAlgorithm{name,
+                                {"inputReconstructedParticlesCollection",
+                                 "inputAssociationsCollection",
+                                 "inputCherenkovParticleIDCollection"},
+                                {"outputReconstructedParticlesCollection",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                 "outputLinks",
+#endif
+                                 "outputAssociationsCollection"},
+                                "Matches tracks to Cherenkov PIDs"} {};
 
   void init() final;
   void process(const Input&, const Output&) const final;

--- a/src/algorithms/pid_lut/PIDLookup.cc
+++ b/src/algorithms/pid_lut/PIDLookup.cc
@@ -8,9 +8,12 @@
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
+#include <podio/detail/Link.h>
+#include <podio/detail/LinkCollectionImpl.h>
 #include <cmath>
 #include <exception>
 #include <gsl/pointers>
+#include <memory>
 #include <random>
 #include <stdexcept>
 #include <vector>

--- a/src/algorithms/pid_lut/PIDLookup.cc
+++ b/src/algorithms/pid_lut/PIDLookup.cc
@@ -3,6 +3,7 @@
 
 #include <algorithms/service.h>
 #include <edm4eic/MCRecoParticleAssociationCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3f.h>
@@ -53,7 +54,11 @@ void PIDLookup::init() {
 
 void PIDLookup::process(const Input& input, const Output& output) const {
   const auto [headers, recoparts_in, partassocs_in] = input;
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  auto [recoparts_out, partlinks_out, partassocs_out, partids_out] = output;
+#else
   auto [recoparts_out, partassocs_out, partids_out] = output;
+#endif
 
   // local random generator
   auto seed = m_uid.getUniqueID(*headers, name());
@@ -70,6 +75,12 @@ void PIDLookup::process(const Input& input, const Output& output) const {
         if ((not best_assoc.isAvailable()) || (best_assoc.getWeight() < assoc_in.getWeight())) {
           best_assoc = assoc_in;
         }
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+        auto link_out = partlinks_out->create();
+        link_out.setFrom(recopart);
+        link_out.setTo(assoc_in.getSim());
+        link_out.setWeight(assoc_in.getWeight());
+#endif
         auto assoc_out = assoc_in.clone();
         assoc_out.setRec(recopart);
         partassocs_out->push_back(assoc_out);

--- a/src/algorithms/pid_lut/PIDLookup.cc
+++ b/src/algorithms/pid_lut/PIDLookup.cc
@@ -2,13 +2,12 @@
 // Copyright (C) 2024, Nathan Brei, Dmitry Kalinkin
 
 #include <algorithms/service.h>
-#include <edm4eic/MCRecoParticleAssociationCollection.h>
 #include <edm4eic/EDM4eicVersion.h>
+#include <edm4eic/MCRecoParticleAssociationCollection.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <fmt/core.h>
 #include <cmath>
 #include <exception>
 #include <gsl/pointers>

--- a/src/algorithms/pid_lut/PIDLookup.h
+++ b/src/algorithms/pid_lut/PIDLookup.h
@@ -7,6 +7,7 @@
 #include <algorithms/algorithm.h>
 #include <algorithms/geo.h>
 #include <edm4eic/MCRecoParticleAssociationCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/EventHeaderCollection.h>
 #include <edm4hep/ParticleIDCollection.h>
@@ -21,12 +22,19 @@
 #include "algorithms/interfaces/WithPodConfig.h"
 #include "services/pid_lut/PIDLookupTable.h"
 
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoParticleLinkCollection.h>
+#endif
+
 namespace eicrecon {
 
 using PIDLookupAlgorithm = algorithms::Algorithm<
     algorithms::Input<edm4hep::EventHeaderCollection, edm4eic::ReconstructedParticleCollection,
                       edm4eic::MCRecoParticleAssociationCollection>,
     algorithms::Output<edm4eic::ReconstructedParticleCollection,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                       edm4eic::MCRecoParticleLinkCollection,
+#endif
                        edm4eic::MCRecoParticleAssociationCollection,
                        edm4hep::ParticleIDCollection>>;
 
@@ -34,11 +42,16 @@ class PIDLookup : public PIDLookupAlgorithm, public WithPodConfig<PIDLookupConfi
 
 public:
   PIDLookup(std::string_view name)
-      : PIDLookupAlgorithm{name,
-                           {"inputParticlesCollection", "inputParticleAssociationsCollection"},
-                           {"outputParticlesCollection", "outputParticleAssociationsCollection",
-                            "outputParticleIDCollection"},
-                           ""} {}
+      : PIDLookupAlgorithm{
+            name,
+            {"eventHeader", "inputParticlesCollection", "inputParticleAssociationsCollection"},
+            {"outputParticlesCollection",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+             "outputParticleLinks",
+#endif
+             "outputParticleAssociationsCollection", "outputParticleIDCollection"},
+            ""} {
+  }
 
   void init() final;
   void process(const Input&, const Output&) const final;

--- a/src/algorithms/reco/MatchClusters.cc
+++ b/src/algorithms/reco/MatchClusters.cc
@@ -15,10 +15,13 @@
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <podio/ObjectID.h>
+#include <podio/detail/Link.h>
+#include <podio/detail/LinkCollectionImpl.h>
 #include <cmath>
 #include <gsl/pointers>
 #include <iterator>
 #include <map>
+#include <memory>
 #include <utility>
 
 #include "MatchClusters.h"

--- a/src/algorithms/reco/MatchClusters.cc
+++ b/src/algorithms/reco/MatchClusters.cc
@@ -7,6 +7,7 @@
 
 #include <algorithms/logger.h>
 #include <edm4eic/ClusterCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <edm4eic/MCRecoParticleAssociationCollection.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
@@ -28,7 +29,11 @@ void MatchClusters::process(const MatchClusters::Input& input,
                             const MatchClusters::Output& output) const {
 
   const auto [mcparticles, inparts, inpartsassoc, clusters, clustersassoc] = input;
-  auto [outparts, outpartsassoc]                                           = output;
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  auto [outparts, outlinks, outpartsassoc] = output;
+#else
+  auto [outparts, outpartsassoc] = output;
+#endif
 
   debug("Processing cluster info for new event");
 
@@ -74,6 +79,12 @@ void MatchClusters::process(const MatchClusters::Input& input,
     }
 
     // create truth associations
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+    auto link = outlinks->create();
+    link.setWeight(1.0);
+    link.setFrom(outpart);
+    link.setTo((*mcparticles)[mcID]);
+#endif
     auto assoc = outpartsassoc->create();
     assoc.setWeight(1.0);
     assoc.setRec(outpart);
@@ -108,6 +119,12 @@ void MatchClusters::process(const MatchClusters::Input& input,
     outparts->push_back(outpart);
 
     // Create truth associations
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+    auto link = outlinks->create();
+    link.setWeight(1.0);
+    link.setFrom(outpart);
+    link.setTo((*mcparticles)[mcID]);
+#endif
     auto assoc = outpartsassoc->create();
     assoc.setWeight(1.0);
     assoc.setRec(outpart);

--- a/src/algorithms/reco/MatchClusters.h
+++ b/src/algorithms/reco/MatchClusters.h
@@ -9,6 +9,7 @@
 
 #include <algorithms/algorithm.h>
 #include <edm4eic/ClusterCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <edm4eic/MCRecoParticleAssociationCollection.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
@@ -20,6 +21,10 @@
 
 #include "algorithms/interfaces/WithPodConfig.h"
 
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoParticleLinkCollection.h>
+#endif
+
 namespace eicrecon {
 
 using MatchClustersAlgorithm = algorithms::Algorithm<
@@ -27,6 +32,9 @@ using MatchClustersAlgorithm = algorithms::Algorithm<
                       edm4eic::MCRecoParticleAssociationCollection, edm4eic::ClusterCollection,
                       edm4eic::MCRecoClusterParticleAssociationCollection>,
     algorithms::Output<edm4eic::ReconstructedParticleCollection,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                       edm4eic::MCRecoParticleLinkCollection,
+#endif
                        edm4eic::MCRecoParticleAssociationCollection>>;
 
 class MatchClusters : public MatchClustersAlgorithm, public WithPodConfig<NoConfig> {
@@ -36,8 +44,13 @@ public:
       : MatchClustersAlgorithm{name,
                                {"MCParticles", "CentralTracks", "CentralTrackAssociations",
                                 "EcalClusters", "EcalClusterAssociations"},
-                               {"ReconstructedParticles", "ReconstructedParticleAssociations"},
-                               "Match tracks with clusters, and assign associations."} {}
+                               {"ReconstructedParticles",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                "ReconstructedParticleLinks",
+#endif
+                                "ReconstructedParticleAssociations"},
+                               "Match tracks with clusters, and assign associations."} {
+  }
 
   void init() final {};
   void process(const Input&, const Output&) const final;

--- a/src/algorithms/tracking/ActsToTracks.cc
+++ b/src/algorithms/tracking/ActsToTracks.cc
@@ -24,6 +24,8 @@
 #include <edm4hep/Vector3f.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
+#include <podio/detail/Link.h>
+#include <podio/detail/LinkCollectionImpl.h>
 #include <Eigen/Core>
 #include <any>
 #include <array>

--- a/src/algorithms/tracking/ActsToTracks.cc
+++ b/src/algorithms/tracking/ActsToTracks.cc
@@ -15,6 +15,7 @@
 #include <ActsExamples/EventData/IndexSourceLink.hpp>
 #include <ActsExamples/EventData/Track.hpp>
 #include <edm4eic/Cov6f.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/RawTrackerHit.h>
 #include <edm4eic/TrackerHit.h>
 #include <edm4hep/MCParticleCollection.h>
@@ -59,7 +60,11 @@ void ActsToTracks::init() {}
 
 void ActsToTracks::process(const Input& input, const Output& output) const {
   const auto [meas2Ds, track_seeds, acts_track_states, acts_tracks, raw_hit_assocs] = input;
-  auto [trajectories, track_parameters, tracks, tracks_assoc]                       = output;
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  auto [trajectories, track_parameters, tracks, tracks_links, tracks_assoc] = output;
+#else
+  auto [trajectories, track_parameters, tracks, tracks_assoc] = output;
+#endif
 
   // Create accessor for seed number dynamic column
   Acts::ConstProxyAccessor<unsigned int> seedNumber("seed");
@@ -210,10 +215,16 @@ void ActsToTracks::process(const Input& input, const Output& output) const {
         mcparticle_weight_by_hit_count.begin(), mcparticle_weight_by_hit_count.end(), 0,
         [](const double sum, const auto& i) { return sum + i.second; });
     for (const auto& [mcparticle, weight] : mcparticle_weight_by_hit_count) {
+      double normalized_weight = weight / total_weight;
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      auto track_link = tracks_links->create();
+      track_link.setFrom(track_out);
+      track_link.setTo(mcparticle);
+      track_link.setWeight(normalized_weight);
+#endif
       auto track_assoc = tracks_assoc->create();
       track_assoc.setRec(track_out);
       track_assoc.setSim(mcparticle);
-      double normalized_weight = weight / total_weight;
       track_assoc.setWeight(normalized_weight);
       debug("track {}: mcparticle {} weight {}", track_out.id().index, mcparticle.id().index,
             normalized_weight);

--- a/src/algorithms/tracking/ActsToTracks.h
+++ b/src/algorithms/tracking/ActsToTracks.h
@@ -7,6 +7,7 @@
 #include <Acts/EventData/VectorTrackContainer.hpp>
 #include <algorithms/algorithm.h>
 #include <edm4eic/MCRecoTrackParticleAssociationCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
 #include <edm4eic/Measurement2DCollection.h>
 #include <edm4eic/TrackCollection.h>
@@ -19,6 +20,10 @@
 
 #include "algorithms/interfaces/WithPodConfig.h"
 
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoTrackParticleLinkCollection.h>
+#endif
+
 namespace eicrecon {
 
 using ActsToTracksAlgorithm = algorithms::Algorithm<
@@ -27,6 +32,9 @@ using ActsToTracksAlgorithm = algorithms::Algorithm<
                       std::optional<edm4eic::MCRecoTrackerHitAssociationCollection>>,
     algorithms::Output<edm4eic::TrajectoryCollection, edm4eic::TrackParametersCollection,
                        edm4eic::TrackCollection,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                       std::optional<edm4eic::MCRecoTrackParticleLinkCollection>,
+#endif
                        std::optional<edm4eic::MCRecoTrackParticleAssociationCollection>>>;
 
 class ActsToTracks : public ActsToTracksAlgorithm, public WithPodConfig<NoConfig> {
@@ -44,6 +52,9 @@ public:
                                   "outputTrajectories",
                                   "outputTrackParameters",
                                   "outputTracks",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                  "outputTrackLinks",
+#endif
                                   "outputTrackAssociations",
                               },
                               "Converts ACTS tracks to EDM4eic"} {};

--- a/src/algorithms/tracking/TracksToParticles.cc
+++ b/src/algorithms/tracking/TracksToParticles.cc
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022 - 2024, Sylvester Joosten, Wouter Deconinck, Dmitry Romanov, Christopher Dilks, Dmitry Kalinkin
 
-#include <edm4eic/TrackParametersCollection.h>
 #include <edm4eic/EDM4eicVersion.h>
+#include <edm4eic/TrackParametersCollection.h>
 #include <edm4eic/TrajectoryCollection.h>
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3d.h>
@@ -10,8 +10,11 @@
 #include <edm4hep/utils/vector_utils.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
+#include <podio/detail/Link.h>
+#include <podio/detail/LinkCollectionImpl.h>
 #include <cmath>
 #include <gsl/pointers>
+#include <memory>
 #include <vector>
 
 #include "TracksToParticles.h"

--- a/src/algorithms/tracking/TracksToParticles.cc
+++ b/src/algorithms/tracking/TracksToParticles.cc
@@ -2,6 +2,7 @@
 // Copyright (C) 2022 - 2024, Sylvester Joosten, Wouter Deconinck, Dmitry Romanov, Christopher Dilks, Dmitry Kalinkin
 
 #include <edm4eic/TrackParametersCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/TrajectoryCollection.h>
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3d.h>
@@ -22,7 +23,11 @@ void TracksToParticles::init() {}
 void TracksToParticles::process(const TracksToParticles::Input& input,
                                 const TracksToParticles::Output& output) const {
   const auto [tracks, track_assocs] = input;
-  auto [parts, part_assocs]         = output;
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  auto [parts, part_links, part_assocs] = output;
+#else
+  auto [parts, part_assocs] = output;
+#endif
 
   for (const auto& track : *tracks) {
     auto trajectory = track.getTrajectory();
@@ -52,6 +57,12 @@ void TracksToParticles::process(const TracksToParticles::Input& input,
           trace("Found track association: index={} -> index={}, weight={}",
                 track_assoc.getRec().getObjectID().index, track_assoc.getSim().getObjectID().index,
                 track_assoc.getWeight());
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          auto part_link = part_links->create();
+          part_link.setFrom(rec_part);
+          part_link.setTo(track_assoc.getSim());
+          part_link.setWeight(track_assoc.getWeight());
+#endif
           auto part_assoc = part_assocs->create();
           part_assoc.setRec(rec_part);
           part_assoc.setSim(track_assoc.getSim());

--- a/src/algorithms/tracking/TracksToParticles.h
+++ b/src/algorithms/tracking/TracksToParticles.h
@@ -5,6 +5,7 @@
 
 #include <algorithms/algorithm.h>
 #include <edm4eic/MCRecoParticleAssociationCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoTrackParticleAssociationCollection.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4eic/TrackCollection.h>
@@ -14,22 +15,32 @@
 
 #include "algorithms/interfaces/WithPodConfig.h"
 
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoParticleLinkCollection.h>
+#endif
+
 namespace eicrecon {
 
 using TracksToParticlesAlgorithm = algorithms::Algorithm<
     algorithms::Input<edm4eic::TrackCollection,
                       std::optional<edm4eic::MCRecoTrackParticleAssociationCollection>>,
     algorithms::Output<edm4eic::ReconstructedParticleCollection,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                       std::optional<edm4eic::MCRecoParticleLinkCollection>,
+#endif
                        std::optional<edm4eic::MCRecoParticleAssociationCollection>>>;
 
 class TracksToParticles : public TracksToParticlesAlgorithm, public WithPodConfig<NoConfig> {
 public:
   TracksToParticles(std::string_view name)
-      : TracksToParticlesAlgorithm{
-            name,
-            {"inputTracksCollection", "inputTrackAssociationsCollection"},
-            {"outputReconstructedParticlesCollection", "outputAssociationsCollection"},
-            "Converts track to particles with associations"} {};
+      : TracksToParticlesAlgorithm{name,
+                                   {"inputTracksCollection", "inputTrackAssociationsCollection"},
+                                   {"outputReconstructedParticlesCollection",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                    "outputLinks",
+#endif
+                                    "outputAssociationsCollection"},
+                                   "Converts track to particles with associations"} {};
 
   void init() final;
   void process(const Input&, const Output&) const final;

--- a/src/detectors/B0ECAL/B0ECAL.cc
+++ b/src/detectors/B0ECAL/B0ECAL.cc
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022 - 2025 Whitney Armstrong, Sylvester Joosten, Chao Peng, David Lawrence, Wouter Deconinck, Kolja Kauder, Nathan Brei, Dmitry Kalinkin, Derek Anderson, Michael Pitt
 
+#include <edm4eic/EDM4eicVersion.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JTypeInfo.h>
@@ -25,7 +26,12 @@ void InitPlugin(JApplication* app) {
   InitJANAPlugin(app);
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-      "B0ECalRawHits", {"EventHeader", "B0ECalHits"}, {"B0ECalRawHits", "B0ECalRawHitAssociations"},
+      "B0ECalRawHits", {"EventHeader", "B0ECalHits"},
+      {"B0ECalRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "B0ECalRawHitLinks",
+#endif
+       "B0ECalRawHitAssociations"},
       {
           // The stochastic term is set using light yield in PbOW4 of N_photons = 145.75 / GeV / mm, for 6x6 mm2 sensors with PDE=0.18 (a=1/sqrt(145.75*36*0.18))
           .eRes          = {0.0326 * sqrt(dd4hep::GeV), 0.00, 0.0 * dd4hep::GeV},
@@ -86,14 +92,21 @@ void InitPlugin(JApplication* app) {
           "B0ECalIslandProtoClusters", // edm4eic::ProtoClusterCollection
           "B0ECalRawHitAssociations"   // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"B0ECalClustersWithoutShapes",             // edm4eic::Cluster
+      {"B0ECalClustersWithoutShapes", // edm4eic::Cluster
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "B0ECalClusterLinksWithoutShapes",
+#endif
        "B0ECalClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 3.6, .enableEtaBounds = false},
       app));
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "B0ECalClusters", {"B0ECalClustersWithoutShapes", "B0ECalClusterAssociationsWithoutShapes"},
-      {"B0ECalClusters", "B0ECalClusterAssociations"},
+      {"B0ECalClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "B0ECalClusterLinks",
+#endif
+       "B0ECalClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 3.6}, app));
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
@@ -102,7 +115,10 @@ void InitPlugin(JApplication* app) {
           "B0ECalTruthProtoClusters", // edm4eic::ProtoClusterCollection
           "B0ECalRawHitAssociations"  // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"B0ECalTruthClustersWithoutShapes",             // edm4eic::Cluster
+      {"B0ECalTruthClustersWithoutShapes", // edm4eic::Cluster
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "B0ECalTruthClusterLinksWithoutShapes",
+#endif
        "B0ECalTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 6.2, .enableEtaBounds = false},
       app));
@@ -110,7 +126,11 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "B0ECalTruthClusters",
       {"B0ECalTruthClustersWithoutShapes", "B0ECalTruthClusterAssociationsWithoutShapes"},
-      {"B0ECalTruthClusters", "B0ECalTruthClusterAssociations"},
+      {"B0ECalTruthClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "B0ECalTruthClusterLinks",
+#endif
+       "B0ECalTruthClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
 }
 }

--- a/src/detectors/B0TRK/B0TRK.cc
+++ b/src/detectors/B0TRK/B0TRK.cc
@@ -5,6 +5,7 @@
 
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplicationFwd.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <vector>
@@ -22,7 +23,13 @@ void InitPlugin(JApplication* app) {
   // Digitization
   app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
       "B0TrackerRawHits", {"EventHeader", "B0TrackerHits"},
-      {"B0TrackerRawHits", "B0TrackerRawHitAssociations"},
+      {"B0TrackerRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+
+       "B0TrackerRawHitLinks",
+#endif
+
+       "B0TrackerRawHitAssociations"},
       {
           .threshold      = 10.0 * dd4hep::keV,
           .timeResolution = 8,

--- a/src/detectors/B0TRK/B0TRK.cc
+++ b/src/detectors/B0TRK/B0TRK.cc
@@ -25,10 +25,8 @@ void InitPlugin(JApplication* app) {
       "B0TrackerRawHits", {"EventHeader", "B0TrackerHits"},
       {"B0TrackerRawHits",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-
        "B0TrackerRawHitLinks",
 #endif
-
        "B0TrackerRawHitAssociations"},
       {
           .threshold      = 10.0 * dd4hep::keV,

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -6,6 +6,7 @@
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <edm4eic/unit_system.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4hep/SimCalorimeterHit.h>
 #include <cmath>
 #include <map>
@@ -173,7 +174,11 @@ void InitPlugin(JApplication* app) {
       ));
   app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
       "EcalBarrelScFiRawHits", {"EventHeader", "EcalBarrelScFiHits"},
-      {"EcalBarrelScFiRawHits", "EcalBarrelScFiRawHitAssociations"},
+      {"EcalBarrelScFiRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalBarrelScFiRawHitLinks",
+#endif
+       "EcalBarrelScFiRawHitAssociations"},
       {
           .eRes          = {0.0 * sqrt(dd4hep::GeV), 0.0, 0.0 * dd4hep::GeV},
           .tRes          = 0.0 * dd4hep::ns,
@@ -238,6 +243,9 @@ void InitPlugin(JApplication* app) {
       {"EcalBarrelScFiProtoClusters",         // edm4eic::ProtoClusterCollection
        "EcalBarrelScFiRawHitAssociations"},   // edm4eic::MCRecoCalorimeterHitAssociation
       {"EcalBarrelScFiClustersWithoutShapes", // edm4eic::Cluster
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalBarrelScFiClusterLinksWithoutShapes",
+#endif
        "EcalBarrelScFiClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 6.2, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -245,7 +253,11 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalBarrelScFiClusters",
       {"EcalBarrelScFiClustersWithoutShapes", "EcalBarrelScFiClusterAssociationsWithoutShapes"},
-      {"EcalBarrelScFiClusters", "EcalBarrelScFiClusterAssociations"},
+      {"EcalBarrelScFiClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalBarrelScFiClusterLinks",
+#endif
+       "EcalBarrelScFiClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 6.2}, app));
 
   // Make sure digi and reco use the same value
@@ -259,7 +271,11 @@ void InitPlugin(JApplication* app) {
       3.25 * dd4hep::nanosecond;
   app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
       "EcalBarrelImagingRawHits", {"EventHeader", "EcalBarrelImagingHits"},
-      {"EcalBarrelImagingRawHits", "EcalBarrelImagingRawHitAssociations"},
+      {"EcalBarrelImagingRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalBarrelImagingRawHitLinks",
+#endif
+       "EcalBarrelImagingRawHitAssociations"},
       {
           .eRes          = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV},
           .tRes          = 0.0 * dd4hep::ns,
@@ -312,6 +328,9 @@ void InitPlugin(JApplication* app) {
       "EcalBarrelImagingClustersWithoutShapes",
       {"EcalBarrelImagingProtoClusters", "EcalBarrelImagingRawHitAssociations"},
       {"EcalBarrelImagingClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalBarrelImagingClusterLinksWithoutShapes",
+#endif
        "EcalBarrelImagingClusterAssociationsWithoutShapes", "EcalBarrelImagingLayers"},
       {
           .trackStopLayer = 6,
@@ -322,14 +341,22 @@ void InitPlugin(JApplication* app) {
       "EcalBarrelImagingClusters",
       {"EcalBarrelImagingClustersWithoutShapes",
        "EcalBarrelImagingClusterAssociationsWithoutShapes"},
-      {"EcalBarrelImagingClusters", "EcalBarrelImagingClusterAssociations"},
+      {"EcalBarrelImagingClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalBarrelImagingClusterLinks",
+#endif
+       "EcalBarrelImagingClusterAssociations"},
       {.longitudinalShowerInfoAvailable = false, .energyWeight = "log", .logWeightBase = 6.2},
       app));
   app->Add(new JOmniFactoryGeneratorT<EnergyPositionClusterMerger_factory>(
       "EcalBarrelClusters",
       {"EcalBarrelScFiClusters", "EcalBarrelScFiClusterAssociations", "EcalBarrelImagingClusters",
        "EcalBarrelImagingClusterAssociations"},
-      {"EcalBarrelClusters", "EcalBarrelClusterAssociations"},
+      {"EcalBarrelClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalBarrelClusterLinks",
+#endif
+       "EcalBarrelClusterAssociations"},
       {
           .energyRelTolerance = 0.5,
           .phiTolerance       = 0.1,
@@ -341,7 +368,11 @@ void InitPlugin(JApplication* app) {
       "EcalBarrelTruthClusters",
       {"MCParticles", "EcalBarrelScFiClusters", "EcalBarrelScFiClusterAssociations",
        "EcalBarrelImagingClusters", "EcalBarrelImagingClusterAssociations"},
-      {"EcalBarrelTruthClusters", "EcalBarrelTruthClusterAssociations"},
+      {"EcalBarrelTruthClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalBarrelTruthClusterLinks",
+#endif
+       "EcalBarrelTruthClusterAssociations"},
       app // TODO: Remove me once fixed
       ));
 }

--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -53,10 +53,8 @@ void InitPlugin(JApplication* app) {
       "HcalBarrelRawHits", {"EventHeader", "HcalBarrelHits"},
       {"HcalBarrelRawHits",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-
        "HcalBarrelRawHitLinks",
 #endif
-
        "HcalBarrelRawHitAssociations"},
       {
           .eRes          = {},

--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -3,6 +3,7 @@
 
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplicationFwd.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <variant>
@@ -50,7 +51,13 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
       "HcalBarrelRawHits", {"EventHeader", "HcalBarrelHits"},
-      {"HcalBarrelRawHits", "HcalBarrelRawHitAssociations"},
+      {"HcalBarrelRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+
+       "HcalBarrelRawHitLinks",
+#endif
+
+       "HcalBarrelRawHitAssociations"},
       {
           .eRes          = {},
           .tRes          = 0.0 * dd4hep::ns,
@@ -128,7 +135,10 @@ void InitPlugin(JApplication* app) {
           "HcalBarrelIslandProtoClusters", // edm4eic::ProtoClusterCollection
           "HcalBarrelRawHitAssociations"   // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"HcalBarrelClustersWithoutShapes",             // edm4eic::Cluster
+      {"HcalBarrelClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalBarrelClusterLinksWithoutShapes",
+#endif
        "HcalBarrelClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 6.2, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -137,7 +147,11 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalBarrelClusters",
       {"HcalBarrelClustersWithoutShapes", "HcalBarrelClusterAssociationsWithoutShapes"},
-      {"HcalBarrelClusters", "HcalBarrelClusterAssociations"},
+      {"HcalBarrelClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalBarrelClusterLinks",
+#endif
+       "HcalBarrelClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
@@ -146,7 +160,10 @@ void InitPlugin(JApplication* app) {
           "HcalBarrelTruthProtoClusters", // edm4eic::ProtoClusterCollection
           "HcalBarrelRawHitAssociations"  // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"HcalBarrelTruthClustersWithoutShapes",             // edm4eic::Cluster
+      {"HcalBarrelTruthClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalBarrelTruthClusterLinksWithoutShapes",
+#endif
        "HcalBarrelTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 6.2, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -155,7 +172,11 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalBarrelTruthClusters",
       {"HcalBarrelTruthClustersWithoutShapes", "HcalBarrelTruthClusterAssociationsWithoutShapes"},
-      {"HcalBarrelTruthClusters", "HcalBarrelTruthClusterAssociations"},
+      {"HcalBarrelTruthClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalBarrelTruthClusterLinks",
+#endif
+       "HcalBarrelTruthClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
 
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMergeSplitter_factory>(
@@ -178,7 +199,10 @@ void InitPlugin(JApplication* app) {
           "HcalBarrelSplitMergeProtoClusters", // edm4eic::ProtoClusterCollection
           "HcalBarrelRawHitAssociations"       // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"HcalBarrelSplitMergeClustersWithoutShapes",             // edm4eic::Cluster
+      {"HcalBarrelSplitMergeClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalBarrelSplitMergeClusterLinksWithoutShapes",
+#endif
        "HcalBarrelSplitMergeClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 6.2, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -188,6 +212,11 @@ void InitPlugin(JApplication* app) {
       "HcalBarrelSplitMergeClusters",
       {"HcalBarrelSplitMergeClustersWithoutShapes",
        "HcalBarrelSplitMergeClusterAssociationsWithoutShapes"},
-      {"HcalBarrelSplitMergeClusters", "HcalBarrelSplitMergeClusterAssociations"}, {}, app));
+      {"HcalBarrelSplitMergeClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalBarrelSplitMergeClusterLinks",
+#endif
+       "HcalBarrelSplitMergeClusterAssociations"},
+      {}, app));
 }
 }

--- a/src/detectors/BTOF/BTOF.cc
+++ b/src/detectors/BTOF/BTOF.cc
@@ -42,10 +42,8 @@ void InitPlugin(JApplication* app) {
       "TOFBarrelRawHits", {"EventHeader", "TOFBarrelHits"},
       {"TOFBarrelRawHits",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-
        "TOFBarrelRawHitLinks",
 #endif
-
        "TOFBarrelRawHitAssociations"},
       {
           .threshold      = 6.0 * dd4hep::keV,

--- a/src/detectors/BTOF/BTOF.cc
+++ b/src/detectors/BTOF/BTOF.cc
@@ -7,6 +7,7 @@
 
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <TMath.h>
@@ -39,7 +40,13 @@ void InitPlugin(JApplication* app) {
   // Digitization
   app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
       "TOFBarrelRawHits", {"EventHeader", "TOFBarrelHits"},
-      {"TOFBarrelRawHits", "TOFBarrelRawHitAssociations"},
+      {"TOFBarrelRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+
+       "TOFBarrelRawHitLinks",
+#endif
+
+       "TOFBarrelRawHitAssociations"},
       {
           .threshold      = 6.0 * dd4hep::keV,
           .timeResolution = 0.025, // [ns]

--- a/src/detectors/BTRK/BTRK.cc
+++ b/src/detectors/BTRK/BTRK.cc
@@ -3,6 +3,7 @@
 //
 //
 
+#include <edm4eic/EDM4eicVersion.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JTypeInfo.h>
@@ -22,7 +23,11 @@ void InitPlugin(JApplication* app) {
   // Digitization
   app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
       "SiBarrelRawHits", {"EventHeader", "SiBarrelHits"},
-      {"SiBarrelRawHits", "SiBarrelRawHitAssociations"},
+      {"SiBarrelRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "SiBarrelRawHitLinks",
+#endif
+       "SiBarrelRawHitAssociations"},
       {
           .threshold = 0.54 * dd4hep::keV,
       },

--- a/src/detectors/BVTX/BVTX.cc
+++ b/src/detectors/BVTX/BVTX.cc
@@ -5,6 +5,7 @@
 
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplicationFwd.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <vector>
@@ -22,7 +23,13 @@ void InitPlugin(JApplication* app) {
   // Digitization
   app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
       "SiBarrelVertexRawHits", {"EventHeader", "VertexBarrelHits"},
-      {"SiBarrelVertexRawHits", "SiBarrelVertexRawHitAssociations"},
+      {"SiBarrelVertexRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+
+       "SiBarrelVertexRawHitLinks",
+#endif
+
+       "SiBarrelVertexRawHitAssociations"},
       {
           .threshold = 0.54 * dd4hep::keV,
       },

--- a/src/detectors/BVTX/BVTX.cc
+++ b/src/detectors/BVTX/BVTX.cc
@@ -25,10 +25,8 @@ void InitPlugin(JApplication* app) {
       "SiBarrelVertexRawHits", {"EventHeader", "VertexBarrelHits"},
       {"SiBarrelVertexRawHits",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-
        "SiBarrelVertexRawHitLinks",
 #endif
-
        "SiBarrelVertexRawHitAssociations"},
       {
           .threshold = 0.54 * dd4hep::keV,

--- a/src/detectors/DIRC/DIRC.cc
+++ b/src/detectors/DIRC/DIRC.cc
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022 - 2025 Christopher Dilks, Nilanga Wickramaarachchi, Dmitry Kalinkin
 
+#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
@@ -37,7 +38,12 @@ void InitPlugin(JApplication* app) {
 
   // digitization
   app->Add(new JOmniFactoryGeneratorT<PhotoMultiplierHitDigi_factory>(
-      "DIRCRawHits", {"EventHeader", "DIRCBarHits"}, {"DIRCRawHits", "DIRCRawHitsAssociations"},
+      "DIRCRawHits", {"EventHeader", "DIRCBarHits"},
+      {"DIRCRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "DIRCRawHitsLinks",
+#endif
+       "DIRCRawHitsAssociations"},
       digi_cfg, app));
 }
 }

--- a/src/detectors/DRICH/DRICH.cc
+++ b/src/detectors/DRICH/DRICH.cc
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2024, Dmitry Kalinkin
 
+#include <edm4eic/EDM4eicVersion.h>
 #include <DD4hep/DetElement.h>
 #include <DD4hep/Detector.h>
 #include <Evaluator/DD4hepUnits.h>
@@ -116,9 +117,14 @@ void InitPlugin(JApplication* app) {
   // wiring between factories and data ///////////////////////////////////////
 
   // digitization
-  app->Add(new JOmniFactoryGeneratorT<PhotoMultiplierHitDigi_factory>(
-      "DRICHRawHits", {"EventHeader", "DRICHHits"}, {"DRICHRawHits", "DRICHRawHitsAssociations"},
-      digi_cfg, app));
+  app->Add(new JOmniFactoryGeneratorT<PhotoMultiplierHitDigi_factory>("DRICHRawHits",
+                                                                      {"EventHeader", "DRICHHits"},
+                                                                      {"DRICHRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                                                       "DRICHRawHitsLinks",
+#endif
+                                                                       "DRICHRawHitsAssociations"},
+                                                                      digi_cfg, app));
 
   // charged particle tracks
   app->Add(new JOmniFactoryGeneratorT<RichTrack_factory>(

--- a/src/detectors/ECTOF/ECTOF.cc
+++ b/src/detectors/ECTOF/ECTOF.cc
@@ -36,10 +36,8 @@ void InitPlugin(JApplication* app) {
       "TOFEndcapRawHits", {"EventHeader", "TOFEndcapHits"},
       {"TOFEndcapRawHits",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-
        "TOFEndcapRawHitLinks",
 #endif
-
        "TOFEndcapRawHitAssociations"},
       {
           .threshold      = 6.0 * dd4hep::keV,

--- a/src/detectors/ECTOF/ECTOF.cc
+++ b/src/detectors/ECTOF/ECTOF.cc
@@ -3,6 +3,7 @@
 
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <TMath.h>
@@ -33,7 +34,13 @@ void InitPlugin(JApplication* app) {
   // Digitization
   app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
       "TOFEndcapRawHits", {"EventHeader", "TOFEndcapHits"},
-      {"TOFEndcapRawHits", "TOFEndcapRawHitAssociations"},
+      {"TOFEndcapRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+
+       "TOFEndcapRawHitLinks",
+#endif
+
+       "TOFEndcapRawHitAssociations"},
       {
           .threshold      = 6.0 * dd4hep::keV,
           .timeResolution = 0.025,

--- a/src/detectors/ECTRK/ECTRK.cc
+++ b/src/detectors/ECTRK/ECTRK.cc
@@ -25,10 +25,8 @@ void InitPlugin(JApplication* app) {
       "SiEndcapTrackerRawHits", {"EventHeader", "TrackerEndcapHits"},
       {"SiEndcapTrackerRawHits",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-
        "SiEndcapTrackerRawHitLinks",
 #endif
-
        "SiEndcapTrackerRawHitAssociations"},
       {
           .threshold = 0.54 * dd4hep::keV,

--- a/src/detectors/ECTRK/ECTRK.cc
+++ b/src/detectors/ECTRK/ECTRK.cc
@@ -5,6 +5,7 @@
 
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplicationFwd.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <vector>
@@ -22,7 +23,13 @@ void InitPlugin(JApplication* app) {
   // Digitization
   app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
       "SiEndcapTrackerRawHits", {"EventHeader", "TrackerEndcapHits"},
-      {"SiEndcapTrackerRawHits", "SiEndcapTrackerRawHitAssociations"},
+      {"SiEndcapTrackerRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+
+       "SiEndcapTrackerRawHitLinks",
+#endif
+
+       "SiEndcapTrackerRawHitAssociations"},
       {
           .threshold = 0.54 * dd4hep::keV,
       },

--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -41,10 +41,8 @@ void InitPlugin(JApplication* app) {
       "EcalEndcapNRawHits", {"EventHeader", "EcalEndcapNHits"},
       {"EcalEndcapNRawHits",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-
        "EcalEndcapNRawHitLinks",
 #endif
-
        "EcalEndcapNRawHitAssociations"},
       {
           .eRes        = {0.0 * sqrt(dd4hep::GeV), 0.0, 0.0 * dd4hep::GeV},

--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -144,7 +144,7 @@ void InitPlugin(JApplication* app) {
       },
       {"EcalEndcapNClustersWithoutPIDAndShapes", // edm4eic::Cluster
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "EcalEndcapNClusterLinkssWithoutPIDAndShapes", // edm4eic::MCRecoClusterParticleLink
+       "EcalEndcapNClusterLinksWithoutPIDAndShapes", // edm4eic::MCRecoClusterParticleLink
 #endif
        "EcalEndcapNClusterAssociationsWithoutPIDAndShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {

--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -3,6 +3,7 @@
 
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplicationFwd.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <cmath>
 #include <string>
@@ -38,7 +39,13 @@ void InitPlugin(JApplication* app) {
       10 * dd4hep::picosecond;
   app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
       "EcalEndcapNRawHits", {"EventHeader", "EcalEndcapNHits"},
-      {"EcalEndcapNRawHits", "EcalEndcapNRawHitAssociations"},
+      {"EcalEndcapNRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+
+       "EcalEndcapNRawHitLinks",
+#endif
+
+       "EcalEndcapNRawHitAssociations"},
       {
           .eRes        = {0.0 * sqrt(dd4hep::GeV), 0.0, 0.0 * dd4hep::GeV},
           .tRes        = 0.0 * dd4hep::ns,
@@ -110,7 +117,10 @@ void InitPlugin(JApplication* app) {
           "EcalEndcapNTruthProtoClusters", // edm4eic::ProtoClusterCollection
           "EcalEndcapNRawHitAssociations"  // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"EcalEndcapNTruthClustersWithoutShapes",             // edm4eic::Cluster
+      {"EcalEndcapNTruthClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalEndcapNTruthClusterLinksWithoutShapes",
+#endif
        "EcalEndcapNTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 4.6, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -119,7 +129,11 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalEndcapNTruthClusters",
       {"EcalEndcapNTruthClustersWithoutShapes", "EcalEndcapNTruthClusterAssociationsWithoutShapes"},
-      {"EcalEndcapNTruthClusters", "EcalEndcapNTruthClusterAssociations"},
+      {"EcalEndcapNTruthClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalEndcapNTruthClusterLinks",
+#endif
+       "EcalEndcapNTruthClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 4.6}, app));
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
@@ -128,7 +142,10 @@ void InitPlugin(JApplication* app) {
           "EcalEndcapNIslandProtoClusters", // edm4eic::ProtoClusterCollection
           "EcalEndcapNRawHitAssociations"   // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"EcalEndcapNClustersWithoutPIDAndShapes",             // edm4eic::Cluster
+      {"EcalEndcapNClustersWithoutPIDAndShapes", // edm4eic::Cluster
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalEndcapNClusterLinkssWithoutPIDAndShapes", // edm4eic::MCRecoClusterParticleLink
+#endif
        "EcalEndcapNClusterAssociationsWithoutPIDAndShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {
           .energyWeight    = "log",
@@ -143,7 +160,11 @@ void InitPlugin(JApplication* app) {
       "EcalEndcapNClustersWithoutPID",
       {"EcalEndcapNClustersWithoutPIDAndShapes",
        "EcalEndcapNClusterAssociationsWithoutPIDAndShapes"},
-      {"EcalEndcapNClustersWithoutPID", "EcalEndcapNClusterAssociationsWithoutPID"},
+      {"EcalEndcapNClustersWithoutPID",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalEndcapNClusterLinksWithoutPID",
+#endif
+       "EcalEndcapNClusterAssociationsWithoutPID"},
       {.energyWeight = "log", .logWeightBase = 3.6}, app));
 
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMergeSplitter_factory>(
@@ -191,8 +212,12 @@ void InitPlugin(JApplication* app) {
           "EcalEndcapNClusterAssociationsWithoutPID",
           "EcalEndcapNParticleIDOutput_probability_tensor",
       },
+
       {
           "EcalEndcapNClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "EcalEndcapNClusterLinks",
+#endif
           "EcalEndcapNClusterAssociations",
           "EcalEndcapNClusterParticleIDs",
       },
@@ -204,7 +229,10 @@ void InitPlugin(JApplication* app) {
           "EcalEndcapNSplitMergeProtoClusters", // edm4eic::ProtoClusterCollection
           "EcalEndcapNRawHitAssociations" // edm4hep::MCRecoCalorimeterHitAssociationCollection
       },
-      {"EcalEndcapNSplitMergeClustersWithoutShapes",             // edm4eic::Cluster
+      {"EcalEndcapNSplitMergeClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalEndcapNSplitMergeClusterLinksWithoutShapes",
+#endif
        "EcalEndcapNSplitMergeClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 3.6, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -212,9 +240,14 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalEndcapNSplitMergeClusters",
+
       {"EcalEndcapNSplitMergeClustersWithoutShapes",
        "EcalEndcapNSplitMergeClusterAssociationsWithoutShapes"},
-      {"EcalEndcapNSplitMergeClusters", "EcalEndcapNSplitMergeClusterAssociations"},
+      {"EcalEndcapNSplitMergeClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalEndcapNSplitMergeClusterLinks",
+#endif
+       "EcalEndcapNSplitMergeClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 3.6}, app));
 }
 }

--- a/src/detectors/EHCAL/EHCAL.cc
+++ b/src/detectors/EHCAL/EHCAL.cc
@@ -40,10 +40,8 @@ void InitPlugin(JApplication* app) {
       "HcalEndcapNRawHits", {"EventHeader", "HcalEndcapNHits"},
       {"HcalEndcapNRawHits",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-
        "HcalEndcapNRawHitLinks",
 #endif
-
        "HcalEndcapNRawHitAssociations"},
       {
           .eRes{},
@@ -130,7 +128,6 @@ void InitPlugin(JApplication* app) {
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
        "HcalEndcapNTruthClusterLinks",
 #endif
-
        "HcalEndcapNTruthClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(

--- a/src/detectors/EHCAL/EHCAL.cc
+++ b/src/detectors/EHCAL/EHCAL.cc
@@ -3,6 +3,7 @@
 
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplicationFwd.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <variant>
@@ -37,7 +38,13 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
       "HcalEndcapNRawHits", {"EventHeader", "HcalEndcapNHits"},
-      {"HcalEndcapNRawHits", "HcalEndcapNRawHitAssociations"},
+      {"HcalEndcapNRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+
+       "HcalEndcapNRawHitLinks",
+#endif
+
+       "HcalEndcapNRawHitAssociations"},
       {
           .eRes{},
           .tRes          = 0.0 * dd4hep::ns,
@@ -108,7 +115,10 @@ void InitPlugin(JApplication* app) {
           "HcalEndcapNTruthProtoClusters", // edm4eic::ProtoClusterCollection
           "HcalEndcapNRawHitAssociations"  // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"HcalEndcapNTruthClustersWithoutShapes",             // edm4eic::Cluster
+      {"HcalEndcapNTruthClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalEndcapNTruthClusterLinksWithoutShapes",
+#endif
        "HcalEndcapNTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 6.2, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -116,7 +126,12 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalEndcapNTruthClusters",
       {"HcalEndcapNTruthClustersWithoutShapes", "HcalEndcapNTruthClusterAssociationsWithoutShapes"},
-      {"HcalEndcapNTruthClusters", "HcalEndcapNTruthClusterAssociations"},
+      {"HcalEndcapNTruthClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalEndcapNTruthClusterLinks",
+#endif
+
+       "HcalEndcapNTruthClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
       "HcalEndcapNClustersWithoutShapes",
@@ -124,7 +139,10 @@ void InitPlugin(JApplication* app) {
           "HcalEndcapNIslandProtoClusters", // edm4eic::ProtoClusterCollection
           "HcalEndcapNRawHitAssociations"   // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"HcalEndcapNClustersWithoutShapes",             // edm4eic::Cluster
+      {"HcalEndcapNClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalEndcapNClusterLinksWithoutShapes",
+#endif
        "HcalEndcapNClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {
           .energyWeight    = "log",
@@ -137,7 +155,11 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalEndcapNClusters",
       {"HcalEndcapNClustersWithoutShapes", "HcalEndcapNClusterAssociationsWithoutShapes"},
-      {"HcalEndcapNClusters", "HcalEndcapNClusterAssociations"},
+      {"HcalEndcapNClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalEndcapNClusterLinks",
+#endif
+       "HcalEndcapNClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMergeSplitter_factory>(
       "HcalEndcapNSplitMergeProtoClusters",
@@ -158,7 +180,10 @@ void InitPlugin(JApplication* app) {
           "HcalEndcapNSplitMergeProtoClusters", // edm4eic::ProtoClusterCollection
           "HcalEndcapNRawHitAssociations" // edm4hep::MCRecoCalorimeterHitAssociationCollection
       },
-      {"HcalEndcapNSplitMergeClustersWithoutShapes",             // edm4eic::Cluster
+      {"HcalEndcapNSplitMergeClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalEndcapNSplitMergeClusterLinksWithoutShapes",
+#endif
        "HcalEndcapNSplitMergeClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 6.2, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -167,7 +192,11 @@ void InitPlugin(JApplication* app) {
       "HcalEndcapNSplitMergeClusters",
       {"HcalEndcapNSplitMergeClustersWithoutShapes",
        "HcalEndcapNSplitMergeClusterAssociationsWithoutShapes"},
-      {"HcalEndcapNSplitMergeClusters", "HcalEndcapNSplitMergeClusterAssociations"},
+      {"HcalEndcapNSplitMergeClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalEndcapNSplitMergeClusterLinks",
+#endif
+       "HcalEndcapNSplitMergeClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
 }
 }

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -4,10 +4,10 @@
 #include <DD4hep/Detector.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
-#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JTypeInfo.h>
-#include <fmt/core.h>
+#include <edm4eic/EDM4eicVersion.h>
+#include <fmt/format.h>
 #include <spdlog/logger.h>
 #include <cmath>
 #include <gsl/pointers>

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -72,10 +72,8 @@ void InitPlugin(JApplication* app) {
         "EcalEndcapPRawHits", {"EventHeader", "EcalEndcapPHits"},
         {"EcalEndcapPRawHits",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-
          "EcalEndcapPRawHitLinks",
 #endif
-
          "EcalEndcapPRawHitAssociations"},
         {
             .eRes = {0.11333 * sqrt(dd4hep::GeV), 0.03,
@@ -103,10 +101,8 @@ void InitPlugin(JApplication* app) {
         "EcalEndcapPRawHits", {"EventHeader", "EcalEndcapPHits"},
         {"EcalEndcapPRawHits",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-
          "EcalEndcapPRawHitLinks",
 #endif
-
          "EcalEndcapPRawHitAssociations"},
         {
             .eRes = {0.0, 0.022, 0.0}, // just constant term 2.2% based on MC data comparison
@@ -195,10 +191,8 @@ void InitPlugin(JApplication* app) {
       {"EcalEndcapPTruthClustersWithoutShapes", "EcalEndcapPTruthClusterAssociationsWithoutShapes"},
       {"EcalEndcapPTruthClusters",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-
        "EcalEndcapPTruthClusterLinks",
 #endif
-
        "EcalEndcapPTruthClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
 

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -4,6 +4,7 @@
 #include <DD4hep/Detector.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <fmt/core.h>
@@ -69,7 +70,13 @@ void InitPlugin(JApplication* app) {
   if (EcalEndcapP_homogeneousFlag <= 1) {
     app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
         "EcalEndcapPRawHits", {"EventHeader", "EcalEndcapPHits"},
-        {"EcalEndcapPRawHits", "EcalEndcapPRawHitAssociations"},
+        {"EcalEndcapPRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+
+         "EcalEndcapPRawHitLinks",
+#endif
+
+         "EcalEndcapPRawHitAssociations"},
         {
             .eRes = {0.11333 * sqrt(dd4hep::GeV), 0.03,
                      0.0 * dd4hep::GeV}, // (11.333% / sqrt(E)) \oplus 3%
@@ -94,7 +101,13 @@ void InitPlugin(JApplication* app) {
   } else if (EcalEndcapP_homogeneousFlag == 2) {
     app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
         "EcalEndcapPRawHits", {"EventHeader", "EcalEndcapPHits"},
-        {"EcalEndcapPRawHits", "EcalEndcapPRawHitAssociations"},
+        {"EcalEndcapPRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+
+         "EcalEndcapPRawHitLinks",
+#endif
+
+         "EcalEndcapPRawHitAssociations"},
         {
             .eRes = {0.0, 0.022, 0.0}, // just constant term 2.2% based on MC data comparison
             .tRes = 0.0,
@@ -168,7 +181,10 @@ void InitPlugin(JApplication* app) {
           "EcalEndcapPTruthProtoClusters", // edm4eic::ProtoClusterCollection
           "EcalEndcapPRawHitAssociations"  // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"EcalEndcapPTruthClustersWithoutShapes",             // edm4eic::Cluster
+      {"EcalEndcapPTruthClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalEndcapPTruthClusterLinksWithoutShapes",
+#endif
        "EcalEndcapPTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 6.2, .enableEtaBounds = true},
       app // TODO: Remove me once fixed
@@ -177,7 +193,13 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalEndcapPTruthClusters",
       {"EcalEndcapPTruthClustersWithoutShapes", "EcalEndcapPTruthClusterAssociationsWithoutShapes"},
-      {"EcalEndcapPTruthClusters", "EcalEndcapPTruthClusterAssociations"},
+      {"EcalEndcapPTruthClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+
+       "EcalEndcapPTruthClusterLinks",
+#endif
+
+       "EcalEndcapPTruthClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
@@ -186,7 +208,10 @@ void InitPlugin(JApplication* app) {
           "EcalEndcapPIslandProtoClusters", // edm4eic::ProtoClusterCollection
           "EcalEndcapPRawHitAssociations"   // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"EcalEndcapPClustersWithoutShapes",             // edm4eic::Cluster
+      {"EcalEndcapPClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalEndcapPClusterLinksWithoutShapes",
+#endif
        "EcalEndcapPClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {
           .energyWeight    = "log",
@@ -200,7 +225,11 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalEndcapPClusters",
       {"EcalEndcapPClustersWithoutShapes", "EcalEndcapPClusterAssociationsWithoutShapes"},
-      {"EcalEndcapPClusters", "EcalEndcapPClusterAssociations"},
+      {"EcalEndcapPClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalEndcapPClusterLinks",
+#endif
+       "EcalEndcapPClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 3.6}, app));
 
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMergeSplitter_factory>(
@@ -223,7 +252,10 @@ void InitPlugin(JApplication* app) {
           "EcalEndcapPSplitMergeProtoClusters", // edm4eic::ProtoClusterCollection
           "EcalEndcapPRawHitAssociations" // edm4hep::MCRecoCalorimeterHitAssociationCollection
       },
-      {"EcalEndcapPSplitMergeClustersWithoutShapes",             // edm4eic::Cluster
+      {"EcalEndcapPSplitMergeClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalEndcapPSplitMergeClusterLinksWithoutShapes",
+#endif
        "EcalEndcapPSplitMergeClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 3.6, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -233,7 +265,11 @@ void InitPlugin(JApplication* app) {
       "EcalEndcapPSplitMergeClusters",
       {"EcalEndcapPSplitMergeClustersWithoutShapes",
        "EcalEndcapPSplitMergeClusterAssociationsWithoutShapes"},
-      {"EcalEndcapPSplitMergeClusters", "EcalEndcapPSplitMergeClusterAssociations"},
+      {"EcalEndcapPSplitMergeClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalEndcapPSplitMergeClusterLinks",
+#endif
+       "EcalEndcapPSplitMergeClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 3.6}, app));
 }
 }

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -3,6 +3,7 @@
 
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplicationFwd.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <TString.h>
 #include <string>
@@ -40,7 +41,13 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
       "HcalEndcapPInsertRawHits", {"EventHeader", "HcalEndcapPInsertHits"},
-      {"HcalEndcapPInsertRawHits", "HcalEndcapPInsertRawHitAssociations"},
+      {"HcalEndcapPInsertRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+
+       "HcalEndcapPInsertRawHitLinks",
+#endif
+
+       "HcalEndcapPInsertRawHitAssociations"},
       {
           .eRes          = {},
           .tRes          = 0.0 * dd4hep::ns,
@@ -124,7 +131,10 @@ void InitPlugin(JApplication* app) {
           "HcalEndcapPInsertTruthProtoClusters", // edm4eic::ProtoClusterCollection
           "HcalEndcapPInsertRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"HcalEndcapPInsertTruthClustersWithoutShapes",             // edm4eic::Cluster
+      {"HcalEndcapPInsertTruthClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalEndcapPInsertTruthClusterLinksWithoutShapes",
+#endif
        "HcalEndcapPInsertTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 0.0257, .logWeightBase = 3.6, .enableEtaBounds = true},
       app // TODO: Remove me once fixed
@@ -134,7 +144,11 @@ void InitPlugin(JApplication* app) {
       "HcalEndcapPInsertTruthClusters",
       {"HcalEndcapPInsertTruthClustersWithoutShapes",
        "HcalEndcapPInsertTruthClusterAssociationsWithoutShapes"},
-      {"HcalEndcapPInsertTruthClusters", "HcalEndcapPInsertTruthClusterAssociations"},
+      {"HcalEndcapPInsertTruthClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalEndcapPInsertTruthClusterLinks",
+#endif
+       "HcalEndcapPInsertTruthClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 3.6}, app));
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
@@ -143,7 +157,10 @@ void InitPlugin(JApplication* app) {
           "HcalEndcapPInsertImagingProtoClusters", // edm4eic::ProtoClusterCollection
           "HcalEndcapPInsertRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"HcalEndcapPInsertClustersWithoutShapes",             // edm4eic::Cluster
+      {"HcalEndcapPInsertClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalEndcapPInsertClusterLinksWithoutShapes",
+#endif
        "HcalEndcapPInsertClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {
           .energyWeight    = "log",
@@ -158,7 +175,11 @@ void InitPlugin(JApplication* app) {
       "HcalEndcapPInsertClusters",
       {"HcalEndcapPInsertClustersWithoutShapes",
        "HcalEndcapPInsertClusterAssociationsWithoutShapes"},
-      {"HcalEndcapPInsertClusters", "HcalEndcapPInsertClusterAssociations"},
+      {"HcalEndcapPInsertClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalEndcapPInsertClusterLinks",
+#endif
+       "HcalEndcapPInsertClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true,
        .energyWeight                    = "log",
        .sampFrac                        = 0.0257,
@@ -173,7 +194,12 @@ void InitPlugin(JApplication* app) {
   decltype(CalorimeterHitDigiConfig::resolutionTDC) LFHCAL_resolutionTDC = 10 * dd4hep::picosecond;
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
-      "LFHCALRawHits", {"EventHeader", "LFHCALHits"}, {"LFHCALRawHits", "LFHCALRawHitAssociations"},
+      "LFHCALRawHits", {"EventHeader", "LFHCALHits"},
+      {"LFHCALRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "LFHCALRawHitLinks",
+#endif
+       "LFHCALRawHitAssociations"},
       {
           .eRes          = {},
           .tRes          = 0.0 * dd4hep::ns,
@@ -258,7 +284,10 @@ void InitPlugin(JApplication* app) {
           "LFHCALTruthProtoClusters", // edm4eic::ProtoClusterCollection
           "LFHCALRawHitAssociations"  // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"LFHCALTruthClustersWithoutShapes",             // edm4eic::Cluster
+      {"LFHCALTruthClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "LFHCALTruthClusterLinksWithoutShapes",
+#endif
        "LFHCALTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 4.5, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -267,7 +296,11 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "LFHCALTruthClusters",
       {"LFHCALTruthClustersWithoutShapes", "LFHCALTruthClusterAssociationsWithoutShapes"},
-      {"LFHCALTruthClusters", "LFHCALTruthClusterAssociations"},
+      {"LFHCALTruthClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "LFHCALTruthClusterLinks",
+#endif
+       "LFHCALTruthClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 4.5}, app));
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
@@ -276,7 +309,10 @@ void InitPlugin(JApplication* app) {
           "LFHCALIslandProtoClusters", // edm4eic::ProtoClusterCollection
           "LFHCALRawHitAssociations"   // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"LFHCALClustersWithoutShapes",             // edm4eic::Cluster
+      {"LFHCALClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "LFHCALClusterLinksWithoutShapes",
+#endif
        "LFHCALClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {
           .energyWeight    = "log",
@@ -289,7 +325,11 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "LFHCALClusters", {"LFHCALClustersWithoutShapes", "LFHCALClusterAssociationsWithoutShapes"},
-      {"LFHCALClusters", "LFHCALClusterAssociations"},
+      {"LFHCALClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "LFHCALClusterLinks",
+#endif
+       "LFHCALClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 4.5}, app));
 
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMergeSplitter_factory>(
@@ -311,7 +351,10 @@ void InitPlugin(JApplication* app) {
           "LFHCALSplitMergeProtoClusters", // edm4eic::ProtoClusterCollection
           "LFHCALRawHitAssociations"       // edm4hep::MCRecoCalorimeterHitAssociationCollection
       },
-      {"LFHCALSplitMergeClustersWithoutShapes",             // edm4eic::Cluster
+      {"LFHCALSplitMergeClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "LFHCALSplitMergeClusterLinksWithoutShapes",
+#endif
        "LFHCALSplitMergeClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 4.5, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -320,7 +363,11 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "LFHCALSplitMergeClusters",
       {"LFHCALSplitMergeClustersWithoutShapes", "LFHCALSplitMergeClusterAssociationsWithoutShapes"},
-      {"LFHCALSplitMergeClusters", "LFHCALSplitMergeClusterAssociations"},
+      {"LFHCALSplitMergeClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "LFHCALSplitMergeClusterLinks",
+#endif
+       "LFHCALSplitMergeClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true}, app));
 }
 }

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -43,10 +43,8 @@ void InitPlugin(JApplication* app) {
       "HcalEndcapPInsertRawHits", {"EventHeader", "HcalEndcapPInsertHits"},
       {"HcalEndcapPInsertRawHits",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-
        "HcalEndcapPInsertRawHitLinks",
 #endif
-
        "HcalEndcapPInsertRawHitAssociations"},
       {
           .eRes          = {},

--- a/src/detectors/FOFFMTRK/FOFFMTRK.cc
+++ b/src/detectors/FOFFMTRK/FOFFMTRK.cc
@@ -5,6 +5,7 @@
 
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplicationFwd.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <vector>
@@ -23,7 +24,13 @@ void InitPlugin(JApplication* app) {
   //Digitized hits, especially for thresholds
   app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
       "ForwardOffMTrackerRawHits", {"EventHeader", "ForwardOffMTrackerHits"},
-      {"ForwardOffMTrackerRawHits", "ForwardOffMTrackerRawHitAssociations"},
+      {"ForwardOffMTrackerRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+
+       "ForwardOffMTrackerRawHitLinks",
+#endif
+
+       "ForwardOffMTrackerRawHitAssociations"},
       {
           .threshold      = 10.0 * dd4hep::keV,
           .timeResolution = 8,

--- a/src/detectors/FOFFMTRK/FOFFMTRK.cc
+++ b/src/detectors/FOFFMTRK/FOFFMTRK.cc
@@ -26,10 +26,8 @@ void InitPlugin(JApplication* app) {
       "ForwardOffMTrackerRawHits", {"EventHeader", "ForwardOffMTrackerHits"},
       {"ForwardOffMTrackerRawHits",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-
        "ForwardOffMTrackerRawHitLinks",
 #endif
-
        "ForwardOffMTrackerRawHitAssociations"},
       {
           .threshold      = 10.0 * dd4hep::keV,

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -5,15 +5,14 @@
 
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
-#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JTypeInfo.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoTrackParticleAssociation.h>
 #include <edm4eic/Track.h>
 #include <edm4eic/TrackerHit.h>
 #include <edm4eic/unit_system.h>
 #include <edm4hep/SimTrackerHit.h>
-#include <fmt/core.h>
 #include <fmt/format.h> // IWYU pragma: keep
 #include <cmath>
 #include <cstddef>
@@ -31,13 +30,13 @@
 #include "factories/digi/SiliconChargeSharing_factory.h"
 #include "factories/digi/SiliconTrackerDigi_factory.h"
 #include "factories/fardetectors/FarDetectorLinearTracking_factory.h"
-#include "factories/tracking/TrackerHitReconstruction_factory.h"
+#include "factories/fardetectors/FarDetectorTrackerCluster_factory.h"
 #include "factories/fardetectors/FarDetectorTransportationPostML_factory.h"
 #include "factories/fardetectors/FarDetectorTransportationPreML_factory.h"
-#include "factories/fardetectors/FarDetectorTrackerCluster_factory.h"
 #include "factories/meta/CollectionCollector_factory.h"
 #include "factories/meta/ONNXInference_factory.h"
 #include "factories/meta/SubDivideCollection_factory.h"
+#include "factories/tracking/TrackerHitReconstruction_factory.h"
 
 extern "C" {
 void InitPlugin(JApplication* app) {

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -92,10 +92,8 @@ void InitPlugin(JApplication* app) {
       "TaggerTrackerRawHits", {"EventHeader", "TaggerTrackerHits"},
       {"TaggerTrackerRawHits",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-
        "TaggerTrackerRawHitLinks",
 #endif
-
        "TaggerTrackerRawHitAssociations"},
       {
           .threshold      = 1.5 * edm4eic::unit::keV,

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -9,13 +9,16 @@
 #include <JANA/Utils/JTypeInfo.h>
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoTrackParticleAssociation.h>
+#include <edm4eic/MCRecoTrackParticleLinkCollection.h>
 #include <edm4eic/Track.h>
 #include <edm4eic/TrackerHit.h>
 #include <edm4eic/unit_system.h>
 #include <edm4hep/SimTrackerHit.h>
 #include <fmt/format.h> // IWYU pragma: keep
+#include <podio/detail/Link.h>
 #include <cmath>
 #include <cstddef>
+#include <deque>
 #include <functional>
 #include <map>
 #include <memory>

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -9,7 +9,9 @@
 #include <JANA/Utils/JTypeInfo.h>
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoTrackParticleAssociation.h>
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
 #include <edm4eic/MCRecoTrackParticleLinkCollection.h>
+#endif
 #include <edm4eic/Track.h>
 #include <edm4eic/TrackerHit.h>
 #include <edm4eic/unit_system.h>

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -174,7 +174,11 @@ void InitPlugin(JApplication* app) {
 
     app->Add(new JOmniFactoryGeneratorT<FarDetectorLinearTracking_factory>(
         outputTrackTag, {inputClusterTags},
-        {outputTrackTag, outputTrackLinkTag, outputTrackAssociationTag},
+        {outputTrackTag,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+         outputTrackLinkTag,
+#endif
+         outputTrackAssociationTag},
         {
             .layer_hits_max       = 200,
             .chi2_max             = 0.001,

--- a/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
+++ b/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
@@ -29,10 +29,8 @@ void InitPlugin(JApplication* app) {
       "EcalLumiSpecRawHits", {"EventHeader", "EcalLumiSpecHits"},
       {"EcalLumiSpecRawHits",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-
        "EcalLumiSpecRawHitLinks",
 #endif
-
        "EcalLumiSpecRawHitAssociations"},
       {
           .eRes          = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV}, // flat 2%
@@ -112,10 +110,8 @@ void InitPlugin(JApplication* app) {
       {"EcalLumiSpecClustersWithoutShapes", "EcalLumiSpecClusterAssociationsWithoutShapes"},
       {"EcalLumiSpecClusters",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-
        "EcalLumiSpecClusterLinks",
 #endif
-
        "EcalLumiSpecClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 3.6}, app));
 

--- a/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
+++ b/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
@@ -3,6 +3,7 @@
 
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplicationFwd.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <cmath>
 #include <string>
@@ -26,7 +27,13 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
       "EcalLumiSpecRawHits", {"EventHeader", "EcalLumiSpecHits"},
-      {"EcalLumiSpecRawHits", "EcalLumiSpecRawHitAssociations"},
+      {"EcalLumiSpecRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+
+       "EcalLumiSpecRawHitLinks",
+#endif
+
+       "EcalLumiSpecRawHitAssociations"},
       {
           .eRes          = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV}, // flat 2%
           .tRes          = 0.0 * dd4hep::ns,
@@ -92,7 +99,10 @@ void InitPlugin(JApplication* app) {
           "EcalLumiSpecIslandProtoClusters", // edm4eic::ProtoClusterCollection
           "EcalLumiSpecRawHitAssociations"   // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"EcalLumiSpecClustersWithoutShapes",             // edm4eic::Cluster
+      {"EcalLumiSpecClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalLumiSpecClusterLinksWithoutShapes",
+#endif
        "EcalLumiSpecClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 3.6, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -100,7 +110,13 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalLumiSpecClusters",
       {"EcalLumiSpecClustersWithoutShapes", "EcalLumiSpecClusterAssociationsWithoutShapes"},
-      {"EcalLumiSpecClusters", "EcalLumiSpecClusterAssociations"},
+      {"EcalLumiSpecClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+
+       "EcalLumiSpecClusterLinks",
+#endif
+
+       "EcalLumiSpecClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 3.6}, app));
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
@@ -109,7 +125,10 @@ void InitPlugin(JApplication* app) {
           "EcalLumiSpecTruthProtoClusters", // edm4eic::ProtoClusterCollection
           "EcalLumiSpecRawHitAssociations"  // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"EcalLumiSpecTruthClustersWithoutShapes",             // edm4eic::Cluster
+      {"EcalLumiSpecTruthClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalLumiSpecTruthClusterLinksWithoutShapes",
+#endif
        "EcalLumiSpecTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 4.6, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -118,7 +137,11 @@ void InitPlugin(JApplication* app) {
       "EcalLumiSpecTruthClusters",
       {"EcalLumiSpecTruthClustersWithoutShapes",
        "EcalLumiSpecTruthClusterAssociationsWithoutShapes"},
-      {"EcalLumiSpecTruthClusters", "EcalLumiSpecTruthClusterAssociations"},
+      {"EcalLumiSpecTruthClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalLumiSpecTruthClusterLinks",
+#endif
+       "EcalLumiSpecTruthClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 4.6}, app));
 }
 }

--- a/src/detectors/MPGD/MPGD.cc
+++ b/src/detectors/MPGD/MPGD.cc
@@ -3,6 +3,7 @@
 //
 //
 
+#include <edm4eic/EDM4eicVersion.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
@@ -52,22 +53,30 @@ void InitPlugin(JApplication* app) {
   if ((SiFactoryPattern & 0x1) != 0U) {
     app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
         "MPGDBarrelRawHits", {"EventHeader", "MPGDBarrelHits"},
-        {"MPGDBarrelRawHits", "MPGDBarrelRawHitAssociations"},
+        {"MPGDBarrelRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+         "MPGDBarrelRawHitLinks",
+#endif
+         "MPGDBarrelRawHitAssociations"},
         {
             .threshold      = 100 * dd4hep::eV,
             .timeResolution = 10,
         },
         app));
   } else {
-    app->Add(new JOmniFactoryGeneratorT<MPGDTrackerDigi_factory>(
-        "MPGDBarrelRawHits", {"EventHeader", "MPGDBarrelHits"},
-        {"MPGDBarrelRawHits", "MPGDBarrelRawHitAssociations"},
-        {
-            .readout        = "MPGDBarrelHits",
-            .threshold      = 100 * dd4hep::eV,
-            .timeResolution = 10,
-        },
-        app));
+    app->Add(new JOmniFactoryGeneratorT<MPGDTrackerDigi_factory>("MPGDBarrelRawHits",
+                                                                 {"EventHeader", "MPGDBarrelHits"},
+                                                                 {"MPGDBarrelRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                                                  "MPGDBarrelRawHitLinks",
+#endif
+                                                                  "MPGDBarrelRawHitAssociations"},
+                                                                 {
+                                                                     .readout   = "MPGDBarrelHits",
+                                                                     .threshold = 100 * dd4hep::eV,
+                                                                     .timeResolution = 10,
+                                                                 },
+                                                                 app));
   }
 
   // Convert raw digitized hits into hits with geometry info (ready for tracking)
@@ -84,7 +93,11 @@ void InitPlugin(JApplication* app) {
   if ((SiFactoryPattern & 0x2) != 0U) {
     app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
         "OuterMPGDBarrelRawHits", {"EventHeader", "OuterMPGDBarrelHits"},
-        {"OuterMPGDBarrelRawHits", "OuterMPGDBarrelRawHitAssociations"},
+        {"OuterMPGDBarrelRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+         "OuterMPGDBarrelRawHitLinks",
+#endif
+         "OuterMPGDBarrelRawHitAssociations"},
         {
             .threshold      = 100 * dd4hep::eV,
             .timeResolution = 10,
@@ -93,7 +106,11 @@ void InitPlugin(JApplication* app) {
   } else {
     app->Add(new JOmniFactoryGeneratorT<MPGDTrackerDigi_factory>(
         "OuterMPGDBarrelRawHits", {"EventHeader", "OuterMPGDBarrelHits"},
-        {"OuterMPGDBarrelRawHits", "OuterMPGDBarrelRawHitAssociations"},
+        {"OuterMPGDBarrelRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+         "OuterMPGDBarrelRawHitLinks",
+#endif
+         "OuterMPGDBarrelRawHitAssociations"},
         {
             .readout        = "OuterMPGDBarrelHits",
             .threshold      = 100 * dd4hep::eV,
@@ -115,7 +132,11 @@ void InitPlugin(JApplication* app) {
   // Digitization
   app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
       "BackwardMPGDEndcapRawHits", {"EventHeader", "BackwardMPGDEndcapHits"},
-      {"BackwardMPGDEndcapRawHits", "BackwardMPGDEndcapRawHitAssociations"},
+      {"BackwardMPGDEndcapRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "BackwardMPGDEndcapRawHitLinks",
+#endif
+       "BackwardMPGDEndcapRawHitAssociations"},
       {
           .threshold      = 100 * dd4hep::eV,
           .timeResolution = 10,
@@ -135,7 +156,11 @@ void InitPlugin(JApplication* app) {
   // Digitization
   app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
       "ForwardMPGDEndcapRawHits", {"EventHeader", "ForwardMPGDEndcapHits"},
-      {"ForwardMPGDEndcapRawHits", "ForwardMPGDEndcapRawHitAssociations"},
+      {"ForwardMPGDEndcapRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "ForwardMPGDEndcapRawHitLinks",
+#endif
+       "ForwardMPGDEndcapRawHitAssociations"},
       {
           .threshold      = 100 * dd4hep::eV,
           .timeResolution = 10,

--- a/src/detectors/PFRICH/PFRICH.cc
+++ b/src/detectors/PFRICH/PFRICH.cc
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2024, Dmitry Kalinkin
 
+#include <edm4eic/EDM4eicVersion.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JTypeInfo.h>
@@ -50,6 +51,11 @@ void InitPlugin(JApplication* app) {
   // digitization
   app->Add(new JOmniFactoryGeneratorT<PhotoMultiplierHitDigi_factory>(
       "RICHEndcapNRawHits", {"EventHeader", "RICHEndcapNHits"},
-      {"RICHEndcapNRawHits", "RICHEndcapNRawHitsAssociations"}, digi_cfg, app));
+      {"RICHEndcapNRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "RICHEndcapNRawHitsLinks",
+#endif
+       "RICHEndcapNRawHitsAssociations"},
+      digi_cfg, app));
 }
 }

--- a/src/detectors/RPOTS/RPOTS.cc
+++ b/src/detectors/RPOTS/RPOTS.cc
@@ -31,10 +31,8 @@ void InitPlugin(JApplication* app) {
       "ForwardRomanPotRawHits", {"EventHeader", "ForwardRomanPotHits"},
       {"ForwardRomanPotRawHits",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-
        "ForwardRomanPotRawHitLinks",
 #endif
-
        "ForwardRomanPotRawHitAssociations"},
       {
           .threshold      = 10.0 * dd4hep::keV,

--- a/src/detectors/RPOTS/RPOTS.cc
+++ b/src/detectors/RPOTS/RPOTS.cc
@@ -5,6 +5,7 @@
 
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplicationFwd.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <vector>
@@ -28,7 +29,13 @@ void InitPlugin(JApplication* app) {
   //Digitized hits, especially for thresholds
   app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
       "ForwardRomanPotRawHits", {"EventHeader", "ForwardRomanPotHits"},
-      {"ForwardRomanPotRawHits", "ForwardRomanPotRawHitAssociations"},
+      {"ForwardRomanPotRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+
+       "ForwardRomanPotRawHitLinks",
+#endif
+
+       "ForwardRomanPotRawHitAssociations"},
       {
           .threshold      = 10.0 * dd4hep::keV,
           .timeResolution = 8,

--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -3,6 +3,7 @@
 
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplicationFwd.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <variant>
@@ -29,7 +30,13 @@ void InitPlugin(JApplication* app) {
   // LYSO part of the ZDC
   app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
       "EcalFarForwardZDCRawHits", {"EventHeader", "EcalFarForwardZDCHits"},
-      {"EcalFarForwardZDCRawHits", "EcalFarForwardZDCRawHitAssociations"},
+      {"EcalFarForwardZDCRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+
+       "EcalFarForwardZDCRawHitLinks",
+#endif
+
+       "EcalFarForwardZDCRawHitAssociations"},
       {
           .eRes{},
           .tRes          = 0.0 * dd4hep::ns,
@@ -93,7 +100,10 @@ void InitPlugin(JApplication* app) {
           "EcalFarForwardZDCTruthProtoClusters", // edm4eic::ProtoClusterCollection
           "EcalFarForwardZDCRawHitAssociations"  // edm4eic::MCRecoClusterHitAssociationCollection
       },
-      {"EcalFarForwardZDCTruthClustersWithoutShapes",             // edm4eic::Cluster
+      {"EcalFarForwardZDCTruthClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalFarForwardZDCTruthClusterLinksWithoutShapes",
+#endif
        "EcalFarForwardZDCTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 3.6, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -103,7 +113,11 @@ void InitPlugin(JApplication* app) {
       "EcalFarForwardZDCTruthClusters",
       {"EcalFarForwardZDCTruthClustersWithoutShapes",
        "EcalFarForwardZDCTruthClusterAssociationsWithoutShapes"},
-      {"EcalFarForwardZDCTruthClusters", "EcalFarForwardZDCTruthClusterAssociations"},
+      {"EcalFarForwardZDCTruthClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalFarForwardZDCTruthClusterLinks",
+#endif
+       "EcalFarForwardZDCTruthClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 3.6}, app));
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
@@ -112,7 +126,10 @@ void InitPlugin(JApplication* app) {
           "EcalFarForwardZDCIslandProtoClusters", // edm4eic::ProtoClusterCollection
           "EcalFarForwardZDCRawHitAssociations"   // edm4eic::MCRecoClusterHitAssociationCollection
       },
-      {"EcalFarForwardZDCClustersWithoutShapes",             // edm4eic::Cluster
+      {"EcalFarForwardZDCClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalFarForwardZDCClusterLinksWithoutShapes",
+#endif
        "EcalFarForwardZDCClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {
           .energyWeight    = "log",
@@ -127,12 +144,20 @@ void InitPlugin(JApplication* app) {
       "EcalFarForwardZDCClusters",
       {"EcalFarForwardZDCClustersWithoutShapes",
        "EcalFarForwardZDCClusterAssociationsWithoutShapes"},
-      {"EcalFarForwardZDCClusters", "EcalFarForwardZDCClusterAssociations"},
+      {"EcalFarForwardZDCClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalFarForwardZDCClusterLinks",
+#endif
+       "EcalFarForwardZDCClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 6.2}, app));
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
       "HcalFarForwardZDCRawHits", {"EventHeader", "HcalFarForwardZDCHits"},
-      {"HcalFarForwardZDCRawHits", "HcalFarForwardZDCRawHitAssociations"},
+      {"HcalFarForwardZDCRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalFarForwardZDCRawHitLinks",
+#endif
+       "HcalFarForwardZDCRawHitAssociations"},
       {
           .eRes{},
           .tRes          = 0.0 * dd4hep::ns,
@@ -224,7 +249,10 @@ void InitPlugin(JApplication* app) {
           "HcalFarForwardZDCImagingProtoClusters", // edm4eic::ProtoClusterCollection
           "HcalFarForwardZDCRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"HcalFarForwardZDCClustersWithoutShapes",             // edm4eic::Cluster
+      {"HcalFarForwardZDCClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalFarForwardZDCClusterLinksWithoutShapes",
+#endif
        "HcalFarForwardZDCClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight        = "log",
        .sampFrac            = 0.0203,
@@ -237,7 +265,11 @@ void InitPlugin(JApplication* app) {
       "HcalFarForwardZDCClusters",
       {"HcalFarForwardZDCClustersWithoutShapes",
        "HcalFarForwardZDCClusterAssociationsWithoutShapes"},
-      {"HcalFarForwardZDCClusters", "HcalFarForwardZDCClusterAssociations"},
+      {"HcalFarForwardZDCClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalFarForwardZDCClusterLinks",
+#endif
+       "HcalFarForwardZDCClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true,
        .energyWeight                    = "log",
        .sampFrac                        = 0.0203,
@@ -280,7 +312,10 @@ void InitPlugin(JApplication* app) {
           "HcalFarForwardZDCTruthProtoClusters", // edm4eic::ProtoClusterCollection
           "HcalFarForwardZDCRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"HcalFarForwardZDCTruthClustersWithoutShapes",             // edm4eic::Cluster
+      {"HcalFarForwardZDCTruthClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalFarForwardZDCTruthClusterLinksWithoutShapes",
+#endif
        "HcalFarForwardZDCTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 3.6, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -290,7 +325,11 @@ void InitPlugin(JApplication* app) {
       "HcalFarForwardZDCTruthClusters",
       {"HcalFarForwardZDCTruthClustersWithoutShapes",
        "HcalFarForwardZDCTruthClusterAssociationsWithoutShapes"},
-      {"HcalFarForwardZDCTruthClusters", "HcalFarForwardZDCTruthClusterAssociations"},
+      {"HcalFarForwardZDCTruthClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalFarForwardZDCTruthClusterLinks",
+#endif
+       "HcalFarForwardZDCTruthClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 3.6}, app));
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
@@ -300,6 +339,9 @@ void InitPlugin(JApplication* app) {
           "HcalFarForwardZDCRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
       {"HcalFarForwardZDCClustersBaselineWithoutShapes", // edm4eic::Cluster
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalFarForwardZDCClusterLinksBaselineWithoutShapes",
+#endif
        "HcalFarForwardZDCClusterAssociationsBaselineWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {
           .energyWeight    = "log",
@@ -314,7 +356,11 @@ void InitPlugin(JApplication* app) {
       "HcalFarForwardZDCClustersBaseline",
       {"HcalFarForwardZDCClustersBaselineWithoutShapes",
        "HcalFarForwardZDCClusterAssociationsBaselineWithoutShapes"},
-      {"HcalFarForwardZDCClustersBaseline", "HcalFarForwardZDCClusterAssociationsBaseline"},
+      {"HcalFarForwardZDCClustersBaseline",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalFarForwardZDCClusterLinksBaseline",
+#endif
+       "HcalFarForwardZDCClusterAssociationsBaseline"},
       {.longitudinalShowerInfoAvailable = true,
        .energyWeight                    = "log",
        .sampFrac                        = 0.0203,

--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -32,10 +32,8 @@ void InitPlugin(JApplication* app) {
       "EcalFarForwardZDCRawHits", {"EventHeader", "EcalFarForwardZDCHits"},
       {"EcalFarForwardZDCRawHits",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-
        "EcalFarForwardZDCRawHitLinks",
 #endif
-
        "EcalFarForwardZDCRawHitAssociations"},
       {
           .eRes{},

--- a/src/factories/calorimetry/CalorimeterClusterRecoCoG_factory.h
+++ b/src/factories/calorimetry/CalorimeterClusterRecoCoG_factory.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <edm4eic/EDM4eicVersion.h>
 #include "algorithms/calorimetry/CalorimeterClusterRecoCoG.h"
 #include "services/algorithms_init/AlgorithmsInit_service.h"
 #include "extensions/jana/JOmniFactory.h"
@@ -22,6 +23,9 @@ private:
   PodioInput<edm4eic::MCRecoCalorimeterHitAssociation> m_mchitassocs_input{this};
 
   PodioOutput<edm4eic::Cluster> m_cluster_output{this};
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  PodioOutput<edm4eic::MCRecoClusterParticleLink> m_links_output{this};
+#endif
   PodioOutput<edm4eic::MCRecoClusterParticleAssociation> m_assoc_output{this};
 
   ParameterRef<std::string> m_energyWeight{this, "energyWeight", config().energyWeight};
@@ -44,8 +48,11 @@ public:
   }
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
-    m_algo->process({m_proto_input(), m_mchitassocs_input()},
-                    {m_cluster_output().get(), m_assoc_output().get()});
+    m_algo->process({m_proto_input(), m_mchitassocs_input()}, {m_cluster_output().get(),
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                                               m_links_output().get(),
+#endif
+                                                               m_assoc_output().get()});
   }
 };
 

--- a/src/factories/calorimetry/CalorimeterClusterShape_factory.h
+++ b/src/factories/calorimetry/CalorimeterClusterShape_factory.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <edm4eic/EDM4eicVersion.h>
 #include "algorithms/calorimetry/CalorimeterClusterShape.h"
 #include "extensions/jana/JOmniFactory.h"
 #include "services/algorithms_init/AlgorithmsInit_service.h"
@@ -25,6 +26,9 @@ private:
 
   // output collections
   PodioOutput<edm4eic::Cluster> m_clusters_output{this};
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  PodioOutput<edm4eic::MCRecoClusterParticleLink> m_links_output{this};
+#endif
   PodioOutput<edm4eic::MCRecoClusterParticleAssociation> m_assocs_output{this};
 
   // parameter bindings
@@ -50,8 +54,11 @@ public:
   }
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
-    m_algo->process({m_clusters_input(), m_assocs_input()},
-                    {m_clusters_output().get(), m_assocs_output().get()});
+    m_algo->process({m_clusters_input(), m_assocs_input()}, {m_clusters_output().get(),
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                                             m_links_output().get(),
+#endif
+                                                             m_assocs_output().get()});
   }
 
 }; // end CalorimeterClusterShape_factory

--- a/src/factories/calorimetry/CalorimeterHitDigi_factory.h
+++ b/src/factories/calorimetry/CalorimeterHitDigi_factory.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <edm4eic/EDM4eicVersion.h>
 #include "algorithms/calorimetry/CalorimeterHitDigi.h"
 #include "services/algorithms_init/AlgorithmsInit_service.h"
 #include "extensions/jana/JOmniFactory.h"
@@ -21,6 +22,9 @@ private:
   PodioInput<edm4hep::EventHeader> m_event_headers_input{this};
   PodioInput<edm4hep::SimCalorimeterHit> m_hits_input{this};
   PodioOutput<edm4hep::RawCalorimeterHit> m_hits_output{this};
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  PodioOutput<edm4eic::MCRecoCalorimeterHitLink> m_links_output{this};
+#endif
   PodioOutput<edm4eic::MCRecoCalorimeterHitAssociation> m_hit_assocs_output{this};
 
   ParameterRef<std::vector<double>> m_energyResolutions{this, "energyResolutions", config().eRes};
@@ -51,8 +55,11 @@ public:
   }
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
-    m_algo->process({m_event_headers_input(), m_hits_input()},
-                    {m_hits_output().get(), m_hit_assocs_output().get()});
+    m_algo->process({m_event_headers_input(), m_hits_input()}, {m_hits_output().get(),
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                                                m_links_output().get(),
+#endif
+                                                                m_hit_assocs_output().get()});
   }
 };
 

--- a/src/factories/calorimetry/CalorimeterParticleIDPostML_factory.h
+++ b/src/factories/calorimetry/CalorimeterParticleIDPostML_factory.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <edm4eic/EDM4eicVersion.h>
 #include "algorithms/onnx/CalorimeterParticleIDPostML.h"
 #include "services/algorithms_init/AlgorithmsInit_service.h"
 #include "extensions/jana/JOmniFactory.h"
@@ -23,6 +24,9 @@ private:
   PodioInput<edm4eic::Tensor> m_prediction_tensor_input{this};
 
   PodioOutput<edm4eic::Cluster> m_cluster_output{this};
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  PodioOutput<edm4eic::MCRecoClusterParticleLink> m_cluster_links_output{this};
+#endif
   PodioOutput<edm4eic::MCRecoClusterParticleAssociation> m_cluster_assoc_output{this};
   PodioOutput<edm4hep::ParticleID> m_particle_id_output{this};
 
@@ -35,9 +39,12 @@ public:
   }
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
-    m_algo->process(
-        {m_cluster_input(), m_cluster_assoc_input(), m_prediction_tensor_input()},
-        {m_cluster_output().get(), m_cluster_assoc_output().get(), m_particle_id_output().get()});
+    m_algo->process({m_cluster_input(), m_cluster_assoc_input(), m_prediction_tensor_input()},
+                    {m_cluster_output().get(),
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                     m_cluster_links_output().get(),
+#endif
+                     m_cluster_assoc_output().get(), m_particle_id_output().get()});
   }
 };
 

--- a/src/factories/calorimetry/EnergyPositionClusterMerger_factory.h
+++ b/src/factories/calorimetry/EnergyPositionClusterMerger_factory.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <edm4eic/EDM4eicVersion.h>
 #include "algorithms/calorimetry/EnergyPositionClusterMerger.h"
 #include "extensions/jana/JOmniFactory.h"
 #include "services/algorithms_init/AlgorithmsInit_service.h"
@@ -24,6 +25,9 @@ private:
   PodioInput<edm4eic::MCRecoClusterParticleAssociation> m_position_assoc_input{this};
 
   PodioOutput<edm4eic::Cluster> m_cluster_output{this};
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  PodioOutput<edm4eic::MCRecoClusterParticleLink> m_links_output{this};
+#endif
   PodioOutput<edm4eic::MCRecoClusterParticleAssociation> m_assoc_output{this};
 
   ParameterRef<double> m_energyRelTolerance{this, "energyRelTolerance",
@@ -44,7 +48,11 @@ public:
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_energy_cluster_input(), m_energy_assoc_input(), m_position_cluster_input(),
                      m_position_assoc_input()},
-                    {m_cluster_output().get(), m_assoc_output().get()});
+                    {m_cluster_output().get(),
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                     m_links_output().get(),
+#endif
+                     m_assoc_output().get()});
   }
 };
 

--- a/src/factories/calorimetry/ImagingClusterReco_factory.h
+++ b/src/factories/calorimetry/ImagingClusterReco_factory.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <edm4eic/EDM4eicVersion.h>
 #include "algorithms/calorimetry/ImagingClusterReco.h"
 #include "extensions/jana/JOmniFactory.h"
 #include "services/algorithms_init/AlgorithmsInit_service.h"
@@ -22,6 +23,9 @@ private:
   PodioInput<edm4eic::MCRecoCalorimeterHitAssociation> m_mchitassocs_input{this};
 
   PodioOutput<edm4eic::Cluster> m_clusters_output{this};
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  PodioOutput<edm4eic::MCRecoClusterParticleLink> m_links_output{this};
+#endif
   PodioOutput<edm4eic::MCRecoClusterParticleAssociation> m_assocs_output{this};
   PodioOutput<edm4eic::Cluster> m_layers_output{this};
 
@@ -39,7 +43,11 @@ public:
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_protos_input(), m_mchitassocs_input()},
-                    {m_clusters_output().get(), m_assocs_output().get(), m_layers_output().get()});
+                    {m_clusters_output().get(),
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                     m_links_output().get(),
+#endif
+                     m_assocs_output().get(), m_layers_output().get()});
   }
 };
 

--- a/src/factories/calorimetry/TruthEnergyPositionClusterMerger_factory.h
+++ b/src/factories/calorimetry/TruthEnergyPositionClusterMerger_factory.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <edm4eic/EDM4eicVersion.h>
 #include "algorithms/calorimetry/TruthEnergyPositionClusterMerger.h"
 #include "extensions/jana/JOmniFactory.h"
 #include "services/algorithms_init/AlgorithmsInit_service.h"
@@ -24,6 +25,9 @@ private:
   PodioInput<edm4eic::MCRecoClusterParticleAssociation> m_position_assocs_input{this};
 
   PodioOutput<edm4eic::Cluster> m_clusters_output{this};
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  PodioOutput<edm4eic::MCRecoClusterParticleLink> m_links_output{this};
+#endif
   PodioOutput<edm4eic::MCRecoClusterParticleAssociation> m_assocs_output{this};
 
   Service<AlgorithmsInit_service> m_algorithmsInit{this};
@@ -39,7 +43,11 @@ public:
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_mcparticles_input(), m_energy_clusters_input(), m_energy_assocs_input(),
                      m_position_clusters_input(), m_position_assocs_input()},
-                    {m_clusters_output().get(), m_assocs_output().get()});
+                    {m_clusters_output().get(),
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                     m_links_output().get(),
+#endif
+                     m_assocs_output().get()});
   }
 };
 

--- a/src/factories/digi/MPGDTrackerDigi_factory.h
+++ b/src/factories/digi/MPGDTrackerDigi_factory.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <edm4eic/EDM4eicVersion.h>
 #include "algorithms/digi/MPGDTrackerDigi.h"
 #include "services/algorithms_init/AlgorithmsInit_service.h"
 #include "extensions/jana/JOmniFactory.h"
@@ -22,6 +23,9 @@ private:
   PodioInput<edm4hep::SimTrackerHit> m_sim_hits_input{this};
 
   PodioOutput<edm4eic::RawTrackerHit> m_raw_hits_output{this};
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  PodioOutput<edm4eic::MCRecoTrackerHitLink> m_links_output{this};
+#endif
   PodioOutput<edm4eic::MCRecoTrackerHitAssociation> m_assoc_output{this};
 
   ParameterRef<double> m_threshold{this, "threshold", config().threshold};
@@ -37,8 +41,11 @@ public:
   }
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
-    m_algo->process({m_event_headers_input(), m_sim_hits_input()},
-                    {m_raw_hits_output().get(), m_assoc_output().get()});
+    m_algo->process({m_event_headers_input(), m_sim_hits_input()}, {m_raw_hits_output().get(),
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                                                    m_links_output().get(),
+#endif
+                                                                    m_assoc_output().get()});
   }
 };
 

--- a/src/factories/digi/PhotoMultiplierHitDigi_factory.h
+++ b/src/factories/digi/PhotoMultiplierHitDigi_factory.h
@@ -5,6 +5,7 @@
 
 #include <JANA/JEvent.h>
 #include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/RawTrackerHitCollection.h>
 #include <memory>
 #include <string>
@@ -36,6 +37,9 @@ private:
   PodioInput<edm4hep::EventHeader> m_event_headers_input{this};
   PodioInput<edm4hep::SimTrackerHit> m_sim_hits_input{this};
   PodioOutput<edm4eic::RawTrackerHit> m_raw_hits_output{this};
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  PodioOutput<edm4eic::MCRecoTrackerHitLink> m_links_output{this};
+#endif
   PodioOutput<edm4eic::MCRecoTrackerHitAssociation> m_raw_assocs_output{this};
 
   ParameterRef<std::string> m_detectorName{this, "detectorName", config().detectorName, ""};
@@ -85,8 +89,11 @@ public:
   }
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
-    m_algo->process({m_event_headers_input(), m_sim_hits_input()},
-                    {m_raw_hits_output().get(), m_raw_assocs_output().get()});
+    m_algo->process({m_event_headers_input(), m_sim_hits_input()}, {m_raw_hits_output().get(),
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                                                    m_links_output().get(),
+#endif
+                                                                    m_raw_assocs_output().get()});
   }
 };
 

--- a/src/factories/digi/PulseCombiner_factory.h
+++ b/src/factories/digi/PulseCombiner_factory.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <edm4eic/EDM4eicVersion.h>
 #include "extensions/jana/JOmniFactory.h"
 #include "services/algorithms_init/AlgorithmsInit_service.h"
 

--- a/src/factories/digi/PulseGeneration_factory.h
+++ b/src/factories/digi/PulseGeneration_factory.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <edm4eic/EDM4eicVersion.h>
 #include "algorithms/digi/PulseGeneration.h"
 #include "services/algorithms_init/AlgorithmsInit_service.h"
 #include "extensions/jana/JOmniFactory.h"

--- a/src/factories/digi/PulseNoise_factory.h
+++ b/src/factories/digi/PulseNoise_factory.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <edm4eic/EDM4eicVersion.h>
 #include "algorithms/digi/PulseNoise.h"
 #include "services/algorithms_init/AlgorithmsInit_service.h"
 #include "extensions/jana/JOmniFactory.h"

--- a/src/factories/digi/SiliconPulseDiscretization_factory.h
+++ b/src/factories/digi/SiliconPulseDiscretization_factory.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <edm4eic/EDM4eicVersion.h>
 #include "services/algorithms_init/AlgorithmsInit_service.h"
 #include "algorithms/digi/SiliconPulseDiscretization.h"
 #include "extensions/jana/JOmniFactory.h"

--- a/src/factories/digi/SiliconTrackerDigi_factory.h
+++ b/src/factories/digi/SiliconTrackerDigi_factory.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <edm4eic/EDM4eicVersion.h>
 #include "algorithms/digi/SiliconTrackerDigi.h"
 #include "services/algorithms_init/AlgorithmsInit_service.h"
 #include "extensions/jana/JOmniFactory.h"
@@ -22,6 +23,9 @@ private:
   PodioInput<edm4hep::SimTrackerHit> m_sim_hits_input{this};
 
   PodioOutput<edm4eic::RawTrackerHit> m_raw_hits_output{this};
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  PodioOutput<edm4eic::MCRecoTrackerHitLink> m_links_output{this};
+#endif
   PodioOutput<edm4eic::MCRecoTrackerHitAssociation> m_assoc_output{this};
 
   ParameterRef<double> m_threshold{this, "threshold", config().threshold};
@@ -36,8 +40,11 @@ public:
   }
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
-    m_algo->process({m_event_headers_input(), m_sim_hits_input()},
-                    {m_raw_hits_output().get(), m_assoc_output().get()});
+    m_algo->process({m_event_headers_input(), m_sim_hits_input()}, {m_raw_hits_output().get(),
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                                                    m_links_output().get(),
+#endif
+                                                                    m_assoc_output().get()});
   }
 };
 

--- a/src/factories/fardetectors/FarDetectorLinearTracking_factory.h
+++ b/src/factories/fardetectors/FarDetectorLinearTracking_factory.h
@@ -7,6 +7,7 @@
 
 // Event Model related classes
 #include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoTrackParticleAssociationCollection.h>
 #include <edm4eic/TrackCollection.h>
 #include <edm4eic/Measurement2DCollection.h>
@@ -29,6 +30,9 @@ private:
   VariadicPodioInput<edm4eic::Measurement2D> m_hits_input{this};
   PodioInput<edm4eic::MCRecoTrackerHitAssociation> m_hits_association_input{this};
   PodioOutput<edm4eic::Track> m_tracks_output{this};
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  PodioOutput<edm4eic::MCRecoTrackParticleLink> m_tracks_links_output{this};
+#endif
   PodioOutput<edm4eic::MCRecoTrackParticleAssociation> m_tracks_association_output{this};
 
   ParameterRef<std::size_t> n_layer{this, "numLayers", config().n_layer};
@@ -55,7 +59,11 @@ public:
       // Prepare the input tuple
       auto input = std::make_tuple(hits, m_hits_association_input());
 
-      m_algo->process(input, {m_tracks_output().get(), m_tracks_association_output().get()});
+      m_algo->process(input, {m_tracks_output().get(),
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                              m_tracks_links_output().get(),
+#endif
+                              m_tracks_association_output().get()});
     } catch (std::exception& e) {
       throw JException(e.what());
     }

--- a/src/factories/fardetectors/FarDetectorTransportationPostML_factory.h
+++ b/src/factories/fardetectors/FarDetectorTransportationPostML_factory.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <edm4eic/EDM4eicVersion.h>
 #include "algorithms/fardetectors/FarDetectorTransportationPostML.h"
 #include "services/algorithms_init/AlgorithmsInit_service.h"
 #include "extensions/jana/JOmniFactory.h"
@@ -24,6 +25,9 @@ private:
   PodioInput<edm4hep::MCParticle> m_beamelectrons_input{this};
 
   PodioOutput<edm4eic::ReconstructedParticle> m_particle_output{this};
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  PodioOutput<edm4eic::MCRecoParticleLink> m_links_output{this};
+#endif
   PodioOutput<edm4eic::MCRecoParticleAssociation> m_association_output{this};
 
   ParameterRef<float> m_beamE{this, "beamE", config().beamE};
@@ -45,7 +49,11 @@ public:
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_prediction_tensor_input(), m_association_input(), m_beamelectrons_input()},
-                    {m_particle_output().get(), m_association_output().get()});
+                    {m_particle_output().get(),
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                     m_links_output().get(),
+#endif
+                     m_association_output().get()});
   }
 };
 

--- a/src/factories/pid/MatchToRICHPID_factory.h
+++ b/src/factories/pid/MatchToRICHPID_factory.h
@@ -6,6 +6,7 @@
 #include "algorithms/pid/MatchToRICHPID.h"
 #include "extensions/jana/JOmniFactory.h"
 #include <edm4eic/CherenkovParticleID.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/ReconstructedParticle.h>
 #include <edm4eic/MCRecoParticleAssociation.h>
 #include <edm4hep/ParticleID.h>
@@ -24,6 +25,9 @@ private:
   PodioInput<edm4eic::MCRecoParticleAssociation> m_assocs_input{this};
   PodioInput<edm4eic::CherenkovParticleID> m_cherenkov_particle_ids_input{this};
   PodioOutput<edm4eic::ReconstructedParticle> m_recoparticles_output{this};
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  PodioOutput<edm4eic::MCRecoParticleLink> m_links_output{this};
+#endif
   PodioOutput<edm4eic::MCRecoParticleAssociation> m_assocs_output{this};
   PodioOutput<edm4hep::ParticleID> m_pids_output{this};
 
@@ -36,9 +40,12 @@ public:
   };
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
-    m_algo->process(
-        {m_recoparticles_input(), m_assocs_input(), m_cherenkov_particle_ids_input()},
-        {m_recoparticles_output().get(), m_assocs_output().get(), m_pids_output().get()});
+    m_algo->process({m_recoparticles_input(), m_assocs_input(), m_cherenkov_particle_ids_input()},
+                    {m_recoparticles_output().get(),
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                     m_links_output().get(),
+#endif
+                     m_assocs_output().get(), m_pids_output().get()});
   }
 };
 

--- a/src/factories/pid_lut/PIDLookup_factory.h
+++ b/src/factories/pid_lut/PIDLookup_factory.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <edm4eic/MCRecoParticleAssociationCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/ParticleIDCollection.h>
@@ -25,6 +26,9 @@ private:
   PodioInput<edm4eic::ReconstructedParticle> m_recoparticles_input{this};
   PodioInput<edm4eic::MCRecoParticleAssociation> m_recoparticle_assocs_input{this};
   PodioOutput<edm4eic::ReconstructedParticle> m_recoparticles_output{this};
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  PodioOutput<edm4eic::MCRecoParticleLink> m_recoparticle_links_output{this};
+#endif
   PodioOutput<edm4eic::MCRecoParticleAssociation> m_recoparticle_assocs_output{this};
   PodioOutput<edm4hep::ParticleID> m_particleids_output{this};
 
@@ -45,8 +49,11 @@ public:
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process(
         {m_event_headers_input(), m_recoparticles_input(), m_recoparticle_assocs_input()},
-        {m_recoparticles_output().get(), m_recoparticle_assocs_output().get(),
-         m_particleids_output().get()});
+        {m_recoparticles_output().get(),
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+         m_recoparticle_links_output().get(),
+#endif
+         m_recoparticle_assocs_output().get(), m_particleids_output().get()});
   }
 };
 

--- a/src/factories/reco/MatchClusters_factory.h
+++ b/src/factories/reco/MatchClusters_factory.h
@@ -6,6 +6,7 @@
 
 #include <algorithms/logger.h>
 #include <edm4eic/ClusterCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <edm4eic/MCRecoParticleAssociationCollection.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
@@ -34,6 +35,9 @@ private:
 
   // Declare outputs
   PodioOutput<edm4eic::ReconstructedParticle> m_rec_parts_output{this};
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  PodioOutput<edm4eic::MCRecoParticleLink> m_rec_links_output{this};
+#endif
   PodioOutput<edm4eic::MCRecoParticleAssociation> m_rec_assocs_output{this};
 
   Service<AlgorithmsInit_service> m_algorithmsInit{this};
@@ -57,6 +61,9 @@ public:
         },
         {
             m_rec_parts_output().get(),
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+            m_rec_links_output().get(),
+#endif
             m_rec_assocs_output().get(),
         });
   }

--- a/src/factories/tracking/ActsToTracks_factory.h
+++ b/src/factories/tracking/ActsToTracks_factory.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <edm4eic/EDM4eicVersion.h>
 #include <cassert>
 #include <memory>
 
@@ -26,6 +27,9 @@ private:
   PodioOutput<edm4eic::Trajectory> m_trajectories_output{this};
   PodioOutput<edm4eic::TrackParameters> m_parameters_output{this};
   PodioOutput<edm4eic::Track> m_tracks_output{this};
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  PodioOutput<edm4eic::MCRecoTrackParticleLink> m_track_links_output{this};
+#endif
   PodioOutput<edm4eic::MCRecoTrackParticleAssociation> m_track_assocs_output{this};
 
 public:
@@ -56,6 +60,9 @@ public:
             m_trajectories_output().get(),
             m_parameters_output().get(),
             m_tracks_output().get(),
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+            m_track_links_output().get(),
+#endif
             m_track_assocs_output().get(),
         });
   }

--- a/src/factories/tracking/TracksToParticles_factory.h
+++ b/src/factories/tracking/TracksToParticles_factory.h
@@ -5,6 +5,7 @@
 
 #include "algorithms/tracking/TracksToParticles.h"
 #include <edm4eic/MCRecoParticleAssociation.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/ReconstructedParticle.h>
 #include <edm4eic/Track.h>
 #include <edm4hep/MCParticleCollection.h>
@@ -23,6 +24,9 @@ private:
   PodioInput<edm4eic::Track> m_tracks_input{this};
   PodioInput<edm4eic::MCRecoTrackParticleAssociation> m_trackassocs_input{this};
   PodioOutput<edm4eic::ReconstructedParticle> m_recoparticles_output{this};
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  PodioOutput<edm4eic::MCRecoParticleLink> m_recolinks_output{this};
+#endif
   PodioOutput<edm4eic::MCRecoParticleAssociation> m_recoassocs_output{this};
 
 public:
@@ -34,8 +38,11 @@ public:
   };
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
-    m_algo->process({m_tracks_input(), m_trackassocs_input()},
-                    {m_recoparticles_output().get(), m_recoassocs_output().get()});
+    m_algo->process({m_tracks_input(), m_trackassocs_input()}, {m_recoparticles_output().get(),
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                                                m_recolinks_output().get(),
+#endif
+                                                                m_recoassocs_output().get()});
   }
 };
 

--- a/src/global/pid/pid.cc
+++ b/src/global/pid/pid.cc
@@ -3,6 +3,7 @@
 
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JTypeInfo.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <string>
 #include <vector>
 
@@ -27,7 +28,10 @@ void InitPlugin(JApplication* app) {
           "DRICHMergedIrtCherenkovParticleID",                  // edm4eic::CherenkovParticleID
       },
       {
-          "ReconstructedChargedRealPIDParticles",            // edm4eic::ReconstructedParticle
+          "ReconstructedChargedRealPIDParticles", // edm4eic::ReconstructedParticle
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "ReconstructedChargedRealPIDParticleLinks", // edm4eic::MCRecoParticleLink
+#endif
           "ReconstructedChargedRealPIDParticleAssociations", // edm4eic::MCRecoParticleAssociationCollection
           "ReconstructedChargedRealPIDParticleIDs",          // edm4hep::ParticleID
       },

--- a/src/global/pid_lut/pid_lut.cc
+++ b/src/global/pid_lut/pid_lut.cc
@@ -6,7 +6,6 @@
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoParticleAssociation.h>
 #include <edm4eic/ReconstructedParticle.h>
-#include <fmt/core.h>
 #include <cmath>
 #include <map>
 #include <memory>

--- a/src/global/pid_lut/pid_lut.cc
+++ b/src/global/pid_lut/pid_lut.cc
@@ -3,6 +3,7 @@
 
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JTypeInfo.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoParticleAssociation.h>
 #include <edm4eic/ReconstructedParticle.h>
 #include <fmt/core.h>
@@ -55,6 +56,9 @@ void InitPlugin(JApplication* app) {
       },
       {
           "ReconstructedTruthSeededChargedWithPFRICHPIDParticles",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "ReconstructedTruthSeededChargedWithPFRICHPIDParticleLinks",
+#endif
           "ReconstructedTruthSeededChargedWithPFRICHPIDParticleAssociations",
           "RICHEndcapNTruthSeededParticleIDs",
       },
@@ -69,6 +73,9 @@ void InitPlugin(JApplication* app) {
       },
       {
           "ReconstructedChargedWithPFRICHPIDParticles",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "ReconstructedChargedWithPFRICHPIDParticleLinks",
+#endif
           "ReconstructedChargedWithPFRICHPIDParticleAssociations",
           "RICHEndcapNParticleIDs",
       },
@@ -101,6 +108,9 @@ void InitPlugin(JApplication* app) {
       },
       {
           "ReconstructedTruthSeededChargedWithPFRICHTOFPIDParticles",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "ReconstructedTruthSeededChargedWithPFRICHTOFPIDParticleLinks",
+#endif
           "ReconstructedTruthSeededChargedWithPFRICHTOFPIDParticleAssociations",
           "CombinedTOFTruthSeededParticleIDs",
       },
@@ -115,6 +125,9 @@ void InitPlugin(JApplication* app) {
       },
       {
           "ReconstructedChargedWithPFRICHTOFPIDParticles",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "ReconstructedChargedWithPFRICHTOFPIDParticleLinks",
+#endif
           "ReconstructedChargedWithPFRICHTOFPIDParticleAssociations",
           "CombinedTOFParticleIDs",
       },
@@ -158,6 +171,9 @@ void InitPlugin(JApplication* app) {
       },
       {
           "ReconstructedTruthSeededChargedWithPFRICHTOFDIRCPIDParticles",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "ReconstructedTruthSeededChargedWithPFRICHTOFDIRCPIDParticleLinks",
+#endif
           "ReconstructedTruthSeededChargedWithPFRICHTOFDIRCPIDParticleAssociations",
           "DIRCTruthSeededParticleIDs",
       },
@@ -172,6 +188,9 @@ void InitPlugin(JApplication* app) {
       },
       {
           "ReconstructedChargedWithPFRICHTOFDIRCPIDParticles",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "ReconstructedChargedWithPFRICHTOFDIRCPIDParticleLinks",
+#endif
           "ReconstructedChargedWithPFRICHTOFDIRCPIDParticleAssociations",
           "DIRCParticleIDs",
       },
@@ -249,6 +268,9 @@ void InitPlugin(JApplication* app) {
       },
       {
           "ReconstructedTruthSeededChargedParticles",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "ReconstructedTruthSeededChargedParticleLinks",
+#endif
           "ReconstructedTruthSeededChargedParticleAssociations",
           "DRICHTruthSeededParticleIDs",
       },
@@ -263,6 +285,9 @@ void InitPlugin(JApplication* app) {
       },
       {
           "ReconstructedChargedParticles",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "ReconstructedChargedParticleLinks",
+#endif
           "ReconstructedChargedParticleAssociations",
           "DRICHParticleIDs",
       },

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -6,6 +6,7 @@
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <edm4eic/Cluster.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/InclusiveKinematics.h>
 #include <edm4eic/MCRecoClusterParticleAssociation.h>
 #include <edm4eic/MCRecoParticleAssociation.h>
@@ -83,7 +84,10 @@ void InitPlugin(JApplication* app) {
           "EcalClusterAssociations",
       },
       {
-          "ReconstructedParticles",           // edm4eic::ReconstructedParticle
+          "ReconstructedParticles", // edm4eic::ReconstructedParticle
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "ReconstructedParticleLinks", // edm4eic::MCRecoParticleLink
+#endif
           "ReconstructedParticleAssociations" // edm4eic::MCRecoParticleAssociation
       },
       app));

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -5,6 +5,7 @@
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JTypeInfo.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoTrackParticleAssociationCollection.h>
 #include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
 #include <edm4eic/TrackCollection.h>
@@ -108,6 +109,9 @@ void InitPlugin(JApplication* app) {
           "CentralCKFTruthSeededTrajectoriesUnfiltered",
           "CentralCKFTruthSeededTrackParametersUnfiltered",
           "CentralCKFTruthSeededTracksUnfiltered",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "CentralCKFTruthSeededTrackUnfilteredLinks",
+#endif
           "CentralCKFTruthSeededTrackUnfilteredAssociations",
       },
       app));
@@ -135,6 +139,9 @@ void InitPlugin(JApplication* app) {
                                                            "CentralCKFTruthSeededTrajectories",
                                                            "CentralCKFTruthSeededTrackParameters",
                                                            "CentralCKFTruthSeededTracks",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                                           "CentralCKFTruthSeededTrackLinks",
+#endif
                                                            "CentralCKFTruthSeededTrackAssociations",
                                                        },
                                                        app));
@@ -164,6 +171,9 @@ void InitPlugin(JApplication* app) {
                                                            "CentralCKFTrajectoriesUnfiltered",
                                                            "CentralCKFTrackParametersUnfiltered",
                                                            "CentralCKFTracksUnfiltered",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                                           "CentralCKFTrackUnfilteredLinks",
+#endif
                                                            "CentralCKFTrackUnfilteredAssociations",
                                                        },
                                                        app));
@@ -189,6 +199,9 @@ void InitPlugin(JApplication* app) {
                                                                 "CentralCKFTrajectories",
                                                                 "CentralCKFTrackParameters",
                                                                 "CentralCKFTracks",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                                                "CentralCKFTrackLinks",
+#endif
                                                                 "CentralCKFTrackAssociations",
                                                             },
                                                             app));
@@ -302,6 +315,9 @@ void InitPlugin(JApplication* app) {
           "B0TrackerCKFTruthSeededTrajectoriesUnfiltered",
           "B0TrackerCKFTruthSeededTrackParametersUnfiltered",
           "B0TrackerCKFTruthSeededTracksUnfiltered",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "B0TrackerCKFTruthSeededTrackUnfilteredLinks",
+#endif
           "B0TrackerCKFTruthSeededTrackUnfilteredAssociations",
       },
       app));
@@ -329,6 +345,9 @@ void InitPlugin(JApplication* app) {
           "B0TrackerCKFTruthSeededTrajectories",
           "B0TrackerCKFTruthSeededTrackParameters",
           "B0TrackerCKFTruthSeededTracks",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "B0TrackerCKFTruthSeededTrackLinks",
+#endif
           "B0TrackerCKFTruthSeededTrackAssociations",
       },
       app));
@@ -358,6 +377,9 @@ void InitPlugin(JApplication* app) {
           "B0TrackerCKFTrajectoriesUnfiltered",
           "B0TrackerCKFTrackParametersUnfiltered",
           "B0TrackerCKFTracksUnfiltered",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "B0TrackerCKFTrackUnfilteredLinks",
+#endif
           "B0TrackerCKFTrackUnfilteredAssociations",
       },
       app));
@@ -383,6 +405,9 @@ void InitPlugin(JApplication* app) {
                                                                 "B0TrackerCKFTrajectories",
                                                                 "B0TrackerCKFTrackParameters",
                                                                 "B0TrackerCKFTracks",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                                                                "B0TrackerCKFTrackLinks",
+#endif
                                                                 "B0TrackerCKFTrackAssociations",
                                                             },
                                                             app));
@@ -442,6 +467,9 @@ void InitPlugin(JApplication* app) {
           "CombinedTruthSeededTrackAssociations",
       },
       {"ReconstructedTruthSeededChargedWithoutPIDParticles",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "ReconstructedTruthSeededChargedWithoutPIDParticleLinks",
+#endif
        "ReconstructedTruthSeededChargedWithoutPIDParticleAssociations"},
       {}, app));
 
@@ -452,6 +480,9 @@ void InitPlugin(JApplication* app) {
           "CombinedTrackAssociations",
       },
       {"ReconstructedChargedWithoutPIDParticles",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "ReconstructedChargedWithoutPIDParticleLinks",
+#endif
        "ReconstructedChargedWithoutPIDParticleAssociations"},
       {}, app));
 }

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -8,6 +8,9 @@
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoTrackParticleAssociationCollection.h>
 #include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoTrackerHitLinkCollection.h>
+#endif
 #include <edm4eic/TrackCollection.h>
 #include <edm4eic/TrackParameters.h>
 #include <edm4eic/TrackSeed.h>
@@ -82,6 +85,19 @@ void InitPlugin(JApplication* app) {
        "ForwardMPGDEndcapRawHitAssociations"},
       {"CentralTrackingRawHitAssociations"}, // Output collection name
       app));
+
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  // Tracker hit links collector
+  app->Add(
+      new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::MCRecoTrackerHitLink, true>>(
+          "CentralTrackingRawHitLinks",
+          {"SiBarrelRawHitLinks", "SiBarrelVertexRawHitLinks", "SiEndcapTrackerRawHitLinks",
+           "TOFBarrelRawHitLinks", "TOFEndcapRawHitLinks", "MPGDBarrelRawHitLinks",
+           "OuterMPGDBarrelRawHitLinks", "BackwardMPGDEndcapRawHitLinks",
+           "ForwardMPGDEndcapRawHitLinks"},
+          {"CentralTrackingRawHitLinks"}, // Output collection name
+          app));
+#endif
 
   app->Add(new JOmniFactoryGeneratorT<TrackerMeasurementFromHits_factory>(
       "CentralTrackerMeasurements", {"CentralTrackingRecHits"}, {"CentralTrackerMeasurements"},

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -15,6 +15,8 @@
 #include <edm4eic/TrackParameters.h>
 #include <edm4eic/TrackSeed.h>
 #include <edm4eic/TrackerHitCollection.h>
+#include <podio/detail/Link.h>
+#include <deque>
 #include <functional>
 #include <map>
 #include <memory>

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -5,6 +5,7 @@
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Services/JParameterManager.h>
 #include <JANA/Utils/JTypeInfo.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <fmt/format.h>
 #include <podio/CollectionBase.h>
 #include <podio/Frame.h>
@@ -59,6 +60,9 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       // Central tracking hits combined
       "CentralTrackerTruthSeeds",
       "CentralTrackingRecHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "CentralTrackingRawHitLinks",
+#endif
       "CentralTrackingRawHitAssociations",
       "CentralTrackSeeds",
       "CentralTrackSeedParameters",
@@ -77,8 +81,17 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       "VertexBarrelHits",
       "TrackerEndcapHits",
 
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "SiBarrelRawHitLinks",
+#endif
       "SiBarrelRawHitAssociations",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "SiBarrelVertexRawHitLinks",
+#endif
       "SiBarrelVertexRawHitAssociations",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "SiEndcapTrackerRawHitLinks",
+#endif
       "SiEndcapTrackerRawHitAssociations",
 
       // TOF
@@ -96,7 +109,13 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       "TOFEndcapSharedHits",
       "TOFEndcapADCTDC",
 
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "TOFBarrelRawHitLinks",
+#endif
       "TOFBarrelRawHitAssociations",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "TOFEndcapRawHitLinks",
+#endif
       "TOFEndcapRawHitAssociations",
 
       "CombinedTOFTruthSeededParticleIDs",
@@ -104,6 +123,9 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
 
       // DRICH
       "DRICHRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "DRICHRawHitsLinks",
+#endif
       "DRICHRawHitsAssociations",
       "DRICHAerogelTracks",
       "DRICHGasTracks",
@@ -114,6 +136,9 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
 
       // PFRICH
       "RICHEndcapNRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "RICHEndcapNRawHitsLinks",
+#endif
       "RICHEndcapNRawHitsAssociations",
       "RICHEndcapNTruthSeededParticleIDs",
       "RICHEndcapNParticleIDs",
@@ -134,9 +159,21 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       "BackwardMPGDEndcapHits",
       "ForwardMPGDEndcapHits",
 
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "MPGDBarrelRawHitLinks",
+#endif
       "MPGDBarrelRawHitAssociations",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "OuterMPGDBarrelRawHitLinks",
+#endif
       "OuterMPGDBarrelRawHitAssociations",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "BackwardMPGDEndcapRawHitLinks",
+#endif
       "BackwardMPGDEndcapRawHitAssociations",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "ForwardMPGDEndcapRawHitLinks",
+#endif
       "ForwardMPGDEndcapRawHitAssociations",
 
       // LOWQ2 hits
@@ -146,6 +183,9 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       "TaggerTrackerCombinedPulses",
       "TaggerTrackerCombinedPulsesWithNoise",
       "TaggerTrackerRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "TaggerTrackerRawHitLinks",
+#endif
       "TaggerTrackerRawHitAssociations",
       "TaggerTrackerM1L0ClusterPositions",
       "TaggerTrackerM1L1ClusterPositions",
@@ -157,11 +197,23 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       "TaggerTrackerM2L3ClusterPositions",
       "TaggerTrackerM1LocalTracks",
       "TaggerTrackerM2LocalTracks",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "TaggerTrackerM1LocalTrackLinks",
+#endif
       "TaggerTrackerM1LocalTrackAssociations",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "TaggerTrackerM2LocalTrackLinks",
+#endif
       "TaggerTrackerM2LocalTrackAssociations",
       "TaggerTrackerLocalTracks",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "TaggerTrackerLocalTrackLinks",
+#endif
       "TaggerTrackerLocalTrackAssociations",
       "TaggerTrackerReconstructedParticles",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "TaggerTrackerReconstructedParticleLinks",
+#endif
       "TaggerTrackerReconstructedParticleAssociations",
 
       // Forward & Far forward hits
@@ -169,6 +221,9 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       "B0TrackerRecHits",
       "B0TrackerRawHits",
       "B0TrackerHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "B0TrackerRawHitLinks",
+#endif
       "B0TrackerRawHitAssociations",
       "B0TrackerSeeds",
       "B0TrackerSeedParameters",
@@ -183,21 +238,36 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
 
       "ForwardRomanPotHits",
       "ForwardRomanPotRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "ForwardRomanPotRawHitLinks",
+#endif
       "ForwardRomanPotRawHitAssociations",
       "ForwardOffMTrackerHits",
       "ForwardOffMTrackerRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "ForwardOffMTrackerRawHitLinks",
+#endif
       "ForwardOffMTrackerRawHitAssociations",
 
       // Reconstructed data
       "GeneratedParticles",
       "GeneratedBreitFrameParticles",
       "ReconstructedParticles",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "ReconstructedParticleLinks",
+#endif
       "ReconstructedParticleAssociations",
       "ReconstructedTruthSeededChargedParticles",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "ReconstructedTruthSeededChargedParticleLinks",
+#endif
       "ReconstructedTruthSeededChargedParticleAssociations",
       "ReconstructedChargedRealPIDParticles",
       "ReconstructedChargedRealPIDParticleIDs",
       "ReconstructedChargedParticles",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "ReconstructedChargedParticleLinks",
+#endif
       "ReconstructedChargedParticleAssociations",
       "MCScatteredElectronAssociations",    // Remove if/when used internally
       "MCNonScatteredElectronAssociations", // Remove if/when used internally
@@ -208,41 +278,65 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       "CentralTrackVertices",
       "CentralCKFTruthSeededTrajectories",
       "CentralCKFTruthSeededTracks",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "CentralCKFTruthSeededTrackLinks",
+#endif
       "CentralCKFTruthSeededTrackAssociations",
       "CentralCKFTruthSeededTrackParameters",
       "CentralCKFTrajectories",
       "CentralCKFTracks",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "CentralCKFTrackLinks",
+#endif
       "CentralCKFTrackAssociations",
       "CentralCKFTrackParameters",
       // tracking properties - true seeding
       "CentralCKFTruthSeededTrajectoriesUnfiltered",
       "CentralCKFTruthSeededTracksUnfiltered",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "CentralCKFTruthSeededTrackUnfilteredLinks",
+#endif
       "CentralCKFTruthSeededTrackUnfilteredAssociations",
       "CentralCKFTruthSeededTrackParametersUnfiltered",
       // tracking properties - realistic seeding
       "CentralCKFTrajectoriesUnfiltered",
       "CentralCKFTracksUnfiltered",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "CentralCKFTrackUnfilteredLinks",
+#endif
       "CentralCKFTrackUnfilteredAssociations",
       "CentralCKFTrackParametersUnfiltered",
 
       // B0 tracking
       "B0TrackerCKFTruthSeededTrajectories",
       "B0TrackerCKFTruthSeededTracks",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "B0TrackerCKFTruthSeededTrackLinks",
+#endif
       "B0TrackerCKFTruthSeededTrackAssociations",
       "B0TrackerCKFTruthSeededTrackParameters",
       "B0TrackerCKFTrajectories",
       "B0TrackerCKFTracks",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "B0TrackerCKFTrackLinks",
+#endif
       "B0TrackerCKFTrackAssociations",
       "B0TrackerCKFTrackParameters",
       // tracking properties - true seeding
       "B0TrackerCKFTruthSeededTrajectoriesUnfiltered",
       "B0TrackerCKFTruthSeededTracksUnfiltered",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "B0TrackerCKFTruthSeededTrackUnfilteredLinks",
+#endif
       "B0TrackerCKFTruthSeededTrackUnfilteredAssociations",
       "B0TrackerCKFTruthSeededTrackParametersUnfiltered",
       // tracking properties - realistic seeding
       "B0TrackerCKFTrajectoriesUnfiltered",
       "B0TrackerCKFTrackParametersUnfiltered",
       "B0TrackerCKFTracksUnfiltered",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "B0TrackerCKFTrackUnfilteredLinks",
+#endif
       "B0TrackerCKFTrackUnfilteredAssociations",
 
       "CentralAndB0TrackVertices",
@@ -277,26 +371,53 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       "EcalEndcapNRawHits",
       "EcalEndcapNRecHits",
       "EcalEndcapNTruthClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "EcalEndcapNTruthClusterLinks",
+#endif
       "EcalEndcapNTruthClusterAssociations",
       "EcalEndcapNClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "EcalEndcapNClusterLinks",
+#endif
       "EcalEndcapNClusterAssociations",
       "EcalEndcapNSplitMergeClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "EcalEndcapNSplitMergeClusterLinks",
+#endif
       "EcalEndcapNSplitMergeClusterAssociations",
       "EcalEndcapPRawHits",
       "EcalEndcapPRecHits",
       "EcalEndcapPTruthClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "EcalEndcapPTruthClusterLinks",
+#endif
       "EcalEndcapPTruthClusterAssociations",
       "EcalEndcapPClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "EcalEndcapPClusterLinks",
+#endif
       "EcalEndcapPClusterAssociations",
       "EcalEndcapPSplitMergeClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "EcalEndcapPSplitMergeClusterLinks",
+#endif
       "EcalEndcapPSplitMergeClusterAssociations",
       "EcalBarrelClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "EcalBarrelClusterLinks",
+#endif
       "EcalBarrelClusterAssociations",
       "EcalBarrelTruthClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "EcalBarrelTruthClusterLinks",
+#endif
       "EcalBarrelTruthClusterAssociations",
       "EcalBarrelImagingRawHits",
       "EcalBarrelImagingRecHits",
       "EcalBarrelImagingClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "EcalBarrelImagingClusterLinks",
+#endif
       "EcalBarrelImagingClusterAssociations",
       "EcalBarrelScFiPAttenuatedHits",
       "EcalBarrelScFiPAttenuatedHitContributions",
@@ -311,53 +432,98 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       "EcalBarrelScFiNCombinedPulsesWithNoise",
       "EcalBarrelScFiRecHits",
       "EcalBarrelScFiClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "EcalBarrelScFiClusterLinks",
+#endif
       "EcalBarrelScFiClusterAssociations",
       "EcalLumiSpecRawHits",
       "EcalLumiSpecRecHits",
       "EcalLumiSpecTruthClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "EcalLumiSpecTruthClusterLinks",
+#endif
       "EcalLumiSpecTruthClusterAssociations",
       "EcalLumiSpecClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "EcalLumiSpecClusterLinks",
+#endif
       "EcalLumiSpecClusterAssociations",
       "HcalEndcapNRawHits",
       "HcalEndcapNRecHits",
       "HcalEndcapNMergedHits",
       "HcalEndcapNClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "HcalEndcapNClusterLinks",
+#endif
       "HcalEndcapNClusterAssociations",
       "HcalEndcapNSplitMergeClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "HcalEndcapNSplitMergeClusterLinks",
+#endif
       "HcalEndcapNSplitMergeClusterAssociations",
       "HcalEndcapPInsertRawHits",
       "HcalEndcapPInsertRecHits",
       "HcalEndcapPInsertMergedHits",
       "HcalEndcapPInsertClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "HcalEndcapPInsertClusterLinks",
+#endif
       "HcalEndcapPInsertClusterAssociations",
       "LFHCALRawHits",
       "LFHCALRecHits",
       "LFHCALClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "LFHCALClusterLinks",
+#endif
       "LFHCALClusterAssociations",
       "LFHCALSplitMergeClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "LFHCALSplitMergeClusterLinks",
+#endif
       "LFHCALSplitMergeClusterAssociations",
       "HcalBarrelRawHits",
       "HcalBarrelRecHits",
       "HcalBarrelMergedHits",
       "HcalBarrelClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "HcalBarrelClusterLinks",
+#endif
       "HcalBarrelClusterAssociations",
       "HcalBarrelSplitMergeClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "HcalBarrelSplitMergeClusterLinks",
+#endif
       "HcalBarrelSplitMergeClusterAssociations",
       "B0ECalRawHits",
       "B0ECalRecHits",
       "B0ECalClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "B0ECalClusterLinks",
+#endif
       "B0ECalClusterAssociations",
       "HcalEndcapNTruthClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "HcalEndcapNTruthClusterLinks",
+#endif
       "HcalEndcapNTruthClusterAssociations",
       "HcalBarrelTruthClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "HcalBarrelTruthClusterLinks",
+#endif
       "HcalBarrelTruthClusterAssociations",
 
       //ZDC Ecal
       "EcalFarForwardZDCRawHits",
       "EcalFarForwardZDCRecHits",
       "EcalFarForwardZDCClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "EcalFarForwardZDCClusterLinks",
+#endif
       "EcalFarForwardZDCClusterAssociations",
       "EcalFarForwardZDCTruthClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "EcalFarForwardZDCTruthClusterLinks",
+#endif
       "EcalFarForwardZDCTruthClusterAssociations",
 
       //ZDC HCal
@@ -365,10 +531,19 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       "HcalFarForwardZDCRecHits",
       "HcalFarForwardZDCSubcellHits",
       "HcalFarForwardZDCClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "HcalFarForwardZDCClusterLinks",
+#endif
       "HcalFarForwardZDCClusterAssociations",
       "HcalFarForwardZDCClustersBaseline",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "HcalFarForwardZDCClusterLinksBaseline",
+#endif
       "HcalFarForwardZDCClusterAssociationsBaseline",
       "HcalFarForwardZDCTruthClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+      "HcalFarForwardZDCTruthClusterLinks",
+#endif
       "HcalFarForwardZDCTruthClusterAssociations",
       "ReconstructedFarForwardZDCNeutrals",
       "ReconstructedFarForwardZDCLambdas",

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
@@ -222,8 +222,13 @@ TEST_CASE("the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]") {
   hitassoc2.setSimHit(simhit2);
 
   // Constructing input and output as per the algorithm's expected signature
-  auto input  = std::make_tuple(&pclust_coll, &hitassocs_coll);
-  auto output = std::make_tuple(clust_coll.get(), assoc_coll.get());
+  auto input = std::make_tuple(&pclust_coll, &hitassocs_coll);
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  edm4eic::MCRecoClusterParticleLinkCollection link_coll;
+  auto output = std::make_tuple(clust_coll.get(), &link_coll, assoc_coll.get());
+#else
+  auto output = std::make_tuple(clust_coll.get(), nullptr, assoc_coll.get());
+#endif
 
   algo.process(input, output);
 

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
@@ -227,7 +227,7 @@ TEST_CASE("the calorimeter CoG algorithm runs", "[CalorimeterClusterRecoCoG]") {
   edm4eic::MCRecoClusterParticleLinkCollection link_coll;
   auto output = std::make_tuple(clust_coll.get(), &link_coll, assoc_coll.get());
 #else
-  auto output = std::make_tuple(clust_coll.get(), nullptr, assoc_coll.get());
+  auto output = std::make_tuple(clust_coll.get(), assoc_coll.get());
 #endif
 
   algo.process(input, output);

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
@@ -6,6 +6,7 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <edm4eic/CalorimeterHitCollection.h>
 #include <edm4eic/ClusterCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoCalorimeterHitAssociationCollection.h>
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <edm4eic/ProtoClusterCollection.h>

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
@@ -10,7 +10,6 @@
 #include <edm4eic/MCRecoCalorimeterHitAssociationCollection.h>
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-#include <edm4eic/MCRecoCalorimeterHitLinkCollection.h>
 #include <edm4eic/MCRecoClusterParticleLinkCollection.h>
 #endif
 #include <edm4eic/ProtoClusterCollection.h>
@@ -28,6 +27,7 @@
 #include <spdlog/common.h>
 #include <spdlog/logger.h>
 #include <spdlog/spdlog.h>
+#include <deque>
 #include <memory>
 #include <string>
 #include <tuple>

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterRecoCoG.cc
@@ -9,6 +9,10 @@
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoCalorimeterHitAssociationCollection.h>
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoCalorimeterHitLinkCollection.h>
+#include <edm4eic/MCRecoClusterParticleLinkCollection.h>
+#endif
 #include <edm4eic/ProtoClusterCollection.h>
 #include <edm4eic/unit_system.h>
 #include <edm4hep/CaloHitContributionCollection.h>

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterShape.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterShape.cc
@@ -81,8 +81,13 @@ TEST_CASE("the calorimeter CoG algorithm runs", "[CalorimeterClusterShape]") {
   // assoc_in.setSim(...);
 
   // Constructing input and output as per the algorithm's expected signature
-  auto input  = std::make_tuple(&clust_in_coll, &assoc_in_coll);
-  auto output = std::make_tuple(clust_out_coll.get(), assoc_out_coll.get());
+  auto input = std::make_tuple(&clust_in_coll, &assoc_in_coll);
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+  edm4eic::MCRecoClusterParticleLinkCollection link_out_coll;
+  auto output = std::make_tuple(clust_out_coll.get(), &link_out_coll, assoc_out_coll.get());
+#else
+  auto output = std::make_tuple(clust_out_coll.get(), nullptr, assoc_out_coll.get());
+#endif
 
   algo.process(input, output);
 

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterShape.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterShape.cc
@@ -30,7 +30,7 @@ using eicrecon::CalorimeterClusterShape;
 using eicrecon::CalorimeterClusterShapeConfig;
 
 TEST_CASE("the calorimeter CoG algorithm runs", "[CalorimeterClusterShape]") {
-  const float EPSILON = 1e-5;
+  const float EPSILON         = 1e-5;
   const float EXPECTED_WEIGHT = 0.123;
 
   CalorimeterClusterShape algo("CalorimeterClusterShape");

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterShape.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterShape.cc
@@ -8,6 +8,8 @@
 #include <edm4eic/ClusterCollection.h>
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
+#include <edm4hep/MCParticle.h>
+#include <podio/detail/Link.h>
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
 #include <edm4eic/MCRecoClusterParticleLinkCollection.h>
 #endif

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterShape.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterShape.cc
@@ -86,7 +86,7 @@ TEST_CASE("the calorimeter CoG algorithm runs", "[CalorimeterClusterShape]") {
   edm4eic::MCRecoClusterParticleLinkCollection link_out_coll;
   auto output = std::make_tuple(clust_out_coll.get(), &link_out_coll, assoc_out_coll.get());
 #else
-  auto output = std::make_tuple(clust_out_coll.get(), nullptr, assoc_out_coll.get());
+  auto output = std::make_tuple(clust_out_coll.get(), assoc_out_coll.get());
 #endif
 
   algo.process(input, output);

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterShape.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterShape.cc
@@ -8,6 +8,9 @@
 #include <edm4eic/ClusterCollection.h>
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoClusterParticleLinkCollection.h>
+#endif
 #include <edm4eic/unit_system.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterShape.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterShape.cc
@@ -6,6 +6,7 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <edm4eic/CalorimeterHitCollection.h>
 #include <edm4eic/ClusterCollection.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <edm4eic/unit_system.h>
 #include <edm4hep/Vector3f.h>

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterShape.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterShape.cc
@@ -18,6 +18,7 @@
 #include <spdlog/logger.h>
 #include <spdlog/spdlog.h>
 #include <cmath>
+#include <deque>
 #include <memory>
 #include <string>
 #include <tuple>

--- a/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
@@ -8,6 +8,7 @@
 #include <algorithms/geo.h>
 #include <algorithms/logger.h>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoCalorimeterHitAssociationCollection.h>
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)

--- a/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
@@ -94,7 +94,7 @@ TEST_CASE("the clustering algorithm runs", "[CalorimeterHitDigi]") {
     edm4eic::MCRecoCalorimeterHitLinkCollection rawlinks;
     algo.process({headers.get(), simhits.get()}, {rawhits.get(), &rawlinks, rawassocs.get()});
 #else
-    algo.process({headers.get(), simhits.get()}, {rawhits.get(), nullptr, rawassocs.get()});
+    algo.process({headers.get(), simhits.get()}, {rawhits.get(), rawassocs.get()});
 #endif
 
     REQUIRE((*rawhits).size() == 1);

--- a/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
@@ -8,9 +8,8 @@
 #include <algorithms/geo.h>
 #include <algorithms/logger.h>
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_floating_point.hpp>
-#include <edm4eic/MCRecoCalorimeterHitAssociationCollection.h>
 #include <edm4eic/EDM4eicVersion.h>
+#include <edm4eic/MCRecoCalorimeterHitAssociationCollection.h>
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
 #include <edm4eic/MCRecoCalorimeterHitLinkCollection.h>
 #endif

--- a/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
@@ -110,11 +110,11 @@ TEST_CASE("the clustering algorithm runs", "[CalorimeterHitDigi]") {
     // Validate links collection
     REQUIRE(rawlinks.size() == 1);
     REQUIRE(rawlinks.size() == (*rawassocs).size());
-    
+
     // Check link from/to relationships match association sim/raw hits
     REQUIRE(rawlinks[0].getFrom() == (*rawhits)[0]);
     REQUIRE(rawlinks[0].getTo() == (*simhits)[0]);
-    
+
     // Verify weights are normalized (should be 1.0 for single hit)
     REQUIRE_THAT(rawlinks[0].getWeight(), Catch::Matchers::WithinAbs(1.0, EPSILON));
 #endif

--- a/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
@@ -36,7 +36,7 @@ using eicrecon::CalorimeterHitDigi;
 using eicrecon::CalorimeterHitDigiConfig;
 
 TEST_CASE("the clustering algorithm runs", "[CalorimeterHitDigi]") {
-  const float EPSILON = 1e-5;
+  [[maybe_unused]] const float EPSILON = 1e-5;
 
   std::shared_ptr<spdlog::logger> logger = spdlog::default_logger()->clone("CalorimeterHitDigi");
   logger->set_level(spdlog::level::trace);

--- a/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
@@ -12,14 +12,6 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoCalorimeterHitAssociationCollection.h>
-#include <podio/detail/Link.h>
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-#include <edm4eic/MCRecoCalorimeterHitLinkCollection.h>
-#endif
-#include <edm4hep/CaloHitContributionCollection.h>
-#include <edm4hep/EventHeaderCollection.h>
-#include <edm4hep/RawCalorimeterHitCollection.h>
-#include <edm4hep/SimCalorimeterHitCollection.h>
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
 #include <edm4eic/MCRecoCalorimeterHitLinkCollection.h>
 #endif

--- a/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
@@ -83,7 +83,12 @@ TEST_CASE("the clustering algorithm runs", "[CalorimeterHitDigi]") {
 
     auto rawhits   = std::make_unique<edm4hep::RawCalorimeterHitCollection>();
     auto rawassocs = std::make_unique<edm4eic::MCRecoCalorimeterHitAssociationCollection>();
-    algo.process({headers.get(), simhits.get()}, {rawhits.get(), rawassocs.get()});
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+    edm4eic::MCRecoCalorimeterHitLinkCollection rawlinks;
+    algo.process({headers.get(), simhits.get()}, {rawhits.get(), &rawlinks, rawassocs.get()});
+#else
+    algo.process({headers.get(), simhits.get()}, {rawhits.get(), nullptr, rawassocs.get()});
+#endif
 
     REQUIRE((*rawhits).size() == 1);
     REQUIRE((*rawhits)[0].getCellID() == id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}));

--- a/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterHitDigi.cc
@@ -8,9 +8,18 @@
 #include <algorithms/geo.h>
 #include <algorithms/logger.h>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoCalorimeterHitAssociationCollection.h>
+#include <podio/detail/Link.h>
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoCalorimeterHitLinkCollection.h>
+#endif
+#include <edm4hep/CaloHitContributionCollection.h>
+#include <edm4hep/EventHeaderCollection.h>
+#include <edm4hep/RawCalorimeterHitCollection.h>
+#include <edm4hep/SimCalorimeterHitCollection.h>
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
 #include <edm4eic/MCRecoCalorimeterHitLinkCollection.h>
 #endif
@@ -19,10 +28,12 @@
 #include <edm4hep/RawCalorimeterHitCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
 #include <edm4hep/Vector3f.h>
+#include <podio/detail/Link.h>
 #include <spdlog/common.h>
 #include <spdlog/logger.h>
 #include <spdlog/spdlog.h>
 #include <cmath>
+#include <deque>
 #include <gsl/pointers>
 #include <memory>
 #include <string>

--- a/src/tests/algorithms_test/pid_lut_PIDLookup.cc
+++ b/src/tests/algorithms_test/pid_lut_PIDLookup.cc
@@ -4,6 +4,7 @@
 #include <algorithms/logger.h>
 #include <catch2/catch_test_macros.hpp>
 #include <edm4eic/Cov4f.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoParticleAssociationCollection.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/EDM4hepVersion.h>

--- a/src/tests/algorithms_test/pid_lut_PIDLookup.cc
+++ b/src/tests/algorithms_test/pid_lut_PIDLookup.cc
@@ -6,6 +6,9 @@
 #include <edm4eic/Cov4f.h>
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoParticleAssociationCollection.h>
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoParticleLinkCollection.h>
+#endif
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/EDM4hepVersion.h>
 #include <edm4hep/EventHeaderCollection.h>

--- a/src/tests/algorithms_test/pid_lut_PIDLookup.cc
+++ b/src/tests/algorithms_test/pid_lut_PIDLookup.cc
@@ -6,14 +6,6 @@
 #include <edm4eic/Cov4f.h>
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoParticleAssociationCollection.h>
-#include <podio/detail/Link.h>
-#include <stddef.h>
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-#include <edm4eic/MCRecoParticleLinkCollection.h>
-#endif
-#include <edm4eic/ReconstructedParticleCollection.h>
-#include <edm4hep/EDM4hepVersion.h>
-#include <edm4hep/EventHeaderCollection.h>
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
 #include <edm4eic/MCRecoParticleLinkCollection.h>
 #endif

--- a/src/tests/algorithms_test/pid_lut_PIDLookup.cc
+++ b/src/tests/algorithms_test/pid_lut_PIDLookup.cc
@@ -6,6 +6,14 @@
 #include <edm4eic/Cov4f.h>
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoParticleAssociationCollection.h>
+#include <podio/detail/Link.h>
+#include <stddef.h>
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+#include <edm4eic/MCRecoParticleLinkCollection.h>
+#endif
+#include <edm4eic/ReconstructedParticleCollection.h>
+#include <edm4hep/EDM4hepVersion.h>
+#include <edm4hep/EventHeaderCollection.h>
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
 #include <edm4eic/MCRecoParticleLinkCollection.h>
 #endif
@@ -19,8 +27,11 @@
 #endif
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
+#include <podio/detail/Link.h>
 #include <spdlog/common.h>
 #include <cmath>
+#include <cstddef>
+#include <deque>
 #include <memory>
 #include <string>
 #include <vector>

--- a/src/tests/algorithms_test/pid_lut_PIDLookup.cc
+++ b/src/tests/algorithms_test/pid_lut_PIDLookup.cc
@@ -104,7 +104,7 @@ TEST_CASE("particles acquire PID", "[PIDLookup]") {
                  {parts_out.get(), &links_out, assocs_out.get(), partids_out.get()});
 #else
     algo.process({headers.get(), parts_in.get(), assocs_in.get()},
-                 {parts_out.get(), nullptr, assocs_out.get(), partids_out.get()});
+                 {parts_out.get(), assocs_out.get(), partids_out.get()});
 #endif
 
     REQUIRE((*parts_in).size() == (*parts_out).size());

--- a/src/tests/algorithms_test/pid_lut_PIDLookup.cc
+++ b/src/tests/algorithms_test/pid_lut_PIDLookup.cc
@@ -112,5 +112,15 @@ TEST_CASE("particles acquire PID", "[PIDLookup]") {
     REQUIRE(
         0 ==
         (*partids_out).size()); // Since our table is empty, there will not be a successful lookup
+
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+    // Verify that links were created and match the associations
+    REQUIRE(links_out.size() == (*assocs_out).size());
+    for (size_t i = 0; i < links_out.size(); ++i) {
+      REQUIRE(links_out[i].getFrom() == (*assocs_out)[i].getRec());
+      REQUIRE(links_out[i].getTo() == (*assocs_out)[i].getSim());
+      REQUIRE(links_out[i].getWeight() == (*assocs_out)[i].getWeight());
+    }
+#endif
   }
 }

--- a/src/tests/algorithms_test/pid_lut_PIDLookup.cc
+++ b/src/tests/algorithms_test/pid_lut_PIDLookup.cc
@@ -98,8 +98,14 @@ TEST_CASE("particles acquire PID", "[PIDLookup]") {
     auto parts_out   = std::make_unique<edm4eic::ReconstructedParticleCollection>();
     auto assocs_out  = std::make_unique<edm4eic::MCRecoParticleAssociationCollection>();
     auto partids_out = std::make_unique<edm4hep::ParticleIDCollection>();
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+    edm4eic::MCRecoParticleLinkCollection links_out;
     algo.process({headers.get(), parts_in.get(), assocs_in.get()},
-                 {parts_out.get(), assocs_out.get(), partids_out.get()});
+                 {parts_out.get(), &links_out, assocs_out.get(), partids_out.get()});
+#else
+    algo.process({headers.get(), parts_in.get(), assocs_in.get()},
+                 {parts_out.get(), nullptr, assocs_out.get(), partids_out.get()});
+#endif
 
     REQUIRE((*parts_in).size() == (*parts_out).size());
     REQUIRE((*assocs_in).size() == (*assocs_out).size());


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Needs:
- [x] #2395 

This PR writes \*Links for all \*Associations that are currently produced, when EDM4EIC >= 8.7.0 is available. In order to avoid even more preprocessor directives, this needs podio version 1.2, which is in our 6 month backwards compatibility window.

Note: This continues to take associations as *input*, and only modifies the *outputs*. Switching the inputs from \*Associations to \*Links can happen in 6 months when we rotate out of the compatibility window, and it won't require as much preprocessor magic then. Or it can be added in isolated instances (e.g. #2367 with [LinkNavigator](https://key4hep.web.cern.ch/podio/links.html#the-linknavigator-utility)).

Reviewer comments about the insufficient handling of optional inputs are deferred to #2380.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: links)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.