### PR TITLE
fix: update transformation calculation and apply_boost

### DIFF
--- a/src/algorithms/reco/Boost.h
+++ b/src/algorithms/reco/Boost.h
@@ -63,7 +63,7 @@ inline LorentzRotation determine_boost(PxPyPzEVector ei, PxPyPzEVector pi) {
   return tf;
 }
 
-inline PxPyPzEVector apply_boost(const LorentzRotation& tf, PxPyPzEVector part) {
+inline PxPyPzEVector apply_boost(const LorentzRotation& tf, const PxPyPzEVector& part) {
 
   // Step 5: Apply boosts and rotations to any particle 4-vector
   // (here too, choices will have to be made as to what the 4-vector is for reconstructed particles)


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Correct boost calculation for crossing angle and modify apply_boost to properly return boosted particle

### What kind of change does this PR introduce?
- [X] Bug fix (issue #2331 )
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

NO

### Does this PR change default behavior?

NO
