### PR TITLE
fix: ensure emacs users can easily format in the editor

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,5 +1,26 @@
 ((c++-mode . ((eval . (progn
-;; Check if the package is installed; if not, try to load it
+                         ;; 1. Set up C++ style to match .clang-format (LLVM style)
+
+                         ;; Define LLVM style if not already defined
+                         (unless (assoc "llvm" c-style-alist)
+                           (c-add-style "llvm"
+                                        '("gnu"
+                                          (c-basic-offset . 2)
+                                          (indent-tabs-mode . nil)
+                                          (c-offsets-alist . ((innamespace . 0)
+                                                              (arglist-intro . ++)
+                                                              (member-init-intro . ++))))))
+
+                         ;; Set default C style to LLVM (base style of .clang-format)
+                         (c-set-style "llvm")
+                         ;; Check if the function exists before calling to be safe
+                         (if (fboundp 'c-guess)
+                             (c-guess t)
+                           (message "c-guess not found; using fallback llvm style."))
+
+                         ;; 2. Set up clang-format key bindings
+
+                         ;; Check if the clang-format package is installed; if not, try to load it
                          (unless (featurep 'clang-format)
                            (condition-case nil
                                (require 'clang-format)

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,20 @@
+((c++-mode . ((eval . (progn
+;; Check if the package is installed; if not, try to load it
+                         (unless (featurep 'clang-format)
+                           (condition-case nil
+                               (require 'clang-format)
+                             (error (message (concat "Warning: clang-format package not found. "
+                                                     "Please install it from melpa package-archive "
+                                                     "at https://melpa.org/packages/ "
+                                                     "with M-x package-install [RET] clang-format.")))))
+
+                         ;; Force load the package so the functions become "commands"
+                         (require 'clang-format nil t)
+
+                         ;; Define buffer-local keybindings
+                         (local-set-key (kbd "C-c i") 'clang-format-region)
+                         (local-set-key (kbd "C-c u") 'clang-format-buffer)
+
+                         ;; Optional: Ensure clang-format-buffer runs on save
+                         ;; (add-hook 'before-save-hook #'clang-format-buffer nil t)
+                         )))))

--- a/.gitignore
+++ b/.gitignore
@@ -141,7 +141,7 @@ flycheck_*.el
 .projectile
 
 # directory configuration
-.dir-locals.el
+.dir-localsi-2.el
 
 # network security
 /network-security.data


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds a local emacs configuration and key binding for clang-format. The key bindings `C-c i` (clang-format-region) and `C-c u` (clang-format-buffer) are defined.

When first starting up emacs on a C++ file inside this repository, this configuration will as you to accept this configuration with `!` (and you won't be asked again).

You will need to have the `clang-format` emacs package installed (in addition to the command `clang-format` provided by a system package).

The `clang-format` emacs package is on the MELPA package archive, which you will need to enable in your configuration if it isn't already.

This PR removes `.dir-locals.el` from `.gitignore` (and adds `.dir-locals-2.el`), and this PR may therefore overwrite local `.dir-locals.el` files (after warning about this). The standard approach is for `.dir-locals.el` to be tracked in git, and for personal additions that are not tracked to be added to `.dir-locals-2.el`.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: formatting code inside emacs is hard)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.