### PR TITLE
fix: rm #if FMT_VERSION >= 90000 since fmt_VERSION_MIN is 9.0.0

### DIFF
--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -42,13 +42,11 @@
 #include "extensions/spdlog/SpdlogToActs.h"
 
 // Formatter for Eigen matrices
-#if FMT_VERSION >= 90000
 #include <Eigen/Core>
 
 template <typename T>
 struct fmt::formatter<T, std::enable_if_t<std::is_base_of_v<Eigen::MatrixBase<T>, T>, char>>
     : fmt::ostream_formatter {};
-#endif // FMT_VERSION >= 90000
 
 // Ensure ActsPlugins namespace is used when present
 #if __has_include(<ActsPlugins/DD4hep/ConvertDD4hepDetector.hpp>)

--- a/src/algorithms/tracking/TrackProjector.cc
+++ b/src/algorithms/tracking/TrackProjector.cc
@@ -33,9 +33,7 @@
 #include "algorithms/interfaces/ActsSvc.h"
 #include "extensions/spdlog/SpdlogFormatters.h" // IWYU pragma: keep
 
-#if FMT_VERSION >= 90000
 template <> struct fmt::formatter<Acts::GeometryIdentifier> : fmt::ostream_formatter {};
-#endif // FMT_VERSION >= 90000
 
 namespace eicrecon {
 

--- a/src/extensions/spdlog/SpdlogFormatters.h
+++ b/src/extensions/spdlog/SpdlogFormatters.h
@@ -15,13 +15,9 @@
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/Vector3d.h>
 
-#if FMT_VERSION >= 90000
-
 template <> struct fmt::formatter<edm4eic::Cov2f> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<edm4eic::Cov3f> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<edm4hep::Vector3f> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<edm4hep::Vector3d> : fmt::ostream_formatter {};
 
 template <> struct fmt::formatter<std::error_code> : fmt::ostream_formatter {};
-
-#endif // FMT_VERSION >= 90000


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes always-satisfied `#if FMT_VERSION >= 90000` since we require this with `fmt_VERSION_MIN` equal to 9.0.0.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: tech debt)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.