### PR TITLE
fix: allow deprecating surface.associatedDetectorElement in Acts v45

### DIFF
--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -100,8 +100,13 @@ void ActsGeometryProvider::initialize(const dd4hep::Detector* dd4hep_geo, std::s
   class ConvertDD4hepDetectorGeometryIdentifierHook : public Acts::GeometryIdentifierHook {
     Acts::GeometryIdentifier decorateIdentifier(Acts::GeometryIdentifier identifier,
                                                 const Acts::Surface& surface) const override {
+#if Acts_VERSION_MAJOR >= 45
+      const auto* placement          = surface.surfacePlacement();
+      const auto* dd4hep_det_element = dynamic_cast<const DD4hepDetectorElement*>(placement);
+#else
       const auto* dd4hep_det_element =
           dynamic_cast<const DD4hepDetectorElement*>(surface.associatedDetectorElement());
+#endif
       if (dd4hep_det_element == nullptr) {
         return identifier;
       }
@@ -166,8 +171,13 @@ void ActsGeometryProvider::initialize(const dd4hep::Detector* dd4hep_geo, std::s
         m_init_log->info("no surface??? ");
         return;
       }
+#if Acts_VERSION_MAJOR >= 45
+      const auto* placement   = surface->surfacePlacement();
+      const auto* det_element = dynamic_cast<const DD4hepDetectorElement*>(placement);
+#else
       const auto* det_element =
           dynamic_cast<const DD4hepDetectorElement*>(surface->associatedDetectorElement());
+#endif
 
       if (det_element == nullptr) {
         m_init_log->error("invalid det_element!!! det_element == nullptr ");


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes the use of deprecated `surface.associatedDetectorElement` when in Acts v45 (https://github.com/acts-project/acts/pull/5005). Before Acts v45 this didn't exist, so no roll-out possible for currently-used Acts versions.

Note that in my testing this is more than just a replacement of one deprecated call with another with equal functionality. In addition to a deprecation warning during compilation, this change is also required to avoid a crash on nullptr surfaces in Acts v45, so it is necessary in addition to advisable.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: deprecated `surface.associatedDetectorElement`, fix crash due to nullptr surfaces)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.