### PR TITLE
fix: rm TOFEndcapSharedHits from default output collections

### DIFF
--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -90,8 +90,6 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       "TOFBarrelClusterHits",
       "TOFBarrelADCTDC",
       "TOFEndcapHits",
-
-      "TOFEndcapSharedHits",
       "TOFEndcapADCTDC",
 
       "TOFBarrelRawHitAssociations",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes TOFEndcapSharedHits from the default output since it affects production running (which uses the default set of collections).

### What kind of change does this PR introduce?
- [x] Bug fix (issue: production output too big)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
Yes, if you rely on having TOFEndcapSharedHits; in that case use `-Ppodio:output_collections=TOFEndcapSharedHits` as argument to EICrecon.

### Does this PR change default behavior?
Yes, TOFEndcapSharedHits removed.