### PR TITLE
feat!: require podio-1.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ set(fmt_VERSION_MIN 9.0.0)
 set(IRT_VERSION_MIN 1.0.5)
 set(JANA_VERSION_MIN 2.4.0)
 set(onnxruntime_MIN_VERSION 1.17)
-set(podio_VERSION_MIN 0.17)
+set(podio_VERSION_MIN 1.2)
 set(ROOT_VERSION_MIN 6.28)
 set(spdlog_VERSION_MIN 1.11.0)
 
@@ -194,10 +194,7 @@ find_package(algorithms ${algorithms_VERSION_MIN} REQUIRED Core)
 
 # PODIO, EDM4HEP, EDM4EIC event models
 find_package(Eigen3 ${Eigen3_VERSION_MIN} REQUIRED)
-find_package(podio ${podio_VERSION_MIN} QUIET)
-if(NOT podio_FOUND)
-  find_package(podio 1.0 REQUIRED)
-endif()
+find_package(podio ${podio_VERSION_MIN} REQUIRED)
 find_package(EDM4HEP ${EDM4HEP_VERSION_MIN} REQUIRED)
 find_package(EDM4EIC ${EDM4EIC_VERSION_MIN} REQUIRED)
 

--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -357,10 +357,7 @@ endmacro()
 macro(plugin_add_event_model _name)
 
   if(NOT podio_FOUND)
-    find_package(podio ${podio_VERSION_MIN} QUIET)
-    if(NOT podio_FOUND)
-      find_package(podio 1.0 REQUIRED)
-    endif()
+    find_package(podio ${podio_VERSION_MIN} REQUIRED)
   endif()
 
   if(NOT EDM4HEP_FOUND)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR upgrades the required podio to 1.2, which means that the links are available in podio (see #2372). This version of podio has been in use for more than 6 months now (see #2258).

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: podio-1.2 required)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
Yes. You'll need podio-1.2 now.

### Does this PR change default behavior?
Yes. You'll need podio-1.2 now.