### PR TITLE
fix(ci): switch collect-docs back to ubuntu-24.04

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -1297,7 +1297,7 @@ jobs:
           if-no-files-found: error
 
   collect-docs:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     needs:
       - get-docs-from-main
       - get-docs-from-open-prs


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR reverts the collect-docs job in CI back to ubuntu-24.04 since we are often timing out the 15 minute max on ubuntu-slim.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: collect-docs timeouts)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.