### PR TITLE
feat: inherit jana::components::JOmniFactory and transition to using upstream JOmniFactory

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -119,7 +119,7 @@ jobs:
             USE_TSAN: ON
           - CXX: clang++
             CMAKE_BUILD_TYPE: Release
-            release: 26.02.0-stable
+            release: 26.03.0-stable
           - CXX: clang++
             CMAKE_BUILD_TYPE: Release
             release: 26.04.1-stable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,29 @@ find_package(spdlog ${spdlog_VERSION_MIN} REQUIRED)
 # Guidelines Support Library
 find_package(Microsoft.GSL CONFIG)
 
+# Check for JANA2 v2.4.3 JOmniFactory issues (fixed in PR #464)
+if(JANA_VERSION VERSION_EQUAL "2.4.3")
+  try_run(
+    JANA_BUG_RESULT
+    JANA_BUG_COMPILED
+    "${CMAKE_BINARY_DIR}"
+    "${CMAKE_SOURCE_DIR}/cmake/test_jana243_f18b66c6.cpp"
+    LINK_LIBRARIES
+    ${JANA_LIB}
+    podio::podio
+    CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${JANA_INCLUDE_DIR}"
+    COMPILE_OUTPUT_VARIABLE _unused_compile_out
+    RUN_OUTPUT_VARIABLE _unused_run_out)
+
+  if(JANA_BUG_COMPILED AND JANA_BUG_RESULT EQUAL 1)
+    message(
+      FATAL_ERROR
+        "JANA2 v2.4.3 has JOmniFactory bugs. Apply fixes with: "
+        "`git cherry-pick -m 1 0421819` or use JANA2 > v2.4.3. "
+        "Ref: https://github.com/JeffersonLab/JANA2/pull/464")
+  endif()
+endif()
+
 # Remove PODIO_JSON_OUTPUT (ref: https://github.com/AIDASoft/podio/issues/475)
 get_target_property(EDM4HEP_INTERFACE_COMPILE_DEFINITIONS EDM4HEP::edm4hep
                     INTERFACE_COMPILE_DEFINITIONS)

--- a/cmake/test_jana243_f18b66c6.cpp
+++ b/cmake/test_jana243_f18b66c6.cpp
@@ -1,0 +1,26 @@
+// Test program to detect JANA2 v2.4.3 Input<T> bug
+// The bug is fixed in commit f18b66c6
+//
+// Bug: Input<T> constructor sets m_databundle_name = m_type_name
+//      but GetCollection() uses m_tag (which is never set)
+// Fix: Removes m_tag member, uses m_databundle_name everywhere
+
+#include <JANA/Components/JHasInputs.h>
+
+// Helper class that can access protected Input<T>
+struct TestHasInputs : public jana::components::JHasInputs {
+  static bool has_bug() {
+    TestHasInputs owner;
+    Input<int> test_input(&owner);
+
+    // In buggy version: constructor sets m_databundle_name = "int"
+    // In fixed version: constructor doesn't set m_databundle_name (empty)
+
+    return test_input.GetDatabundleName() == "int";
+  }
+};
+
+int main() {
+  // Return 1 if bug detected, 0 if fixed
+  return TestHasInputs::has_bug() ? 1 : 0;
+}

--- a/src/detectors/B0ECAL/B0ECAL.cc
+++ b/src/detectors/B0ECAL/B0ECAL.cc
@@ -2,7 +2,9 @@
 // Copyright (C) 2022 - 2025 Whitney Armstrong, Sylvester Joosten, Chao Peng, David Lawrence, Wouter Deconinck, Kolja Kauder, Nathan Brei, Dmitry Kalinkin, Derek Anderson, Michael Pitt
 
 #include <Evaluator/DD4hepUnits.h>
+#include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <cmath>
 #include <string>

