### PR TITLE
fix: try-catch on cellID position lookup in TrackerHitReco/LGAD

### DIFF
--- a/src/algorithms/reco/LGADHitCalibration.cc
+++ b/src/algorithms/reco/LGADHitCalibration.cc
@@ -34,7 +34,13 @@ void LGADHitCalibration::process(const LGADHitCalibration::Input& input,
     auto id = TDCADC_hit.getCellID();
 
     // Get position and dimension
-    auto pos   = m_converter->position(id);
+    dd4hep::Position pos;
+    try {
+      pos = m_converter->position(id);
+    } catch (const std::exception& e) {
+      error("Failed to get position for cell ID {:x}: {}", id, e.what());
+      continue; // Skip this hit and continue with the next one
+    }
     double ADC = TDCADC_hit.getCharge();
     double TDC = TDCADC_hit.getTimeStamp();
 

--- a/src/algorithms/reco/LGADHitCalibration.cc
+++ b/src/algorithms/reco/LGADHitCalibration.cc
@@ -3,6 +3,7 @@
 
 #include "LGADHitCalibration.h"
 
+#include <DD4hep/Objects.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <Math/GenVector/Cartesian3D.h>
 #include <Math/GenVector/DisplacementVector3D.h>
@@ -11,6 +12,7 @@
 #include <edm4hep/Vector3f.h>
 #include <algorithm>
 #include <cmath>
+#include <exception>
 #include <gsl/pointers>
 #include <vector>
 

--- a/src/algorithms/tracking/TrackerHitReconstruction.cc
+++ b/src/algorithms/tracking/TrackerHitReconstruction.cc
@@ -3,14 +3,15 @@
 
 #include "TrackerHitReconstruction.h"
 
+#include <DD4hep/Objects.h>
 #include <Evaluator/DD4hepUnits.h>
 #include <Math/GenVector/Cartesian3D.h>
 #include <Math/GenVector/DisplacementVector3D.h>
 #include <algorithms/logger.h>
 #include <edm4eic/CovDiag3f.h>
 #include <edm4hep/Vector3f.h>
-#include <fmt/core.h>
 #include <cstddef>
+#include <exception>
 #include <iterator>
 #include <vector>
 

--- a/src/algorithms/tracking/TrackerHitReconstruction.cc
+++ b/src/algorithms/tracking/TrackerHitReconstruction.cc
@@ -38,8 +38,15 @@ void TrackerHitReconstruction::process(const Input& input, const Output& output)
     auto id = raw_hit.getCellID();
 
     // Get position and dimension
-    auto pos = m_converter->position(id);
-    auto dim = m_converter->cellDimensions(id);
+    dd4hep::Position pos;
+    std::vector<double> dim;
+    try {
+      pos = m_converter->position(id);
+      dim = m_converter->cellDimensions(id);
+    } catch (const std::exception& e) {
+      error("Failed to get position and dimension for cell ID {:x}: {}", id, e.what());
+      continue; // Skip this hit and continue with the next one
+    }
 
     // >oO trace
     if (level() == algorithms::LogLevel::kTrace) {


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR (cherry-picked from #2450) adds a try-catch around cellID position lookup in the TrackerHitReconstruction.cc and LGADHitCalibration.cc. This helps build resiliency when running EICrecon against a simulation file created with a different geometry than that used in reconstruction (see e.g. #2000 which was ultimately caused by this, along with stricter treatment of exceptions in JANA2 factories used there). This shifts geometry mismatch from exceptional error to logic error (but likely a noisy one).

One could argue that geometry mismatches should be treated as exceptional, but that is more true if we can do this on `init` instead of during `process`.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: don't treat cellID lookup failures as exceptional)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.