### PR TITLE
feat: support free surfaces in Acts v45+

### DIFF
--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -178,7 +178,13 @@ void ActsGeometryProvider::initialize(const dd4hep::Detector* dd4hep_geo, std::s
 #endif
 
       if (det_element == nullptr) {
-        m_init_log->error("invalid det_element!!! det_element == nullptr ");
+        if (surface->geometryId().value() != 0) {
+          m_init_log->debug("Free surface with geometry ID: {}", surface->geometryId().value());
+          // Store free surface using geometry ID
+          this->m_surfaces.insert_or_assign(surface->geometryId().value(), surface);
+        } else {
+          m_init_log->debug("Skipping free surface without geometry ID");
+        }
         return;
       }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
In Acts v45 surfaces can exist without connection to a detector element (e.g. effective surfaces inside calorimeters). This PR aims to support these surfaces. This functionality is currently unused.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: support free surfaces)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.