--- a/src/detectors/B0ECAL/B0ECAL.cc
+++ b/src/detectors/B0ECAL/B0ECAL.cc
@@ -21,6 +21,7 @@ extern "C" {
 void InitPlugin(JApplication* app) {
 
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   InitJANAPlugin(app);
 

--- a/src/detectors/B0TRK/B0TRK.cc
+++ b/src/detectors/B0TRK/B0TRK.cc
@@ -18,6 +18,7 @@ void InitPlugin(JApplication* app) {
   InitJANAPlugin(app);
 
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   // Digitization
   app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(

--- a/src/detectors/B0TRK/B0TRK.cc
+++ b/src/detectors/B0TRK/B0TRK.cc
@@ -7,7 +7,6 @@
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JEventLevel.h>
-#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <vector>

--- a/src/detectors/B0TRK/B0TRK.cc
+++ b/src/detectors/B0TRK/B0TRK.cc
@@ -4,7 +4,10 @@
 //
 
 #include <Evaluator/DD4hepUnits.h>
+#include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <vector>
@@ -23,7 +26,11 @@ void InitPlugin(JApplication* app) {
   // Digitization
   app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
       "B0TrackerRawHits", {"EventHeader", "B0TrackerHits"},
-      {"B0TrackerRawHits", "B0TrackerRawHitLinks", "B0TrackerRawHitAssociations"},
+      {"B0TrackerRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "B0TrackerRawHitLinks",
+#endif
+       "B0TrackerRawHitAssociations"},
       {
           .threshold      = 10.0 * dd4hep::keV,
           .timeResolution = 8,

--- a/src/detectors/B0TRK/B0TRK.cc
+++ b/src/detectors/B0TRK/B0TRK.cc
@@ -26,11 +26,7 @@ void InitPlugin(JApplication* app) {
   // Digitization
   app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
       "B0TrackerRawHits", {"EventHeader", "B0TrackerHits"},
-      {"B0TrackerRawHits",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "B0TrackerRawHitLinks",
-#endif
-       "B0TrackerRawHitAssociations"},
+      {"B0TrackerRawHits", "B0TrackerRawHitLinks", "B0TrackerRawHitAssociations"},
       {
           .threshold      = 10.0 * dd4hep::keV,
           .timeResolution = 8,

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -45,6 +45,7 @@ extern "C" {
 void InitPlugin(JApplication* app) {
 
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   InitJANAPlugin(app);
 

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -4,6 +4,7 @@
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/unit_system.h>

--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -25,6 +25,7 @@ extern "C" {
 void InitPlugin(JApplication* app) {
 
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   InitJANAPlugin(app);
 

--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -54,11 +54,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
       "HcalBarrelRawHits", {"EventHeader", "HcalBarrelHits"},
-      {"HcalBarrelRawHits",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "HcalBarrelRawHitLinks",
-#endif
-       "HcalBarrelRawHitAssociations"},
+      {"HcalBarrelRawHits", "HcalBarrelRawHitLinks", "HcalBarrelRawHitAssociations"},
       {
           .eRes          = {},
           .tRes          = 0.0 * dd4hep::ns,
@@ -134,15 +130,10 @@ void InitPlugin(JApplication* app) {
       "HcalBarrelClustersWithoutShapes",
       {
           "HcalBarrelIslandProtoClusters", // edm4eic::ProtoClusterCollection
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-          "HcalBarrelRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
-#endif
-          "HcalBarrelRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
+          "HcalBarrelRawHitLinks",         // edm4eic::MCRecoCalorimeterHitLink
+          "HcalBarrelRawHitAssociations"   // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"HcalBarrelClustersWithoutShapes",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "HcalBarrelClusterLinksWithoutShapes",
-#endif
+      {"HcalBarrelClustersWithoutShapes", "HcalBarrelClusterLinksWithoutShapes",
        "HcalBarrelClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 6.2, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -151,26 +142,17 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalBarrelClusters",
       {"HcalBarrelClustersWithoutShapes", "HcalBarrelClusterAssociationsWithoutShapes"},
-      {"HcalBarrelClusters",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "HcalBarrelClusterLinks",
-#endif
-       "HcalBarrelClusterAssociations"},
+      {"HcalBarrelClusters", "HcalBarrelClusterLinks", "HcalBarrelClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
       "HcalBarrelTruthClustersWithoutShapes",
       {
           "HcalBarrelTruthProtoClusters", // edm4eic::ProtoClusterCollection
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-          "HcalBarrelRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
-#endif
-          "HcalBarrelRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
+          "HcalBarrelRawHitLinks",        // edm4eic::MCRecoCalorimeterHitLink
+          "HcalBarrelRawHitAssociations"  // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"HcalBarrelTruthClustersWithoutShapes",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "HcalBarrelTruthClusterLinksWithoutShapes",
-#endif
+      {"HcalBarrelTruthClustersWithoutShapes", "HcalBarrelTruthClusterLinksWithoutShapes",
        "HcalBarrelTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 6.2, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -179,10 +161,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalBarrelTruthClusters",
       {"HcalBarrelTruthClustersWithoutShapes", "HcalBarrelTruthClusterAssociationsWithoutShapes"},
-      {"HcalBarrelTruthClusters",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "HcalBarrelTruthClusterLinks",
-#endif
+      {"HcalBarrelTruthClusters", "HcalBarrelTruthClusterLinks",
        "HcalBarrelTruthClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
 
@@ -190,12 +169,9 @@ void InitPlugin(JApplication* app) {
       "HcalBarrelSplitMergeProtoClusters",
       {"HcalBarrelTrackClusterMatches", "HcalBarrelClustersWithoutShapes",
        "CalorimeterTrackProjections"},
-      {"HcalBarrelSplitMergeProtoClusters",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "HcalBarrelTrackSplitMergeProtoClusterLinks"
-#else
-       "HcalBarrelTrackSplitMergeProtoClusterMatches"
-#endif
+      {
+          "HcalBarrelSplitMergeProtoClusters",
+          "HcalBarrelTrackSplitMergeProtoClusterLinks",
       },
       {.minSigCut                    = -2.0,
        .avgEP                        = 0.50,
@@ -210,15 +186,10 @@ void InitPlugin(JApplication* app) {
       "HcalBarrelSplitMergeClustersWithoutShapes",
       {
           "HcalBarrelSplitMergeProtoClusters", // edm4eic::ProtoClusterCollection
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-          "HcalBarrelRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
-#endif
-          "HcalBarrelRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
+          "HcalBarrelRawHitLinks",             // edm4eic::MCRecoCalorimeterHitLink
+          "HcalBarrelRawHitAssociations"       // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"HcalBarrelSplitMergeClustersWithoutShapes",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "HcalBarrelSplitMergeClusterLinksWithoutShapes",
-#endif
+      {"HcalBarrelSplitMergeClustersWithoutShapes", "HcalBarrelSplitMergeClusterLinksWithoutShapes",
        "HcalBarrelSplitMergeClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 6.2, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -228,10 +199,7 @@ void InitPlugin(JApplication* app) {
       "HcalBarrelSplitMergeClusters",
       {"HcalBarrelSplitMergeClustersWithoutShapes",
        "HcalBarrelSplitMergeClusterAssociationsWithoutShapes"},
-      {"HcalBarrelSplitMergeClusters",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "HcalBarrelSplitMergeClusterLinks",
-#endif
+      {"HcalBarrelSplitMergeClusters", "HcalBarrelSplitMergeClusterLinks",
        "HcalBarrelSplitMergeClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
 }

--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -5,7 +5,6 @@
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JEventLevel.h>
-#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <variant>

--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -2,7 +2,10 @@
 // Copyright (C) 2022 - 2024 David Lawrence, Derek Anderson, Wouter Deconinck
 
 #include <Evaluator/DD4hepUnits.h>
+#include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <variant>
@@ -51,7 +54,11 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
       "HcalBarrelRawHits", {"EventHeader", "HcalBarrelHits"},
-      {"HcalBarrelRawHits", "HcalBarrelRawHitLinks", "HcalBarrelRawHitAssociations"},
+      {"HcalBarrelRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalBarrelRawHitLinks",
+#endif
+       "HcalBarrelRawHitAssociations"},
       {
           .eRes          = {},
           .tRes          = 0.0 * dd4hep::ns,
@@ -127,10 +134,15 @@ void InitPlugin(JApplication* app) {
       "HcalBarrelClustersWithoutShapes",
       {
           "HcalBarrelIslandProtoClusters", // edm4eic::ProtoClusterCollection
-          "HcalBarrelRawHitLinks",         // edm4eic::MCRecoCalorimeterHitLink
-          "HcalBarrelRawHitAssociations"   // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "HcalBarrelRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "HcalBarrelRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"HcalBarrelClustersWithoutShapes", "HcalBarrelClusterLinksWithoutShapes",
+      {"HcalBarrelClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalBarrelClusterLinksWithoutShapes",
+#endif
        "HcalBarrelClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 6.2, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -139,17 +151,26 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalBarrelClusters",
       {"HcalBarrelClustersWithoutShapes", "HcalBarrelClusterAssociationsWithoutShapes"},
-      {"HcalBarrelClusters", "HcalBarrelClusterLinks", "HcalBarrelClusterAssociations"},
+      {"HcalBarrelClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalBarrelClusterLinks",
+#endif
+       "HcalBarrelClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
       "HcalBarrelTruthClustersWithoutShapes",
       {
           "HcalBarrelTruthProtoClusters", // edm4eic::ProtoClusterCollection
-          "HcalBarrelRawHitLinks",        // edm4eic::MCRecoCalorimeterHitLink
-          "HcalBarrelRawHitAssociations"  // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "HcalBarrelRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "HcalBarrelRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"HcalBarrelTruthClustersWithoutShapes", "HcalBarrelTruthClusterLinksWithoutShapes",
+      {"HcalBarrelTruthClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalBarrelTruthClusterLinksWithoutShapes",
+#endif
        "HcalBarrelTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 6.2, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -158,7 +179,10 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalBarrelTruthClusters",
       {"HcalBarrelTruthClustersWithoutShapes", "HcalBarrelTruthClusterAssociationsWithoutShapes"},
-      {"HcalBarrelTruthClusters", "HcalBarrelTruthClusterLinks",
+      {"HcalBarrelTruthClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalBarrelTruthClusterLinks",
+#endif
        "HcalBarrelTruthClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
 
@@ -166,7 +190,13 @@ void InitPlugin(JApplication* app) {
       "HcalBarrelSplitMergeProtoClusters",
       {"HcalBarrelTrackClusterMatches", "HcalBarrelClustersWithoutShapes",
        "CalorimeterTrackProjections"},
-      {"HcalBarrelSplitMergeProtoClusters", "HcalBarrelTrackSplitMergeProtoClusterLinks"},
+      {"HcalBarrelSplitMergeProtoClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalBarrelTrackSplitMergeProtoClusterLinks"
+#else
+       "HcalBarrelTrackSplitMergeProtoClusterMatches"
+#endif
+      },
       {.minSigCut                    = -2.0,
        .avgEP                        = 0.50,
        .sigEP                        = 0.25,
@@ -180,10 +210,15 @@ void InitPlugin(JApplication* app) {
       "HcalBarrelSplitMergeClustersWithoutShapes",
       {
           "HcalBarrelSplitMergeProtoClusters", // edm4eic::ProtoClusterCollection
-          "HcalBarrelRawHitLinks",             // edm4eic::MCRecoCalorimeterHitLink
-          "HcalBarrelRawHitAssociations"       // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "HcalBarrelRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "HcalBarrelRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"HcalBarrelSplitMergeClustersWithoutShapes", "HcalBarrelSplitMergeClusterLinksWithoutShapes",
+      {"HcalBarrelSplitMergeClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalBarrelSplitMergeClusterLinksWithoutShapes",
+#endif
        "HcalBarrelSplitMergeClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 6.2, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -193,7 +228,10 @@ void InitPlugin(JApplication* app) {
       "HcalBarrelSplitMergeClusters",
       {"HcalBarrelSplitMergeClustersWithoutShapes",
        "HcalBarrelSplitMergeClusterAssociationsWithoutShapes"},
-      {"HcalBarrelSplitMergeClusters", "HcalBarrelSplitMergeClusterLinks",
+      {"HcalBarrelSplitMergeClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalBarrelSplitMergeClusterLinks",
+#endif
        "HcalBarrelSplitMergeClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
 }

--- a/src/detectors/BTOF/BTOF.cc
+++ b/src/detectors/BTOF/BTOF.cc
@@ -8,6 +8,7 @@
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <TMath.h>
 #include <edm4eic/unit_system.h>

--- a/src/detectors/BTOF/BTOF.cc
+++ b/src/detectors/BTOF/BTOF.cc
@@ -35,6 +35,7 @@ void InitPlugin(JApplication* app) {
   InitJANAPlugin(app);
 
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   // Convert raw digitized hits into calibrated hits
   // time walk correction is still TBD

--- a/src/detectors/BTRK/BTRK.cc
+++ b/src/detectors/BTRK/BTRK.cc
@@ -18,6 +18,7 @@ void InitPlugin(JApplication* app) {
   InitJANAPlugin(app);
 
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   // Digitization
   app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(

--- a/src/detectors/BTRK/BTRK.cc
+++ b/src/detectors/BTRK/BTRK.cc
@@ -4,7 +4,9 @@
 //
 
 #include <Evaluator/DD4hepUnits.h>
+#include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <vector>

--- a/src/detectors/BVTX/BVTX.cc
+++ b/src/detectors/BVTX/BVTX.cc
@@ -18,6 +18,7 @@ void InitPlugin(JApplication* app) {
   InitJANAPlugin(app);
 
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   // Digitization
   app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(

--- a/src/detectors/BVTX/BVTX.cc
+++ b/src/detectors/BVTX/BVTX.cc
@@ -7,7 +7,6 @@
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JEventLevel.h>
-#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <vector>

--- a/src/detectors/BVTX/BVTX.cc
+++ b/src/detectors/BVTX/BVTX.cc
@@ -26,11 +26,7 @@ void InitPlugin(JApplication* app) {
   // Digitization
   app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
       "SiBarrelVertexRawHits", {"EventHeader", "VertexBarrelHits"},
-      {"SiBarrelVertexRawHits",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "SiBarrelVertexRawHitLinks",
-#endif
-       "SiBarrelVertexRawHitAssociations"},
+      {"SiBarrelVertexRawHits", "SiBarrelVertexRawHitLinks", "SiBarrelVertexRawHitAssociations"},
       {
           .threshold = 0.54 * dd4hep::keV,
       },

--- a/src/detectors/BVTX/BVTX.cc
+++ b/src/detectors/BVTX/BVTX.cc
@@ -4,7 +4,10 @@
 //
 
 #include <Evaluator/DD4hepUnits.h>
+#include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <vector>
@@ -23,7 +26,11 @@ void InitPlugin(JApplication* app) {
   // Digitization
   app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
       "SiBarrelVertexRawHits", {"EventHeader", "VertexBarrelHits"},
-      {"SiBarrelVertexRawHits", "SiBarrelVertexRawHitLinks", "SiBarrelVertexRawHitAssociations"},
+      {"SiBarrelVertexRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "SiBarrelVertexRawHitLinks",
+#endif
+       "SiBarrelVertexRawHitAssociations"},
       {
           .threshold = 0.54 * dd4hep::keV,
       },

--- a/src/detectors/DIRC/DIRC.cc
+++ b/src/detectors/DIRC/DIRC.cc
@@ -18,6 +18,7 @@ void InitPlugin(JApplication* app) {
   InitJANAPlugin(app);
 
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   // configuration parameters ///////////////////////////////////////////////
 

--- a/src/detectors/DIRC/DIRC.cc
+++ b/src/detectors/DIRC/DIRC.cc
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022 - 2025 Christopher Dilks, Nilanga Wickramaarachchi, Dmitry Kalinkin
 
-#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JEventLevel.h>

--- a/src/detectors/DIRC/DIRC.cc
+++ b/src/detectors/DIRC/DIRC.cc
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022 - 2025 Christopher Dilks, Nilanga Wickramaarachchi, Dmitry Kalinkin
 
+#include <edm4eic/EDM4eicVersion.h>
+#include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <utility>
@@ -39,6 +42,11 @@ void InitPlugin(JApplication* app) {
   // digitization
   app->Add(new JOmniFactoryGeneratorT<PhotoMultiplierHitDigi_factory>(
       "DIRCRawHits", {"EventHeader", "DIRCBarHits"},
-      {"DIRCRawHits", "DIRCRawHitsLinks", "DIRCRawHitsAssociations"}, digi_cfg, app));
+      {"DIRCRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "DIRCRawHitsLinks",
+#endif
+       "DIRCRawHitsAssociations"},
+      digi_cfg, app));
 }
 }

--- a/src/detectors/DIRC/DIRC.cc
+++ b/src/detectors/DIRC/DIRC.cc
@@ -41,12 +41,7 @@ void InitPlugin(JApplication* app) {
 
   // digitization
   app->Add(new JOmniFactoryGeneratorT<PhotoMultiplierHitDigi_factory>(
-      "DIRCRawHits", {"EventHeader", "DIRCBarHits"},
-      {"DIRCRawHits",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "DIRCRawHitsLinks",
-#endif
-       "DIRCRawHitsAssociations"},
+      "DIRCRawHits", {"EventHeader", "DIRCBarHits"}, {"DIRCRawHits", "DIRCRawHitsLinks", "DIRCRawHitsAssociations"},
       digi_cfg, app));
 }
 }

--- a/src/detectors/DIRC/DIRC.cc
+++ b/src/detectors/DIRC/DIRC.cc
@@ -41,7 +41,7 @@ void InitPlugin(JApplication* app) {
 
   // digitization
   app->Add(new JOmniFactoryGeneratorT<PhotoMultiplierHitDigi_factory>(
-      "DIRCRawHits", {"EventHeader", "DIRCBarHits"}, {"DIRCRawHits", "DIRCRawHitsLinks", "DIRCRawHitsAssociations"},
-      digi_cfg, app));
+      "DIRCRawHits", {"EventHeader", "DIRCBarHits"},
+      {"DIRCRawHits", "DIRCRawHitsLinks", "DIRCRawHitsAssociations"}, digi_cfg, app));
 }
 }

--- a/src/detectors/DRICH/DRICH.cc
+++ b/src/detectors/DRICH/DRICH.cc
@@ -9,6 +9,7 @@
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <functional>
 #include <map>

--- a/src/detectors/DRICH/DRICH.cc
+++ b/src/detectors/DRICH/DRICH.cc
@@ -39,6 +39,7 @@ void InitPlugin(JApplication* app) {
   InitJANAPlugin(app);
 
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   // configuration parameters ///////////////////////////////////////////////
 
@@ -129,9 +130,10 @@ void InitPlugin(JApplication* app) {
       "DRICHGasTracks", {"CentralCKFTracks", "CentralCKFActsTrackStates", "CentralCKFActsTracks"},
       {"DRICHGasTracks"}, gas_track_cfg, app));
 
-  app->Add(new JOmniFactoryGeneratorT<MergeTrack_factory>("DRICHMergedTracks",
-                                                          {"DRICHAerogelTracks", "DRICHGasTracks"},
-                                                          {"DRICHMergedTracks"}, {}, app));
+  app->Add(new JOmniFactoryGeneratorT<MergeTrack_factory>(
+      {.tag                  = "DRICHMergedTracks",
+       .variadic_input_names = {{"DRICHAerogelTracks", "DRICHGasTracks"}},
+       .output_names         = {"DRICHMergedTracks"}}));
 
   // PID algorithm
   app->Add(new JOmniFactoryGeneratorT<IrtCherenkovParticleID_factory>(
@@ -142,9 +144,11 @@ void InitPlugin(JApplication* app) {
 
   // merge aerogel and gas PID results
   app->Add(new JOmniFactoryGeneratorT<MergeCherenkovParticleID_factory>(
-      "DRICHMergedIrtCherenkovParticleID",
-      {"DRICHAerogelIrtCherenkovParticleID", "DRICHGasIrtCherenkovParticleID"},
-      {"DRICHMergedIrtCherenkovParticleID"}, merge_cfg, app));
+      {.tag                  = "DRICHMergedIrtCherenkovParticleID",
+       .variadic_input_names = {{"DRICHAerogelIrtCherenkovParticleID",
+                                 "DRICHGasIrtCherenkovParticleID"}},
+       .output_names         = {"DRICHMergedIrtCherenkovParticleID"},
+       .configs              = merge_cfg}));
 
   // clang-format on
 }

--- a/src/detectors/ECTOF/ECTOF.cc
+++ b/src/detectors/ECTOF/ECTOF.cc
@@ -4,6 +4,7 @@
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <TMath.h>
 #include <edm4eic/unit_system.h>

--- a/src/detectors/ECTOF/ECTOF.cc
+++ b/src/detectors/ECTOF/ECTOF.cc
@@ -30,6 +30,7 @@ void InitPlugin(JApplication* app) {
   InitJANAPlugin(app);
 
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   // cluster all hits in a sensor into one hit location
   // Currently it's just a simple weighted average

--- a/src/detectors/ECTRK/ECTRK.cc
+++ b/src/detectors/ECTRK/ECTRK.cc
@@ -18,6 +18,7 @@ void InitPlugin(JApplication* app) {
   InitJANAPlugin(app);
 
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   // Digitization
   app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(

--- a/src/detectors/ECTRK/ECTRK.cc
+++ b/src/detectors/ECTRK/ECTRK.cc
@@ -7,7 +7,6 @@
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JEventLevel.h>
-#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <vector>

--- a/src/detectors/ECTRK/ECTRK.cc
+++ b/src/detectors/ECTRK/ECTRK.cc
@@ -4,7 +4,10 @@
 //
 
 #include <Evaluator/DD4hepUnits.h>
+#include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <vector>
@@ -23,7 +26,11 @@ void InitPlugin(JApplication* app) {
   // Digitization
   app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
       "SiEndcapTrackerRawHits", {"EventHeader", "TrackerEndcapHits"},
-      {"SiEndcapTrackerRawHits", "SiEndcapTrackerRawHitLinks", "SiEndcapTrackerRawHitAssociations"},
+      {"SiEndcapTrackerRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "SiEndcapTrackerRawHitLinks",
+#endif
+       "SiEndcapTrackerRawHitAssociations"},
       {
           .threshold = 0.54 * dd4hep::keV,
       },

--- a/src/detectors/ECTRK/ECTRK.cc
+++ b/src/detectors/ECTRK/ECTRK.cc
@@ -26,11 +26,7 @@ void InitPlugin(JApplication* app) {
   // Digitization
   app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
       "SiEndcapTrackerRawHits", {"EventHeader", "TrackerEndcapHits"},
-      {"SiEndcapTrackerRawHits",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "SiEndcapTrackerRawHitLinks",
-#endif
-       "SiEndcapTrackerRawHitAssociations"},
+      {"SiEndcapTrackerRawHits", "SiEndcapTrackerRawHitLinks", "SiEndcapTrackerRawHitAssociations"},
       {
           .threshold = 0.54 * dd4hep::keV,
       },

--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -2,7 +2,10 @@
 // Copyright (C) 2022 - 2025 Sylvester Joosten, Chao, Chao Peng, Whitney Armstrong, Thomas Britton, David Lawrence, Dhevan Gangadharan, Wouter Deconinck, Dmitry Kalinkin, Derek Anderson
 
 #include <Evaluator/DD4hepUnits.h>
+#include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <cmath>
 #include <string>
@@ -39,7 +42,11 @@ void InitPlugin(JApplication* app) {
       10 * dd4hep::picosecond;
   app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
       "EcalEndcapNRawHits", {"EventHeader", "EcalEndcapNHits"},
-      {"EcalEndcapNRawHits", "EcalEndcapNRawHitLinks", "EcalEndcapNRawHitAssociations"},
+      {"EcalEndcapNRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalEndcapNRawHitLinks",
+#endif
+       "EcalEndcapNRawHitAssociations"},
       {
           .eRes        = {0.0 * sqrt(dd4hep::GeV), 0.0, 0.0 * dd4hep::GeV},
           .tRes        = 0.0 * dd4hep::ns,
@@ -109,10 +116,15 @@ void InitPlugin(JApplication* app) {
       "EcalEndcapNTruthClustersWithoutShapes",
       {
           "EcalEndcapNTruthProtoClusters", // edm4eic::ProtoClusterCollection
-          "EcalEndcapNRawHitLinks",        // edm4eic::MCRecoCalorimeterHitLink
-          "EcalEndcapNRawHitAssociations"  // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "EcalEndcapNRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "EcalEndcapNRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"EcalEndcapNTruthClustersWithoutShapes", "EcalEndcapNTruthClusterLinksWithoutShapes",
+      {"EcalEndcapNTruthClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalEndcapNTruthClusterLinksWithoutShapes",
+#endif
        "EcalEndcapNTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 4.6, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -121,7 +133,10 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalEndcapNTruthClusters",
       {"EcalEndcapNTruthClustersWithoutShapes", "EcalEndcapNTruthClusterAssociationsWithoutShapes"},
-      {"EcalEndcapNTruthClusters", "EcalEndcapNTruthClusterLinks",
+      {"EcalEndcapNTruthClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalEndcapNTruthClusterLinks",
+#endif
        "EcalEndcapNTruthClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 4.6}, app));
 
@@ -129,11 +144,15 @@ void InitPlugin(JApplication* app) {
       "EcalEndcapNClustersWithoutPIDAndShapes",
       {
           "EcalEndcapNIslandProtoClusters", // edm4eic::ProtoClusterCollection
-          "EcalEndcapNRawHitLinks",         // edm4eic::MCRecoCalorimeterHitLink
-          "EcalEndcapNRawHitAssociations"   // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "EcalEndcapNRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "EcalEndcapNRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"EcalEndcapNClustersWithoutPIDAndShapes",             // edm4eic::Cluster
-       "EcalEndcapNClusterLinksWithoutPIDAndShapes",         // edm4eic::MCRecoClusterParticleLink
+      {"EcalEndcapNClustersWithoutPIDAndShapes", // edm4eic::Cluster
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalEndcapNClusterLinksWithoutPIDAndShapes", // edm4eic::MCRecoClusterParticleLink
+#endif
        "EcalEndcapNClusterAssociationsWithoutPIDAndShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {
           .energyWeight    = "log",
@@ -148,7 +167,10 @@ void InitPlugin(JApplication* app) {
       "EcalEndcapNClustersWithoutPID",
       {"EcalEndcapNClustersWithoutPIDAndShapes",
        "EcalEndcapNClusterAssociationsWithoutPIDAndShapes"},
-      {"EcalEndcapNClustersWithoutPID", "EcalEndcapNClusterLinksWithoutPID",
+      {"EcalEndcapNClustersWithoutPID",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalEndcapNClusterLinksWithoutPID",
+#endif
        "EcalEndcapNClusterAssociationsWithoutPID"},
       {.energyWeight = "log", .logWeightBase = 3.6}, app));
 
@@ -164,7 +186,7 @@ void InitPlugin(JApplication* app) {
       },
       app));
 
-  app->Add(new jana::components::JOmniFactoryGeneratorT<ONNXInference_factory>(
+  app->Add(new JOmniFactoryGeneratorT<ONNXInference_factory>(
       {.tag                   = "EcalEndcapNParticleIDInference",
        .variadic_input_names  = {{"EcalEndcapNParticleIDInput_features"}},
        .variadic_output_names = {{"EcalEndcapNParticleIDOutput_label",
@@ -182,7 +204,9 @@ void InitPlugin(JApplication* app) {
 
       {
           "EcalEndcapNClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
           "EcalEndcapNClusterLinks",
+#endif
           "EcalEndcapNClusterAssociations",
           "EcalEndcapNClusterParticleIDs",
       },
@@ -192,7 +216,13 @@ void InitPlugin(JApplication* app) {
       "EcalEndcapNSplitMergeProtoClusters",
       {"EcalEndcapNTrackClusterMatches", "EcalEndcapNClustersWithoutPID",
        "CalorimeterTrackProjections"},
-      {"EcalEndcapNSplitMergeProtoClusters", "EcalEndcapNTrackSplitMergeProtoClusterLinks"},
+      {"EcalEndcapNSplitMergeProtoClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalEndcapNTrackSplitMergeProtoClusterLinks"
+#else
+       "EcalEndcapNTrackSplitMergeProtoClusterMatches"
+#endif
+      },
       {.minSigCut                    = -1.0,
        .avgEP                        = 1.0,
        .sigEP                        = 0.10,
@@ -204,10 +234,14 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
       "EcalEndcapNSplitMergeClustersWithoutShapes",
       {"EcalEndcapNSplitMergeProtoClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
        "EcalEndcapNRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
        "EcalEndcapNRawHitAssociations"},
       {"EcalEndcapNSplitMergeClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
        "EcalEndcapNSplitMergeClusterLinksWithoutShapes",
+#endif
        "EcalEndcapNSplitMergeClusterAssociationsWithoutShapes"},
       {
           .energyWeight    = "log",
@@ -222,7 +256,10 @@ void InitPlugin(JApplication* app) {
 
       {"EcalEndcapNSplitMergeClustersWithoutShapes",
        "EcalEndcapNSplitMergeClusterAssociationsWithoutShapes"},
-      {"EcalEndcapNSplitMergeClusters", "EcalEndcapNSplitMergeClusterLinks",
+      {"EcalEndcapNSplitMergeClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalEndcapNSplitMergeClusterLinks",
+#endif
        "EcalEndcapNSplitMergeClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 3.6}, app));
 }

--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -5,7 +5,6 @@
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JEventLevel.h>
-#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <cmath>
 #include <string>

--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -26,6 +26,7 @@ extern "C" {
 void InitPlugin(JApplication* app) {
 
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   InitJANAPlugin(app);
 
@@ -162,19 +163,15 @@ void InitPlugin(JApplication* app) {
           "EcalEndcapNParticleIDTarget",
       },
       app));
-  app->Add(new JOmniFactoryGeneratorT<ONNXInference_factory>(
-      "EcalEndcapNParticleIDInference",
-      {
-          "EcalEndcapNParticleIDInput_features",
-      },
-      {
-          "EcalEndcapNParticleIDOutput_label",
-          "EcalEndcapNParticleIDOutput_probability_tensor",
-      },
-      {
-          .modelPath = "calibrations/onnx/EcalEndcapN_pi_rejection.onnx",
-      },
-      app));
+
+  app->Add(new jana::components::JOmniFactoryGeneratorT<ONNXInference_factory>(
+      {.tag                   = "EcalEndcapNParticleIDInference",
+       .variadic_input_names  = {{"EcalEndcapNParticleIDInput_features"}},
+       .variadic_output_names = {{"EcalEndcapNParticleIDOutput_label",
+                                  "EcalEndcapNParticleIDOutput_probability_tensor"}},
+       .configs               = {
+           .modelPath = "calibrations/onnx/EcalEndcapN_pi_rejection.onnx",
+       }}));
   app->Add(new JOmniFactoryGeneratorT<CalorimeterParticleIDPostML_factory>(
       "EcalEndcapNParticleIDPostML",
       {

--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -42,11 +42,7 @@ void InitPlugin(JApplication* app) {
       10 * dd4hep::picosecond;
   app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
       "EcalEndcapNRawHits", {"EventHeader", "EcalEndcapNHits"},
-      {"EcalEndcapNRawHits",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "EcalEndcapNRawHitLinks",
-#endif
-       "EcalEndcapNRawHitAssociations"},
+      {"EcalEndcapNRawHits", "EcalEndcapNRawHitLinks", "EcalEndcapNRawHitAssociations"},
       {
           .eRes        = {0.0 * sqrt(dd4hep::GeV), 0.0, 0.0 * dd4hep::GeV},
           .tRes        = 0.0 * dd4hep::ns,
@@ -116,15 +112,10 @@ void InitPlugin(JApplication* app) {
       "EcalEndcapNTruthClustersWithoutShapes",
       {
           "EcalEndcapNTruthProtoClusters", // edm4eic::ProtoClusterCollection
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-          "EcalEndcapNRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
-#endif
-          "EcalEndcapNRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
+          "EcalEndcapNRawHitLinks",        // edm4eic::MCRecoCalorimeterHitLink
+          "EcalEndcapNRawHitAssociations"  // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"EcalEndcapNTruthClustersWithoutShapes",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "EcalEndcapNTruthClusterLinksWithoutShapes",
-#endif
+      {"EcalEndcapNTruthClustersWithoutShapes", "EcalEndcapNTruthClusterLinksWithoutShapes",
        "EcalEndcapNTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 4.6, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -133,10 +124,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalEndcapNTruthClusters",
       {"EcalEndcapNTruthClustersWithoutShapes", "EcalEndcapNTruthClusterAssociationsWithoutShapes"},
-      {"EcalEndcapNTruthClusters",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "EcalEndcapNTruthClusterLinks",
-#endif
+      {"EcalEndcapNTruthClusters", "EcalEndcapNTruthClusterLinks",
        "EcalEndcapNTruthClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 4.6}, app));
 
@@ -144,15 +132,11 @@ void InitPlugin(JApplication* app) {
       "EcalEndcapNClustersWithoutPIDAndShapes",
       {
           "EcalEndcapNIslandProtoClusters", // edm4eic::ProtoClusterCollection
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-          "EcalEndcapNRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
-#endif
-          "EcalEndcapNRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
+          "EcalEndcapNRawHitLinks",         // edm4eic::MCRecoCalorimeterHitLink
+          "EcalEndcapNRawHitAssociations"   // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"EcalEndcapNClustersWithoutPIDAndShapes", // edm4eic::Cluster
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "EcalEndcapNClusterLinksWithoutPIDAndShapes", // edm4eic::MCRecoClusterParticleLink
-#endif
+      {"EcalEndcapNClustersWithoutPIDAndShapes",             // edm4eic::Cluster
+       "EcalEndcapNClusterLinksWithoutPIDAndShapes",         // edm4eic::MCRecoClusterParticleLink
        "EcalEndcapNClusterAssociationsWithoutPIDAndShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {
           .energyWeight    = "log",
@@ -167,10 +151,7 @@ void InitPlugin(JApplication* app) {
       "EcalEndcapNClustersWithoutPID",
       {"EcalEndcapNClustersWithoutPIDAndShapes",
        "EcalEndcapNClusterAssociationsWithoutPIDAndShapes"},
-      {"EcalEndcapNClustersWithoutPID",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "EcalEndcapNClusterLinksWithoutPID",
-#endif
+      {"EcalEndcapNClustersWithoutPID", "EcalEndcapNClusterLinksWithoutPID",
        "EcalEndcapNClusterAssociationsWithoutPID"},
       {.energyWeight = "log", .logWeightBase = 3.6}, app));
 
@@ -204,9 +185,7 @@ void InitPlugin(JApplication* app) {
 
       {
           "EcalEndcapNClusters",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
           "EcalEndcapNClusterLinks",
-#endif
           "EcalEndcapNClusterAssociations",
           "EcalEndcapNClusterParticleIDs",
       },
@@ -216,12 +195,9 @@ void InitPlugin(JApplication* app) {
       "EcalEndcapNSplitMergeProtoClusters",
       {"EcalEndcapNTrackClusterMatches", "EcalEndcapNClustersWithoutPID",
        "CalorimeterTrackProjections"},
-      {"EcalEndcapNSplitMergeProtoClusters",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "EcalEndcapNTrackSplitMergeProtoClusterLinks"
-#else
-       "EcalEndcapNTrackSplitMergeProtoClusterMatches"
-#endif
+      {
+          "EcalEndcapNSplitMergeProtoClusters",
+          "EcalEndcapNTrackSplitMergeProtoClusterLinks",
       },
       {.minSigCut                    = -1.0,
        .avgEP                        = 1.0,
@@ -233,15 +209,10 @@ void InitPlugin(JApplication* app) {
       ));
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
       "EcalEndcapNSplitMergeClustersWithoutShapes",
-      {"EcalEndcapNSplitMergeProtoClusters",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "EcalEndcapNRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
-#endif
+      {"EcalEndcapNSplitMergeProtoClusters", "EcalEndcapNRawHitLinks",
        "EcalEndcapNRawHitAssociations"},
       {"EcalEndcapNSplitMergeClustersWithoutShapes",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
        "EcalEndcapNSplitMergeClusterLinksWithoutShapes",
-#endif
        "EcalEndcapNSplitMergeClusterAssociationsWithoutShapes"},
       {
           .energyWeight    = "log",
@@ -256,10 +227,7 @@ void InitPlugin(JApplication* app) {
 
       {"EcalEndcapNSplitMergeClustersWithoutShapes",
        "EcalEndcapNSplitMergeClusterAssociationsWithoutShapes"},
-      {"EcalEndcapNSplitMergeClusters",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "EcalEndcapNSplitMergeClusterLinks",
-#endif
+      {"EcalEndcapNSplitMergeClusters", "EcalEndcapNSplitMergeClusterLinks",
        "EcalEndcapNSplitMergeClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 3.6}, app));
 }

--- a/src/detectors/EHCAL/EHCAL.cc
+++ b/src/detectors/EHCAL/EHCAL.cc
@@ -23,6 +23,7 @@ extern "C" {
 void InitPlugin(JApplication* app) {
 
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   InitJANAPlugin(app);
   // Make sure digi and reco use the same value

--- a/src/detectors/EHCAL/EHCAL.cc
+++ b/src/detectors/EHCAL/EHCAL.cc
@@ -41,11 +41,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
       "HcalEndcapNRawHits", {"EventHeader", "HcalEndcapNHits"},
-      {"HcalEndcapNRawHits",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "HcalEndcapNRawHitLinks",
-#endif
-       "HcalEndcapNRawHitAssociations"},
+      {"HcalEndcapNRawHits", "HcalEndcapNRawHitLinks", "HcalEndcapNRawHitAssociations"},
       {
           .eRes{},
           .tRes          = 0.0 * dd4hep::ns,
@@ -114,15 +110,10 @@ void InitPlugin(JApplication* app) {
       "HcalEndcapNTruthClustersWithoutShapes",
       {
           "HcalEndcapNTruthProtoClusters", // edm4eic::ProtoClusterCollection
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-          "HcalEndcapNRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
-#endif
-          "HcalEndcapNRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
+          "HcalEndcapNRawHitLinks",        // edm4eic::MCRecoCalorimeterHitLink
+          "HcalEndcapNRawHitAssociations"  // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"HcalEndcapNTruthClustersWithoutShapes",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "HcalEndcapNTruthClusterLinksWithoutShapes",
-#endif
+      {"HcalEndcapNTruthClustersWithoutShapes", "HcalEndcapNTruthClusterLinksWithoutShapes",
        "HcalEndcapNTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 6.2, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -130,25 +121,17 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalEndcapNTruthClusters",
       {"HcalEndcapNTruthClustersWithoutShapes", "HcalEndcapNTruthClusterAssociationsWithoutShapes"},
-      {"HcalEndcapNTruthClusters",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "HcalEndcapNTruthClusterLinks",
-#endif
+      {"HcalEndcapNTruthClusters", "HcalEndcapNTruthClusterLinks",
        "HcalEndcapNTruthClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
       "HcalEndcapNClustersWithoutShapes",
       {
           "HcalEndcapNIslandProtoClusters", // edm4eic::ProtoClusterCollection
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-          "HcalEndcapNRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
-#endif
-          "HcalEndcapNRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
+          "HcalEndcapNRawHitLinks",         // edm4eic::MCRecoCalorimeterHitLink
+          "HcalEndcapNRawHitAssociations"   // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"HcalEndcapNClustersWithoutShapes",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "HcalEndcapNClusterLinksWithoutShapes",
-#endif
+      {"HcalEndcapNClustersWithoutShapes", "HcalEndcapNClusterLinksWithoutShapes",
        "HcalEndcapNClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {
           .energyWeight    = "log",
@@ -161,21 +144,14 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalEndcapNClusters",
       {"HcalEndcapNClustersWithoutShapes", "HcalEndcapNClusterAssociationsWithoutShapes"},
-      {"HcalEndcapNClusters",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "HcalEndcapNClusterLinks",
-#endif
-       "HcalEndcapNClusterAssociations"},
+      {"HcalEndcapNClusters", "HcalEndcapNClusterLinks", "HcalEndcapNClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMergeSplitter_factory>(
       "HcalEndcapNSplitMergeProtoClusters",
       {"HcalEndcapNTrackClusterMatches", "HcalEndcapNClusters", "CalorimeterTrackProjections"},
-      {"HcalEndcapNSplitMergeProtoClusters",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "HcalEndcapNTrackSplitMergeProtoClusterLinks"
-#else
-       "HcalEndcapNTrackSplitMergeProtoClusterMatches"
-#endif
+      {
+          "HcalEndcapNSplitMergeProtoClusters",
+          "HcalEndcapNTrackSplitMergeProtoClusterLinks",
       },
       {.minSigCut                    = -2.0,
        .avgEP                        = 0.60,
@@ -187,15 +163,10 @@ void InitPlugin(JApplication* app) {
       ));
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
       "HcalEndcapNClustersWithoutShapes",
-      {"HcalEndcapNSplitMergeProtoClusters",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "HcalEndcapNRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
-#endif
+      {"HcalEndcapNSplitMergeProtoClusters", "HcalEndcapNRawHitLinks",
        "HcalEndcapNRawHitAssociations"},
       {"HcalEndcapNSplitMergeClustersWithoutShapes",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
        "HcalEndcapNSplitMergeClusterLinksWithoutShapes",
-#endif
        "HcalEndcapNSplitMergeClusterAssociationsWithoutShapes"},
       {
           .energyWeight    = "log",
@@ -209,10 +180,7 @@ void InitPlugin(JApplication* app) {
       "HcalEndcapNSplitMergeClusters",
       {"HcalEndcapNSplitMergeClustersWithoutShapes",
        "HcalEndcapNSplitMergeClusterAssociationsWithoutShapes"},
-      {"HcalEndcapNSplitMergeClusters",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "HcalEndcapNSplitMergeClusterLinks",
-#endif
+      {"HcalEndcapNSplitMergeClusters", "HcalEndcapNSplitMergeClusterLinks",
        "HcalEndcapNSplitMergeClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
 }

--- a/src/detectors/EHCAL/EHCAL.cc
+++ b/src/detectors/EHCAL/EHCAL.cc
@@ -2,7 +2,10 @@
 // Copyright (C) 2022 - 2025 Sylvester Joosten, Chao, Chao Peng, Whitney Armstrong, David Lawrence, Friederike Bock, Nathan Brei, Wouter Deconinck, Dmitry Kalinkin, Derek Anderson
 
 #include <Evaluator/DD4hepUnits.h>
+#include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <variant>
@@ -38,7 +41,11 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
       "HcalEndcapNRawHits", {"EventHeader", "HcalEndcapNHits"},
-      {"HcalEndcapNRawHits", "HcalEndcapNRawHitLinks", "HcalEndcapNRawHitAssociations"},
+      {"HcalEndcapNRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalEndcapNRawHitLinks",
+#endif
+       "HcalEndcapNRawHitAssociations"},
       {
           .eRes{},
           .tRes          = 0.0 * dd4hep::ns,
@@ -107,10 +114,15 @@ void InitPlugin(JApplication* app) {
       "HcalEndcapNTruthClustersWithoutShapes",
       {
           "HcalEndcapNTruthProtoClusters", // edm4eic::ProtoClusterCollection
-          "HcalEndcapNRawHitLinks",        // edm4eic::MCRecoCalorimeterHitLink
-          "HcalEndcapNRawHitAssociations"  // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "HcalEndcapNRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "HcalEndcapNRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"HcalEndcapNTruthClustersWithoutShapes", "HcalEndcapNTruthClusterLinksWithoutShapes",
+      {"HcalEndcapNTruthClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalEndcapNTruthClusterLinksWithoutShapes",
+#endif
        "HcalEndcapNTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 6.2, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -118,17 +130,25 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalEndcapNTruthClusters",
       {"HcalEndcapNTruthClustersWithoutShapes", "HcalEndcapNTruthClusterAssociationsWithoutShapes"},
-      {"HcalEndcapNTruthClusters", "HcalEndcapNTruthClusterLinks",
+      {"HcalEndcapNTruthClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalEndcapNTruthClusterLinks",
+#endif
        "HcalEndcapNTruthClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
       "HcalEndcapNClustersWithoutShapes",
       {
           "HcalEndcapNIslandProtoClusters", // edm4eic::ProtoClusterCollection
-          "HcalEndcapNRawHitLinks",         // edm4eic::MCRecoCalorimeterHitLink
-          "HcalEndcapNRawHitAssociations"   // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "HcalEndcapNRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "HcalEndcapNRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"HcalEndcapNClustersWithoutShapes", "HcalEndcapNClusterLinksWithoutShapes",
+      {"HcalEndcapNClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalEndcapNClusterLinksWithoutShapes",
+#endif
        "HcalEndcapNClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {
           .energyWeight    = "log",
@@ -141,12 +161,22 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalEndcapNClusters",
       {"HcalEndcapNClustersWithoutShapes", "HcalEndcapNClusterAssociationsWithoutShapes"},
-      {"HcalEndcapNClusters", "HcalEndcapNClusterLinks", "HcalEndcapNClusterAssociations"},
+      {"HcalEndcapNClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalEndcapNClusterLinks",
+#endif
+       "HcalEndcapNClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMergeSplitter_factory>(
       "HcalEndcapNSplitMergeProtoClusters",
       {"HcalEndcapNTrackClusterMatches", "HcalEndcapNClusters", "CalorimeterTrackProjections"},
-      {"HcalEndcapNSplitMergeProtoClusters", "HcalEndcapNTrackSplitMergeProtoClusterLinks"},
+      {"HcalEndcapNSplitMergeProtoClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalEndcapNTrackSplitMergeProtoClusterLinks"
+#else
+       "HcalEndcapNTrackSplitMergeProtoClusterMatches"
+#endif
+      },
       {.minSigCut                    = -2.0,
        .avgEP                        = 0.60,
        .sigEP                        = 0.40,
@@ -158,10 +188,14 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
       "HcalEndcapNClustersWithoutShapes",
       {"HcalEndcapNSplitMergeProtoClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
        "HcalEndcapNRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
        "HcalEndcapNRawHitAssociations"},
       {"HcalEndcapNSplitMergeClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
        "HcalEndcapNSplitMergeClusterLinksWithoutShapes",
+#endif
        "HcalEndcapNSplitMergeClusterAssociationsWithoutShapes"},
       {
           .energyWeight    = "log",
@@ -175,7 +209,10 @@ void InitPlugin(JApplication* app) {
       "HcalEndcapNSplitMergeClusters",
       {"HcalEndcapNSplitMergeClustersWithoutShapes",
        "HcalEndcapNSplitMergeClusterAssociationsWithoutShapes"},
-      {"HcalEndcapNSplitMergeClusters", "HcalEndcapNSplitMergeClusterLinks",
+      {"HcalEndcapNSplitMergeClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalEndcapNSplitMergeClusterLinks",
+#endif
        "HcalEndcapNSplitMergeClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
 }

--- a/src/detectors/EHCAL/EHCAL.cc
+++ b/src/detectors/EHCAL/EHCAL.cc
@@ -5,7 +5,6 @@
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JEventLevel.h>
-#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <variant>

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -31,6 +31,7 @@ extern "C" {
 void InitPlugin(JApplication* app) {
 
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   InitJANAPlugin(app);
 

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -5,6 +5,7 @@
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <fmt/format.h>
 #include <spdlog/logger.h>

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -27,6 +27,7 @@ extern "C" {
 void InitPlugin(JApplication* app) {
 
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   InitJANAPlugin(app);
 

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -2,7 +2,10 @@
 // Copyright (C) 2023 - 2025 Friederike Bock, Wouter Deconinck
 
 #include <Evaluator/DD4hepUnits.h>
+#include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <TString.h>
 #include <string>
@@ -41,7 +44,10 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
       "HcalEndcapPInsertRawHits", {"EventHeader", "HcalEndcapPInsertHits"},
-      {"HcalEndcapPInsertRawHits", "HcalEndcapPInsertRawHitLinks",
+      {"HcalEndcapPInsertRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalEndcapPInsertRawHitLinks",
+#endif
        "HcalEndcapPInsertRawHitAssociations"},
       {
           .eRes          = {},
@@ -124,11 +130,15 @@ void InitPlugin(JApplication* app) {
       "HcalEndcapPInsertTruthClustersWithoutShapes",
       {
           "HcalEndcapPInsertTruthProtoClusters", // edm4eic::ProtoClusterCollection
-          "HcalEndcapPInsertRawHitLinks",        // edm4eic::MCRecoCalorimeterHitLink
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "HcalEndcapPInsertRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
           "HcalEndcapPInsertRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
       {"HcalEndcapPInsertTruthClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
        "HcalEndcapPInsertTruthClusterLinksWithoutShapes",
+#endif
        "HcalEndcapPInsertTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 0.0257, .logWeightBase = 3.6, .enableEtaBounds = true},
       app // TODO: Remove me once fixed
@@ -138,7 +148,10 @@ void InitPlugin(JApplication* app) {
       "HcalEndcapPInsertTruthClusters",
       {"HcalEndcapPInsertTruthClustersWithoutShapes",
        "HcalEndcapPInsertTruthClusterAssociationsWithoutShapes"},
-      {"HcalEndcapPInsertTruthClusters", "HcalEndcapPInsertTruthClusterLinks",
+      {"HcalEndcapPInsertTruthClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalEndcapPInsertTruthClusterLinks",
+#endif
        "HcalEndcapPInsertTruthClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 3.6}, app));
 
@@ -146,10 +159,15 @@ void InitPlugin(JApplication* app) {
       "HcalEndcapPInsertClustersWithoutShapes",
       {
           "HcalEndcapPInsertImagingProtoClusters", // edm4eic::ProtoClusterCollection
-          "HcalEndcapPInsertRawHitLinks",          // edm4eic::MCRecoCalorimeterHitLink
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "HcalEndcapPInsertRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
           "HcalEndcapPInsertRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"HcalEndcapPInsertClustersWithoutShapes", "HcalEndcapPInsertClusterLinksWithoutShapes",
+      {"HcalEndcapPInsertClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalEndcapPInsertClusterLinksWithoutShapes",
+#endif
        "HcalEndcapPInsertClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {
           .energyWeight    = "log",
@@ -164,7 +182,10 @@ void InitPlugin(JApplication* app) {
       "HcalEndcapPInsertClusters",
       {"HcalEndcapPInsertClustersWithoutShapes",
        "HcalEndcapPInsertClusterAssociationsWithoutShapes"},
-      {"HcalEndcapPInsertClusters", "HcalEndcapPInsertClusterLinks",
+      {"HcalEndcapPInsertClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "HcalEndcapPInsertClusterLinks",
+#endif
        "HcalEndcapPInsertClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true,
        .energyWeight                    = "log",
@@ -181,7 +202,11 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
       "LFHCALRawHits", {"EventHeader", "LFHCALHits"},
-      {"LFHCALRawHits", "LFHCALRawHitLinks", "LFHCALRawHitAssociations"},
+      {"LFHCALRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "LFHCALRawHitLinks",
+#endif
+       "LFHCALRawHitAssociations"},
       {
           .eRes          = {},
           .tRes          = 0.0 * dd4hep::ns,
@@ -264,10 +289,15 @@ void InitPlugin(JApplication* app) {
       "LFHCALTruthClustersWithoutShapes",
       {
           "LFHCALTruthProtoClusters", // edm4eic::ProtoClusterCollection
-          "LFHCALRawHitLinks",        // edm4eic::MCRecoCalorimeterHitLink
-          "LFHCALRawHitAssociations"  // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "LFHCALRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "LFHCALRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"LFHCALTruthClustersWithoutShapes", "LFHCALTruthClusterLinksWithoutShapes",
+      {"LFHCALTruthClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "LFHCALTruthClusterLinksWithoutShapes",
+#endif
        "LFHCALTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 4.5, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -276,17 +306,26 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "LFHCALTruthClusters",
       {"LFHCALTruthClustersWithoutShapes", "LFHCALTruthClusterAssociationsWithoutShapes"},
-      {"LFHCALTruthClusters", "LFHCALTruthClusterLinks", "LFHCALTruthClusterAssociations"},
+      {"LFHCALTruthClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "LFHCALTruthClusterLinks",
+#endif
+       "LFHCALTruthClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 4.5}, app));
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
       "LFHCALClustersWithoutShapes",
       {
           "LFHCALIslandProtoClusters", // edm4eic::ProtoClusterCollection
-          "LFHCALRawHitLinks",         // edm4eic::MCRecoCalorimeterHitLink
-          "LFHCALRawHitAssociations"   // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "LFHCALRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "LFHCALRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"LFHCALClustersWithoutShapes", "LFHCALClusterLinksWithoutShapes",
+      {"LFHCALClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "LFHCALClusterLinksWithoutShapes",
+#endif
        "LFHCALClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {
           .energyWeight    = "log",
@@ -299,13 +338,23 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "LFHCALClusters", {"LFHCALClustersWithoutShapes", "LFHCALClusterAssociationsWithoutShapes"},
-      {"LFHCALClusters", "LFHCALClusterLinks", "LFHCALClusterAssociations"},
+      {"LFHCALClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "LFHCALClusterLinks",
+#endif
+       "LFHCALClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 4.5}, app));
 
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMergeSplitter_factory>(
       "LFHCALSplitMergeProtoClusters",
       {"LFHCALTrackClusterMatches", "LFHCALClusters", "CalorimeterTrackProjections"},
-      {"LFHCALSplitMergeProtoClusters", "LFHCALTrackSplitMergeProtoClusterLinks"},
+      {"LFHCALSplitMergeProtoClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "LFHCALTrackSplitMergeProtoClusterLinks"
+#else
+       "LFHCALTrackSplitMergeProtoClusterMatches"
+#endif
+      },
       {.minSigCut                    = -2.0,
        .avgEP                        = 0.50,
        .sigEP                        = 0.25,
@@ -319,10 +368,15 @@ void InitPlugin(JApplication* app) {
       "LFHCALSplitMergeClustersWithoutShapes",
       {
           "LFHCALSplitMergeProtoClusters", // edm4eic::ProtoClusterCollection
-          "LFHCALRawHitLinks",             // edm4eic::MCRecoCalorimeterHitLink
-          "LFHCALRawHitAssociations"       // edm4hep::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "LFHCALRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "LFHCALRawHitAssociations" // edm4hep::MCRecoCalorimeterHitAssociationCollection
       },
-      {"LFHCALSplitMergeClustersWithoutShapes", "LFHCALSplitMergeClusterLinksWithoutShapes",
+      {"LFHCALSplitMergeClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "LFHCALSplitMergeClusterLinksWithoutShapes",
+#endif
        "LFHCALSplitMergeClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {
           .energyWeight    = "log",
@@ -336,7 +390,10 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "LFHCALSplitMergeClusters",
       {"LFHCALSplitMergeClustersWithoutShapes", "LFHCALSplitMergeClusterAssociationsWithoutShapes"},
-      {"LFHCALSplitMergeClusters", "LFHCALSplitMergeClusterLinks",
+      {"LFHCALSplitMergeClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "LFHCALSplitMergeClusterLinks",
+#endif
        "LFHCALSplitMergeClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true}, app));
 }

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -5,7 +5,6 @@
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JEventLevel.h>
-#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <TString.h>
 #include <string>

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -44,10 +44,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
       "HcalEndcapPInsertRawHits", {"EventHeader", "HcalEndcapPInsertHits"},
-      {"HcalEndcapPInsertRawHits",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "HcalEndcapPInsertRawHitLinks",
-#endif
+      {"HcalEndcapPInsertRawHits", "HcalEndcapPInsertRawHitLinks",
        "HcalEndcapPInsertRawHitAssociations"},
       {
           .eRes          = {},
@@ -130,15 +127,11 @@ void InitPlugin(JApplication* app) {
       "HcalEndcapPInsertTruthClustersWithoutShapes",
       {
           "HcalEndcapPInsertTruthProtoClusters", // edm4eic::ProtoClusterCollection
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-          "HcalEndcapPInsertRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
-#endif
+          "HcalEndcapPInsertRawHitLinks",        // edm4eic::MCRecoCalorimeterHitLink
           "HcalEndcapPInsertRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
       {"HcalEndcapPInsertTruthClustersWithoutShapes",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
        "HcalEndcapPInsertTruthClusterLinksWithoutShapes",
-#endif
        "HcalEndcapPInsertTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 0.0257, .logWeightBase = 3.6, .enableEtaBounds = true},
       app // TODO: Remove me once fixed
@@ -148,10 +141,7 @@ void InitPlugin(JApplication* app) {
       "HcalEndcapPInsertTruthClusters",
       {"HcalEndcapPInsertTruthClustersWithoutShapes",
        "HcalEndcapPInsertTruthClusterAssociationsWithoutShapes"},
-      {"HcalEndcapPInsertTruthClusters",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "HcalEndcapPInsertTruthClusterLinks",
-#endif
+      {"HcalEndcapPInsertTruthClusters", "HcalEndcapPInsertTruthClusterLinks",
        "HcalEndcapPInsertTruthClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 3.6}, app));
 
@@ -159,15 +149,10 @@ void InitPlugin(JApplication* app) {
       "HcalEndcapPInsertClustersWithoutShapes",
       {
           "HcalEndcapPInsertImagingProtoClusters", // edm4eic::ProtoClusterCollection
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-          "HcalEndcapPInsertRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
-#endif
+          "HcalEndcapPInsertRawHitLinks",          // edm4eic::MCRecoCalorimeterHitLink
           "HcalEndcapPInsertRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"HcalEndcapPInsertClustersWithoutShapes",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "HcalEndcapPInsertClusterLinksWithoutShapes",
-#endif
+      {"HcalEndcapPInsertClustersWithoutShapes", "HcalEndcapPInsertClusterLinksWithoutShapes",
        "HcalEndcapPInsertClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {
           .energyWeight    = "log",
@@ -182,10 +167,7 @@ void InitPlugin(JApplication* app) {
       "HcalEndcapPInsertClusters",
       {"HcalEndcapPInsertClustersWithoutShapes",
        "HcalEndcapPInsertClusterAssociationsWithoutShapes"},
-      {"HcalEndcapPInsertClusters",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "HcalEndcapPInsertClusterLinks",
-#endif
+      {"HcalEndcapPInsertClusters", "HcalEndcapPInsertClusterLinks",
        "HcalEndcapPInsertClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true,
        .energyWeight                    = "log",
@@ -202,11 +184,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
       "LFHCALRawHits", {"EventHeader", "LFHCALHits"},
-      {"LFHCALRawHits",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "LFHCALRawHitLinks",
-#endif
-       "LFHCALRawHitAssociations"},
+      {"LFHCALRawHits", "LFHCALRawHitLinks", "LFHCALRawHitAssociations"},
       {
           .eRes          = {},
           .tRes          = 0.0 * dd4hep::ns,
@@ -289,15 +267,10 @@ void InitPlugin(JApplication* app) {
       "LFHCALTruthClustersWithoutShapes",
       {
           "LFHCALTruthProtoClusters", // edm4eic::ProtoClusterCollection
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-          "LFHCALRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
-#endif
-          "LFHCALRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
+          "LFHCALRawHitLinks",        // edm4eic::MCRecoCalorimeterHitLink
+          "LFHCALRawHitAssociations"  // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"LFHCALTruthClustersWithoutShapes",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "LFHCALTruthClusterLinksWithoutShapes",
-#endif
+      {"LFHCALTruthClustersWithoutShapes", "LFHCALTruthClusterLinksWithoutShapes",
        "LFHCALTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 4.5, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -306,26 +279,17 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "LFHCALTruthClusters",
       {"LFHCALTruthClustersWithoutShapes", "LFHCALTruthClusterAssociationsWithoutShapes"},
-      {"LFHCALTruthClusters",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "LFHCALTruthClusterLinks",
-#endif
-       "LFHCALTruthClusterAssociations"},
+      {"LFHCALTruthClusters", "LFHCALTruthClusterLinks", "LFHCALTruthClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 4.5}, app));
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
       "LFHCALClustersWithoutShapes",
       {
           "LFHCALIslandProtoClusters", // edm4eic::ProtoClusterCollection
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-          "LFHCALRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
-#endif
-          "LFHCALRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
+          "LFHCALRawHitLinks",         // edm4eic::MCRecoCalorimeterHitLink
+          "LFHCALRawHitAssociations"   // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"LFHCALClustersWithoutShapes",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "LFHCALClusterLinksWithoutShapes",
-#endif
+      {"LFHCALClustersWithoutShapes", "LFHCALClusterLinksWithoutShapes",
        "LFHCALClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {
           .energyWeight    = "log",
@@ -338,22 +302,15 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "LFHCALClusters", {"LFHCALClustersWithoutShapes", "LFHCALClusterAssociationsWithoutShapes"},
-      {"LFHCALClusters",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "LFHCALClusterLinks",
-#endif
-       "LFHCALClusterAssociations"},
+      {"LFHCALClusters", "LFHCALClusterLinks", "LFHCALClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 4.5}, app));
 
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMergeSplitter_factory>(
       "LFHCALSplitMergeProtoClusters",
       {"LFHCALTrackClusterMatches", "LFHCALClusters", "CalorimeterTrackProjections"},
-      {"LFHCALSplitMergeProtoClusters",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "LFHCALTrackSplitMergeProtoClusterLinks"
-#else
-       "LFHCALTrackSplitMergeProtoClusterMatches"
-#endif
+      {
+          "LFHCALSplitMergeProtoClusters",
+          "LFHCALTrackSplitMergeProtoClusterLinks",
       },
       {.minSigCut                    = -2.0,
        .avgEP                        = 0.50,
@@ -368,15 +325,10 @@ void InitPlugin(JApplication* app) {
       "LFHCALSplitMergeClustersWithoutShapes",
       {
           "LFHCALSplitMergeProtoClusters", // edm4eic::ProtoClusterCollection
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-          "LFHCALRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
-#endif
-          "LFHCALRawHitAssociations" // edm4hep::MCRecoCalorimeterHitAssociationCollection
+          "LFHCALRawHitLinks",             // edm4eic::MCRecoCalorimeterHitLink
+          "LFHCALRawHitAssociations"       // edm4hep::MCRecoCalorimeterHitAssociationCollection
       },
-      {"LFHCALSplitMergeClustersWithoutShapes",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "LFHCALSplitMergeClusterLinksWithoutShapes",
-#endif
+      {"LFHCALSplitMergeClustersWithoutShapes", "LFHCALSplitMergeClusterLinksWithoutShapes",
        "LFHCALSplitMergeClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {
           .energyWeight    = "log",
@@ -390,10 +342,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "LFHCALSplitMergeClusters",
       {"LFHCALSplitMergeClustersWithoutShapes", "LFHCALSplitMergeClusterAssociationsWithoutShapes"},
-      {"LFHCALSplitMergeClusters",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "LFHCALSplitMergeClusterLinks",
-#endif
+      {"LFHCALSplitMergeClusters", "LFHCALSplitMergeClusterLinks",
        "LFHCALSplitMergeClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true}, app));
 }

--- a/src/detectors/FOFFMTRK/FOFFMTRK.cc
+++ b/src/detectors/FOFFMTRK/FOFFMTRK.cc
@@ -18,7 +18,9 @@
 extern "C" {
 void InitPlugin(JApplication* app) {
   InitJANAPlugin(app);
+
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   //Digitized hits, especially for thresholds
   app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(

--- a/src/detectors/FOFFMTRK/FOFFMTRK.cc
+++ b/src/detectors/FOFFMTRK/FOFFMTRK.cc
@@ -28,7 +28,8 @@ void InitPlugin(JApplication* app) {
   //Digitized hits, especially for thresholds
   app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
       "ForwardOffMTrackerRawHits", {"EventHeader", "ForwardOffMTrackerHits"},
-      {"ForwardOffMTrackerRawHits", "ForwardOffMTrackerRawHitLinks", "ForwardOffMTrackerRawHitAssociations"},
+      {"ForwardOffMTrackerRawHits", "ForwardOffMTrackerRawHitLinks",
+       "ForwardOffMTrackerRawHitAssociations"},
       {
           .threshold      = 10.0 * dd4hep::keV,
           .timeResolution = 8,

--- a/src/detectors/FOFFMTRK/FOFFMTRK.cc
+++ b/src/detectors/FOFFMTRK/FOFFMTRK.cc
@@ -7,7 +7,6 @@
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JEventLevel.h>
-#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <vector>

--- a/src/detectors/FOFFMTRK/FOFFMTRK.cc
+++ b/src/detectors/FOFFMTRK/FOFFMTRK.cc
@@ -28,11 +28,7 @@ void InitPlugin(JApplication* app) {
   //Digitized hits, especially for thresholds
   app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
       "ForwardOffMTrackerRawHits", {"EventHeader", "ForwardOffMTrackerHits"},
-      {"ForwardOffMTrackerRawHits",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "ForwardOffMTrackerRawHitLinks",
-#endif
-       "ForwardOffMTrackerRawHitAssociations"},
+      {"ForwardOffMTrackerRawHits", "ForwardOffMTrackerRawHitLinks", "ForwardOffMTrackerRawHitAssociations"},
       {
           .threshold      = 10.0 * dd4hep::keV,
           .timeResolution = 8,

--- a/src/detectors/FOFFMTRK/FOFFMTRK.cc
+++ b/src/detectors/FOFFMTRK/FOFFMTRK.cc
@@ -4,7 +4,10 @@
 //
 
 #include <Evaluator/DD4hepUnits.h>
+#include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <vector>
@@ -25,7 +28,10 @@ void InitPlugin(JApplication* app) {
   //Digitized hits, especially for thresholds
   app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
       "ForwardOffMTrackerRawHits", {"EventHeader", "ForwardOffMTrackerHits"},
-      {"ForwardOffMTrackerRawHits", "ForwardOffMTrackerRawHitLinks",
+      {"ForwardOffMTrackerRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "ForwardOffMTrackerRawHitLinks",
+#endif
        "ForwardOffMTrackerRawHitAssociations"},
       {
           .threshold      = 10.0 * dd4hep::keV,

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -8,6 +8,7 @@
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JEventLevel.h>
 #include <JANA/Utils/JTypeInfo.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoTrackParticleAssociation.h>
 #include <edm4eic/MCRecoTrackParticleLinkCollection.h>
 #include <edm4eic/Track.h>
@@ -117,17 +118,13 @@ void InitPlugin(JApplication* app) {
   std::vector<std::string> geometryDivisionCollectionNames;
   std::vector<std::string> outputClusterCollectionNames;
   std::vector<std::string> outputTrackTags;
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
   std::vector<std::string> outputTrackLinkTags;
-#endif
   std::vector<std::string> outputTrackAssociationTags;
   std::vector<std::vector<std::string>> moduleClusterTags;
 
   for (int mod_id : moduleIDs) {
     outputTrackTags.push_back(fmt::format("TaggerTrackerM{}LocalTracks", mod_id));
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
     outputTrackLinkTags.push_back(fmt::format("TaggerTrackerM{}LocalTrackLinks", mod_id));
-#endif
     outputTrackAssociationTags.push_back(
         fmt::format("TaggerTrackerM{}LocalTrackAssociations", mod_id));
     moduleClusterTags.emplace_back();
@@ -162,16 +159,12 @@ void InitPlugin(JApplication* app) {
 
   // Linear tracking for each module, loop over modules
   for (std::size_t i = 0; i < moduleIDs.size(); i++) {
-    std::string outputTrackTag = outputTrackTags[i];
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-    std::string outputTrackLinkTag = outputTrackLinkTags[i];
-#endif
-    std::string outputTrackAssociationTag = outputTrackAssociationTags[i];
+    std::string outputTrackTag                = outputTrackTags[i];
+    std::string outputTrackLinkTag            = outputTrackLinkTags[i];
+    std::string outputTrackAssociationTag     = outputTrackAssociationTags[i];
     std::vector<std::string> inputClusterTags(moduleClusterTags[i]);
 
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
     inputClusterTags.emplace_back("TaggerTrackerRawHitLinks");
-#endif
     inputClusterTags.emplace_back("TaggerTrackerRawHitAssociations");
     app->Add(new JOmniFactoryGeneratorT<FarDetectorLinearTracking_factory>(
         {.tag                  = outputTrackTag,
@@ -179,9 +172,7 @@ void InitPlugin(JApplication* app) {
          .output_names =
              {
                  outputTrackTag,
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
                  outputTrackLinkTag,
-#endif
                  outputTrackAssociationTag,
              },
          .configs = {
@@ -202,14 +193,12 @@ void InitPlugin(JApplication* app) {
        .variadic_input_names = {outputTrackTags},
        .output_names         = {"TaggerTrackerLocalTracks"}}));
 
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
   // Combine the track links from each module into one collection
   app->Add(new JOmniFactoryGeneratorT<
            CollectionCollector_factory<edm4eic::MCRecoTrackParticleLink, true>>(
       {.tag                  = "TaggerTrackerLocalTrackLinks",
        .variadic_input_names = {outputTrackLinkTags},
        .output_names         = {"TaggerTrackerLocalTrackLinks"}}));
-#endif
 
   // Combine the associations from each module into one collection
   app->Add(new JOmniFactoryGeneratorT<

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -159,9 +159,9 @@ void InitPlugin(JApplication* app) {
 
   // Linear tracking for each module, loop over modules
   for (std::size_t i = 0; i < moduleIDs.size(); i++) {
-    std::string outputTrackTag                = outputTrackTags[i];
-    std::string outputTrackLinkTag            = outputTrackLinkTags[i];
-    std::string outputTrackAssociationTag     = outputTrackAssociationTags[i];
+    std::string outputTrackTag            = outputTrackTags[i];
+    std::string outputTrackLinkTag        = outputTrackLinkTags[i];
+    std::string outputTrackAssociationTag = outputTrackAssociationTags[i];
     std::vector<std::string> inputClusterTags(moduleClusterTags[i]);
 
     inputClusterTags.emplace_back("TaggerTrackerRawHitLinks");

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -6,6 +6,7 @@
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <edm4eic/MCRecoTrackParticleAssociation.h>
 #include <edm4eic/MCRecoTrackParticleLinkCollection.h>

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -8,7 +8,6 @@
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JEventLevel.h>
 #include <JANA/Utils/JTypeInfo.h>
-#include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/MCRecoTrackParticleAssociation.h>
 #include <edm4eic/MCRecoTrackParticleLinkCollection.h>
 #include <edm4eic/Track.h>

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -45,6 +45,7 @@ void InitPlugin(JApplication* app) {
   InitJANAPlugin(app);
 
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   std::string readout = "TaggerTrackerHits";
 
@@ -115,13 +116,17 @@ void InitPlugin(JApplication* app) {
   std::vector<std::string> geometryDivisionCollectionNames;
   std::vector<std::string> outputClusterCollectionNames;
   std::vector<std::string> outputTrackTags;
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
   std::vector<std::string> outputTrackLinkTags;
+#endif
   std::vector<std::string> outputTrackAssociationTags;
   std::vector<std::vector<std::string>> moduleClusterTags;
 
   for (int mod_id : moduleIDs) {
     outputTrackTags.push_back(fmt::format("TaggerTrackerM{}LocalTracks", mod_id));
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
     outputTrackLinkTags.push_back(fmt::format("TaggerTrackerM{}LocalTrackLinks", mod_id));
+#endif
     outputTrackAssociationTags.push_back(
         fmt::format("TaggerTrackerM{}LocalTrackAssociations", mod_id));
     moduleClusterTags.emplace_back();
@@ -136,62 +141,81 @@ void InitPlugin(JApplication* app) {
   }
 
   app->Add(new JOmniFactoryGeneratorT<SubDivideCollection_factory<edm4eic::TrackerHit>>(
-      "TaggerTrackerSplitHits", {"TaggerTrackerRecHits"}, geometryDivisionCollectionNames,
-      {
-          .function = GeometrySplit{geometryDivisions, readout, geometryLabels},
-      },
-      app));
+      {.tag                   = "TaggerTrackerSplitHits",
+       .input_names           = {"TaggerTrackerRecHits"},
+       .variadic_output_names = {geometryDivisionCollectionNames},
+       .configs               = {
+           .function = GeometrySplit{geometryDivisions, readout, geometryLabels},
+       }}));
 
   app->Add(new JOmniFactoryGeneratorT<FarDetectorTrackerCluster_factory>(
-      "TaggerTrackerClustering", geometryDivisionCollectionNames, outputClusterCollectionNames,
-      {
-          .readout        = "TaggerTrackerHits",
-          .x_field        = "x",
-          .y_field        = "y",
-          .hit_time_limit = 10 * edm4eic::unit::ns,
-      },
-      app));
+      {.tag                   = "TaggerTrackerClustering",
+       .variadic_input_names  = {geometryDivisionCollectionNames},
+       .variadic_output_names = {outputClusterCollectionNames},
+       .configs               = {
+           .readout        = "TaggerTrackerHits",
+           .x_field        = "x",
+           .y_field        = "y",
+           .hit_time_limit = 10 * edm4eic::unit::ns,
+       }}));
 
   // Linear tracking for each module, loop over modules
   for (std::size_t i = 0; i < moduleIDs.size(); i++) {
-    std::string outputTrackTag                = outputTrackTags[i];
-    std::string outputTrackLinkTag            = outputTrackLinkTags[i];
-    std::string outputTrackAssociationTag     = outputTrackAssociationTags[i];
-    std::vector<std::string> inputClusterTags = moduleClusterTags[i];
+    std::string outputTrackTag = outputTrackTags[i];
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+    std::string outputTrackLinkTag = outputTrackLinkTags[i];
+#endif
+    std::string outputTrackAssociationTag = outputTrackAssociationTags[i];
+    std::vector<std::string> inputClusterTags(moduleClusterTags[i]);
 
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
     inputClusterTags.emplace_back("TaggerTrackerRawHitLinks");
+#endif
     inputClusterTags.emplace_back("TaggerTrackerRawHitAssociations");
-
     app->Add(new JOmniFactoryGeneratorT<FarDetectorLinearTracking_factory>(
-        outputTrackTag, {inputClusterTags},
-        {outputTrackTag, outputTrackLinkTag, outputTrackAssociationTag},
-        {
-            .layer_hits_max       = 200,
-            .chi2_max             = 0.001,
-            .n_layer              = 4,
-            .layer_weights        = {1.0, 1.0, 1.0, 1.0},
-            .restrict_direction   = true,
-            .optimum_theta        = -M_PI + 0.026,
-            .optimum_phi          = 0,
-            .step_angle_tolerance = 0.05,
-        },
-        app));
+        {.tag                  = outputTrackTag,
+         .variadic_input_names = {inputClusterTags},
+         .output_names =
+             {
+                 outputTrackTag,
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+                 outputTrackLinkTag,
+#endif
+                 outputTrackAssociationTag,
+             },
+         .configs = {
+             .layer_hits_max       = 200,
+             .chi2_max             = 0.001,
+             .n_layer              = 4,
+             .layer_weights        = {1.0, 1.0, 1.0, 1.0},
+             .restrict_direction   = true,
+             .optimum_theta        = -M_PI + 0.026,
+             .optimum_phi          = 0,
+             .step_angle_tolerance = 0.05,
+         }}));
   }
 
   // Combine the tracks from each module into one collection
   app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track, true>>(
-      "TaggerTrackerLocalTracks", outputTrackTags, {"TaggerTrackerLocalTracks"}, app));
+      {.tag                  = "TaggerTrackerLocalTracks",
+       .variadic_input_names = {outputTrackTags},
+       .output_names         = {"TaggerTrackerLocalTracks"}}));
 
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
   // Combine the track links from each module into one collection
   app->Add(new JOmniFactoryGeneratorT<
            CollectionCollector_factory<edm4eic::MCRecoTrackParticleLink, true>>(
-      "TaggerTrackerLocalTrackLinks", outputTrackLinkTags, {"TaggerTrackerLocalTrackLinks"}, app));
+      {.tag                  = "TaggerTrackerLocalTrackLinks",
+       .variadic_input_names = {outputTrackLinkTags},
+       .output_names         = {"TaggerTrackerLocalTrackLinks"}}));
+#endif
 
   // Combine the associations from each module into one collection
   app->Add(new JOmniFactoryGeneratorT<
            CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation, true>>(
-      "TaggerTrackerLocalTrackAssociations", outputTrackAssociationTags,
-      {"TaggerTrackerLocalTrackAssociations"}, app));
+      {.tag                  = "TaggerTrackerLocalTrackAssociations",
+       .variadic_input_names = {outputTrackAssociationTags},
+       .output_names         = {"TaggerTrackerLocalTrackAssociations"}}));
 
   app->Add(new JOmniFactoryGeneratorT<FarDetectorTransportationPreML_factory>(
       "TaggerTrackerTransportationPreML",
@@ -199,15 +223,14 @@ void InitPlugin(JApplication* app) {
       {"TaggerTrackerFeatureTensor", "TaggerTrackerTargetTensor"},
       {
           .beamE = 10.0,
-      },
-      app));
+      }));
   app->Add(new JOmniFactoryGeneratorT<ONNXInference_factory>(
-      "TaggerTrackerTransportationInference", {"TaggerTrackerFeatureTensor"},
-      {"TaggerTrackerPredictionTensor"},
-      {
-          .modelPath = "calibrations/onnx/Low-Q2_Steering_Reconstruction.onnx",
-      },
-      app));
+      {.tag                   = "TaggerTrackerTransportationInference",
+       .variadic_input_names  = {{"TaggerTrackerFeatureTensor"}},
+       .variadic_output_names = {{"TaggerTrackerPredictionTensor"}},
+       .configs               = {
+           .modelPath = "calibrations/onnx/Low-Q2_Steering_Reconstruction.onnx",
+       }}));
   app->Add(new JOmniFactoryGeneratorT<FarDetectorTransportationPostML_factory>(
       "TaggerTrackerTransportationPostML",
       {"TaggerTrackerPredictionTensor", "TaggerTrackerLocalTrackAssociations", "MCBeamElectrons"},
@@ -215,7 +238,6 @@ void InitPlugin(JApplication* app) {
        "TaggerTrackerReconstructedParticleAssociations"},
       {
           .beamE = 10.0,
-      },
-      app));
+      }));
 }
 }

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -162,11 +162,9 @@ void InitPlugin(JApplication* app) {
     std::string outputTrackLinkTag        = outputTrackLinkTags[i];
     std::string outputTrackAssociationTag = outputTrackAssociationTags[i];
     std::vector<std::string> inputClusterTags(moduleClusterTags[i]);
-
-    inputClusterTags.emplace_back("TaggerTrackerRawHitLinks");
-    inputClusterTags.emplace_back("TaggerTrackerRawHitAssociations");
     app->Add(new JOmniFactoryGeneratorT<FarDetectorLinearTracking_factory>(
         {.tag                  = outputTrackTag,
+         .input_names          = {"TaggerTrackerRawHitLinks", "TaggerTrackerRawHitAssociations"},
          .variadic_input_names = {inputClusterTags},
          .output_names =
              {

--- a/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
+++ b/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
@@ -21,6 +21,7 @@ extern "C" {
 void InitPlugin(JApplication* app) {
 
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   InitJANAPlugin(app);
 

--- a/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
+++ b/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
@@ -5,7 +5,6 @@
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JEventLevel.h>
-#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <cmath>
 #include <string>

--- a/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
+++ b/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
@@ -30,11 +30,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
       "EcalLumiSpecRawHits", {"EventHeader", "EcalLumiSpecHits"},
-      {"EcalLumiSpecRawHits",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "EcalLumiSpecRawHitLinks",
-#endif
-       "EcalLumiSpecRawHitAssociations"},
+      {"EcalLumiSpecRawHits", "EcalLumiSpecRawHitLinks", "EcalLumiSpecRawHitAssociations"},
       {
           .eRes          = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV}, // flat 2%
           .tRes          = 0.0 * dd4hep::ns,
@@ -98,15 +94,10 @@ void InitPlugin(JApplication* app) {
       "EcalLumiSpecClustersWithoutShapes",
       {
           "EcalLumiSpecIslandProtoClusters", // edm4eic::ProtoClusterCollection
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-          "EcalLumiSpecRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
-#endif
-          "EcalLumiSpecRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
+          "EcalLumiSpecRawHitLinks",         // edm4eic::MCRecoCalorimeterHitLink
+          "EcalLumiSpecRawHitAssociations"   // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"EcalLumiSpecClustersWithoutShapes",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "EcalLumiSpecClusterLinksWithoutShapes",
-#endif
+      {"EcalLumiSpecClustersWithoutShapes", "EcalLumiSpecClusterLinksWithoutShapes",
        "EcalLumiSpecClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 3.6, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -114,26 +105,17 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalLumiSpecClusters",
       {"EcalLumiSpecClustersWithoutShapes", "EcalLumiSpecClusterAssociationsWithoutShapes"},
-      {"EcalLumiSpecClusters",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "EcalLumiSpecClusterLinks",
-#endif
-       "EcalLumiSpecClusterAssociations"},
+      {"EcalLumiSpecClusters", "EcalLumiSpecClusterLinks", "EcalLumiSpecClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 3.6}, app));
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
       "EcalLumiSpecTruthClustersWithoutShapes",
       {
           "EcalLumiSpecTruthProtoClusters", // edm4eic::ProtoClusterCollection
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-          "EcalLumiSpecRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
-#endif
-          "EcalLumiSpecRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
+          "EcalLumiSpecRawHitLinks",        // edm4eic::MCRecoCalorimeterHitLink
+          "EcalLumiSpecRawHitAssociations"  // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"EcalLumiSpecTruthClustersWithoutShapes",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "EcalLumiSpecTruthClusterLinksWithoutShapes",
-#endif
+      {"EcalLumiSpecTruthClustersWithoutShapes", "EcalLumiSpecTruthClusterLinksWithoutShapes",
        "EcalLumiSpecTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 4.6, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -142,10 +124,7 @@ void InitPlugin(JApplication* app) {
       "EcalLumiSpecTruthClusters",
       {"EcalLumiSpecTruthClustersWithoutShapes",
        "EcalLumiSpecTruthClusterAssociationsWithoutShapes"},
-      {"EcalLumiSpecTruthClusters",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "EcalLumiSpecTruthClusterLinks",
-#endif
+      {"EcalLumiSpecTruthClusters", "EcalLumiSpecTruthClusterLinks",
        "EcalLumiSpecTruthClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 4.6}, app));
 }

--- a/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
+++ b/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
@@ -2,7 +2,10 @@
 // Copyright (C) 2022 - 2025 Sylvester Joosten, Chao, Chao Peng, Whitney Armstrong, David Lawrence, Dhevan Gangadharan, Nathan Brei,, Wouter Deconinck, Dmitry Kalinkin, Derek Anderson
 
 #include <Evaluator/DD4hepUnits.h>
+#include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <cmath>
 #include <string>
@@ -27,7 +30,11 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterHitDigi_factory>(
       "EcalLumiSpecRawHits", {"EventHeader", "EcalLumiSpecHits"},
-      {"EcalLumiSpecRawHits", "EcalLumiSpecRawHitLinks", "EcalLumiSpecRawHitAssociations"},
+      {"EcalLumiSpecRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalLumiSpecRawHitLinks",
+#endif
+       "EcalLumiSpecRawHitAssociations"},
       {
           .eRes          = {0.0 * sqrt(dd4hep::GeV), 0.02, 0.0 * dd4hep::GeV}, // flat 2%
           .tRes          = 0.0 * dd4hep::ns,
@@ -91,10 +98,15 @@ void InitPlugin(JApplication* app) {
       "EcalLumiSpecClustersWithoutShapes",
       {
           "EcalLumiSpecIslandProtoClusters", // edm4eic::ProtoClusterCollection
-          "EcalLumiSpecRawHitLinks",         // edm4eic::MCRecoCalorimeterHitLink
-          "EcalLumiSpecRawHitAssociations"   // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "EcalLumiSpecRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "EcalLumiSpecRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"EcalLumiSpecClustersWithoutShapes", "EcalLumiSpecClusterLinksWithoutShapes",
+      {"EcalLumiSpecClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalLumiSpecClusterLinksWithoutShapes",
+#endif
        "EcalLumiSpecClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 3.6, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -102,17 +114,26 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalLumiSpecClusters",
       {"EcalLumiSpecClustersWithoutShapes", "EcalLumiSpecClusterAssociationsWithoutShapes"},
-      {"EcalLumiSpecClusters", "EcalLumiSpecClusterLinks", "EcalLumiSpecClusterAssociations"},
+      {"EcalLumiSpecClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalLumiSpecClusterLinks",
+#endif
+       "EcalLumiSpecClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 3.6}, app));
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
       "EcalLumiSpecTruthClustersWithoutShapes",
       {
           "EcalLumiSpecTruthProtoClusters", // edm4eic::ProtoClusterCollection
-          "EcalLumiSpecRawHitLinks",        // edm4eic::MCRecoCalorimeterHitLink
-          "EcalLumiSpecRawHitAssociations"  // edm4eic::MCRecoCalorimeterHitAssociationCollection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+          "EcalLumiSpecRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
+#endif
+          "EcalLumiSpecRawHitAssociations" // edm4eic::MCRecoCalorimeterHitAssociationCollection
       },
-      {"EcalLumiSpecTruthClustersWithoutShapes", "EcalLumiSpecTruthClusterLinksWithoutShapes",
+      {"EcalLumiSpecTruthClustersWithoutShapes",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalLumiSpecTruthClusterLinksWithoutShapes",
+#endif
        "EcalLumiSpecTruthClusterAssociationsWithoutShapes"}, // edm4eic::MCRecoClusterParticleAssociation
       {.energyWeight = "log", .sampFrac = 1.0, .logWeightBase = 4.6, .enableEtaBounds = false},
       app // TODO: Remove me once fixed
@@ -121,7 +142,10 @@ void InitPlugin(JApplication* app) {
       "EcalLumiSpecTruthClusters",
       {"EcalLumiSpecTruthClustersWithoutShapes",
        "EcalLumiSpecTruthClusterAssociationsWithoutShapes"},
-      {"EcalLumiSpecTruthClusters", "EcalLumiSpecTruthClusterLinks",
+      {"EcalLumiSpecTruthClusters",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "EcalLumiSpecTruthClusterLinks",
+#endif
        "EcalLumiSpecTruthClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 4.6}, app));
 }

--- a/src/detectors/MPGD/MPGD.cc
+++ b/src/detectors/MPGD/MPGD.cc
@@ -8,6 +8,7 @@
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/JException.h>
+#include <JANA/Utils/JEventLevel.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <fmt/format.h>
 #include <spdlog/logger.h>

--- a/src/detectors/MPGD/MPGD.cc
+++ b/src/detectors/MPGD/MPGD.cc
@@ -40,6 +40,7 @@ void InitPlugin(JApplication* app) {
   InitJANAPlugin(app);
 
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   // ***** PIXEL or 2DSTRIP DIGITIZATION?
   // - This determines which of the MPGDTrackerDigi or SiliconTrackerDigi

--- a/src/detectors/PFRICH/PFRICH.cc
+++ b/src/detectors/PFRICH/PFRICH.cc
@@ -22,6 +22,7 @@ void InitPlugin(JApplication* app) {
   InitJANAPlugin(app);
 
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   // configuration parameters ///////////////////////////////////////////////
 

--- a/src/detectors/PFRICH/PFRICH.cc
+++ b/src/detectors/PFRICH/PFRICH.cc
@@ -5,7 +5,9 @@
 // Copyright (C) 2024, Dmitry Kalinkin
 
 #include <Evaluator/DD4hepUnits.h>
+#include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <utility>

--- a/src/detectors/RPOTS/RPOTS.cc
+++ b/src/detectors/RPOTS/RPOTS.cc
@@ -20,7 +20,9 @@
 extern "C" {
 void InitPlugin(JApplication* app) {
   InitJANAPlugin(app);
+
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   MatrixTransferStaticConfig recon_cfg;
   PolynomialMatrixReconstructionConfig recon_poly_cfg;

--- a/src/detectors/RPOTS/RPOTS.cc
+++ b/src/detectors/RPOTS/RPOTS.cc
@@ -7,7 +7,6 @@
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JEventLevel.h>
-#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <vector>

--- a/src/detectors/RPOTS/RPOTS.cc
+++ b/src/detectors/RPOTS/RPOTS.cc
@@ -33,11 +33,7 @@ void InitPlugin(JApplication* app) {
   //Digitized hits, especially for thresholds
   app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
       "ForwardRomanPotRawHits", {"EventHeader", "ForwardRomanPotHits"},
-      {"ForwardRomanPotRawHits",
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-       "ForwardRomanPotRawHitLinks",
-#endif
-       "ForwardRomanPotRawHitAssociations"},
+      {"ForwardRomanPotRawHits", "ForwardRomanPotRawHitLinks", "ForwardRomanPotRawHitAssociations"},
       {
           .threshold      = 10.0 * dd4hep::keV,
           .timeResolution = 8,

--- a/src/detectors/RPOTS/RPOTS.cc
+++ b/src/detectors/RPOTS/RPOTS.cc
@@ -4,7 +4,10 @@
 //
 
 #include <Evaluator/DD4hepUnits.h>
+#include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
+#include <edm4eic/EDM4eicVersion.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <vector>
@@ -30,7 +33,11 @@ void InitPlugin(JApplication* app) {
   //Digitized hits, especially for thresholds
   app->Add(new JOmniFactoryGeneratorT<SiliconTrackerDigi_factory>(
       "ForwardRomanPotRawHits", {"EventHeader", "ForwardRomanPotHits"},
-      {"ForwardRomanPotRawHits", "ForwardRomanPotRawHitLinks", "ForwardRomanPotRawHitAssociations"},
+      {"ForwardRomanPotRawHits",
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
+       "ForwardRomanPotRawHitLinks",
+#endif
+       "ForwardRomanPotRawHitAssociations"},
       {
           .threshold      = 10.0 * dd4hep::keV,
           .timeResolution = 8,

--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -2,7 +2,9 @@
 // Copyright (C) 2021 - 2025, Chao Peng, Sylvester Joosten, Whitney Armstrong, David Lawrence, Friederike Bock, Wouter Deconinck, Nathan Brei, Sebouh Paul, Dmitry Kalinkin, Barak Schmookler
 
 #include <Evaluator/DD4hepUnits.h>
+#include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <variant>

--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -24,6 +24,7 @@ extern "C" {
 void InitPlugin(JApplication* app) {
 
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   InitJANAPlugin(app);
 

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -123,7 +123,16 @@ public:
   virtual void Process(int32_t /* run_number */, uint64_t /* event_number */) {};
 
   /// Retrieve reference to already-configured logger
-  std::shared_ptr<spdlog::logger>& logger() { return m_logger; }
+  std::shared_ptr<spdlog::logger>& logger() {
+#if EICRECON_JANA_IS_243
+    // JANA 2.4.3 does not invoke our PreInit() path, so m_logger may not be initialized.
+    if (m_logger == nullptr) {
+      m_logger =
+          this->GetApplication()->template GetService<Log_service>()->logger(this->GetPrefix());
+    }
+#endif
+    return m_logger;
+  }
 };
 
 } // namespace eicrecon

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -4,574 +4,112 @@
 
 #pragma once
 
-/**
- * Omnifactories are a lightweight layer connecting JANA to generic algorithms
- * It is assumed multiple input data (controlled by input tags)
- * which might be changed by user parameters.
- */
-
-#include <JANA/JEvent.h>
-#include <JANA/JMultifactory.h>
+#include <JANA/Components/JOmniFactory.h>
+#include <JANA/Utils/JEventLevel.h>
 #include <spdlog/spdlog.h>
 #include <spdlog/version.h>
 #if SPDLOG_VERSION >= 11400 && (!defined(SPDLOG_NO_TLS) || !SPDLOG_NO_TLS)
 #include <spdlog/mdc.h>
 #endif
 
-#include "services/io/podio/datamodel_glue.h"
 #include "services/log/Log_service.h"
 
+#include <memory>
 #include <string>
 #include <vector>
 
-struct EmptyConfig {};
-
-template <typename AlgoT, typename ConfigT = EmptyConfig>
-class JOmniFactory : public JMultifactory {
-public:
-  /// ========================
-  /// Handle input collections
-  /// ========================
-
-  struct InputBase {
-    std::string type_name;
-    std::vector<std::string> collection_names;
-    bool is_variadic = false;
-
-    virtual void GetCollection(const JEvent& event) = 0;
-  };
-
-  template <typename T, bool IsOptional = false> class Input : public InputBase {
-
-    std::vector<const T*> m_data;
-
-  public:
-    Input(JOmniFactory* owner, std::string default_tag = "") {
-      owner->RegisterInput(this);
-      this->collection_names.push_back(default_tag);
-      this->type_name = JTypeInfo::demangle<T>();
-    }
-
-    const std::vector<const T*>& operator()() { return m_data; }
-
-  private:
-    friend class JOmniFactory;
-
-    void GetCollection(const JEvent& event) {
-      try {
-        m_data = event.Get<T>(this->collection_names[0], !IsOptional);
-      } catch (const JException& e) {
-        if constexpr (!IsOptional) {
-          throw JException("JOmniFactory: Failed to get collection %s: %s",
-                           this->collection_names[0].c_str(), e.what());
-        }
-      }
-    }
-  };
-
-  template <typename PodioT, bool IsOptional = false> class PodioInput : public InputBase {
-
-    const typename PodioTypeMap<PodioT>::collection_t* m_data;
-
-  public:
-    PodioInput(JOmniFactory* owner, std::string default_collection_name = "") {
-      owner->RegisterInput(this);
-      this->collection_names.push_back(default_collection_name);
-      this->type_name = JTypeInfo::demangle<PodioT>();
-    }
-
-    const typename PodioTypeMap<PodioT>::collection_t* operator()() { return m_data; }
-
-  private:
-    friend class JOmniFactory;
-
-    void GetCollection(const JEvent& event) {
-      try {
-        m_data = event.GetCollection<PodioT>(this->collection_names[0], !IsOptional);
-      } catch (const JException& e) {
-        if constexpr (!IsOptional) {
-          throw JException("JOmniFactory: Failed to get collection %s: %s",
-                           this->collection_names[0].c_str(), e.what());
-        }
-      }
-    }
-  };
-
-  template <typename PodioT, bool IsOptional = false> class VariadicPodioInput : public InputBase {
-
-    std::vector<const typename PodioTypeMap<PodioT>::collection_t*> m_data;
-
-  public:
-    VariadicPodioInput(JOmniFactory* owner, std::vector<std::string> default_names = {}) {
-      owner->RegisterInput(this);
-      this->collection_names = default_names;
-      this->type_name        = JTypeInfo::demangle<PodioT>();
-      this->is_variadic      = true;
-    }
-
-    const std::vector<const typename PodioTypeMap<PodioT>::collection_t*> operator()() {
-      return m_data;
-    }
-
-  private:
-    friend class JOmniFactory;
-
-    void GetCollection(const JEvent& event) {
-      m_data.clear();
-      for (auto& coll_name : this->collection_names) {
-        try {
-          m_data.push_back(event.GetCollection<PodioT>(coll_name, !IsOptional));
-        } catch (const JException& e) {
-          if constexpr (!IsOptional) {
-            throw JException("JOmniFactory: Failed to get collection %s: %s", coll_name.c_str(),
-                             e.what());
-          }
-        }
-      }
-    }
-  };
-
-  void RegisterInput(InputBase* input) { m_inputs.push_back(input); }
-
-  /// =========================
-  /// Handle output collections
-  /// =========================
-
-  struct OutputBase {
-    std::string type_name;
-    std::vector<std::string> collection_names;
-    bool is_variadic = false;
-
-    virtual void CreateHelperFactory(JOmniFactory& fac) = 0;
-    virtual void SetCollection(JOmniFactory& fac)       = 0;
-    virtual void Reset()                                = 0;
-  };
-
-  template <typename T> class Output : public OutputBase {
-    std::vector<T*> m_data;
-
-  public:
-    Output(JOmniFactory* owner, std::string default_tag_name = "") {
-      owner->RegisterOutput(this);
-      this->collection_names.push_back(default_tag_name);
-      this->type_name = JTypeInfo::demangle<T>();
-    }
-
-    std::vector<T*>& operator()() { return m_data; }
-
-  private:
-    friend class JOmniFactory;
-
-    void CreateHelperFactory(JOmniFactory& fac) override {
-      fac.DeclareOutput<T>(this->collection_names[0]);
-    }
-
-    void SetCollection(JOmniFactory& fac) override {
-      fac.SetData<T>(this->collection_names[0], this->m_data);
-    }
-
-    void Reset() override { m_data.clear(); }
-  };
-
-  template <typename PodioT> class PodioOutput : public OutputBase {
-
-    std::unique_ptr<typename PodioTypeMap<PodioT>::collection_t> m_data;
-
-  public:
-    PodioOutput(JOmniFactory* owner, std::string default_collection_name = "") {
-      owner->RegisterOutput(this);
-      this->collection_names.push_back(default_collection_name);
-      this->type_name = JTypeInfo::demangle<PodioT>();
-    }
-
-    std::unique_ptr<typename PodioTypeMap<PodioT>::collection_t>& operator()() { return m_data; }
-
-  private:
-    friend class JOmniFactory;
-
-    void CreateHelperFactory(JOmniFactory& fac) override {
-      fac.DeclarePodioOutput<PodioT>(this->collection_names[0]);
-    }
-
-    void SetCollection(JOmniFactory& fac) override {
-      if (m_data == nullptr) {
-        throw JException("JOmniFactory: SetCollection failed due to missing output collection '%s'",
-                         this->collection_names[0].c_str());
-        // Otherwise this leads to a PODIO segfault
-      }
-      fac.SetCollection<PodioT>(this->collection_names[0], std::move(this->m_data));
-    }
-
-    void Reset() override {
-      m_data = std::move(std::make_unique<typename PodioTypeMap<PodioT>::collection_t>());
-    }
-  };
-
-  template <typename PodioT> class VariadicPodioOutput : public OutputBase {
-
-    std::vector<std::unique_ptr<typename PodioTypeMap<PodioT>::collection_t>> m_data;
-
-  public:
-    VariadicPodioOutput(JOmniFactory* owner,
-                        std::vector<std::string> default_collection_names = {}) {
-      owner->RegisterOutput(this);
-      this->collection_names = default_collection_names;
-      this->type_name        = JTypeInfo::demangle<PodioT>();
-      this->is_variadic      = true;
-    }
-
-    std::vector<std::unique_ptr<typename PodioTypeMap<PodioT>::collection_t>>& operator()() {
-      return m_data;
-    }
-
-  private:
-    friend class JOmniFactory;
-
-    void CreateHelperFactory(JOmniFactory& fac) override {
-      for (auto& coll_name : this->collection_names) {
-        fac.DeclarePodioOutput<PodioT>(coll_name);
-      }
-    }
-
-    void SetCollection(JOmniFactory& fac) override {
-      if (m_data.size() != this->collection_names.size()) {
-        throw JException("JOmniFactory: VariadicPodioOutput SetCollection failed: Declared %d "
-                         "collections, but provided %d.",
-                         this->collection_names.size(), m_data.size());
-        // Otherwise this leads to a PODIO segfault
-      }
-      std::size_t i = 0;
-      for (auto& coll_name : this->collection_names) {
-        fac.SetCollection<PodioT>(coll_name, std::move(this->m_data[i++]));
-      }
-    }
-
-    void Reset() override {
-      m_data.clear();
-      for (auto& coll_name [[maybe_unused]] : this->collection_names) {
-        m_data.push_back(std::make_unique<typename PodioTypeMap<PodioT>::collection_t>());
-      }
-    }
-  };
-
-  void RegisterOutput(OutputBase* output) { m_outputs.push_back(output); }
-
-  // =================
-  // Handle parameters
-  // =================
-
-  struct ParameterBase {
-    std::string m_name;
-    std::string m_description;
-    virtual void Configure(JParameterManager& parman, const std::string& prefix) = 0;
-    virtual void Configure(std::map<std::string, std::string> fields)            = 0;
-  };
-
-  template <typename T> class ParameterRef : public ParameterBase {
-
-    T* m_data;
-
-  public:
-    ParameterRef(JOmniFactory* owner, std::string name, T& slot, std::string description = "") {
-      owner->RegisterParameter(this);
-      this->m_name        = name;
-      this->m_description = description;
-      m_data              = &slot;
-    }
-
-    const T& operator()() { return *m_data; }
-
-  private:
-    friend class JOmniFactory;
-
-    void Configure(JParameterManager& parman, const std::string& prefix) override {
-      parman.SetDefaultParameter(prefix + ":" + this->m_name, *m_data, this->m_description);
-    }
-    void Configure(std::map<std::string, std::string> fields) override {
-      auto it = fields.find(this->m_name);
-      if (it != fields.end()) {
-        const auto& value_str = it->second;
-        JParameterManager::Parse(value_str, *m_data);
-      }
-    }
-  };
-
-  template <typename T> class Parameter : public ParameterBase {
-
-    T m_data;
-
-  public:
-    Parameter(JOmniFactory* owner, std::string name, T default_value, std::string description) {
-      owner->RegisterParameter(this);
-      this->m_name        = name;
-      this->m_description = description;
-      m_data              = default_value;
-    }
-
-    const T& operator()() { return m_data; }
-
-  private:
-    friend class JOmniFactory;
-
-    void Configure(JParameterManager& parman, const std::string& /* prefix */) override {
-      parman.SetDefaultParameter(m_prefix + ":" + this->m_name, m_data, this->m_description);
-    }
-    void Configure(std::map<std::string, std::string> fields) override {
-      auto it = fields.find(this->m_name);
-      if (it != fields.end()) {
-        const auto& value_str = it->second;
-        if constexpr (10000 * JVersion::major + 100 * JVersion::minor + 1 * JVersion::patch <
-                      20102) {
-          m_data = JParameterManager::Parse<T>(value_str);
-        } else {
-          JParameterManager::Parse(value_str, m_data);
-        }
-      }
-    }
-  };
-
-  void RegisterParameter(ParameterBase* parameter) { m_parameters.push_back(parameter); }
-
-  void ConfigureAllParameters(std::map<std::string, std::string> fields) {
-    for (auto* parameter : this->m_parameters) {
-      parameter->Configure(fields);
-    }
-  }
-
-  // ===============
-  // Handle services
-  // ===============
-
-  struct ServiceBase {
-    virtual void Init(JApplication* app) = 0;
-  };
-
-  template <typename ServiceT> class Service : public ServiceBase {
-
-    std::shared_ptr<ServiceT> m_data;
-
-  public:
-    Service(JOmniFactory* owner) { owner->RegisterService(this); }
-
-    ServiceT& operator()() { return *m_data; }
-
-  private:
-    friend class JOmniFactory;
-
-    void Init(JApplication* app) { m_data = app->GetService<ServiceT>(); }
-  };
-
-  void RegisterService(ServiceBase* service) { m_services.push_back(service); }
-
-  // ================
-  // Handle resources
-  // ================
-
-  struct ResourceBase {
-    virtual void ChangeRun(const JEvent& event) = 0;
-  };
-
-  template <typename ServiceT, typename ResourceT, typename LambdaT>
-  class Resource : public ResourceBase {
-    ResourceT m_data;
-    LambdaT m_lambda;
-
-  public:
-    Resource(JOmniFactory* owner, LambdaT lambda) : m_lambda(lambda) {
-      owner->RegisterResource(this);
-    };
-
-    const ResourceT& operator()() { return m_data; }
-
-  private:
-    friend class JOmniFactory;
-
-    void ChangeRun(const JEvent& event) {
-      auto run_nr                       = event.GetRunNumber();
-      std::shared_ptr<ServiceT> service = event.GetJApplication()->template GetService<ServiceT>();
-      m_data                            = m_lambda(service, run_nr);
-    }
-  };
-
-  void RegisterResource(ResourceBase* resource) { m_resources.push_back(resource); }
-
-public:
-  std::vector<InputBase*> m_inputs;
-  std::vector<OutputBase*> m_outputs;
-  std::vector<ParameterBase*> m_parameters;
-  std::vector<ServiceBase*> m_services;
-  std::vector<ResourceBase*> m_resources;
-
+namespace eicrecon {
+
+/**
+ * This shim class for jana::components::JOmniFactory serves two purposes:
+ * - plugging in the spdlog-based logger service we are using in EICrecon
+ * - setting the event number in the spdlog Mapped Diagnostic Context (MDC)
+ */
+template <typename AlgoT, typename ConfigT = jana::components::EmptyConfig>
+class JOmniFactory : public jana::components::JOmniFactory<AlgoT, ConfigT> {
 private:
-  // App belongs on JMultifactory, it is just missing temporarily
-  JApplication* m_app;
+  using JANA_JOmniFactory = jana::components::JOmniFactory<AlgoT, ConfigT>;
 
-  // Plugin name belongs on JMultifactory, it is just missing temporarily
-  std::string m_plugin_name;
-
-  // Prefix for parameters and loggers, derived from plugin name and tag in PreInit().
-  std::string m_prefix;
+  // Hide Process(JEvent) in private to prevent accidental use
+  using JANA_JOmniFactory::Process;
 
   /// Current logger
   std::shared_ptr<spdlog::logger> m_logger;
 
-  /// Configuration
-  ConfigT m_config;
-
 public:
-  std::size_t FindVariadicCollectionCount(std::size_t total_input_count,
-                                          std::size_t variadic_input_count,
-                                          std::size_t total_collection_count, bool is_input) {
+  template <typename T> using ParameterRef = jana::components::JComponent::ParameterRef<T>;
 
-    std::size_t variadic_collection_count =
-        total_collection_count - (total_input_count - variadic_input_count);
+  template <typename T> using Parameter = jana::components::JComponent::Parameter<T>;
 
-    if (variadic_input_count == 0) {
-      // No variadic inputs: check that collection_name count matches input count exactly
-      if (total_input_count != total_collection_count) {
-        throw JException(
-            "JOmniFactory '%s': Wrong number of %s collection names: %d expected, %d found.",
-            m_prefix.c_str(), (is_input ? "input" : "output"), total_input_count,
-            total_collection_count);
-      }
-    } else {
-      // Variadic inputs: check that we have enough collection names for the non-variadic inputs
-      if (total_input_count - variadic_input_count > total_collection_count) {
-        throw JException("JOmniFactory '%s': Not enough %s collection names: %d needed, %d found.",
-                         m_prefix.c_str(), (is_input ? "input" : "output"),
-                         total_input_count - variadic_input_count, total_collection_count);
-      }
+  template <typename T> using Service = jana::components::JComponent::Service<T>;
 
-      // Variadic inputs: check that the variadic collection names is evenly divided by the variadic input count
-      if (variadic_collection_count % variadic_input_count != 0) {
-        throw JException("JOmniFactory '%s': Wrong number of %s collection names: %d found total, "
-                         "but %d can't be distributed among %d variadic inputs evenly.",
-                         m_prefix.c_str(), (is_input ? "input" : "output"), total_collection_count,
-                         variadic_collection_count, variadic_input_count);
-      }
-    }
-    return variadic_collection_count;
+  template <typename T> using Input = jana::components::JHasInputs::Input<T>;
+
+  template <typename T> using VariadicInput = jana::components::JHasInputs::VariadicPodioInput<T>;
+
+  template <typename PodioT, bool IsOptional = false>
+  class PodioInput : public jana::components::JHasInputs::PodioInput<PodioT> {
+  public:
+    explicit PodioInput(JOmniFactory* owner, std::string default_collection_name = "")
+        : jana::components::JHasInputs::PodioInput<PodioT>(
+              owner, jana::components::JHasInputs::InputOptions{
+                         .name        = std::move(default_collection_name),
+                         .is_optional = IsOptional,
+                     }) {}
+
+    explicit PodioInput(JOmniFactory* owner, jana::components::JHasInputs::InputOptions options)
+        : jana::components::JHasInputs::PodioInput<PodioT>(owner, options) {}
+  };
+
+  template <typename PodioT, bool IsOptional = false>
+  class VariadicPodioInput : public jana::components::JHasInputs::VariadicPodioInput<PodioT> {
+  public:
+    explicit VariadicPodioInput(JOmniFactory* owner, std::vector<std::string> default_names = {})
+        : jana::components::JHasInputs::VariadicPodioInput<PodioT>(
+              owner, jana::components::JHasInputs::VariadicInputOptions{
+                         .names       = std::move(default_names),
+                         .is_optional = IsOptional,
+                     }) {}
+
+    explicit VariadicPodioInput(JOmniFactory* owner,
+                                jana::components::JHasInputs::VariadicInputOptions options)
+        : jana::components::JHasInputs::VariadicPodioInput<PodioT>(owner, options) {}
+  };
+
+  template <typename PodioT> using PodioOutput = jana::components::PodioOutput<PodioT>;
+
+  template <typename PodioT>
+  using VariadicPodioOutput = jana::components::VariadicPodioOutput<PodioT>;
+
+  inline void PreInit(std::string tag, JEventLevel level,
+                      std::vector<std::string> input_collection_names,
+                      std::vector<JEventLevel> input_collection_levels,
+                      std::vector<std::vector<std::string>> variadic_input_collection_names,
+                      std::vector<JEventLevel> variadic_input_collection_levels,
+                      std::vector<std::string> output_collection_names,
+                      std::vector<std::vector<std::string>> variadic_output_collection_names) {
+
+    // PreInit using the underlying JANA JOmniFactory
+    JANA_JOmniFactory::PreInit(tag, level, input_collection_names, input_collection_levels,
+                               variadic_input_collection_names, variadic_input_collection_levels,
+                               output_collection_names, variadic_output_collection_names);
+
+    // But obtain our own logger (defines the parameter option)
+    m_logger =
+        this->GetApplication()->template GetService<Log_service>()->logger(this->GetPrefix());
   }
 
-  inline void PreInit(std::string tag, std::vector<std::string> default_input_collection_names,
-                      std::vector<std::string> default_output_collection_names) {
-
-    m_prefix = (this->GetPluginName().empty()) ? tag : this->GetPluginName() + ":" + tag;
-
-    // Obtain collection name overrides if provided.
-    // Priority = [JParameterManager, JOmniFactoryGenerator]
-    m_app->SetDefaultParameter(m_prefix + ":InputTags", default_input_collection_names,
-                               "Input collection names");
-    m_app->SetDefaultParameter(m_prefix + ":OutputTags", default_output_collection_names,
-                               "Output collection names");
-
-    // Figure out variadic inputs
-    std::size_t variadic_input_count = 0;
-    for (auto* input : m_inputs) {
-      if (input->is_variadic) {
-        variadic_input_count += 1;
-      }
-    }
-    std::size_t variadic_input_collection_count = FindVariadicCollectionCount(
-        m_inputs.size(), variadic_input_count, default_input_collection_names.size(), true);
-
-    // Set input collection names
-    for (std::size_t i = 0; auto* input : m_inputs) {
-      input->collection_names.clear();
-      if (input->is_variadic) {
-        for (std::size_t j = 0; j < (variadic_input_collection_count / variadic_input_count); ++j) {
-          input->collection_names.push_back(default_input_collection_names[i++]);
-        }
-      } else {
-        input->collection_names.push_back(default_input_collection_names[i++]);
-      }
-    }
-
-    // Figure out variadic outputs
-    std::size_t variadic_output_count = 0;
-    for (auto* output : m_outputs) {
-      if (output->is_variadic) {
-        variadic_output_count += 1;
-      }
-    }
-    std::size_t variadic_output_collection_count = FindVariadicCollectionCount(
-        m_outputs.size(), variadic_output_count, default_output_collection_names.size(), true);
-
-    // Set output collection names and create corresponding helper factories
-    for (std::size_t i = 0; auto* output : m_outputs) {
-      output->collection_names.clear();
-      if (output->is_variadic) {
-        for (std::size_t j = 0; j < (variadic_output_collection_count / variadic_output_count);
-             ++j) {
-          output->collection_names.push_back(default_output_collection_names[i++]);
-        }
-      } else {
-        output->collection_names.push_back(default_output_collection_names[i++]);
-      }
-      output->CreateHelperFactory(*this);
-    }
-
-    // Obtain logger (defines the parameter option)
-    m_logger = m_app->GetService<Log_service>()->logger(m_prefix);
-  }
-
-  void Init() override {
-    auto app = GetApplication();
-    for (auto* parameter : m_parameters) {
-      parameter->Configure(*(app->GetJParameterManager()), m_prefix);
-    }
-    for (auto* service : m_services) {
-      service->Init(app);
-    }
-    static_cast<AlgoT*>(this)->Configure();
-  }
-
-  void BeginRun(const std::shared_ptr<const JEvent>& event) override {
-    for (auto* resource : m_resources) {
-      resource->ChangeRun(*event);
-    }
-    static_cast<AlgoT*>(this)->ChangeRun(event->GetRunNumber());
-  }
-
-  virtual void ChangeRun(int32_t /* run_number */) override {};
+  virtual void Execute(int32_t run_number, uint64_t event_number) {
+#if SPDLOG_VERSION >= 11400 && (!defined(SPDLOG_NO_TLS) || !SPDLOG_NO_TLS)
+    spdlog::mdc::put("e", std::to_string(event_number));
+#endif
+    static_cast<AlgoT*>(this)->Process(run_number, event_number);
+  };
 
   virtual void Process(int32_t /* run_number */, uint64_t /* event_number */) {};
 
-  void Process(const std::shared_ptr<const JEvent>& event) override {
-    try {
-      for (auto* input : m_inputs) {
-        input->GetCollection(*event);
-      }
-      for (auto* output : m_outputs) {
-        output->Reset();
-      }
-#if SPDLOG_VERSION >= 11400 && (!defined(SPDLOG_NO_TLS) || !SPDLOG_NO_TLS)
-      spdlog::mdc::put("e", std::to_string(event->GetEventNumber()));
-#endif
-      static_cast<AlgoT*>(this)->Process(event->GetRunNumber(), event->GetEventNumber());
-      for (auto* output : m_outputs) {
-        output->SetCollection(*this);
-      }
-    } catch (std::exception& e) {
-      throw JException(e.what());
-    }
-  }
-
-  using ConfigType = ConfigT;
-
-  void SetApplication(JApplication* app) { m_app = app; }
-
-  JApplication* GetApplication() { return m_app; }
-
-  void SetPluginName(std::string plugin_name) { m_plugin_name = plugin_name; }
-
-  std::string GetPluginName() { return m_plugin_name; }
-
-  inline std::string GetPrefix() { return m_prefix; }
-
   /// Retrieve reference to already-configured logger
   std::shared_ptr<spdlog::logger>& logger() { return m_logger; }
-
-  /// Retrieve reference to embedded config object
-  ConfigT& config() { return m_config; }
 };
+
+} // namespace eicrecon

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -124,13 +124,12 @@ public:
 
   /// Retrieve reference to already-configured logger
   std::shared_ptr<spdlog::logger>& logger() {
-#if EICRECON_JANA_IS_243
-    // JANA 2.4.3 does not invoke our PreInit() path, so m_logger may not be initialized.
+    // Some JANA releases may call Configure() before our PreInit() path.
+    // Lazily initialize to keep factory Configure() safe across layouts.
     if (m_logger == nullptr) {
       m_logger =
           this->GetApplication()->template GetService<Log_service>()->logger(this->GetPrefix());
     }
-#endif
     return m_logger;
   }
 };

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -5,6 +5,15 @@
 #pragma once
 
 #include <JANA/Components/JOmniFactory.h>
+#if defined(JANA_VERSION_MAJOR) && defined(JANA_VERSION_MINOR) && defined(JANA_VERSION_PATCH)
+#define EICRECON_JANA_IS_243                                                                       \
+  (JANA_VERSION_MAJOR == 2 && JANA_VERSION_MINOR == 4 && JANA_VERSION_PATCH == 3)
+#else
+#define EICRECON_JANA_IS_243 1
+#endif
+#if !EICRECON_JANA_IS_243
+#include <JANA/Components/JPodioOutput.h>
+#endif
 #include <JANA/Utils/JEventLevel.h>
 #include <spdlog/spdlog.h>
 #include <spdlog/version.h>
@@ -76,10 +85,15 @@ public:
         : jana::components::JHasInputs::VariadicPodioInput<PodioT>(owner, options) {}
   };
 
+#if EICRECON_JANA_IS_243
+  template <typename PodioT> using PodioOutput = jana::components::JHasOutputs::PodioOutput<PodioT>;
+  template <typename PodioT>
+  using VariadicPodioOutput = jana::components::JHasOutputs::VariadicPodioOutput<PodioT>;
+#else
   template <typename PodioT> using PodioOutput = jana::components::PodioOutput<PodioT>;
-
   template <typename PodioT>
   using VariadicPodioOutput = jana::components::VariadicPodioOutput<PodioT>;
+#endif
 
   inline void PreInit(std::string tag, JEventLevel level,
                       std::vector<std::string> input_collection_names,
@@ -113,3 +127,5 @@ public:
 };
 
 } // namespace eicrecon
+
+#undef EICRECON_JANA_IS_243

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -5,15 +5,7 @@
 #pragma once
 
 #include <JANA/Components/JOmniFactory.h>
-#if defined(JANA_VERSION_MAJOR) && defined(JANA_VERSION_MINOR) && defined(JANA_VERSION_PATCH)
-#define EICRECON_JANA_IS_243                                                                       \
-  (JANA_VERSION_MAJOR == 2 && JANA_VERSION_MINOR == 4 && JANA_VERSION_PATCH == 3)
-#else
-#define EICRECON_JANA_IS_243 1
-#endif
-#if !EICRECON_JANA_IS_243
 #include <JANA/Components/JPodioOutput.h>
-#endif
 #include <JANA/Utils/JEventLevel.h>
 #include <spdlog/spdlog.h>
 #include <spdlog/version.h>
@@ -85,15 +77,9 @@ public:
         : jana::components::JHasInputs::VariadicPodioInput<PodioT>(owner, options) {}
   };
 
-#if EICRECON_JANA_IS_243
   template <typename PodioT> using PodioOutput = jana::components::JHasOutputs::PodioOutput<PodioT>;
   template <typename PodioT>
   using VariadicPodioOutput = jana::components::JHasOutputs::VariadicPodioOutput<PodioT>;
-#else
-  template <typename PodioT> using PodioOutput = jana::components::PodioOutput<PodioT>;
-  template <typename PodioT>
-  using VariadicPodioOutput = jana::components::VariadicPodioOutput<PodioT>;
-#endif
 
   inline void PreInit(std::string tag, JEventLevel level,
                       std::vector<std::string> input_collection_names,
@@ -135,5 +121,3 @@ public:
 };
 
 } // namespace eicrecon
-
-#undef EICRECON_JANA_IS_243

--- a/src/extensions/jana/JOmniFactory.h
+++ b/src/extensions/jana/JOmniFactory.h
@@ -5,7 +5,15 @@
 #pragma once
 
 #include <JANA/Components/JOmniFactory.h>
+#if defined(JANA_VERSION_MAJOR) && defined(JANA_VERSION_MINOR) && defined(JANA_VERSION_PATCH)
+#define EICRECON_JANA_IS_243                                                                       \
+  (JANA_VERSION_MAJOR == 2 && JANA_VERSION_MINOR == 4 && JANA_VERSION_PATCH == 3)
+#else
+#define EICRECON_JANA_IS_243 1
+#endif
+#if !EICRECON_JANA_IS_243
 #include <JANA/Components/JPodioOutput.h>
+#endif
 #include <JANA/Utils/JEventLevel.h>
 #include <spdlog/spdlog.h>
 #include <spdlog/version.h>
@@ -77,9 +85,15 @@ public:
         : jana::components::JHasInputs::VariadicPodioInput<PodioT>(owner, options) {}
   };
 
+#if EICRECON_JANA_IS_243
   template <typename PodioT> using PodioOutput = jana::components::JHasOutputs::PodioOutput<PodioT>;
   template <typename PodioT>
   using VariadicPodioOutput = jana::components::JHasOutputs::VariadicPodioOutput<PodioT>;
+#else
+  template <typename PodioT> using PodioOutput = jana::components::PodioOutput<PodioT>;
+  template <typename PodioT>
+  using VariadicPodioOutput = jana::components::VariadicPodioOutput<PodioT>;
+#endif
 
   inline void PreInit(std::string tag, JEventLevel level,
                       std::vector<std::string> input_collection_names,
@@ -121,3 +135,5 @@ public:
 };
 
 } // namespace eicrecon
+
+#undef EICRECON_JANA_IS_243

--- a/src/extensions/jana/JOmniFactoryGeneratorT.h
+++ b/src/extensions/jana/JOmniFactoryGeneratorT.h
@@ -4,96 +4,37 @@
 
 #pragma once
 
-#include <JANA/JFactorySet.h>
-#include <JANA/JFactoryGenerator.h>
+#include <JANA/Components/JOmniFactoryGeneratorT.h>
+#include <JANA/JApplicationFwd.h>
+
+#include <string>
+#include <utility>
 #include <vector>
 
-template <class FactoryT> class JOmniFactoryGeneratorT : public JFactoryGenerator {
+namespace eicrecon {
+
+// Fallthrough to JANA's built-in JOmniFactoryGeneratorT, but allow for unused app argument in constructor
+template <class FactoryT>
+class JOmniFactoryGeneratorT : public jana::components::JOmniFactoryGeneratorT<FactoryT> {
 public:
   using FactoryConfigType = typename FactoryT::ConfigType;
+  using TypedWiring = typename jana::components::JOmniFactoryGeneratorT<FactoryT>::TypedWiring;
 
-private:
-  struct TypedWiring {
-    std::string m_tag;
-    std::vector<std::string> m_default_input_tags;
-    std::vector<std::string> m_default_output_tags;
-    FactoryConfigType m_default_cfg; /// Must be properly copyable!
-  };
+  explicit JOmniFactoryGeneratorT() = default;
 
-  struct UntypedWiring {
-    std::string m_tag;
-    std::vector<std::string> m_default_input_tags;
-    std::vector<std::string> m_default_output_tags;
-    std::map<std::string, std::string> m_config_params;
-  };
+  explicit JOmniFactoryGeneratorT(std::string tag, std::vector<std::string> input_names,
+                                  std::vector<std::string> output_names, FactoryConfigType configs,
+                                  JApplication* /* app */ = nullptr)
+      : jana::components::JOmniFactoryGeneratorT<FactoryT>(tag, input_names, output_names,
+                                                           configs) {}
 
-public:
-  explicit JOmniFactoryGeneratorT(std::string tag, std::vector<std::string> default_input_tags,
-                                  std::vector<std::string> default_output_tags,
-                                  FactoryConfigType cfg, JApplication* app) {
-    m_app = app;
-    m_wirings.push_back({.m_tag                 = tag,
-                         .m_default_input_tags  = default_input_tags,
-                         .m_default_output_tags = default_output_tags,
-                         .m_default_cfg         = cfg});
-  };
+  explicit JOmniFactoryGeneratorT(std::string tag, std::vector<std::string> input_names,
+                                  std::vector<std::string> output_names,
+                                  JApplication* /* app */ = nullptr)
+      : jana::components::JOmniFactoryGeneratorT<FactoryT>(tag, input_names, output_names) {}
 
-  explicit JOmniFactoryGeneratorT(std::string tag, std::vector<std::string> default_input_tags,
-                                  std::vector<std::string> default_output_tags, JApplication* app) {
-    m_app = app;
-    m_wirings.push_back({.m_tag                 = tag,
-                         .m_default_input_tags  = default_input_tags,
-                         .m_default_output_tags = default_output_tags,
-                         .m_default_cfg         = {}});
-  }
-
-  explicit JOmniFactoryGeneratorT(JApplication* app) : m_app(app) {}
-
-  void AddWiring(std::string tag, std::vector<std::string> default_input_tags,
-                 std::vector<std::string> default_output_tags, FactoryConfigType cfg) {
-
-    m_wirings.push_back({.m_tag                 = tag,
-                         .m_default_input_tags  = default_input_tags,
-                         .m_default_output_tags = default_output_tags,
-                         .m_default_cfg         = cfg});
-  }
-
-  void AddWiring(std::string tag, std::vector<std::string> default_input_tags,
-                 std::vector<std::string> default_output_tags,
-                 std::map<std::string, std::string> config_params) {
-
-    // Create throwaway factory so we can populate its config using our map<string,string>.
-    FactoryT factory;
-    factory.ConfigureAllParameters(config_params);
-    auto config = factory.config();
-
-    m_wirings.push_back({.m_tag                 = tag,
-                         .m_default_input_tags  = default_input_tags,
-                         .m_default_output_tags = default_output_tags,
-                         .m_default_cfg         = config});
-  }
-
-  void GenerateFactories(JFactorySet* factory_set) override {
-
-    for (const auto& wiring : m_wirings) {
-
-      FactoryT* factory = new FactoryT;
-      factory->SetApplication(m_app);
-      factory->SetPluginName(this->GetPluginName());
-      factory->SetFactoryName(JTypeInfo::demangle<FactoryT>());
-      factory->config() = wiring.m_default_cfg;
-
-      // Set up all of the wiring prereqs so that Init() can do its thing
-      // Specifically, it needs valid input/output tags, a valid logger, and
-      // valid default values in its Config object
-      factory->PreInit(wiring.m_tag, wiring.m_default_input_tags, wiring.m_default_output_tags);
-
-      // Factory is ready
-      factory_set->Add(factory);
-    }
-  }
-
-private:
-  std::vector<TypedWiring> m_wirings;
-  JApplication* m_app;
+  explicit JOmniFactoryGeneratorT(TypedWiring&& wiring)
+      : jana::components::JOmniFactoryGeneratorT<FactoryT>(std::move(wiring)) {}
 };
+
+} // namespace eicrecon

--- a/src/factories/digi/CFDROCDigitization_factory.h
+++ b/src/factories/digi/CFDROCDigitization_factory.h
@@ -35,8 +35,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_in_sim_track()}, {m_out_reco_particles().get()});
   }

--- a/src/factories/meta/CollectionCollector_factory.h
+++ b/src/factories/meta/CollectionCollector_factory.h
@@ -18,8 +18,8 @@ private:
   std::unique_ptr<AlgoT> m_algo;
 
   typename JOmniFactory<CollectionCollector_factory<T, IsOptional>,
-                        NoConfig>::template VariadicPodioInput<T, IsOptional>
-      m_inputs{this};
+                        NoConfig>::template VariadicPodioInput<T>
+      m_inputs{this, {.is_optional = IsOptional}};
   typename JOmniFactory<CollectionCollector_factory<T, IsOptional>,
                         NoConfig>::template PodioOutput<T>
       m_output{this};

--- a/src/factories/meta/CollectionCollector_factory.h
+++ b/src/factories/meta/CollectionCollector_factory.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <JANA/JException.h>
+
 #include "extensions/jana/JOmniFactory.h"
 #include "algorithms/meta/CollectionCollector.h"
 
@@ -35,6 +37,13 @@ public:
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     std::vector<gsl::not_null<const typename T::collection_type*>> in_collections;
     for (const auto& in_collection : m_inputs()) {
+      if (in_collection == nullptr) {
+        if constexpr (IsOptional) {
+          continue;
+        }
+        throw JException("CollectionCollector '%s' received null required input collection.",
+                         this->GetPrefix().c_str());
+      }
       in_collections.push_back(gsl::not_null<const typename T::collection_type*>{in_collection});
     }
     typename T::collection_type* merged_collection = m_output().get();

--- a/src/factories/reco/ChargedMCParticleSelector_factory.h
+++ b/src/factories/reco/ChargedMCParticleSelector_factory.h
@@ -18,7 +18,7 @@ private:
   std::unique_ptr<AlgoT> m_algo;
 
   // input collection
-  PodioInput<edm4hep::MCParticle> m_pars_in{this, "GeneratedParticles"};
+  PodioInput<edm4hep::MCParticle> m_pars_in{this};
 
   // output collection
   PodioOutput<edm4hep::MCParticle> m_pars_out{this};

--- a/src/factories/reco/ChargedReconstructedParticleSelector_factory.h
+++ b/src/factories/reco/ChargedReconstructedParticleSelector_factory.h
@@ -18,7 +18,7 @@ private:
   std::unique_ptr<AlgoT> m_algo;
 
   // input collection
-  PodioInput<edm4eic::ReconstructedParticle> m_pars_in{this, "GeneratedParticles"};
+  PodioInput<edm4eic::ReconstructedParticle> m_pars_in{this};
 
   // output collection
   PodioOutput<edm4eic::ReconstructedParticle> m_pars_out{this};

--- a/src/factories/reco/LGADHitCalibration_factory.h
+++ b/src/factories/reco/LGADHitCalibration_factory.h
@@ -30,8 +30,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_raw_hits_input()}, {m_rec_hits_output().get()});
   }

--- a/src/factories/reco/ReconstructedElectrons_factory.h
+++ b/src/factories/reco/ReconstructedElectrons_factory.h
@@ -19,7 +19,7 @@ private:
   std::unique_ptr<AlgoT> m_algo;
 
   // Declare inputs
-  PodioInput<edm4eic::ReconstructedParticle> m_in_rc_particles{this, "ReconstructedParticles"};
+  PodioInput<edm4eic::ReconstructedParticle> m_in_rc_particles{this};
 
   // Declare outputs
   PodioOutput<edm4eic::ReconstructedParticle> m_out_reco_particles{this};

--- a/src/factories/tracking/LGADHitClustering_factory.h
+++ b/src/factories/tracking/LGADHitClustering_factory.h
@@ -29,8 +29,6 @@ public:
     m_algo->init();
   }
 
-  void ChangeRun(int32_t /* run_number */) {}
-
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_hits_input()}, {m_clusters_output().get()});
   }

--- a/src/global/beam/beam.cc
+++ b/src/global/beam/beam.cc
@@ -5,9 +5,9 @@
 
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <edm4hep/MCParticleCollection.h>
-#include <fmt/core.h>
 #include <functional>
 #include <map>
 #include <memory>

--- a/src/global/beam/beam.cc
+++ b/src/global/beam/beam.cc
@@ -24,6 +24,7 @@ void InitPlugin(JApplication* app) {
   InitJANAPlugin(app);
 
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   // Divide MCParticle collection based on generator status and PDG
   std::vector<std::string> outCollections{"MCBeamElectrons",    "MCBeamProtons",
@@ -33,16 +34,19 @@ void InitPlugin(JApplication* app) {
                                        {1, 11}, {1, 2212}, {1, 2112}};
 
   app->Add(new JOmniFactoryGeneratorT<SubDivideCollection_factory<edm4hep::MCParticle>>(
-      "BeamParticles", {"MCParticles"}, outCollections,
-      {
-          .function =
-              ValueSplit<&edm4hep::MCParticle::getGeneratorStatus, &edm4hep::MCParticle::getPDG>{
-                  values},
-      },
-      app));
+      {.tag                   = "BeamParticles",
+       .input_names           = {"MCParticles"},
+       .variadic_output_names = {outCollections},
+       .configs               = {
+           .function =
+               ValueSplit<&edm4hep::MCParticle::getGeneratorStatus, &edm4hep::MCParticle::getPDG>{
+                   values},
+       }}));
 
   // Combine beam protons and neutrons into beam hadrons
   app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4hep::MCParticle, true>>(
-      "MCBeamHadrons", {"MCBeamProtons", "MCBeamNeutrons"}, {"MCBeamHadrons"}, app));
+      {.tag                  = "MCBeamHadrons",
+       .variadic_input_names = {{"MCBeamProtons", "MCBeamNeutrons"}},
+       .output_names         = {"MCBeamHadrons"}}));
 }
 }

--- a/src/global/beam/beam.cc
+++ b/src/global/beam/beam.cc
@@ -9,7 +9,6 @@
 #include <JANA/Utils/JTypeInfo.h>
 #include <edm4hep/MCParticleCollection.h>
 #include <functional>
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>

--- a/src/global/particle_flow/particle_flow.cc
+++ b/src/global/particle_flow/particle_flow.cc
@@ -27,6 +27,7 @@ extern "C" {
 void InitPlugin(JApplication* app) {
 
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   InitJANAPlugin(app);
 

--- a/src/global/particle_flow/particle_flow.cc
+++ b/src/global/particle_flow/particle_flow.cc
@@ -3,6 +3,7 @@
 
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <edm4eic/TrackClusterMatch.h>
 #include <edm4eic/TrackPoint.h>

--- a/src/global/pid/pid.cc
+++ b/src/global/pid/pid.cc
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022, 2023, Christopher Dilks
 
+#include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <vector>

--- a/src/global/pid/pid.cc
+++ b/src/global/pid/pid.cc
@@ -15,6 +15,7 @@ void InitPlugin(JApplication* app) {
   InitJANAPlugin(app);
 
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   // wiring between factories and data ///////////////////////////////////////
 

--- a/src/global/pid_lut/pid_lut.cc
+++ b/src/global/pid_lut/pid_lut.cc
@@ -21,6 +21,7 @@ void InitPlugin(JApplication* app) {
   InitJANAPlugin(app);
 
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   //-------------------------------------------------------------------------
   // PFRICH PID
@@ -187,33 +188,35 @@ void InitPlugin(JApplication* app) {
 
   app->Add(
       new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::ReconstructedParticle, true>>(
-          "ReconstructedWithPFRICHTOFDIRCLOWQ2PIDChargedParticles",
-          {"ReconstructedChargedWithPFRICHTOFDIRCPIDParticles",
-           "TaggerTrackerReconstructedParticles"},
-          {"ReconstructedWithPFRICHTOFDIRCLOWQ2PIDChargedParticles"}, app));
+          {.tag                  = "ReconstructedWithPFRICHTOFDIRCLOWQ2PIDChargedParticles",
+           .variadic_input_names = {{"ReconstructedChargedWithPFRICHTOFDIRCPIDParticles",
+                                     "TaggerTrackerReconstructedParticles"}},
+           .output_names         = {"ReconstructedWithPFRICHTOFDIRCLOWQ2PIDChargedParticles"}}));
 
   app->Add(new JOmniFactoryGeneratorT<
            CollectionCollector_factory<edm4eic::MCRecoParticleAssociation, true>>(
-      "ReconstructedChargedWithPFRICHTOFDIRCLOWQ2PIDParticleAssociations",
-      {"ReconstructedChargedWithPFRICHTOFDIRCPIDParticleAssociations",
-       "TaggerTrackerReconstructedParticleAssociations"},
-      {"ReconstructedChargedWithPFRICHTOFDIRCLOWQ2PIDParticleAssociations"}, app));
+      {.tag                  = "ReconstructedChargedWithPFRICHTOFDIRCLOWQ2PIDParticleAssociations",
+       .variadic_input_names = {{"ReconstructedChargedWithPFRICHTOFDIRCPIDParticleAssociations",
+                                 "TaggerTrackerReconstructedParticleAssociations"}},
+       .output_names = {"ReconstructedChargedWithPFRICHTOFDIRCLOWQ2PIDParticleAssociations"}}));
 
   // And the same for truth seeded particles and associations
 
   app->Add(
       new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::ReconstructedParticle, true>>(
-          "ReconstructedTruthSeededChargedWithPFRICHTOFDIRCLOWQ2PIDParticles",
-          {"ReconstructedTruthSeededChargedWithPFRICHTOFDIRCPIDParticles",
-           "TaggerTrackerReconstructedParticles"},
-          {"ReconstructedTruthSeededChargedWithPFRICHTOFDIRCLOWQ2PIDParticles"}, app));
+          {.tag = "ReconstructedTruthSeededChargedWithPFRICHTOFDIRCLOWQ2PIDParticles",
+           .variadic_input_names = {{"ReconstructedTruthSeededChargedWithPFRICHTOFDIRCPIDParticles",
+                                     "TaggerTrackerReconstructedParticles"}},
+           .output_names = {"ReconstructedTruthSeededChargedWithPFRICHTOFDIRCLOWQ2PIDParticles"}}));
 
   app->Add(new JOmniFactoryGeneratorT<
            CollectionCollector_factory<edm4eic::MCRecoParticleAssociation, true>>(
-      "ReconstructedTruthSeededChargedWithPFRICHTOFDIRCLOWQ2PIDParticleAssociations",
-      {"ReconstructedTruthSeededChargedWithPFRICHTOFDIRCPIDParticleAssociations",
-       "TaggerTrackerReconstructedParticleAssociations"},
-      {"ReconstructedTruthSeededChargedWithPFRICHTOFDIRCLOWQ2PIDParticleAssociations"}, app));
+      {.tag = "ReconstructedTruthSeededChargedWithPFRICHTOFDIRCLOWQ2PIDParticleAssociations",
+       .variadic_input_names =
+           {{"ReconstructedTruthSeededChargedWithPFRICHTOFDIRCPIDParticleAssociations",
+             "TaggerTrackerReconstructedParticleAssociations"}},
+       .output_names = {
+           "ReconstructedTruthSeededChargedWithPFRICHTOFDIRCLOWQ2PIDParticleAssociations"}}));
 
   //-------------------------------------------------------------------------
   // DRICH PID

--- a/src/global/pid_lut/pid_lut.cc
+++ b/src/global/pid_lut/pid_lut.cc
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022-2025 Christopher Dilks, Simon Gardner
 
+#include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <edm4eic/MCRecoParticleAssociation.h>
 #include <edm4eic/ReconstructedParticle.h>

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -4,6 +4,7 @@
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <edm4eic/Cluster.h>
 #include <edm4eic/InclusiveKinematics.h>

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -50,6 +50,7 @@ void InitPlugin(JApplication* app) {
   InitJANAPlugin(app);
 
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   // Finds associations matched to initial scattered electrons
   app->Add(
@@ -64,15 +65,18 @@ void InitPlugin(JApplication* app) {
       "GeneratedParticles", {"MCParticles"}, {"GeneratedParticles"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Cluster, true>>(
-      "EcalClusters", {"EcalEndcapNClusters", "EcalBarrelScFiClusters", "EcalEndcapPClusters"},
-      {"EcalClusters"}, app));
+      {.tag                  = "EcalClusters",
+       .variadic_input_names = {{"EcalEndcapNClusters", "EcalBarrelScFiClusters",
+                                 "EcalEndcapPClusters"}},
+       .output_names         = {"EcalClusters"}}));
 
   app->Add(new JOmniFactoryGeneratorT<
            CollectionCollector_factory<edm4eic::MCRecoClusterParticleAssociation, true>>(
-      "EcalClusterAssociations",
-      {"EcalEndcapNClusterAssociations", "EcalBarrelScFiClusterAssociations",
-       "EcalEndcapPClusterAssociations"},
-      {"EcalClusterAssociations"}, app));
+      {.tag                  = "EcalClusterAssociations",
+       .variadic_input_names = {{"EcalEndcapNClusterAssociations",
+                                 "EcalBarrelScFiClusterAssociations",
+                                 "EcalEndcapPClusterAssociations"}},
+       .output_names         = {"EcalClusterAssociations"}}));
 
   app->Add(new JOmniFactoryGeneratorT<MatchClusters_factory>(
       "ReconstructedParticlesWithAssoc",
@@ -119,8 +123,9 @@ void InitPlugin(JApplication* app) {
 
   // InclusiveKinematicseSigma is deprecated and will be removed, use InclusiveKinematicsESigma instead
   app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::InclusiveKinematics>>(
-      "InclusiveKinematicseSigma_legacy", {"InclusiveKinematicsESigma"},
-      {"InclusiveKinematicseSigma"}, app));
+      {.tag                  = "InclusiveKinematicseSigma_legacy",
+       .variadic_input_names = {{"InclusiveKinematicsESigma"}},
+       .output_names         = {"InclusiveKinematicseSigma"}}));
 
   app->Add(new JOmniFactoryGeneratorT<
            InclusiveKinematicsReconstructed_factory<InclusiveKinematicsSigma>>(

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -5,6 +5,7 @@
 #include <Evaluator/DD4hepUnits.h>
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
+#include <JANA/Utils/JEventLevel.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <edm4eic/MCRecoTrackParticleAssociationCollection.h>
 #include <edm4eic/MCRecoTrackerHitAssociationCollection.h>

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -48,6 +48,7 @@ void InitPlugin(JApplication* app) {
   InitJANAPlugin(app);
 
   using namespace eicrecon;
+  using eicrecon::JOmniFactoryGeneratorT;
 
   app->Add(new JOmniFactoryGeneratorT<TrackParamTruthInit_factory>(
       "TrackerTruthSeeds", {"EventHeader", "MCParticles"},
@@ -56,36 +57,35 @@ void InitPlugin(JApplication* app) {
   std::vector<std::pair<double, double>> thetaRanges{{0, 50 * dd4hep::mrad},
                                                      {50 * dd4hep::mrad, 180 * dd4hep::deg}};
   app->Add(new JOmniFactoryGeneratorT<SubDivideCollection_factory<edm4eic::TrackSeed>>(
-      "CentralB0TrackerTruthSeeds", {"TrackerTruthSeeds"},
-      {"B0TrackerTruthSeeds", "CentralTrackerTruthSeeds"},
-      {
-          .function = RangeSplit<
-              Chain<&edm4eic::TrackSeed::getParams, &edm4eic::TrackParameters::getTheta>>(
-              thetaRanges),
-      },
-      app));
-
+      {.tag                   = "CentralB0TrackTruthSeeds",
+       .input_names           = {"TrackerTruthSeeds"},
+       .variadic_output_names = {{"B0TrackerTruthSeeds", "CentralTrackerTruthSeeds"}},
+       .configs               = {
+           .function = RangeSplit<Chain<&edm4eic::TrackSeed::getParams,
+                                        &edm4eic::TrackParameters::getTheta>>(thetaRanges),
+       }}));
   // CENTRAL TRACKER
 
   // Tracker hits collector
   app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::TrackerHit, true>>(
-      "CentralTrackingRecHits",
-      {"SiBarrelTrackerRecHits", "SiBarrelVertexRecHits", "SiEndcapTrackerRecHits",
-       "MPGDBarrelRecHits", "OuterMPGDBarrelRecHits", "BackwardMPGDEndcapRecHits",
-       "ForwardMPGDEndcapRecHits"},
-      {"CentralTrackingRecHits"}, // Output collection name
-      app));
+      {.tag                  = "CentralTrackingRecHits",
+       .variadic_input_names = {{"SiBarrelTrackerRecHits", "SiBarrelVertexRecHits",
+                                 "SiEndcapTrackerRecHits", "TOFBarrelRecHits", "TOFEndcapRecHits",
+                                 "MPGDBarrelRecHits", "OuterMPGDBarrelRecHits",
+                                 "BackwardMPGDEndcapRecHits", "ForwardMPGDEndcapRecHits"}},
+       .output_names         = {"CentralTrackingRecHits"}}));
 
   // Tracker hit associations collector
   app->Add(new JOmniFactoryGeneratorT<
            CollectionCollector_factory<edm4eic::MCRecoTrackerHitAssociation, true>>(
-      "CentralTrackingRawHitAssociations",
-      {"SiBarrelRawHitAssociations", "SiBarrelVertexRawHitAssociations",
-       "SiEndcapTrackerRawHitAssociations", "MPGDBarrelRawHitAssociations",
-       "OuterMPGDBarrelRawHitAssociations", "BackwardMPGDEndcapRawHitAssociations",
-       "ForwardMPGDEndcapRawHitAssociations"},
-      {"CentralTrackingRawHitAssociations"}, // Output collection name
-      app));
+      {.tag                  = "CentralTrackingRawHitAssociations",
+       .variadic_input_names = {{"SiBarrelRawHitAssociations", "SiBarrelVertexRawHitAssociations",
+                                 "SiEndcapTrackerRawHitAssociations", "TOFBarrelRawHitAssociations",
+                                 "TOFEndcapRawHitAssociations", "MPGDBarrelRawHitAssociations",
+                                 "OuterMPGDBarrelRawHitAssociations",
+                                 "BackwardMPGDEndcapRawHitAssociations",
+                                 "ForwardMPGDEndcapRawHitAssociations"}},
+       .output_names         = {"CentralTrackingRawHitAssociations"}}));
 
   // Tracker hit links collector
   app->Add(
@@ -460,7 +460,9 @@ void InitPlugin(JApplication* app) {
 
   // Add central and B0 tracks
   app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track, true>>(
-      "CombinedTracks", {"CentralCKFTracks", "B0TrackerCKFTracks"}, {"CombinedTracks"}, app));
+      {.tag                  = "CombinedTracks",
+       .variadic_input_names = {{"CentralCKFTracks", "B0TrackerCKFTracks"}},
+       .output_names         = {"CombinedTracks"}}));
 
   app->Add(new JOmniFactoryGeneratorT<SecondaryVertexFinder_factory>(
       "PrimaryVerticesAMVF",
@@ -489,18 +491,21 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<
            CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation, true>>(
-      "CombinedTrackAssociations", {"CentralCKFTrackAssociations", "B0TrackerCKFTrackAssociations"},
-      {"CombinedTrackAssociations"}, app));
+      {.tag                  = "CombinedTrackAssociations",
+       .variadic_input_names = {{"CentralCKFTrackAssociations", "B0TrackerCKFTrackAssociations"}},
+       .output_names         = {"CombinedTrackAssociations"}}));
 
   app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track, true>>(
-      "CombinedTruthSeededTracks", {"CentralCKFTruthSeededTracks", "B0TrackerCKFTruthSeededTracks"},
-      {"CombinedTruthSeededTracks"}, app));
+      {.tag                  = "CombinedTruthSeededTracks",
+       .variadic_input_names = {{"CentralCKFTruthSeededTracks", "B0TrackerCKFTruthSeededTracks"}},
+       .output_names         = {"CombinedTruthSeededTracks"}}));
 
   app->Add(new JOmniFactoryGeneratorT<
            CollectionCollector_factory<edm4eic::MCRecoTrackParticleAssociation, true>>(
-      "CombinedTruthSeededTrackAssociations",
-      {"CentralCKFTruthSeededTrackAssociations", "B0TrackerCKFTruthSeededTrackAssociations"},
-      {"CombinedTruthSeededTrackAssociations"}, app));
+      {.tag                  = "CombinedTruthSeededTrackAssociations",
+       .variadic_input_names = {{"CentralCKFTruthSeededTrackAssociations",
+                                 "B0TrackerCKFTruthSeededTrackAssociations"}},
+       .output_names         = {"CombinedTruthSeededTrackAssociations"}}));
 
   app->Add(new JOmniFactoryGeneratorT<TracksToParticles_factory>(
       "ChargedTruthSeededParticlesWithAssociations",

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -58,7 +58,7 @@ void InitPlugin(JApplication* app) {
   std::vector<std::pair<double, double>> thetaRanges{{0, 50 * dd4hep::mrad},
                                                      {50 * dd4hep::mrad, 180 * dd4hep::deg}};
   app->Add(new JOmniFactoryGeneratorT<SubDivideCollection_factory<edm4eic::TrackSeed>>(
-      {.tag                   = "CentralB0TrackTruthSeeds",
+      {.tag                   = "CentralB0TrackerTruthSeeds",
        .input_names           = {"TrackerTruthSeeds"},
        .variadic_output_names = {{"B0TrackerTruthSeeds", "CentralTrackerTruthSeeds"}},
        .configs               = {

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -71,7 +71,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::TrackerHit, true>>(
       {.tag                  = "CentralTrackingRecHits",
        .variadic_input_names = {{"SiBarrelTrackerRecHits", "SiBarrelVertexRecHits",
-                                 "SiEndcapTrackerRecHits", "TOFBarrelRecHits", "TOFEndcapRecHits",
+                                 "SiEndcapTrackerRecHits",
                                  "MPGDBarrelRecHits", "OuterMPGDBarrelRecHits",
                                  "BackwardMPGDEndcapRecHits", "ForwardMPGDEndcapRecHits"}},
        .output_names         = {"CentralTrackingRecHits"}}));
@@ -81,8 +81,8 @@ void InitPlugin(JApplication* app) {
            CollectionCollector_factory<edm4eic::MCRecoTrackerHitAssociation, true>>(
       {.tag                  = "CentralTrackingRawHitAssociations",
        .variadic_input_names = {{"SiBarrelRawHitAssociations", "SiBarrelVertexRawHitAssociations",
-                                 "SiEndcapTrackerRawHitAssociations", "TOFBarrelRawHitAssociations",
-                                 "TOFEndcapRawHitAssociations", "MPGDBarrelRawHitAssociations",
+                                 "SiEndcapTrackerRawHitAssociations",
+                                 "MPGDBarrelRawHitAssociations",
                                  "OuterMPGDBarrelRawHitAssociations",
                                  "BackwardMPGDEndcapRawHitAssociations",
                                  "ForwardMPGDEndcapRawHitAssociations"}},

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -71,9 +71,9 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::TrackerHit, true>>(
       {.tag                  = "CentralTrackingRecHits",
        .variadic_input_names = {{"SiBarrelTrackerRecHits", "SiBarrelVertexRecHits",
-                                 "SiEndcapTrackerRecHits",
-                                 "MPGDBarrelRecHits", "OuterMPGDBarrelRecHits",
-                                 "BackwardMPGDEndcapRecHits", "ForwardMPGDEndcapRecHits"}},
+                                 "SiEndcapTrackerRecHits", "MPGDBarrelRecHits",
+                                 "OuterMPGDBarrelRecHits", "BackwardMPGDEndcapRecHits",
+                                 "ForwardMPGDEndcapRecHits"}},
        .output_names         = {"CentralTrackingRecHits"}}));
 
   // Tracker hit associations collector


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR reapplies #1959 (reverted in #2005) and merges in #2002 for good measure. This removes our own extensive JOmniFactory support in favor of the JANA upstream JOmniFactory when version 2.4.3 is available: a thin forwarding shim class is used to allow us to keep the `app` argument in place for now, since it is required for < 2.4.3 versions. The only plugin factory wirings that have been modified are those where the new `TypedWiring` is required for variadic inputs.

The issues reported in #2000 are ultimately due to exceptions in the track reconstruction for the file used there (likely an out of sync geometry). These exceptions are gracefully absorbed in pre-2.4.3 local-JOmniFactory, but not anymore when using the upstream JOmniFactory. To make them less lethal, the exceptions are caught in the algorithm now. This shifts geometry mismatch from exceptional error to logic error (but likely a noisy one).

Needs:
- [x] https://github.com/eic/eic-spack/pull/827 and https://github.com/eic/containers/pull/160
- [ ] #2783 

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.