### PR TITLE
fix: avoid Acts-v45 deprecated Acts::TrackStateFlag enum values

### DIFF
--- a/src/algorithms/tracking/ActsToTracks.cc
+++ b/src/algorithms/tracking/ActsToTracks.cc
@@ -176,16 +176,28 @@ void ActsToTracks::process(const Input& input, const Output& output) const {
             state.getUncalibratedSourceLink().template get<ActsExamples::IndexSourceLink>().index();
 
         // no hit on this state/surface, skip
+#if Acts_VERSION_MAJOR >= 45
+        if (typeFlags.isHole()) {
+#else
         if (typeFlags.test(Acts::TrackStateFlag::HoleFlag)) {
+#endif
           debug("No hit found on geo id={}", geoID);
 
         } else {
           auto meas2D = (*meas2Ds)[srclink_index];
+#if Acts_VERSION_MAJOR >= 45
+          if (typeFlags.isOutlier()) {
+#else
           if (typeFlags.test(Acts::TrackStateFlag::OutlierFlag)) {
+#endif
             trajectory.addToOutliers_deprecated(meas2D);
             debug("Outlier on geo id={}, index={}, loc={},{}", geoID, srclink_index,
                   meas2D.getLoc().a, meas2D.getLoc().b);
+#if Acts_VERSION_MAJOR >= 45
+          } else if (typeFlags.isMeasurement()) {
+#else
           } else if (typeFlags.test(Acts::TrackStateFlag::MeasurementFlag)) {
+#endif
             track_out.addToMeasurements(meas2D);
             trajectory.addToMeasurements_deprecated(meas2D);
             debug("Measurement on geo id={}, index={}, loc={},{}", geoID, srclink_index,


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes the deprecated TrackState type flags in Acts v45 (https://github.com/acts-project/acts/pull/4945).

### What kind of change does this PR introduce?
- [x] Bug fix (issue: avoid deprecated functionality)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.