### PR TITLE
fix: rm measurements input from AmbiguitySolver

### DIFF
--- a/src/algorithms/tracking/AmbiguitySolver.cc
+++ b/src/algorithms/tracking/AmbiguitySolver.cc
@@ -13,7 +13,6 @@
 #include <ActsExamples/EventData/Track.hpp>
 #include <boost/container/flat_set.hpp>
 #include <boost/container/vector.hpp>
-#include <edm4eic/Measurement2DCollection.h>
 #include <any>
 #include <cstddef>
 #include <string>
@@ -57,8 +56,7 @@ void AmbiguitySolver::init(std::shared_ptr<spdlog::logger> log) {
 std::tuple<std::vector<Acts::ConstVectorMultiTrajectory*>,
            std::vector<Acts::ConstVectorTrackContainer*>>
 AmbiguitySolver::process(std::vector<const Acts::ConstVectorMultiTrajectory*> input_track_states,
-                         std::vector<const Acts::ConstVectorTrackContainer*> input_tracks,
-                         const edm4eic::Measurement2DCollection& /* meas2Ds */) {
+                         std::vector<const Acts::ConstVectorTrackContainer*> input_tracks) {
 
   // Create output vectors
   std::vector<Acts::ConstVectorMultiTrajectory*> output_track_states;

--- a/src/algorithms/tracking/AmbiguitySolver.h
+++ b/src/algorithms/tracking/AmbiguitySolver.h
@@ -5,7 +5,6 @@
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
 #include <Acts/EventData/VectorTrackContainer.hpp>
 #include <Acts/Utilities/Logger.hpp>
-#include <edm4eic/Measurement2D.h>
 #include <spdlog/logger.h>
 #include <memory>
 #include <tuple>
@@ -28,8 +27,7 @@ public:
   std::tuple<std::vector<Acts::ConstVectorMultiTrajectory*>,
              std::vector<Acts::ConstVectorTrackContainer*>>
   process(std::vector<const Acts::ConstVectorMultiTrajectory*> input_track_states,
-          std::vector<const Acts::ConstVectorTrackContainer*> input_tracks,
-          const edm4eic::Measurement2DCollection& meas2Ds);
+          std::vector<const Acts::ConstVectorTrackContainer*> input_tracks);
 
 private:
   std::shared_ptr<spdlog::logger> m_log;

--- a/src/factories/tracking/AmbiguitySolver_factory.h
+++ b/src/factories/tracking/AmbiguitySolver_factory.h
@@ -25,7 +25,6 @@ private:
 
   Input<Acts::ConstVectorMultiTrajectory> m_acts_track_states_input{this};
   Input<Acts::ConstVectorTrackContainer> m_acts_tracks_input{this};
-  PodioInput<edm4eic::Measurement2D> m_measurements_input{this};
   Output<Acts::ConstVectorMultiTrajectory> m_acts_track_states_output{this};
   Output<Acts::ConstVectorTrackContainer> m_acts_tracks_output{this};
 
@@ -62,7 +61,7 @@ public:
     assert(tracks_vec.front() != nullptr && "ConstVectorTrackContainer pointer should not be null");
 
     auto [output_track_states, output_tracks] =
-        m_algo->process(track_states_vec, tracks_vec, *m_measurements_input());
+        m_algo->process(track_states_vec, tracks_vec);
 
     // Transfer ownership to output collections in a single, exception-safe operation
     m_acts_track_states_output() = std::move(output_track_states);

--- a/src/factories/tracking/AmbiguitySolver_factory.h
+++ b/src/factories/tracking/AmbiguitySolver_factory.h
@@ -60,8 +60,7 @@ public:
     assert(!tracks_vec.empty() && "ConstVectorTrackContainer vector should not be empty");
     assert(tracks_vec.front() != nullptr && "ConstVectorTrackContainer pointer should not be null");
 
-    auto [output_track_states, output_tracks] =
-        m_algo->process(track_states_vec, tracks_vec);
+    auto [output_track_states, output_tracks] = m_algo->process(track_states_vec, tracks_vec);
 
     // Transfer ownership to output collections in a single, exception-safe operation
     m_acts_track_states_output() = std::move(output_track_states);

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -115,7 +115,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<AmbiguitySolver_factory>(
       "TruthSeededAmbiguityResolutionSolver",
       {"CentralCKFTruthSeededActsTrackStatesUnfiltered",
-       "CentralCKFTruthSeededActsTracksUnfiltered", "CentralTrackerMeasurements"},
+       "CentralCKFTruthSeededActsTracksUnfiltered"},
       {
           "CentralCKFTruthSeededActsTrackStates",
           "CentralCKFTruthSeededActsTracks",
@@ -170,8 +170,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<AmbiguitySolver_factory>(
       "AmbiguityResolutionSolver",
-      {"CentralCKFActsTrackStatesUnfiltered", "CentralCKFActsTracksUnfiltered",
-       "CentralTrackerMeasurements"},
+      {"CentralCKFActsTrackStatesUnfiltered", "CentralCKFActsTracksUnfiltered"},
       {
           "CentralCKFActsTrackStates",
           "CentralCKFActsTracks",
@@ -310,7 +309,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<AmbiguitySolver_factory>(
       "B0TrackerTruthSeededAmbiguityResolutionSolver",
       {"B0TrackerCKFTruthSeededActsTrackStatesUnfiltered",
-       "B0TrackerCKFTruthSeededActsTracksUnfiltered", "B0TrackerMeasurements"},
+       "B0TrackerCKFTruthSeededActsTracksUnfiltered"},
       {
           "B0TrackerCKFTruthSeededActsTrackStates",
           "B0TrackerCKFTruthSeededActsTracks",
@@ -365,8 +364,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<AmbiguitySolver_factory>(
       "B0TrackerAmbiguityResolutionSolver",
-      {"B0TrackerCKFActsTrackStatesUnfiltered", "B0TrackerCKFActsTracksUnfiltered",
-       "B0TrackerMeasurements"},
+      {"B0TrackerCKFActsTrackStatesUnfiltered", "B0TrackerCKFActsTracksUnfiltered"},
       {
           "B0TrackerCKFActsTrackStates",
           "B0TrackerCKFActsTracks",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes the unused measurements input from the AmbiguitySolver algorithm.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: unused input)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.