### PR TITLE
SimCalorimeterHitProcessor: swallow exception when attenuationReferencePosition value is not available

### DIFF
--- a/src/algorithms/calorimetry/SimCalorimeterHitProcessor.cc
+++ b/src/algorithms/calorimetry/SimCalorimeterHitProcessor.cc
@@ -23,6 +23,7 @@
 #include <stdexcept>
 #include <tuple>
 #include <unordered_map>
+#include <utility>
 #include <variant>
 #include <vector>
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Resolves: #2516
This prevents JANA2 from repeatedly trying to init the factory with printing of a huge std::exception::what() value.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No