### PR TITLE
m_contribution_id_mask is initialized even when contributionMergeFields is empty

### DIFF
--- a/src/algorithms/calorimetry/SimCalorimeterHitProcessor.cc
+++ b/src/algorithms/calorimetry/SimCalorimeterHitProcessor.cc
@@ -128,8 +128,8 @@ void SimCalorimeterHitProcessor::init() {
       for (auto& field : m_cfg.contributionMergeFields) {
         id_inverse_mask |= m_id_spec.field(field)->mask();
       }
-      m_contribution_id_mask = ~id_inverse_mask;
     }
+    m_contribution_id_mask = ~id_inverse_mask;
     debug("ID mask in {:s}: {:#064b}", m_cfg.readout, m_contribution_id_mask.value());
   }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
If `contributionMergeFields` is empty, `m_contribution_id_mask` is not properly initialized due to is position, and makes the corresponding output excluded from the podio output. To resolve this issue, it has been moved outside of `if` block.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #2474 )
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No