### PR TITLE
fix: centralize Acts contexts for consistency

### DIFF
--- a/src/algorithms/tracking/ActsGeometryProvider.h
+++ b/src/algorithms/tracking/ActsGeometryProvider.h
@@ -7,8 +7,10 @@
 #include <Acts/Definitions/Units.hpp>
 #include <Acts/Geometry/GeometryContext.hpp>
 #include <Acts/Geometry/TrackingGeometry.hpp>
+#include <Acts/MagneticField/MagneticFieldContext.hpp>
 #include <Acts/MagneticField/MagneticFieldProvider.hpp>
 #include <Acts/Surfaces/Surface.hpp>
+#include <Acts/Utilities/CalibrationContext.hpp>
 #include <Acts/Visualization/ViewConfig.hpp>
 #include <DD4hep/Detector.h>
 #include <DD4hep/Fields.h>
@@ -63,6 +65,10 @@ public:
   std::map<int64_t, dd4hep::rec::Surface*> getDD4hepSurfaceMap() const { return m_surfaceMap; }
 
   const Acts::GeometryContext& getActsGeometryContext() const { return m_trackingGeoCtx; }
+  const Acts::MagneticFieldContext& getActsMagneticFieldContext() const {
+    return m_magneticFieldCtx;
+  }
+  const Acts::CalibrationContext& getActsCalibrationContext() const { return m_calibrationCtx; }
 
   ///  ACTS general logger that is used for running ACTS
   std::shared_ptr<spdlog::logger> getActsRelatedLogger() const { return m_log; }
@@ -83,7 +89,17 @@ private:
   std::map<int64_t, dd4hep::rec::Surface*> m_surfaceMap;
 
   /// ACTS Tracking Geometry Context
+#if Acts_VERSION_MAJOR >= 45
+  Acts::GeometryContext m_trackingGeoCtx = Acts::GeometryContext::dangerouslyDefaultConstruct();
+#else
   Acts::GeometryContext m_trackingGeoCtx;
+#endif
+
+  /// ACTS Magnetic Field Context
+  Acts::MagneticFieldContext m_magneticFieldCtx;
+
+  /// ACTS Calibration Context
+  Acts::CalibrationContext m_calibrationCtx;
 
   /// ACTS Tracking Geometry
   std::shared_ptr<const Acts::TrackingGeometry> m_trackingGeo{nullptr};

--- a/src/algorithms/tracking/CKFTracking.h
+++ b/src/algorithms/tracking/CKFTracking.h
@@ -5,13 +5,10 @@
 
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
 #include <Acts/EventData/VectorTrackContainer.hpp>
-#include <Acts/Geometry/GeometryContext.hpp>
 #include <Acts/Geometry/TrackingGeometry.hpp>
-#include <Acts/MagneticField/MagneticFieldContext.hpp>
 #include <Acts/MagneticField/MagneticFieldProvider.hpp>
 #include <Acts/TrackFinding/CombinatorialKalmanFilter.hpp>
 #include <Acts/TrackFinding/MeasurementSelector.hpp>
-#include <Acts/Utilities/CalibrationContext.hpp>
 #include <Acts/Utilities/Logger.hpp>
 #include <Acts/Utilities/Result.hpp>
 #if Acts_VERSION_MAJOR < 39

--- a/src/algorithms/tracking/CKFTracking.h
+++ b/src/algorithms/tracking/CKFTracking.h
@@ -90,9 +90,6 @@ private:
   std::shared_ptr<const ActsGeometryProvider> m_geoSvc{
       algorithms::ActsSvc::instance().acts_geometry_provider()};
   std::shared_ptr<const Acts::MagneticFieldProvider> m_BField{m_geoSvc->getFieldProvider()};
-  Acts::MagneticFieldContext m_fieldctx{};
-  Acts::GeometryContext m_geoctx{};
-  Acts::CalibrationContext m_calibctx{};
 
   Acts::MeasurementSelector::Config m_sourcelinkSelectorCfg;
 

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -43,6 +43,7 @@
 #include <utility>
 #include <vector>
 
