### PR TITLE
fix: adapt to Acts one charge hypothesis

### DIFF
--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -16,19 +16,18 @@
 #include <Acts/EventData/MeasurementHelpers.hpp>
 #include <Acts/EventData/TrackStatePropMask.hpp>
 #include <Acts/Geometry/GeometryHierarchyMap.hpp>
+#include <Acts/TrackFinding/CombinatorialKalmanFilterExtensions.hpp>
 #include <spdlog/common.h>
 #include <algorithm>
 #include <any>
 #include <array>
 #include <cstddef>
 #include <functional>
-#include <gsl/pointers>
 #include <stdexcept>
 #include <string>
 #include <system_error>
 #include <tuple>
 #include <utility>
-#include <Acts/TrackFinding/CombinatorialKalmanFilterExtensions.hpp>
 #if Acts_VERSION_MAJOR < 43
 #include <Acts/Utilities/Iterator.hpp>
 #endif

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -11,7 +11,6 @@
 #else
 #include <Acts/EventData/TrackParameters.hpp>
 #endif
-#include <Acts/EventData/TrackContainer.hpp>
 #include <Acts/EventData/TrackProxy.hpp>
 #include <Acts/Propagator/EigenStepper.hpp>
 #include <Acts/Propagator/Propagator.hpp>
@@ -40,10 +39,9 @@
 #include <edm4hep/Vector4f.h>
 #include <podio/RelationRange.h>
 #include <spdlog/common.h>
-#include <Eigen/Core>
 #include <cmath>
-#include <gsl/pointers>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -9,6 +9,7 @@
 #if Acts_VERSION_MAJOR > 45
 #include <Acts/EventData/BoundTrackParameters.hpp>
 #else
+#include <Acts/EventData/GenericBoundTrackParameters.hpp>
 #include <Acts/EventData/TrackParameters.hpp>
 #endif
 #include <Acts/EventData/MultiTrajectoryHelpers.hpp>
@@ -34,6 +35,7 @@
 #include <edm4eic/Cov3f.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
+#include <spdlog/common.h>
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <algorithm>
@@ -43,7 +45,6 @@
 #include <iterator>
 #include <map>
 #include <optional>
-#include <spdlog/common.h>
 #include <stdexcept>
 #include <string>
 #include <tuple>

--- a/src/algorithms/tracking/TrackPropagation.h
+++ b/src/algorithms/tracking/TrackPropagation.h
@@ -8,7 +8,6 @@
 #else
 #include <Acts/EventData/TrackParameters.hpp>
 #endif
-#include <Acts/EventData/TrackContainer.hpp>
 #include <Acts/EventData/TrackProxy.hpp>
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
 #include <Acts/EventData/VectorTrackContainer.hpp>
@@ -27,6 +26,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <tuple>
 #include <vector>
 
 #include "algorithms/interfaces/ActsSvc.h"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adapts to https://github.com/acts-project/acts/pull/5076, which removes the multiple charge hypothesis types and moves some headers around.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: tech debt)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.