### PR TITLE
fix: avoid nan in InclusiveKinematicsJB when y >= 1 and/or x >= 1

### DIFF
--- a/src/algorithms/reco/InclusiveKinematicsJB.cc
+++ b/src/algorithms/reco/InclusiveKinematicsJB.cc
@@ -62,14 +62,14 @@ void InclusiveKinematicsJB::process(const InclusiveKinematicsJB::Input& input,
   // Calculate kinematic variables
   static const auto m_proton = m_particleSvc.particle(2212).mass;
   const auto y_jb            = sigma_h / (2. * ei.energy());
-  if (y_jb > 1) {
+  if (y_jb >= 1) {
     // y > 0 is mathematically guaranteed by sigma_h > 0, but y < 1 is not
     debug("InclusiveKinematicsJB: event with y > 1 skipped");
     return;
   }
   const auto Q2_jb = ptsum * ptsum / (1. - y_jb);
   const auto x_jb  = Q2_jb / (4. * ei.energy() * pi.energy() * y_jb);
-  if (x_jb > 1) {
+  if (x_jb >= 1) {
     // x > 0 is mathematically guaranteed by 0 < y < 1, but x < 1 is not
     debug("InclusiveKinematicsJB: event with x > 1 skipped");
     return;

--- a/src/algorithms/reco/InclusiveKinematicsJB.cc
+++ b/src/algorithms/reco/InclusiveKinematicsJB.cc
@@ -64,14 +64,14 @@ void InclusiveKinematicsJB::process(const InclusiveKinematicsJB::Input& input,
   const auto y_jb            = sigma_h / (2. * ei.energy());
   if (y_jb >= 1) {
     // y > 0 is mathematically guaranteed by sigma_h > 0, but y < 1 is not
-    debug("InclusiveKinematicsJB: event with y > 1 skipped");
+    debug("InclusiveKinematicsJB: event with y >= 1 skipped");
     return;
   }
   const auto Q2_jb = ptsum * ptsum / (1. - y_jb);
   const auto x_jb  = Q2_jb / (4. * ei.energy() * pi.energy() * y_jb);
   if (x_jb >= 1) {
     // x > 0 is mathematically guaranteed by 0 < y < 1, but x < 1 is not
-    debug("InclusiveKinematicsJB: event with x > 1 skipped");
+    debug("InclusiveKinematicsJB: event with x >= 1 skipped");
     return;
   }
   const auto nu_jb = Q2_jb / (2. * m_proton * x_jb);

--- a/src/algorithms/reco/InclusiveKinematicsJB.cc
+++ b/src/algorithms/reco/InclusiveKinematicsJB.cc
@@ -67,16 +67,16 @@ void InclusiveKinematicsJB::process(const InclusiveKinematicsJB::Input& input,
     debug("InclusiveKinematicsJB: event with y > 1 skipped");
     return;
   }
-  const auto Q2_jb           = ptsum * ptsum / (1. - y_jb);
-  const auto x_jb            = Q2_jb / (4. * ei.energy() * pi.energy() * y_jb);
+  const auto Q2_jb = ptsum * ptsum / (1. - y_jb);
+  const auto x_jb  = Q2_jb / (4. * ei.energy() * pi.energy() * y_jb);
   if (x_jb > 1) {
     // x > 0 is mathematically guaranteed by 0 < y < 1, but x < 1 is not
     debug("InclusiveKinematicsJB: event with x > 1 skipped");
     return;
   }
-  const auto nu_jb           = Q2_jb / (2. * m_proton * x_jb);
-  const auto W_jb            = sqrt(m_proton * m_proton + 2 * m_proton * nu_jb - Q2_jb);
-  auto kin                   = out_kinematics->create(x_jb, Q2_jb, W_jb, y_jb, nu_jb);
+  const auto nu_jb = Q2_jb / (2. * m_proton * x_jb);
+  const auto W_jb  = sqrt(m_proton * m_proton + 2 * m_proton * nu_jb - Q2_jb);
+  auto kin         = out_kinematics->create(x_jb, Q2_jb, W_jb, y_jb, nu_jb);
   if (escat->empty()) {
     debug("No scattered electron found");
   } else {

--- a/src/algorithms/reco/InclusiveKinematicsJB.cc
+++ b/src/algorithms/reco/InclusiveKinematicsJB.cc
@@ -62,8 +62,18 @@ void InclusiveKinematicsJB::process(const InclusiveKinematicsJB::Input& input,
   // Calculate kinematic variables
   static const auto m_proton = m_particleSvc.particle(2212).mass;
   const auto y_jb            = sigma_h / (2. * ei.energy());
+  if (y_jb > 1) {
+    // y > 0 is mathematically guaranteed by sigma_h > 0, but y < 1 is not
+    debug("InclusiveKinematicsJB: event with y > 1 skipped");
+    return;
+  }
   const auto Q2_jb           = ptsum * ptsum / (1. - y_jb);
   const auto x_jb            = Q2_jb / (4. * ei.energy() * pi.energy() * y_jb);
+  if (x_jb > 1) {
+    // x > 0 is mathematically guaranteed by 0 < y < 1, but x < 1 is not
+    debug("InclusiveKinematicsJB: event with x > 1 skipped");
+    return;
+  }
   const auto nu_jb           = Q2_jb / (2. * m_proton * x_jb);
   const auto W_jb            = sqrt(m_proton * m_proton + 2 * m_proton * nu_jb - Q2_jb);
   auto kin                   = out_kinematics->create(x_jb, Q2_jb, W_jb, y_jb, nu_jb);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes #2391 by avoiding any inclusive kinematics with y > 1 or x > 1. These are possible in reconstruction (since stuff may be reconstructed in ways that violate energy conservation), and may lead to nan in W due to sqrt of negative numbers.

Note: In the case of ion targets where x > 1 is allowable this will need modifications. But I assume that will require changes to the assumptions early in this algorithm too (e.g. mass of proton assumption).

### What kind of change does this PR introduce?
- [x] Bug fix (issue #2391)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.