### PR TITLE
chore: drop support for Acts < 39.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 # Minimal dependency versions
-set(Acts_VERSION_MIN 36.1.0)
+set(Acts_VERSION_MIN 39.2.0)
 set(algorithms_VERSION_MIN 1.0.0)
 set(DD4hep_VERSION_MIN 1.21)
 set(EDM4EIC_VERSION_MIN 8.0)

--- a/src/algorithms/tracking/ActsGeometryProvider.h
+++ b/src/algorithms/tracking/ActsGeometryProvider.h
@@ -119,19 +119,11 @@ private:
   std::shared_ptr<spdlog::logger> m_init_log;
 
   /// Configuration for obj export
-#if Acts_VERSION_MAJOR >= 37
   Acts::ViewConfig m_containerView{.color = {220, 220, 220}}; // alto
   Acts::ViewConfig m_volumeView{.color = {220, 220, 0}};      // barberry yellow
   Acts::ViewConfig m_sensitiveView{.color = {0, 180, 240}};   // picton blue
   Acts::ViewConfig m_passiveView{.color = {240, 180, 0}};     // lightning yellow
   Acts::ViewConfig m_gridView{.color = {220, 0, 0}};          // scarlet red
-#else
-  Acts::ViewConfig m_containerView{{220, 220, 220}}; // alto
-  Acts::ViewConfig m_volumeView{{220, 220, 0}};      // barberry yellow
-  Acts::ViewConfig m_sensitiveView{{0, 180, 240}};   // picton blue
-  Acts::ViewConfig m_passiveView{{240, 180, 0}};     // lightning yellow
-  Acts::ViewConfig m_gridView{{220, 0, 0}};          // scarlet red
-#endif
   bool m_objWriteIt{false};
   bool m_plyWriteIt{false};
   std::string m_outputTag{""};
@@ -148,11 +140,7 @@ public:
   void setOutputDir(std::string dir) { m_outputDir = dir; }
   std::string getOutputDir() const { return m_outputDir; }
 
-#if Acts_VERSION_MAJOR >= 37
   using Color = Acts::Color;
-#else
-  using Color = Acts::ColorRGB;
-#endif
   void setContainerView(std::array<int, 3> c) { m_containerView.color = Color(c); }
   const Acts::ViewConfig& getContainerView() const { return m_containerView; }
   void setVolumeView(std::array<int, 3> c) { m_volumeView.color = Color(c); }

--- a/src/algorithms/tracking/AmbiguitySolver.cc
+++ b/src/algorithms/tracking/AmbiguitySolver.cc
@@ -8,7 +8,7 @@
 #include <Acts/EventData/TrackStatePropMask.hpp>
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
 #include <Acts/EventData/VectorTrackContainer.hpp>
-#if (Acts_VERSION_MAJOR >= 37) && (Acts_VERSION_MAJOR < 43)
+#if Acts_VERSION_MAJOR < 43
 #include <Acts/Utilities/Iterator.hpp>
 #endif
 #include <ActsExamples/EventData/IndexSourceLink.hpp>

--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -24,10 +24,8 @@
 #include <system_error>
 #include <tuple>
 #include <utility>
-#if Acts_VERSION_MAJOR >= 39
 #include <Acts/TrackFinding/CombinatorialKalmanFilterExtensions.hpp>
-#endif
-#if (Acts_VERSION_MAJOR >= 37) && (Acts_VERSION_MAJOR < 43)
+#if Acts_VERSION_MAJOR < 43
 #include <Acts/Utilities/Iterator.hpp>
 #endif
 #include <Acts/EventData/ParticleHypothesis.hpp>
@@ -38,12 +36,7 @@
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
 #include <Acts/EventData/VectorTrackContainer.hpp>
 #include <Acts/Geometry/GeometryIdentifier.hpp>
-#if Acts_VERSION_MAJOR >= 37
 #include <Acts/Propagator/ActorList.hpp>
