### PR TITLE
fix: avoid deprecated ActsVector, ActsSquareMatrix

### DIFF
--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -12,19 +12,18 @@
 #include <Acts/EventData/MeasurementHelpers.hpp>
 #include <Acts/EventData/TrackStatePropMask.hpp>
 #include <Acts/Geometry/GeometryHierarchyMap.hpp>
+#include <Acts/TrackFinding/CombinatorialKalmanFilterExtensions.hpp>
 #include <spdlog/common.h>
 #include <algorithm>
 #include <any>
 #include <array>
 #include <cstddef>
 #include <functional>
-#include <gsl/pointers>
 #include <stdexcept>
 #include <string>
 #include <system_error>
 #include <tuple>
 #include <utility>
-#include <Acts/TrackFinding/CombinatorialKalmanFilterExtensions.hpp>
 #if Acts_VERSION_MAJOR < 43
 #include <Acts/Utilities/Iterator.hpp>
 #endif


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Needs:
- [x] #2503 

In https://github.com/acts-project/acts/pull/5072, released in v45.1.0, the Acts::BoundSquareMatrix type is deprecated. In https://github.com/acts-project/acts/pull/5073, released in Acts v45.2.0, the Acts::ActsVector and Acts::Acts*Matrix types are deprecated. This PR adapts our code to this.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: tech debt)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.