### PR TITLE
hotfix: rename to PFRICH

### DIFF
--- a/src/detectors/PFRICH/PFRICH.cc
+++ b/src/detectors/PFRICH/PFRICH.cc
@@ -50,7 +50,7 @@ void InitPlugin(JApplication* app) {
 
   // digitization
   app->Add(new JOmniFactoryGeneratorT<PhotoMultiplierHitDigi_factory>(
-      "RICHEndcapNRawHits", {"EventHeader", "RICHEndcapNHits"},
+      "RICHEndcapNRawHits", {"EventHeader", "PFRICHHits"},
       {"RICHEndcapNRawHits",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
        "RICHEndcapNRawHitsLinks",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The [PFRICH was renamed](https://github.com/eic/epic/pull/1040) and caused issues in the initialization of the RichGeo_service which was still expecting the old name, leading to hangs during multi-threaded running, e.g. https://github.com/eic/EICrecon/actions/runs/22216845564/job/64266690591

Resiliency of the RichGeo_service is not a priority since we switch to IRT2 which passes all geometry info via DD4hep.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/EICrecon/actions/runs/22216845564/job/64266690591)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.