### PR TITLE
feat: support RNTuple read/write by using generic podio::Reader/Writer

### DIFF
--- a/src/services/geometry/acts/CMakeLists.txt
+++ b/src/services/geometry/acts/CMakeLists.txt
@@ -28,5 +28,5 @@ plugin_glob_all(${PLUGIN_NAME})
 # Add libraries (same as target_include_directories but for both plugin and
 # library)
 plugin_link_libraries(
-  ${PLUGIN_NAME} podio::podio podio::podioRootIO algorithms_digi_library
+  ${PLUGIN_NAME} podio::podio podio::podioIO algorithms_digi_library
   algorithms_tracking_library dd4hep_library)

--- a/src/services/io/podio/CMakeLists.txt
+++ b/src/services/io/podio/CMakeLists.txt
@@ -94,7 +94,7 @@ plugin_link_libraries(
   EDM4HEP::edm4hepDict
   EDM4EIC::edm4eic
   EDM4EIC::edm4eic_utils
-  podio::podioRootIO
+  podio::podioIO
   $<TARGET_NAME_IF_EXISTS:${Acts_NAMESPACE_PREFIX}PluginPodio>
   $<TARGET_NAME_IF_EXISTS:ActsPodioEdm>
   log_library)

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -423,7 +423,7 @@ void JEventProcessorPODIO::Init() {
   try {
     m_writer = std::make_unique<podio::Writer>(podio::makeWriter(m_output_file, backend_lower));
   } catch (const std::exception& e) {
-    m_log->error("Failed to create writer with backend '{}': {}. Falling back to default backend.",
+    m_log->error("Failed to create writer with backend '{}': {}. Falling back to 'default' backend.",
                  backend_lower, e.what());
     m_writer = std::make_unique<podio::Writer>(podio::makeWriter(m_output_file, "default"));
   }

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -424,10 +424,8 @@ void JEventProcessorPODIO::Init() {
   try {
     m_writer = std::make_unique<podio::Writer>(podio::makeWriter(m_output_file, backend_lower));
   } catch (const std::exception& e) {
-    m_log->error(
-        "Failed to create writer with backend '{}': {}. Falling back to 'default' backend.",
-        backend_lower, e.what());
-    m_writer = std::make_unique<podio::Writer>(podio::makeWriter(m_output_file, "default"));
+    throw std::runtime_error(
+        fmt::format("Failed to create writer with backend '{}': {}", backend_lower, e.what()));
   }
 }
 

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -16,6 +16,7 @@
 #include <iterator>
 #include <regex>
 #include <sstream>
+#include <stdexcept>
 
 #include "services/log/Log_service.h"
 

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -423,8 +423,9 @@ void JEventProcessorPODIO::Init() {
   try {
     m_writer = std::make_unique<podio::Writer>(podio::makeWriter(m_output_file, backend_lower));
   } catch (const std::exception& e) {
-    m_log->error("Failed to create writer with backend '{}': {}. Falling back to 'default' backend.",
-                 backend_lower, e.what());
+    m_log->error(
+        "Failed to create writer with backend '{}': {}. Falling back to 'default' backend.",
+        backend_lower, e.what());
     m_writer = std::make_unique<podio::Writer>(podio::makeWriter(m_output_file, "default"));
   }
 }

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -10,6 +10,7 @@
 #include <podio/Frame.h>
 #include <podio/Writer.h>
 #include <algorithm>
+#include <cctype>
 #include <exception>
 #include <functional>
 #include <iterator>

--- a/src/services/io/podio/JEventProcessorPODIO.h
+++ b/src/services/io/podio/JEventProcessorPODIO.h
@@ -3,7 +3,7 @@
 
 #include <JANA/JEvent.h>
 #include <JANA/JEventProcessor.h>
-#include <podio/ROOTWriter.h>
+#include <podio/Writer.h>
 #include <spdlog/logger.h>
 #include <memory>
 #include <mutex>
@@ -23,13 +23,14 @@ public:
 
   void FindCollectionsToWrite(const std::shared_ptr<const JEvent>& event);
 
-  std::unique_ptr<podio::ROOTWriter> m_writer;
+  std::unique_ptr<podio::Writer> m_writer;
   std::mutex m_mutex;
   std::once_flag m_is_first_event;
   std::shared_ptr<spdlog::logger> m_log;
 
   std::string m_output_file          = "podio_output.root";
   std::string m_output_file_copy_dir = "";
+  std::string m_output_backend       = "root";
   std::set<std::string> m_output_collections;         // config. parameter
   std::set<std::string> m_output_exclude_collections; // config. parameter
   std::vector<std::string> m_collections_to_write;    // derived from above config. parameters

--- a/src/services/io/podio/JEventSourcePODIO.cc
+++ b/src/services/io/podio/JEventSourcePODIO.cc
@@ -25,7 +25,6 @@
 #include <map>
 #include <memory>
 #include <sstream>
-#include <utility>
 #include <vector>
 
 #include "services/io/podio/datamodel_glue_compat.h"     // IWYU pragma: keep

--- a/src/services/io/podio/JEventSourcePODIO.cc
+++ b/src/services/io/podio/JEventSourcePODIO.cc
@@ -126,7 +126,7 @@ void JEventSourcePODIO::Open() {
   // std::string background_filename = GetApplication()->GetParameterValue<std::string>("podio:background_filename");;
   // int num_background_events = GetApplication()->GetParameterValue<int>("podio:num_background_events");;
 
-  // Open primary events file (auto-detects format: TTree, RNTuple, or SIO)
+  // Open primary events file (auto-detects format: TTree or RNTuple)
   try {
 
     m_reader = std::make_unique<podio::Reader>(podio::makeReader(GetResourceName()));

--- a/src/services/io/podio/JEventSourcePODIO.h
+++ b/src/services/io/podio/JEventSourcePODIO.h
@@ -7,7 +7,7 @@
 #include <JANA/JApplicationFwd.h>
 #include <JANA/JEventSource.h>
 #include <JANA/JEventSourceGeneratorT.h>
-#include <podio/ROOTReader.h>
+#include <podio/Reader.h>
 #include <spdlog/logger.h>
 #include <cstddef>
 #include <memory>
@@ -31,7 +31,7 @@ public:
   void PrintCollectionTypeTable(void);
 
 protected:
-  podio::ROOTReader m_reader;
+  std::unique_ptr<podio::Reader> m_reader;
 
   std::size_t Nevents_in_file = 0;
   std::size_t Nevents_read    = 0;

--- a/src/tests/algorithms_test/CMakeLists.txt
+++ b/src/tests/algorithms_test/CMakeLists.txt
@@ -33,7 +33,7 @@ target_link_libraries(
           particle_service_library
           pid_lut_library
           podio::podio
-          podio::podioRootIO)
+          podio::podioIO)
 
 # Install executable
 install(TARGETS ${TEST_NAME} DESTINATION bin)

--- a/src/tests/omnifactory_test/CMakeLists.txt
+++ b/src/tests/omnifactory_test/CMakeLists.txt
@@ -27,7 +27,7 @@ if(NOT JANA_VERSION VERSION_GREATER "2.4.2")
             EDM4HEP::edm4hep
             ${JANA_LIB}
             podio::podio
-            podio::podioRootIO
+            podio::podioIO
             ${ROOT_LIBRARIES}
             Catch2::Catch2WithMain
             ${CMAKE_DL_LIBS})


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR enables EICrecon to read both ROOT TTree and RNTuple files (transparently with auto-detection), and to write ROOT TTree or RNTuple (based on a parameter).

Related development: https://github.com/AIDASoft/DD4hep/pull/1566

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.