### PR TITLE
hotfix: revert "feat: use free-threading IRT1 when detected as thread-safe (#2370)"

### DIFF
--- a/src/algorithms/pid/IrtCherenkovParticleID.cc
+++ b/src/algorithms/pid/IrtCherenkovParticleID.cc
@@ -24,7 +24,6 @@
 #include <podio/RelationRange.h>
 #include <algorithm>
 #include <cmath>
-#include <concepts>
 #include <cstddef>
 #include <functional>
 #include <iterator>
@@ -37,66 +36,9 @@
 #include "algorithms/pid/IrtCherenkovParticleIDConfig.h"
 #include "algorithms/pid/Tools.h"
 
-// Feature detection: Check if RadiatorHistory has GetLocations() method
-namespace {
-template <typename T>
-concept HasGetLocations = requires(const T& t) {
-  { t.GetLocations() } -> std::same_as<const std::vector<std::pair<TVector3, TVector3>>&>;
-};
-
-constexpr bool IRT_HAS_RADIATOR_HISTORY_GET_LOCATIONS = HasGetLocations<RadiatorHistory>;
-
-// Helper classes using template specialization to call appropriate methods
-// We use templated helper methods and delayed name lookup to avoid
-// compilation errors when methods don't exist in the unused specialization
-template <bool UseRadiatorHistory> struct IrtHelpers;
-
-// Specialization for new IRT (RadiatorHistory has the methods)
-template <> struct IrtHelpers<true> {
-  template <typename RH, typename CR>
-  static void SetTrajectoryBinCount(RH* rad_history, CR* /*rad*/, unsigned bins) {
-    rad_history->SetTrajectoryBinCount(bins);
-  }
-
-  template <typename RH, typename CR> static void ResetLocations(RH* rad_history, CR* /*rad*/) {
-    rad_history->ResetLocations();
-  }
-
-  template <typename RH, typename CR>
-  static void AddLocation(RH* rad_history, CR* /*rad*/, const TVector3& x, const TVector3& n) {
-    rad_history->AddLocation(x, n);
-  }
-};
-
-// Specialization for old IRT (CherenkovRadiator has the methods)
-template <> struct IrtHelpers<false> {
-  template <typename RH, typename CR>
-  static void SetTrajectoryBinCount(RH* /*rad_history*/, CR* rad, unsigned bins) {
-    rad->SetTrajectoryBinCount(bins);
-  }
-
-  template <typename RH, typename CR> static void ResetLocations(RH* /*rad_history*/, CR* rad) {
-    rad->ResetLocations();
-  }
-
-  template <typename RH, typename CR>
-  static void AddLocation(RH* /*rad_history*/, CR* rad, const TVector3& x, const TVector3& n) {
-    rad->AddLocation(x, n);
-  }
-};
-
-using IrtHelper = IrtHelpers<IRT_HAS_RADIATOR_HISTORY_GET_LOCATIONS>;
-} // namespace
-
 namespace eicrecon {
 
 void IrtCherenkovParticleID::init(CherenkovDetectorCollection* irt_det_coll) {
-  // lock for old IRT versions that use shared radiator state
-  [[maybe_unused]] std::unique_lock<std::mutex> lock;
-  if constexpr (!IRT_HAS_RADIATOR_HISTORY_GET_LOCATIONS) {
-    lock = std::unique_lock<std::mutex>(m_irt_det_mutex);
-  }
-
   // members
   m_irt_det_coll = irt_det_coll;
 
@@ -135,6 +77,7 @@ void IrtCherenkovParticleID::init(CherenkovDetectorCollection* irt_det_coll) {
   trace("Rebinning refractive index tables to have {} bins", m_cfg.numRIndexBins);
   for (auto [rad_name, irt_rad] : m_irt_det->Radiators()) {
     // FIXME: m_cfg.numRIndexBins should be a service configurable
+    std::lock_guard<std::mutex> lock(m_irt_det_mutex);
     auto ri_lookup_table_orig = irt_rad->m_ri_lookup_table;
     if (ri_lookup_table_orig.size() != m_cfg.numRIndexBins) {
       irt_rad->m_ri_lookup_table.clear();
@@ -154,6 +97,7 @@ void IrtCherenkovParticleID::init(CherenkovDetectorCollection* irt_det_coll) {
 
   // check radiators' configuration, and pass it to `m_irt_det`'s radiators
   for (auto [rad_name, irt_rad] : m_pid_radiators) {
+    std::lock_guard<std::mutex> lock(m_irt_det_mutex);
     // find `cfg_rad`, the associated `IrtCherenkovParticleIDConfig` radiator
     auto cfg_rad_it = m_cfg.radiators.find(rad_name);
     if (cfg_rad_it != m_cfg.radiators.end()) {
@@ -235,13 +179,9 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
     auto irt_particle = std::make_unique<ChargedParticle>();
 
     // loop over radiators
-    // note: for old IRT versions, this must run exclusively since irt_rad points to shared IRT
-    // objects that are owned by the RichGeo_service; it holds state (e.g. IrtHelpers::ResetLocations())
-    [[maybe_unused]] std::unique_lock<std::mutex> lock;
-    if constexpr (!IRT_HAS_RADIATOR_HISTORY_GET_LOCATIONS) {
-      lock = std::unique_lock<std::mutex>(m_irt_det_mutex);
-    }
-
+    // note: this must run exclusively since irt_rad points to shared IRT objects that are
+    // owned by the RichGeo_service; it holds state (e.g. irt_rad->ResetLocation())
+    std::lock_guard<std::mutex> lock(m_irt_det_mutex);
     for (auto [rad_name, irt_rad] : m_pid_radiators) {
 
       // get the `charged_particle` for this radiator
@@ -258,23 +198,21 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
         trace("No propagated track points in radiator '{}'", rad_name);
         continue;
       }
+      irt_rad->SetTrajectoryBinCount(charged_particle.points_size() - 1);
 
       // start a new IRT `RadiatorHistory`
       // - must be a raw pointer for `irt` compatibility
       // - it will be destroyed when `irt_particle` is destroyed
       auto* irt_rad_history = new RadiatorHistory();
-
-      IrtHelper::SetTrajectoryBinCount(irt_rad_history, irt_rad,
-                                       charged_particle.points_size() - 1);
       irt_particle->StartRadiatorHistory({irt_rad, irt_rad_history});
 
       // loop over `TrackPoint`s of this `charged_particle`, adding each to the IRT radiator
-      IrtHelper::ResetLocations(irt_rad_history, irt_rad);
+      irt_rad->ResetLocations();
       trace("TrackPoints in '{}' radiator:", rad_name);
       for (const auto& point : charged_particle.getPoints()) {
         TVector3 position = Tools::PodioVector3_to_TVector3(point.position);
         TVector3 momentum = Tools::PodioVector3_to_TVector3(point.momentum);
-        IrtHelper::AddLocation(irt_rad_history, irt_rad, position, momentum);
+        irt_rad->AddLocation(position, momentum);
         trace(Tools::PrintTVector3(" point: x", position));
         trace(Tools::PrintTVector3("        p", momentum));
       }

--- a/src/algorithms/pid/IrtCherenkovParticleID.h
+++ b/src/algorithms/pid/IrtCherenkovParticleID.h
@@ -59,10 +59,7 @@ public:
   void process(const Input&, const Output&) const;
 
 private:
-  // Locking for m_irt_det_coll, m_irt_det, m_pid_radiators:
-  // - Required for old/non-thread-safe IRT versions (detected by !IRT_HAS_RADIATOR_HISTORY_GET_LOCATIONS)
-  //   that use shared radiator state
-  // - Not required for newer thread-safe IRT versions (IRT_HAS_RADIATOR_HISTORY_GET_LOCATIONS)
+  // any access (R or W) to m_irt_det_coll, m_irt_det, m_pid_radiators must be locked
   inline static std::mutex m_irt_det_mutex;
   CherenkovDetectorCollection* m_irt_det_coll;
   CherenkovDetector* m_irt_det;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This reverts commit 416ac68a40a8bbf5b985df7dcc3142b157592b8e. There are data races in IRT1 reported by TSAN, e.g. https://github.com/eic/EICrecon/actions/runs/22039630117/job/63678425060#step:7:557. Data races are failure conditions for CI. Reverting will again force the full serialization of IRT1 (until the data races can be identified and fixed in a future PR).

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.