+#include "ActsGeometryProvider.h"
 #include "algorithms/tracking/IterativeVertexFinderConfig.h"
 #include "extensions/spdlog/SpdlogToActs.h"
 

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -101,8 +101,14 @@ void eicrecon::IterativeVertexFinder::process(const Input& input, const Output& 
   finderCfg.trackLinearizer.connect<&Linearizer::linearizeTrack>(&linearizer);
   finderCfg.field = m_BField;
   VertexFinder finder(std::move(finderCfg));
-  Acts::IVertexFinder::State state(std::in_place_type<VertexFinder::State>, *m_BField, m_fieldctx);
-  VertexFinderOptions finderOpts(m_geoctx, m_fieldctx);
+
+  // Get run-scoped contexts from service
+  const auto& gctx = m_geoSvc->getActsGeometryContext();
+  const auto& mctx = m_geoSvc->getActsMagneticFieldContext();
+
+  Acts::IVertexFinder::State state(std::in_place_type<VertexFinder::State>, *m_BField, mctx);
+
+  VertexFinderOptions finderOpts(gctx, mctx);
 
   std::vector<Acts::InputTrack> inputTracks;
   std::vector<Acts::BoundTrackParameters> trackParameters;

--- a/src/algorithms/tracking/IterativeVertexFinder.h
+++ b/src/algorithms/tracking/IterativeVertexFinder.h
@@ -6,8 +6,6 @@
 
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
 #include <Acts/EventData/VectorTrackContainer.hpp>
-#include <Acts/Geometry/GeometryContext.hpp>
-#include <Acts/MagneticField/MagneticFieldContext.hpp>
 #include <Acts/MagneticField/MagneticFieldProvider.hpp>
 #include <algorithms/algorithm.h>
 #include <edm4eic/ReconstructedParticleCollection.h>

--- a/src/algorithms/tracking/IterativeVertexFinder.h
+++ b/src/algorithms/tracking/IterativeVertexFinder.h
@@ -45,7 +45,5 @@ private:
   std::shared_ptr<const ActsGeometryProvider> m_geoSvc{
       algorithms::ActsSvc::instance().acts_geometry_provider()};
   std::shared_ptr<const Acts::MagneticFieldProvider> m_BField{m_geoSvc->getFieldProvider()};
-  Acts::GeometryContext m_geoctx{};
-  Acts::MagneticFieldContext m_fieldctx{};
 };
 } // namespace eicrecon

--- a/src/algorithms/tracking/SpacePoint.h
+++ b/src/algorithms/tracking/SpacePoint.h
@@ -38,11 +38,11 @@ public:
   float t() const { return getTime(); }
   float varianceT() const { return getTimeError(); }
 
-  bool isOnSurface() const {
+  bool isOnSurface(const Acts::GeometryContext& gctx) const {
     if (m_surface == nullptr) {
       return false;
     }
-    return m_surface->isOnSurface(Acts::GeometryContext(), {x(), y(), z()}, {0, 0, 0});
+    return m_surface->isOnSurface(gctx, {x(), y(), z()}, {0, 0, 0});
   }
 };
 

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -277,7 +277,12 @@ TrackPropagation::propagate(const edm4eic::Track& /* track */,
                         Acts::Navigator({.trackingGeometry = m_geoSvc->trackingGeometry()},
                                         logger().cloneWithSuffix("Navigator")),
                         logger().cloneWithSuffix("Propagator"));
-  PropagatorOptions propagationOptions(m_geoContext, m_fieldContext);
+
+  // Get run-scoped contexts from service
+  const auto& gctx = m_geoSvc->getActsGeometryContext();
+  const auto& mctx = m_geoSvc->getActsMagneticFieldContext();
+
+  PropagatorOptions propagationOptions(gctx, mctx);
 
   auto result = propagator.propagate(initBoundParams, *targetSurf, propagationOptions);
 