-#else
-#include <Acts/Propagator/AbortList.hpp>
-#include <Acts/Propagator/ActionList.hpp>
-#endif
 #include <Acts/Propagator/EigenStepper.hpp>
 #include <Acts/Propagator/MaterialInteractor.hpp>
 #include <Acts/Propagator/Navigator.hpp>
@@ -52,9 +45,7 @@
 #include <Acts/Propagator/StandardAborters.hpp>
 #include <Acts/Surfaces/PerigeeSurface.hpp>
 #include <Acts/Surfaces/Surface.hpp>
-#if Acts_VERSION_MAJOR >= 39
 #include <Acts/TrackFinding/TrackStateCreator.hpp>
-#endif
 #include <Acts/TrackFitting/GainMatrixUpdater.hpp>
 #include <Acts/Utilities/Logger.hpp>
 #include <Acts/Utilities/TrackHelpers.hpp>
@@ -115,29 +106,10 @@ void CKFTracking::process(const Input& input, const Output& output) const {
   // create sourcelink and measurement containers
   auto measurements = std::make_shared<ActsExamples::MeasurementContainer>();
 
-  // need list here for stable addresses
-#if Acts_VERSION_MAJOR < 37 || (Acts_VERSION_MAJOR == 37 && Acts_VERSION_MINOR < 1)
-  std::list<ActsExamples::IndexSourceLink> sourceLinkStorage;
-  ActsExamples::IndexSourceLinkContainer src_links;
-  src_links.reserve(meas2Ds->size());
-  std::size_t hit_index = 0;
-#endif
-
   for (const auto& meas2D : *meas2Ds) {
 
     Acts::GeometryIdentifier geoId{meas2D.getSurface()};
 
-#if Acts_VERSION_MAJOR < 37 || (Acts_VERSION_MAJOR == 37 && Acts_VERSION_MINOR < 1)
-    // --follow example from ACTS to create source links
-    sourceLinkStorage.emplace_back(geoId, hit_index);
-    ActsExamples::IndexSourceLink& sourceLink = sourceLinkStorage.back();
-    // Add to output containers:
-    // index map and source link container are geometry-ordered.
-    // since the input is also geometry-ordered, new items can
-    // be added at the end.
-    src_links.insert(src_links.end(), sourceLink);
-#endif
-    // ---
     // Create ACTS measurements
 
     Acts::ActsVector<2> loc = Acts::Vector2::Zero();
@@ -150,7 +122,6 @@ void CKFTracking::process(const Input& input, const Output& output) const {
     cov(0, 1)                     = meas2D.getCovariance().xy;
     cov(1, 0)                     = meas2D.getCovariance().xy;
 
-#if Acts_VERSION_MAJOR > 37 || (Acts_VERSION_MAJOR == 37 && Acts_VERSION_MINOR >= 1)
     std::array<Acts::BoundIndices, 2> indices{Acts::eBoundLoc0, Acts::eBoundLoc1};
     Acts::visit_measurement(
         indices.size(), [&](auto dim) -> ActsExamples::VariableBoundMeasurementProxy {
@@ -161,27 +132,6 @@ void CKFTracking::process(const Input& input, const Output& output) const {
             throw std::runtime_error("Dimension not supported in measurement creation");
           }
         });
-#elif Acts_VERSION_MAJOR == 37 && Acts_VERSION_MINOR == 0
-    std::array<Acts::BoundIndices, 2> indices{Acts::eBoundLoc0, Acts::eBoundLoc1};
-    Acts::visit_measurement(
-        indices.size(), [&](auto dim) -> ActsExamples::VariableBoundMeasurementProxy {
-          if constexpr (dim == indices.size()) {
-            return ActsExamples::VariableBoundMeasurementProxy{
-                measurements->emplaceMeasurement<dim>(Acts::SourceLink{sourceLink}, indices, loc,
-                                                      cov)};
-          } else {
-            throw std::runtime_error("Dimension not supported in measurement creation");
-          }
-        });
-#else
-    auto measurement = ActsExamples::makeVariableSizeMeasurement(
-        Acts::SourceLink{sourceLink}, loc, cov, Acts::eBoundLoc0, Acts::eBoundLoc1);
-    measurements->emplace_back(std::move(measurement));
-#endif
-
-#if Acts_VERSION_MAJOR < 37 || (Acts_VERSION_MAJOR == 37 && Acts_VERSION_MINOR < 1)
-    hit_index++;
-#endif
   }
 
   ActsExamples::TrackParametersContainer acts_init_trk_params;
@@ -237,24 +187,11 @@ void CKFTracking::process(const Input& input, const Output& output) const {
   Acts::MeasurementSelector measSel{m_sourcelinkSelectorCfg};
 
   Acts::CombinatorialKalmanFilterExtensions<ActsExamples::TrackContainer> extensions;
-#if Acts_VERSION_MAJOR < 39
-  extensions.calibrator.connect<&ActsExamples::MeasurementCalibratorAdapter::calibrate>(
-      &calibrator);
-#endif
   extensions.updater.connect<&Acts::GainMatrixUpdater::operator()<
       typename ActsExamples::TrackContainer::TrackStateContainerBackend>>(&kfUpdater);
-#if Acts_VERSION_MAJOR < 39
-  extensions.measurementSelector.connect<&Acts::MeasurementSelector::select<
-      typename ActsExamples::TrackContainer::TrackStateContainerBackend>>(&measSel);
-#endif
 
   ActsExamples::IndexSourceLinkAccessor slAccessor;
-#if Acts_VERSION_MAJOR > 37 || (Acts_VERSION_MAJOR == 37 && Acts_VERSION_MINOR >= 1)
   slAccessor.container = &measurements->orderedIndices();
-#else
-  slAccessor.container = &src_links;
-#endif
-#if Acts_VERSION_MAJOR >= 39
   using TrackStateCreatorType =
       Acts::TrackStateCreator<ActsExamples::IndexSourceLinkAccessor::Iterator,
                               ActsExamples::TrackContainer>;
@@ -268,29 +205,13 @@ void CKFTracking::process(const Input& input, const Output& output) const {
 
   extensions.createTrackStates.template connect<&TrackStateCreatorType::createTrackStates>(
       &trackStateCreator);
-#else
-  Acts::SourceLinkAccessorDelegate<ActsExamples::IndexSourceLinkAccessor::Iterator>
-      slAccessorDelegate;
-  slAccessorDelegate.connect<&ActsExamples::IndexSourceLinkAccessor::range>(&slAccessor);
-#endif
 
   // Set the CombinatorialKalmanFilter options
-#if Acts_VERSION_MAJOR >= 39
   CKFTracking::TrackFinderOptions options(gctx, mctx, cctx, extensions, pOptions);
-#else
-  CKFTracking::TrackFinderOptions options(gctx, mctx, cctx, slAccessorDelegate, extensions,
-                                          pOptions);
-#endif
 
-  using Extrapolator = Acts::Propagator<Acts::EigenStepper<>, Acts::Navigator>;
-#if Acts_VERSION_MAJOR >= 37
+  using Extrapolator        = Acts::Propagator<Acts::EigenStepper<>, Acts::Navigator>;
   using ExtrapolatorOptions = Extrapolator::template Options<
       Acts::ActorList<Acts::MaterialInteractor, Acts::EndOfWorldReached>>;
-#else
-  using ExtrapolatorOptions =
-      Extrapolator::template Options<Acts::ActionList<Acts::MaterialInteractor>,
-                                     Acts::AbortList<Acts::EndOfWorldReached>>;
-#endif
   Extrapolator extrapolator(Acts::EigenStepper<>(m_BField),
                             Acts::Navigator({.trackingGeometry = m_geoSvc->trackingGeometry()},
                                             acts_logger().cloneWithSuffix("Navigator")),

--- a/src/algorithms/tracking/CKFTracking.h
+++ b/src/algorithms/tracking/CKFTracking.h
@@ -11,9 +11,6 @@
 #include <Acts/TrackFinding/MeasurementSelector.hpp>
 #include <Acts/Utilities/Logger.hpp>
 #include <Acts/Utilities/Result.hpp>
-#if Acts_VERSION_MAJOR < 39
-#include <ActsExamples/EventData/IndexSourceLink.hpp>
-#endif
 #include <ActsExamples/EventData/Track.hpp>
 #include <algorithms/algorithm.h>
 #include <edm4eic/Measurement2DCollection.h>
@@ -43,14 +40,8 @@ class CKFTracking : public CKFTrackingAlgorithm, public WithPodConfig<eicrecon::
 public:
   /// Track finder function that takes input measurements, initial trackstate
   /// and track finder options and returns some track-finder-specific result.
-#if Acts_VERSION_MAJOR >= 39
   using TrackFinderOptions = Acts::CombinatorialKalmanFilterOptions<ActsExamples::TrackContainer>;
-#else
-  using TrackFinderOptions =
-      Acts::CombinatorialKalmanFilterOptions<ActsExamples::IndexSourceLinkAccessor::Iterator,
-                                             ActsExamples::TrackContainer>;
-#endif
-  using TrackFinderResult = Acts::Result<std::vector<ActsExamples::TrackContainer::TrackProxy>>;
+  using TrackFinderResult  = Acts::Result<std::vector<ActsExamples::TrackContainer::TrackProxy>>;
 
   /// Find function that takes the above parameters
   /// @note This is separated into a virtual interface to keep compilation units

--- a/src/algorithms/tracking/SpacePoint.h
+++ b/src/algorithms/tracking/SpacePoint.h
@@ -1,10 +1,6 @@
 #pragma once
 
-#if Acts_VERSION_MAJOR >= 37
 #include <Acts/EventData/Seed.hpp>
-#else
-#include <Acts/Seeding/Seed.hpp>
-#endif
 #include <Acts/Geometry/GeometryIdentifier.hpp>
 #include <Acts/Surfaces/Surface.hpp>
 #include "ActsGeometryProvider.h"

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -13,12 +13,7 @@
 #include <Acts/Geometry/TrackingGeometry.hpp>
 #include <Acts/MagneticField/MagneticFieldProvider.hpp>
 #include <Acts/Material/MaterialInteraction.hpp>
-#if Acts_VERSION_MAJOR >= 37
 #include <Acts/Propagator/ActorList.hpp>
-#else
-#include <Acts/Propagator/AbortList.hpp>
-#include <Acts/Propagator/ActionList.hpp>
-#endif
 #include <Acts/Propagator/EigenStepper.hpp>
 #include <Acts/Propagator/MaterialInteractor.hpp>
 #include <Acts/Propagator/Navigator.hpp>
@@ -266,13 +261,8 @@ TrackPropagation::propagate(const edm4eic::Track& /* track */,
   const auto acts_level   = eicrecon::SpdlogToActsLevel(spdlog_level);
   ACTS_LOCAL_LOGGER(Acts::getDefaultLogger("PROP", acts_level));
 
-  using Propagator = Acts::Propagator<Acts::EigenStepper<>, Acts::Navigator>;
-#if Acts_VERSION_MAJOR >= 37
+  using Propagator        = Acts::Propagator<Acts::EigenStepper<>, Acts::Navigator>;
   using PropagatorOptions = Propagator::template Options<Acts::ActorList<Acts::MaterialInteractor>>;
-#else
-  using PropagatorOptions =
-      Propagator::template Options<Acts::ActionList<Acts::MaterialInteractor>>;
-#endif
   Propagator propagator(Acts::EigenStepper<>(magneticField),
                         Acts::Navigator({.trackingGeometry = m_geoSvc->trackingGeometry()},
                                         logger().cloneWithSuffix("Navigator")),

--- a/src/algorithms/tracking/TrackSeeding.h
+++ b/src/algorithms/tracking/TrackSeeding.h
@@ -3,21 +3,13 @@
 
 #pragma once
 
-#if Acts_VERSION_MAJOR >= 37
 #include <Acts/EventData/SpacePointContainer.hpp>
-#endif
-#if Acts_VERSION_MAJOR >= 37
 #include <Acts/EventData/Seed.hpp>
-#else
-#include <Acts/Seeding/Seed.hpp>
-#endif
 #include <Acts/Seeding/SeedFilterConfig.hpp>
 #include <Acts/Seeding/SeedFinderConfig.hpp>
 #include <Acts/Seeding/SeedFinderOrthogonalConfig.hpp>
 #include <Acts/Utilities/Holders.hpp>
-#if Acts_VERSION_MAJOR >= 37
 #include <ActsExamples/EventData/SpacePointContainer.hpp>
-#endif
 #include <algorithms/algorithm.h>
 #include <edm4eic/TrackParametersCollection.h>
 #include <edm4eic/TrackSeedCollection.h>
@@ -48,11 +40,9 @@ using TrackSeedingAlgorithm = algorithms::Algorithm<
 class TrackSeeding : public TrackSeedingAlgorithm,
                      public WithPodConfig<OrthogonalTrackSeedingConfig> {
 public:
-#if Acts_VERSION_MAJOR >= 37
   using proxy_type = typename Acts::SpacePointContainer<
       ActsExamples::SpacePointContainer<std::vector<const SpacePoint*>>,
       Acts::detail::RefHolder>::SpacePointProxyType;
-#endif
 
   TrackSeeding(std::string_view name)
       : TrackSeedingAlgorithm{name,
@@ -69,11 +59,7 @@ private:
 
   Acts::SeedFilterConfig m_seedFilterConfig;
   Acts::SeedFinderOptions m_seedFinderOptions;
-#if Acts_VERSION_MAJOR >= 37
   Acts::SeedFinderOrthogonalConfig<proxy_type> m_seedFinderConfig;
-#else
-  Acts::SeedFinderOrthogonalConfig<SpacePoint> m_seedFinderConfig;
-#endif
 
   static int determineCharge(std::vector<std::pair<float, float>>& positions,
                              const std::pair<float, float>& PCA,

--- a/src/services/geometry/acts/ACTSGeo_service.cc
+++ b/src/services/geometry/acts/ACTSGeo_service.cc
@@ -75,19 +75,11 @@ std::shared_ptr<const ActsGeometryProvider> ACTSGeo_service::actsGeoProvider() {
       m_acts_provider->setOutputTag(outputTag);
       m_acts_provider->setOutputDir(outputDir);
 
-#if Acts_VERSION_MAJOR >= 37
       std::array<int, 3> containerView = m_acts_provider->getContainerView().color.rgb;
       std::array<int, 3> volumeView    = m_acts_provider->getVolumeView().color.rgb;
       std::array<int, 3> sensitiveView = m_acts_provider->getSensitiveView().color.rgb;
       std::array<int, 3> passiveView   = m_acts_provider->getPassiveView().color.rgb;
       std::array<int, 3> gridView      = m_acts_provider->getGridView().color.rgb;
-#else
-            std::array<int,3> containerView = m_acts_provider->getContainerView().color;
-            std::array<int,3> volumeView = m_acts_provider->getVolumeView().color;
-            std::array<int,3> sensitiveView = m_acts_provider->getSensitiveView().color;
-            std::array<int,3> passiveView = m_acts_provider->getPassiveView().color;
-            std::array<int,3> gridView = m_acts_provider->getGridView().color;
-#endif
       m_app->SetDefaultParameter("acts:ContainerView", containerView, "RGB for container views");
       m_app->SetDefaultParameter("acts:VolumeView", volumeView, "RGB for volume views");
       m_app->SetDefaultParameter("acts:SensitiveView", sensitiveView, "RGB for sensitive views");


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR drops support for Acts < 39.2.0, which has been part of our standard environment since 25.08.0-stable (https://github.com/eic/EICrecon/issues/2258). We are already not supporting 25.08.0-stable or earlier due to the older podio version in those environment versions.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: tech debt)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.