### PR TITLE
fix: use find_if instead of iterator loops with break

### DIFF
--- a/src/algorithms/reco/Beam.h
+++ b/src/algorithms/reco/Beam.h
@@ -6,6 +6,7 @@
 #include <Math/Vector4D.h>
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
+#include <algorithm>
 #include <set>
 
 using ROOT::Math::PxPyPzEVector;
@@ -15,11 +16,10 @@ namespace eicrecon {
 template <class T> auto find_first_with_pdg(const T* parts, const std::set<int32_t>& pdg) {
   T c;
   c.setSubsetCollection();
-  for (const auto& p : *parts) {
-    if (pdg.count(p.getPDG()) > 0) {
-      c.push_back(p);
-      break;
-    }
+  const auto it = std::find_if(parts->begin(), parts->end(),
+                               [&pdg](const auto& p) { return pdg.count(p.getPDG()) > 0; });
+  if (it != parts->end()) {
+    c.push_back(*it);
   }
   return c;
 }
@@ -29,11 +29,11 @@ auto find_first_with_status_pdg(const T* parts, const std::set<int32_t>& status,
                                 const std::set<int32_t>& pdg) {
   T c;
   c.setSubsetCollection();
-  for (const auto& p : *parts) {
-    if (status.count(p.getGeneratorStatus()) > 0 && pdg.count(p.getPDG()) > 0) {
-      c.push_back(p);
-      break;
-    }
+  const auto it = std::find_if(parts->begin(), parts->end(), [&status, &pdg](const auto& p) {
+    return status.count(p.getGeneratorStatus()) > 0 && pdg.count(p.getPDG()) > 0;
+  });
+  if (it != parts->end()) {
+    c.push_back(*it);
   }
   return c;
 }

--- a/src/algorithms/reco/Beam.h
+++ b/src/algorithms/reco/Beam.h
@@ -8,6 +8,8 @@
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <algorithm>
 #include <set>
+#include <vector>
+#include <cmath>
 
 using ROOT::Math::PxPyPzEVector;
 

--- a/src/algorithms/reco/HadronicFinalState.cc
+++ b/src/algorithms/reco/HadronicFinalState.cc
@@ -68,21 +68,15 @@ void HadronicFinalState::process(const HadronicFinalState::Input& input,
   }
 
   // Associate first scattered electron with reconstructed electrons
-  //const auto ef_assoc = std::find_if(
-  //  rcassoc->begin(),
-  //  rcassoc->end(),
-  //  [&ef_coll](const auto& a){ return a.getSim().getObjectID() == ef_coll[0].getObjectID(); });
-  auto ef_assoc = rcassoc->begin();
-  for (; ef_assoc != rcassoc->end(); ++ef_assoc) {
-    if (ef_assoc->getSim().getObjectID() == ef_coll[0].getObjectID()) {
-      break;
-    }
-  }
-  if (!(ef_assoc != rcassoc->end())) {
+  const auto ef_assoc = std::find_if(rcassoc->begin(), rcassoc->end(), [&ef_coll](const auto& a) {
+    return a.getSim().getObjectID() == ef_coll[0].getObjectID();
+  });
+
+  if (ef_assoc == rcassoc->end()) {
     debug("Truth scattered electron not in reconstructed particles");
     return;
   }
-  const auto ef_rc{ef_assoc->getRec()};
+  const auto ef_rc{(*ef_assoc).getRec()};
   const auto ef_rc_id{ef_rc.getObjectID().index};
 
   // Sums in colinear frame

--- a/src/algorithms/reco/HadronicFinalState.cc
+++ b/src/algorithms/reco/HadronicFinalState.cc
@@ -77,7 +77,7 @@ void HadronicFinalState::process(const HadronicFinalState::Input& input,
     debug("Truth scattered electron not in reconstructed particles");
     return;
   }
-  const auto ef_rc{ef_assoc->getRec()};
+  const auto ef_rc{(*ef_assoc).getRec()};
   const auto ef_rc_id{ef_rc.getObjectID().index};
 
   // Sums in colinear frame

--- a/src/algorithms/reco/HadronicFinalState.cc
+++ b/src/algorithms/reco/HadronicFinalState.cc
@@ -10,6 +10,7 @@
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <podio/ObjectID.h>
+#include <algorithm>
 #include <cmath>
 #include <gsl/pointers>
 #include <vector>

--- a/src/algorithms/reco/HadronicFinalState.cc
+++ b/src/algorithms/reco/HadronicFinalState.cc
@@ -76,7 +76,7 @@ void HadronicFinalState::process(const HadronicFinalState::Input& input,
     debug("Truth scattered electron not in reconstructed particles");
     return;
   }
-  const auto ef_rc{(*ef_assoc).getRec()};
+  const auto ef_rc{ef_assoc->getRec()};
   const auto ef_rc_id{ef_rc.getObjectID().index};
 
   // Sums in colinear frame

--- a/src/algorithms/reco/InclusiveKinematicsElectron.cc
+++ b/src/algorithms/reco/InclusiveKinematicsElectron.cc
@@ -27,54 +27,6 @@ void InclusiveKinematicsElectron::process(const InclusiveKinematicsElectron::Inp
   const auto [mc_beam_electrons, mc_beam_protons, escat, hfs] = input;
   auto [kinematics]                                           = output;
 
-  // 1. find_if
-  //const auto mc_first_electron = std::find_if(
-  //  mcparts.begin(),
-  //  mcparts.end(),
-  //  [](const auto& p){ return p.getPDG() == 11; });
-
-  // 2a. simple loop over iterator (post-increment)
-  //auto mc_first_electron = mcparts.end();
-  //for (auto p = mcparts.begin(); p != mcparts.end(); p++) {
-  //  if (p.getPDG() == 11) {
-  //    mc_first_electron = p;
-  //    break;
-  //  }
-  //}
-  // 2b. simple loop over iterator (pre-increment)
-  //auto mc_first_electron = mcparts.end();
-  //for (auto p = mcparts.begin(); p != mcparts.end(); ++p) {
-  //  if (p.getPDG() == 11) {
-  //    mc_first_electron = p;
-  //    break;
-  //  }
-  //}
-
-  // 3. pre-initialized simple loop
-  //auto mc_first_electron = mcparts.begin();
-  //for (; mc_first_electron != mcparts.end(); ++mc_first_electron) {
-  //  if (mc_first_electron.getPDG() == 11) {
-  //    break;
-  //  }
-  //}
-
-  // 4a. iterator equality
-  //if (mc_first_electron == mcparts.end()) {
-  //  debug() << "No electron found" << endmsg;
-  //  return StatusCode::FAILURE;
-  //}
-  // 4b. iterator inequality
-  //if (!(mc_first_electron != mcparts.end())) {
-  //  debug() << "No electron found" << endmsg;
-  //  return StatusCode::FAILURE;
-  //}
-
-  // 5. ranges and views
-  //auto is_electron = [](const auto& p){ return p.getPDG() == 11; };
-  //for (const auto& e: mcparts | std::views::filter(is_electron)) {
-  //  break;
-  //}
-
   // Get first (should be only) beam electron
   if (mc_beam_electrons->empty()) {
     debug("No beam electron found");

--- a/src/algorithms/reco/ScatteredElectronsTruth.cc
+++ b/src/algorithms/reco/ScatteredElectronsTruth.cc
@@ -66,7 +66,7 @@ void ScatteredElectronsTruth::process(const ScatteredElectronsTruth::Input& inpu
   }
 
   // Get the reconstructed electron object
-  const auto ef_rc{(*ef_assoc).getRec()};
+  const auto ef_rc{ef_assoc->getRec()};
   const auto ef_rc_id{ef_rc.getObjectID()};
 
   // Use these to compute the E-Pz

--- a/src/algorithms/reco/ScatteredElectronsTruth.cc
+++ b/src/algorithms/reco/ScatteredElectronsTruth.cc
@@ -66,7 +66,7 @@ void ScatteredElectronsTruth::process(const ScatteredElectronsTruth::Input& inpu
   }
 
   // Get the reconstructed electron object
-  const auto ef_rc{ef_assoc->getRec()};
+  const auto ef_rc{(*ef_assoc).getRec()};
   const auto ef_rc_id{ef_rc.getObjectID()};
 
   // Use these to compute the E-Pz

--- a/src/algorithms/reco/ScatteredElectronsTruth.cc
+++ b/src/algorithms/reco/ScatteredElectronsTruth.cc
@@ -11,6 +11,7 @@
 #include <edm4hep/Vector3f.h>
 #include <fmt/core.h>
 #include <podio/ObjectID.h>
+#include <algorithm>
 #include <gsl/pointers>
 #include <vector>
 
@@ -53,24 +54,19 @@ void ScatteredElectronsTruth::process(const ScatteredElectronsTruth::Input& inpu
     return;
   }
 
-  // Associate first scattered electron
-  // with reconstructed electron
-  auto ef_assoc = rcassoc->begin();
-  for (; ef_assoc != rcassoc->end(); ++ef_assoc) {
-    if (ef_assoc->getSim().getObjectID() == ef_coll[0].getObjectID()) {
-      break;
-    }
-  }
+  // Associate first scattered electron with reconstructed electron
+  const auto ef_assoc = std::find_if(rcassoc->begin(), rcassoc->end(), [&ef_coll](const auto& a) {
+    return a.getSim().getObjectID() == ef_coll[0].getObjectID();
+  });
 
-  // Check to see if the associated reconstructed
-  // particle is available
-  if (!(ef_assoc != rcassoc->end())) {
+  // Check to see if the associated reconstructed particle is available
+  if (ef_assoc == rcassoc->end()) {
     trace("Truth scattered electron not in reconstructed particles");
     return;
   }
 
   // Get the reconstructed electron object
-  const auto ef_rc{ef_assoc->getRec()};
+  const auto ef_rc{(*ef_assoc).getRec()};
   const auto ef_rc_id{ef_rc.getObjectID()};
 
   // Use these to compute the E-Pz

--- a/src/algorithms/reco/ScatteredElectronsTruth.cc
+++ b/src/algorithms/reco/ScatteredElectronsTruth.cc
@@ -9,7 +9,6 @@
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3f.h>
-#include <fmt/core.h>
 #include <podio/ObjectID.h>
 #include <algorithm>
 #include <gsl/pointers>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Needs:
- [x] podio-1.3 (https://github.com/AIDASoft/podio/pull/626), in eic-shell as of 2025.09

In a few places, due to historical limitations of podio collections, we were still using iterator-based loops with tests and early break to do things that are more nicely done with `find_if` nowadays. This PR introduces the `find_if` based approach in a few cases, and removes a comment block complaints about all that used to not work...

### What kind of change does this PR introduce?
- [x] Bug fix (issue: tech debt)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.