### PR TITLE
fix: getTrack(addTrack) -> makeTrack in  ActsTrackMerger

### DIFF
--- a/src/algorithms/tracking/ActsTrackMerger.cc
+++ b/src/algorithms/tracking/ActsTrackMerger.cc
@@ -70,12 +70,8 @@ ActsTrackMerger::merge(
 
     // Copy each track
     for (const auto& srcTrack : inputContainer) {
-      auto destTrack = mergedTracks.getTrack(mergedTracks.addTrack());
-#if Acts_VERSION_MAJOR < 43 || (Acts_VERSION_MAJOR == 43 && Acts_VERSION_MINOR < 2)
-      destTrack.copyFrom(srcTrack, true); // true = copy track states
-#else
+      auto destTrack = mergedTracks.makeTrack();
       destTrack.copyFrom(srcTrack);
-#endif
     }
   }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR applies https://github.com/eic/EICrecon/pull/2400/changes/b8e40614d05c62f0384c45b014617995b4402465 to the only other place the same pattern occurs. In addition, this simplifies the copyFrom call below, since pre-43.2 this was default to true for the second arg anyway.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: fix once fix everwhere)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.