@@ -299,7 +304,7 @@ TrackPropagation::propagate(const edm4eic::Track& /* track */,
   trace("    path len = {}", pathLength);
 
   // Position:
-  auto projectionPos = trackStateParams.position(m_geoContext);
+  auto projectionPos = trackStateParams.position(gctx);
   const decltype(edm4eic::TrackPoint::position) position{static_cast<float>(projectionPos(0)),
                                                          static_cast<float>(projectionPos(1)),
                                                          static_cast<float>(projectionPos(2))};

--- a/src/algorithms/tracking/TrackPropagation.h
+++ b/src/algorithms/tracking/TrackPropagation.h
@@ -8,9 +8,7 @@
 #include <Acts/EventData/TrackProxy.hpp>
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
 #include <Acts/EventData/VectorTrackContainer.hpp>
-#include <Acts/Geometry/GeometryContext.hpp>
 #include <Acts/Geometry/GeometryIdentifier.hpp>
-#include <Acts/MagneticField/MagneticFieldContext.hpp>
 #include <Acts/Surfaces/Surface.hpp>
 #include <Acts/Utilities/Result.hpp>
 #include <ActsExamples/EventData/Track.hpp>

--- a/src/algorithms/tracking/TrackPropagation.h
+++ b/src/algorithms/tracking/TrackPropagation.h
@@ -101,8 +101,6 @@ public:
   void propagateToSurfaceList(const Input& input, const Output& output) const;
 
 private:
-  Acts::GeometryContext m_geoContext;
-  Acts::MagneticFieldContext m_fieldContext;
   std::shared_ptr<const ActsGeometryProvider> m_geoSvc{
       algorithms::ActsSvc::instance().acts_geometry_provider()};
   const dd4hep::Detector* m_detector{algorithms::GeoSvc::instance().detector()};

--- a/src/algorithms/tracking/TrackerMeasurementFromHits.cc
+++ b/src/algorithms/tracking/TrackerMeasurementFromHits.cc
@@ -43,6 +43,9 @@ void TrackerMeasurementFromHits::process(const Input& input, const Output& outpu
   constexpr double mm_acts = Acts::UnitConstants::mm;
   constexpr double mm_conv = mm_acts / dd4hep::mm; // = 1/0.1
 
+  // Get run-scoped geometry context from service
+  const auto& gctx = m_acts_context->getActsGeometryContext();
+
   // output collections
   auto const& surfaceMap = m_acts_context->surfaceMap();
 
@@ -88,10 +91,9 @@ void TrackerMeasurementFromHits::process(const Input& input, const Output& outpu
 
     try {
       // transform global position into local coordinates
-      // geometry context contains nothing here
       pos = surface
-                ->globalToLocal(Acts::GeometryContext(), {hit_pos.x, hit_pos.y, hit_pos.z},
-                                {0, 0, 0}, onSurfaceTolerance)
+                ->globalToLocal(gctx, {hit_pos.x, hit_pos.y, hit_pos.z}, {0, 0, 0},
+                                onSurfaceTolerance)
                 .value();
 
     } catch (std::exception& ex) {
@@ -111,9 +113,9 @@ void TrackerMeasurementFromHits::process(const Input& input, const Output& outpu
       auto local_position = (alignment.worldToLocal(
                                 {hit_pos.x / mm_conv, hit_pos.y / mm_conv, hit_pos.z / mm_conv})) *
                             mm_conv;
-      double surf_center_x = surface->center(Acts::GeometryContext()).transpose()[0];
-      double surf_center_y = surface->center(Acts::GeometryContext()).transpose()[1];
-      double surf_center_z = surface->center(Acts::GeometryContext()).transpose()[2];
+      double surf_center_x = surface->center(gctx).transpose()[0];
+      double surf_center_y = surface->center(gctx).transpose()[1];
+      double surf_center_z = surface->center(gctx).transpose()[2];
       trace("   hit position     : {:>10.2f} {:>10.2f} {:>10.2f}", hit_pos.x, hit_pos.y, hit_pos.z);
       trace("   local position   : {:>10.2f} {:>10.2f} {:>10.2f}", local_position.x(),
             local_position.y(), local_position.z());

--- a/src/algorithms/tracking/TrackerMeasurementFromHits.cc
+++ b/src/algorithms/tracking/TrackerMeasurementFromHits.cc
@@ -6,7 +6,6 @@
 #include <Acts/Definitions/Algebra.hpp>
 #include <Acts/Definitions/TrackParametrization.hpp>
 #include <Acts/Definitions/Units.hpp>
-#include <Acts/Geometry/GeometryContext.hpp>
 #include <Acts/Geometry/GeometryIdentifier.hpp>
 #include <Acts/Surfaces/Surface.hpp>
 #include <Acts/Utilities/Result.hpp>
@@ -22,7 +21,6 @@
 #include <edm4eic/CovDiag3f.h>
 #include <edm4hep/Vector2f.h>
 #include <edm4hep/Vector3f.h>
-#include <fmt/core.h>
 #include <Eigen/Core>
 #include <exception>
 #include <unordered_map>

--- a/src/tests/geometry_navigation_test/GeometryNavigationSteps_processor.h
+++ b/src/tests/geometry_navigation_test/GeometryNavigationSteps_processor.h
@@ -43,7 +43,11 @@ public:
 private:
   /// Directory to store histograms to
   TDirectory* m_dir_main{};
+#if Acts_VERSION_MAJOR >= 45
+  Acts::GeometryContext m_geoContext = Acts::GeometryContext::dangerouslyDefaultConstruct();
+#else
   Acts::GeometryContext m_geoContext;
+#endif
   Acts::MagneticFieldContext m_fieldContext;
   std::shared_ptr<spdlog::logger> m_log;
 };


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR centralizes all default-constructed Acts contexts to be consistent with each other and handed out (by const reference) by the ActsGeometryProvider. This ensures that any future run-dependent contexts can be provided without major changes. It also avoids the many deprecation warnings that are associated with default constructed contexts (when not gotten from a new static factory) in Acts v45 (https://github.com/acts-project/acts/pull/4957).

### What kind of change does this PR introduce?
- [x] Bug fix (issue: too many contexts)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.