### PR TITLE
fix: avoid TGraph2D data races by creating without global TDirectory

### DIFF
--- a/src/algorithms/fardetectors/PolynomialMatrixReconstruction.cc
+++ b/src/algorithms/fardetectors/PolynomialMatrixReconstruction.cc
@@ -148,7 +148,7 @@ void eicrecon::PolynomialMatrixReconstruction::process(
     if (std::filesystem::exists(filename)) {
       // Prevent ROOT from registering TGraph2D in global directory
       gDirectory = nullptr;
-      xLGraph = std::make_unique<TGraph2D>(filename.c_str(), "%lf %lf %lf");
+      xLGraph    = std::make_unique<TGraph2D>(filename.c_str(), "%lf %lf %lf");
       xLGraph->SetDirectory(nullptr);
     } else {
       error("Cannot find lookup xL table for {}", nomMomentum);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR addresses a [thread-safety issue flagged by ThreadSanitizer](https://github.com/eic/EICrecon/actions/runs/21733613255/job/62693930727#step:7:863) and which was also at the cause of the following warning:
```
Warning in <TROOT::Append>: Replacing existing TGraph2D: Graph2D (Potential memory leak).
```

When a TGraph2D is created, it is created in the global ROOT directory. Each algorithm that creates the TGraph2D tries to write it to that global ROOT directory (hence, the second one replaces an existing one). Writing to a shared resources such as the global ROOT directory also opens the possibility for data races.

This PR modifies the TGraph2D creation to use a [ROOT context manager](https://root.cern.ch/doc/master/classTDirectory_1_1TContext.html) without a directory, i.e. nullptr. We also explicitly set the directory for the TGraph2D to nullptr.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/EICrecon/actions/runs/21733613255/job/62693930727#step:7:863)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.