### PR TITLE
fix: adjust tracking time unit conversion from ACTS internal units to ns

### DIFF
--- a/src/algorithms/tracking/ActsToTracks.cc
+++ b/src/algorithms/tracking/ActsToTracks.cc
@@ -122,7 +122,7 @@ void ActsToTracks::process(const Input& input, const Output& output) const {
     pars.setTheta(static_cast<float>(parameter[Acts::eBoundTheta]));
     pars.setPhi(static_cast<float>(parameter[Acts::eBoundPhi]));
     pars.setQOverP(static_cast<float>(parameter[Acts::eBoundQOverP]));
-    pars.setTime(static_cast<float>(parameter[Acts::eBoundTime]));
+    pars.setTime(static_cast<float>(parameter[Acts::eBoundTime] / Acts::UnitConstants::ns));
     edm4eic::Cov6f cov;
     for (std::size_t i = 0; const auto& [a, x] : edm4eic_indexed_units) {
       for (std::size_t j = 0; const auto& [b, y] : edm4eic_indexed_units) {
@@ -147,9 +147,10 @@ void ActsToTracks::process(const Input& input, const Output& output) const {
     track_out.setPositionMomentumCovariance( // Covariance matrix in basis [x,y,z,px,py,pz]
         edm4eic::Cov6f());
     track_out.setTime( // Track time at the vertex [ns]
-        static_cast<float>(parameter[Acts::eBoundTime]));
+        static_cast<float>(parameter[Acts::eBoundTime] / Acts::UnitConstants::ns));
     track_out.setTimeError( // Error on the track vertex time
-        sqrt(static_cast<float>(covariance(Acts::eBoundTime, Acts::eBoundTime))));
+        static_cast<float>(sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)) /
+                           Acts::UnitConstants::ns));
     track_out.setCharge( // Particle charge
         std::copysign(1., parameter[Acts::eBoundQOverP]));
     track_out.setChi2(trajectoryState.chi2Sum); // Total chi2

--- a/src/algorithms/tracking/ActsToTracks.cc
+++ b/src/algorithms/tracking/ActsToTracks.cc
@@ -2,11 +2,11 @@
 // Copyright (C) 2024 - 2025 Whitney Armstrong, Wouter Deconinck, Dmitry Romanov, Shujie Li, Dmitry Kalinkin
 
 #include <Acts/Definitions/TrackParametrization.hpp>
+#include <Acts/Definitions/Units.hpp>
 #include <Acts/EventData/MultiTrajectoryHelpers.hpp>
 #include <Acts/EventData/ParticleHypothesis.hpp>
 #include <Acts/EventData/ProxyAccessor.hpp>
 #include <Acts/EventData/SourceLink.hpp>
-#include <Acts/EventData/TrackContainer.hpp>
 #include <Acts/EventData/TrackProxy.hpp>
 #include <Acts/EventData/TrackStateType.hpp>
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
@@ -26,15 +26,15 @@
 #include <podio/RelationRange.h>
 #include <podio/detail/Link.h>
 #include <podio/detail/LinkCollectionImpl.h>
-#include <Eigen/Core>
 #include <any>
 #include <array>
 #include <cmath>
 #include <cstddef>
-#include <gsl/pointers>
 #include <map>
 #include <memory>
 #include <numeric>
+#include <tuple>
+#include <utility>
 #include <vector>
 
 #include "ActsToTracks.h"

--- a/src/algorithms/tracking/ActsToTracks.cc
+++ b/src/algorithms/tracking/ActsToTracks.cc
@@ -3,6 +3,7 @@
 
 #include <Acts/Definitions/Algebra.hpp>
 #include <Acts/Definitions/TrackParametrization.hpp>
+#include <Acts/Definitions/Units.hpp>
 #include <Acts/EventData/MultiTrajectoryHelpers.hpp>
 #include <Acts/EventData/ParticleHypothesis.hpp>
 #include <Acts/EventData/ProxyAccessor.hpp>

--- a/src/algorithms/tracking/ActsToTracks.cc
+++ b/src/algorithms/tracking/ActsToTracks.cc
@@ -119,7 +119,7 @@ void ActsToTracks::process(const Input& input, const Output& output) const {
     pars.setTheta(static_cast<float>(parameter[Acts::eBoundTheta]));
     pars.setPhi(static_cast<float>(parameter[Acts::eBoundPhi]));
     pars.setQOverP(static_cast<float>(parameter[Acts::eBoundQOverP]));
-    pars.setTime(static_cast<float>(parameter[Acts::eBoundTime]));
+    pars.setTime(static_cast<float>(parameter[Acts::eBoundTime] / Acts::UnitConstants::ns));
     edm4eic::Cov6f cov;
     for (std::size_t i = 0; const auto& [a, x] : edm4eic_indexed_units) {
       for (std::size_t j = 0; const auto& [b, y] : edm4eic_indexed_units) {
@@ -172,10 +172,11 @@ void ActsToTracks::process(const Input& input, const Output& output) const {
 
     track_out.setPositionMomentumCovariance( // Covariance matrix in basis [x,y,z,px,py,pz]
         edm4eic::Cov6f());
-    track_out.setTime( // Track time at the perigee [ns]
-        static_cast<float>(parameter[Acts::eBoundTime]));
-    track_out.setTimeError( // Error on the track perigee time
-        sqrt(static_cast<float>(covariance(Acts::eBoundTime, Acts::eBoundTime))));
+    track_out.setTime( // Track time at the vertex [ns]
+        static_cast<float>(parameter[Acts::eBoundTime] / Acts::UnitConstants::ns));
+    track_out.setTimeError( // Error on the track vertex time
+        static_cast<float>(sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)) /
+                           Acts::UnitConstants::ns));
     const double charge = // Particle charge (0 if qOverP is invalid or zero)
         (std::isfinite(qOverP) && qOverP != 0.0) ? std::copysign(1.0, qOverP) : 0.0;
     track_out.setCharge(charge);

--- a/src/algorithms/tracking/ActsToTracks.cc
+++ b/src/algorithms/tracking/ActsToTracks.cc
@@ -176,8 +176,8 @@ void ActsToTracks::process(const Input& input, const Output& output) const {
     track_out.setTime( // Track time at the perigee [ns]
         static_cast<float>(parameter[Acts::eBoundTime] / Acts::UnitConstants::ns));
     track_out.setTimeError( // Error on the track perigee time
-        static_cast<float>(sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)) /
-                           Acts::UnitConstants::ns));
+        static_cast<float>(sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime))) /
+        Acts::UnitConstants::ns);
     const double charge = // Particle charge (0 if qOverP is invalid or zero)
         (std::isfinite(qOverP) && qOverP != 0.0) ? std::copysign(1.0, qOverP) : 0.0;
     track_out.setCharge(charge);

--- a/src/algorithms/tracking/ActsToTracks.cc
+++ b/src/algorithms/tracking/ActsToTracks.cc
@@ -115,11 +115,11 @@ void ActsToTracks::process(const Input& input, const Output& output) const {
 
     auto pars = track_parameters->create();
     pars.setType(0); // type: track head --> 0
-    pars.setLoc({static_cast<float>(parameter[Acts::eBoundLoc0]),
-                 static_cast<float>(parameter[Acts::eBoundLoc1])});
-    pars.setTheta(static_cast<float>(parameter[Acts::eBoundTheta]));
-    pars.setPhi(static_cast<float>(parameter[Acts::eBoundPhi]));
-    pars.setQOverP(static_cast<float>(parameter[Acts::eBoundQOverP]));
+    pars.setLoc({static_cast<float>(parameter[Acts::eBoundLoc0] / Acts::UnitConstants::mm),
+                 static_cast<float>(parameter[Acts::eBoundLoc1] / Acts::UnitConstants::mm)});
+    pars.setTheta(static_cast<float>(parameter[Acts::eBoundTheta] / Acts::UnitConstants::rad));
+    pars.setPhi(static_cast<float>(parameter[Acts::eBoundPhi] / Acts::UnitConstants::rad));
+    pars.setQOverP(static_cast<float>(parameter[Acts::eBoundQOverP] * Acts::UnitConstants::GeV));
     pars.setTime(static_cast<float>(parameter[Acts::eBoundTime] / Acts::UnitConstants::ns));
     edm4eic::Cov6f cov;
     for (std::size_t i = 0; const auto& [a, x] : edm4eic_indexed_units) {

--- a/src/algorithms/tracking/ActsToTracks.cc
+++ b/src/algorithms/tracking/ActsToTracks.cc
@@ -173,9 +173,9 @@ void ActsToTracks::process(const Input& input, const Output& output) const {
 
     track_out.setPositionMomentumCovariance( // Covariance matrix in basis [x,y,z,px,py,pz]
         edm4eic::Cov6f());
-    track_out.setTime( // Track time at the vertex [ns]
+    track_out.setTime( // Track time at the perigee [ns]
         static_cast<float>(parameter[Acts::eBoundTime] / Acts::UnitConstants::ns));
-    track_out.setTimeError( // Error on the track vertex time
+    track_out.setTimeError( // Error on the track perigee time
         static_cast<float>(sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)) /
                            Acts::UnitConstants::ns));
     const double charge = // Particle charge (0 if qOverP is invalid or zero)

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -142,9 +142,9 @@ void eicrecon::IterativeVertexFinder::process(const Input& input, const Output& 
   }
 
   for (const auto& vtx : vertices) {
-    static constexpr float mm_to_mm =
+    static constexpr auto mm_to_mm =
         static_cast<float>(edm4eic::unit::mm / Acts::UnitConstants::mm);
-    static constexpr float ns_to_ns =
+    static constexpr auto ns_to_ns =
         static_cast<float>(edm4eic::unit::ns / Acts::UnitConstants::ns);
     static constexpr float mm2_to_mm2     = mm_to_mm * mm_to_mm;
     static constexpr float ns2_to_ns2     = ns_to_ns * ns_to_ns;

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -146,13 +146,9 @@ void eicrecon::IterativeVertexFinder::process(const Input& input, const Output& 
         static_cast<float>(edm4eic::unit::mm / Acts::UnitConstants::mm);
     static constexpr float ns_to_ns =
         static_cast<float>(edm4eic::unit::ns / Acts::UnitConstants::ns);
-    static constexpr float mm2_to_mm2 =
-        static_cast<float>(std::pow(edm4eic::unit::mm / Acts::UnitConstants::mm, 2));
-    static constexpr float ns2_to_ns2 =
-        static_cast<float>(std::pow(edm4eic::unit::ns / Acts::UnitConstants::ns, 2));
-    static constexpr float mm_ns_to_mm_ns =
-        static_cast<float>((edm4eic::unit::mm / Acts::UnitConstants::mm) *
-                           (edm4eic::unit::ns / Acts::UnitConstants::ns));
+    static constexpr float mm2_to_mm2     = mm_to_mm * mm_to_mm;
+    static constexpr float ns2_to_ns2     = ns_to_ns * ns_to_ns;
+    static constexpr float mm_ns_to_mm_ns = mm_to_mm * ns_to_ns;
     edm4eic::Cov4f cov(
         vtx.fullCovariance()(0, 0) * mm2_to_mm2, vtx.fullCovariance()(1, 1) * mm2_to_mm2,
         vtx.fullCovariance()(2, 2) * mm2_to_mm2, vtx.fullCovariance()(3, 3) * ns2_to_ns2,

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -142,20 +142,32 @@ void eicrecon::IterativeVertexFinder::process(const Input& input, const Output& 
   }
 
   for (const auto& vtx : vertices) {
-    edm4eic::Cov4f cov(vtx.fullCovariance()(0, 0), vtx.fullCovariance()(1, 1),
-                       vtx.fullCovariance()(2, 2), vtx.fullCovariance()(3, 3),
-                       vtx.fullCovariance()(0, 1), vtx.fullCovariance()(0, 2),
-                       vtx.fullCovariance()(0, 3), vtx.fullCovariance()(1, 2),
-                       vtx.fullCovariance()(1, 3), vtx.fullCovariance()(2, 3));
+    static constexpr float mm_to_mm =
+        static_cast<float>(edm4eic::unit::mm / Acts::UnitConstants::mm);
+    static constexpr float ns_to_ns =
+        static_cast<float>(edm4eic::unit::ns / Acts::UnitConstants::ns);
+    static constexpr float mm2_to_mm2 =
+        static_cast<float>(std::pow(edm4eic::unit::mm / Acts::UnitConstants::mm, 2));
+    static constexpr float ns2_to_ns2 =
+        static_cast<float>(std::pow(edm4eic::unit::ns / Acts::UnitConstants::ns, 2));
+    static constexpr float mm_ns_to_mm_ns =
+        static_cast<float>((edm4eic::unit::mm / Acts::UnitConstants::mm) *
+                           (edm4eic::unit::ns / Acts::UnitConstants::ns));
+    edm4eic::Cov4f cov(
+        vtx.fullCovariance()(0, 0) * mm2_to_mm2, vtx.fullCovariance()(1, 1) * mm2_to_mm2,
+        vtx.fullCovariance()(2, 2) * mm2_to_mm2, vtx.fullCovariance()(3, 3) * ns2_to_ns2,
+        vtx.fullCovariance()(0, 1) * mm2_to_mm2, vtx.fullCovariance()(0, 2) * mm2_to_mm2,
+        vtx.fullCovariance()(0, 3) * mm_ns_to_mm_ns, vtx.fullCovariance()(1, 2) * mm2_to_mm2,
+        vtx.fullCovariance()(1, 3) * mm_ns_to_mm_ns, vtx.fullCovariance()(2, 3) * mm_ns_to_mm_ns);
     auto eicvertex = outputVertices->create();
     eicvertex.setType(1); // boolean flag if vertex is primary vertex of event
     eicvertex.setChi2((float)vtx.fitQuality().first); // chi2
     eicvertex.setNdf((float)vtx.fitQuality().second); // ndf
     eicvertex.setPosition({
-        (float)vtx.position().x(),
-        (float)vtx.position().y(),
-        (float)vtx.position().z(),
-        (float)vtx.time(),
+        static_cast<float>(vtx.position().x() * mm_to_mm),
+        static_cast<float>(vtx.position().y() * mm_to_mm),
+        static_cast<float>(vtx.position().z() * mm_to_mm),
+        static_cast<float>(vtx.time() * ns_to_ns),
     });                              // vtxposition
     eicvertex.setPositionError(cov); // covariance
 

--- a/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
+++ b/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
@@ -94,6 +94,6 @@ struct OrthogonalTrackSeedingConfig {
   float phiError    = 0.02 * Acts::UnitConstants::rad;  //Error on phi
   float thetaError  = 0.002 * Acts::UnitConstants::rad; //Error on theta
   float qOverPError = 0.025 / Acts::UnitConstants::GeV; //Error on q over p
-  float timeError   = 1.0 * Acts::UnitConstants::ns;    // Error on time
+  float timeError   = 1.0 * Acts::UnitConstants::ns;    //Error on time
 };
 } // namespace eicrecon

--- a/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
+++ b/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
@@ -94,7 +94,8 @@ struct OrthogonalTrackSeedingConfig {
   float phiError    = 0.02 * Acts::UnitConstants::rad;  //Error on phi
   float thetaError  = 0.002 * Acts::UnitConstants::rad; //Error on theta
   float qOverPError = 0.025 / Acts::UnitConstants::GeV; //Error on q over p
-  float timeError   = 0.1 * Acts::UnitConstants::mm;    //Error on time
-  // Note: Acts native time units are mm: https://acts.readthedocs.io/en/latest/core/definitions/units.html
+  // Time variance in (mm/c)^2 (Acts native time units).
+  // Acts::UnitConstants::ns = 299.792 mm/c, so 1 ns^2 = Acts::UnitConstants::ns^2.
+  float timeError = Acts::UnitConstants::ns * Acts::UnitConstants::ns; // sigma_t = 1 ns
 };
 } // namespace eicrecon

--- a/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
+++ b/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
@@ -94,6 +94,6 @@ struct OrthogonalTrackSeedingConfig {
   float phiError    = 0.02 * Acts::UnitConstants::rad;  //Error on phi
   float thetaError  = 0.002 * Acts::UnitConstants::rad; //Error on theta
   float qOverPError = 0.025 / Acts::UnitConstants::GeV; //Error on q over p
-  float timeError = 1.0 * Acts::UnitConstants::ns;    // Error on time
+  float timeError   = 1.0 * Acts::UnitConstants::ns;    // Error on time
 };
 } // namespace eicrecon

--- a/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
+++ b/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
@@ -94,8 +94,6 @@ struct OrthogonalTrackSeedingConfig {
   float phiError    = 0.02 * Acts::UnitConstants::rad;  //Error on phi
   float thetaError  = 0.002 * Acts::UnitConstants::rad; //Error on theta
   float qOverPError = 0.025 / Acts::UnitConstants::GeV; //Error on q over p
-  // Time variance in (mm/c)^2 (Acts native time units).
-  // Acts::UnitConstants::ns = 299.792 mm/c, so 1 ns^2 = Acts::UnitConstants::ns^2.
-  float timeError = Acts::UnitConstants::ns * Acts::UnitConstants::ns; // sigma_t = 1 ns
+  float timeError = 1.0 * Acts::UnitConstants::ns;    // Error on time
 };
 } // namespace eicrecon

--- a/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
+++ b/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
@@ -89,11 +89,15 @@ struct OrthogonalTrackSeedingConfig {
 
   //////////////////////////////////////
   ///Seed Covariance Error Matrix
-  float locaError   = 1.5 * Acts::UnitConstants::mm;    //Error on Loc a
-  float locbError   = 1.5 * Acts::UnitConstants::mm;    //Error on Loc b
-  float phiError    = 0.02 * Acts::UnitConstants::rad;  //Error on phi
-  float thetaError  = 0.002 * Acts::UnitConstants::rad; //Error on theta
-  float qOverPError = 0.025 / Acts::UnitConstants::GeV; //Error on q over p
-  float timeError   = 1.0 * Acts::UnitConstants::ns;    //Error on time
+  float locaError   = std::sqrt(1.5) * Acts::UnitConstants::mm;    //Error on Loc a
+  float locbError   = std::sqrt(1.5) * Acts::UnitConstants::mm;    //Error on Loc b
+  float phiError    = std::sqrt(0.02) * Acts::UnitConstants::rad;  //Error on phi
+  float thetaError  = std::sqrt(0.002) * Acts::UnitConstants::rad; //Error on theta
+  float qOverPError = std::sqrt(0.025) / Acts::UnitConstants::GeV; //Error on q over p
+  float timeError   = std::sqrt(0.1 * Acts::UnitConstants::mm / Acts::UnitConstants::ns) *
+                      Acts::UnitConstants::ns; //Error on time
+  // FIXME timeError is currently set to 0.0183 ns in these units since:
+  // Acts::UnitConstants::mm = 1
+  // Acts::UnitConstants::ns = 299.792458
 };
 } // namespace eicrecon

--- a/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
+++ b/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
@@ -97,7 +97,7 @@ struct OrthogonalTrackSeedingConfig {
   float qOverPError = std::sqrt(0.025) / Acts::UnitConstants::GeV; //Error on q over p
   float timeError   = std::sqrt(0.1 * Acts::UnitConstants::mm / Acts::UnitConstants::ns) *
                       Acts::UnitConstants::ns; //Error on time
-  // FIXME timeError is currently set to 0.0183 ns in these units since:
+  // FIXME timeError is currently set to 0.0183 = 5.5 ns in these units since:
   // Acts::UnitConstants::mm = 1
   // Acts::UnitConstants::ns = 299.792458
 };

--- a/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
+++ b/src/algorithms/tracking/OrthogonalTrackSeedingConfig.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <cstddef>
 
 #include <Acts/Definitions/Units.hpp>

--- a/src/algorithms/tracking/TrackProjector.cc
+++ b/src/algorithms/tracking/TrackProjector.cc
@@ -4,7 +4,6 @@
 #include <Acts/Definitions/TrackParametrization.hpp>
 #include <Acts/Definitions/Units.hpp>
 #include <Acts/EventData/MultiTrajectoryHelpers.hpp>
-#include <Acts/EventData/TrackContainer.hpp>
 #include <Acts/EventData/TrackProxy.hpp>
 #include <Acts/EventData/TransformationHelpers.hpp>
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
@@ -28,7 +27,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
-#include <gsl/pointers>
+#include <tuple>
 
 #include "TrackProjector.h"
 #include "algorithms/interfaces/ActsSvc.h"

--- a/src/algorithms/tracking/TrackProjector.cc
+++ b/src/algorithms/tracking/TrackProjector.cc
@@ -2,6 +2,7 @@
 // Copyright (C) 2022 - 2025 wfan, Whitney Armstrong, Sylvester Joosten, Dmitry Kalinkin
 
 #include <Acts/Definitions/TrackParametrization.hpp>
+#include <Acts/Definitions/Units.hpp>
 #include <Acts/EventData/MultiTrajectoryHelpers.hpp>
 #include <Acts/EventData/TrackContainer.hpp>
 #include <Acts/EventData/TrackProxy.hpp>
@@ -141,8 +142,9 @@ void TrackProjector::process(const Input& input, const Output& output) const {
           static_cast<float>(boundCov(Acts::eBoundTheta, Acts::eBoundPhi)),
           static_cast<float>(boundCov(Acts::eBoundTheta, Acts::eBoundQOverP)),
           static_cast<float>(boundCov(Acts::eBoundPhi, Acts::eBoundQOverP))};
-      const float time{static_cast<float>(boundParams(Acts::eBoundTime))};
-      const float timeError{static_cast<float>(sqrt(boundCov(Acts::eBoundTime, Acts::eBoundTime)))};
+      const float time{static_cast<float>(boundParams(Acts::eBoundTime) / Acts::UnitConstants::ns)};
+      const float timeError{static_cast<float>(sqrt(boundCov(Acts::eBoundTime, Acts::eBoundTime)) /
+                                               Acts::UnitConstants::ns)};
       const float theta(boundParams[Acts::eBoundTheta]);
       const float phi(boundParams[Acts::eBoundPhi]);
       const decltype(edm4eic::TrackPoint::directionError) directionError{

--- a/src/algorithms/tracking/TrackProjector.cc
+++ b/src/algorithms/tracking/TrackProjector.cc
@@ -142,8 +142,8 @@ void TrackProjector::process(const Input& input, const Output& output) const {
           static_cast<float>(boundCov(Acts::eBoundTheta, Acts::eBoundQOverP)),
           static_cast<float>(boundCov(Acts::eBoundPhi, Acts::eBoundQOverP))};
       const float time{static_cast<float>(boundParams(Acts::eBoundTime) / Acts::UnitConstants::ns)};
-      const float timeError{static_cast<float>(sqrt(boundCov(Acts::eBoundTime, Acts::eBoundTime)) /
-                                               Acts::UnitConstants::ns)};
+      const float timeError{static_cast<float>(sqrt(boundCov(Acts::eBoundTime, Acts::eBoundTime))) /
+                            Acts::UnitConstants::ns};
       const float theta(boundParams[Acts::eBoundTheta]);
       const float phi(boundParams[Acts::eBoundPhi]);
       const decltype(edm4eic::TrackPoint::directionError) directionError{

--- a/src/algorithms/tracking/TrackProjector.cc
+++ b/src/algorithms/tracking/TrackProjector.cc
@@ -142,8 +142,8 @@ void TrackProjector::process(const Input& input, const Output& output) const {
           static_cast<float>(boundCov(Acts::eBoundTheta, Acts::eBoundQOverP)),
           static_cast<float>(boundCov(Acts::eBoundPhi, Acts::eBoundQOverP))};
       const float time{static_cast<float>(boundParams(Acts::eBoundTime) / Acts::UnitConstants::ns)};
-      const float timeError{static_cast<float>(sqrt(boundCov(Acts::eBoundTime, Acts::eBoundTime))) /
-                            Acts::UnitConstants::ns};
+      const float timeError{static_cast<float>(sqrt(boundCov(Acts::eBoundTime, Acts::eBoundTime)) /
+                                               Acts::UnitConstants::ns)};
       const float theta(boundParams[Acts::eBoundTheta]);
       const float phi(boundParams[Acts::eBoundPhi]);
       const decltype(edm4eic::TrackPoint::directionError) directionError{

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -317,8 +317,9 @@ TrackPropagation::propagate(const edm4eic::Track& /* track */,
       static_cast<float>(covariance(Acts::eBoundPhi, Acts::eBoundQOverP))};
 
   // time
-  const float time{static_cast<float>(parameter(Acts::eBoundTime))};
-  const float timeError{static_cast<float>(sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)))};
+  const float time{static_cast<float>(parameter(Acts::eBoundTime) / Acts::UnitConstants::ns)};
+  const float timeError{static_cast<float>(sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)) /
+                                           Acts::UnitConstants::ns)};
 
   // Direction
   const float theta(parameter[Acts::eBoundTheta]);

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -350,8 +350,8 @@ TrackPropagation::propagate(const edm4eic::Track& /* track */,
 
   // time
   const float time{static_cast<float>(parameter(Acts::eBoundTime) / Acts::UnitConstants::ns)};
-  const float timeError{static_cast<float>(sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)) /
-                                           Acts::UnitConstants::ns)};
+  const float timeError{static_cast<float>(sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime))) /
+                        Acts::UnitConstants::ns};
 
   // Direction
   const float theta(parameter[Acts::eBoundTheta]);

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -343,8 +343,9 @@ TrackPropagation::propagate(const edm4eic::Track& /* track */,
       static_cast<float>(covariance(Acts::eBoundPhi, Acts::eBoundQOverP))};
 
   // time
-  const float time{static_cast<float>(parameter(Acts::eBoundTime))};
-  const float timeError{static_cast<float>(sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)))};
+  const float time{static_cast<float>(parameter(Acts::eBoundTime) / Acts::UnitConstants::ns)};
+  const float timeError{static_cast<float>(sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)) /
+                                           Acts::UnitConstants::ns)};
 
   // Direction
   const float theta(parameter[Acts::eBoundTheta]);

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -350,8 +350,8 @@ TrackPropagation::propagate(const edm4eic::Track& /* track */,
 
   // time
   const float time{static_cast<float>(parameter(Acts::eBoundTime) / Acts::UnitConstants::ns)};
-  const float timeError{static_cast<float>(sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime))) /
-                        Acts::UnitConstants::ns};
+  const float timeError{static_cast<float>(sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)) /
+                                           Acts::UnitConstants::ns)};
 
   // Direction
   const float theta(parameter[Acts::eBoundTheta]);

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -331,16 +331,22 @@ TrackPropagation::propagate(const edm4eic::Track& /* track */,
 
   // Momentum
   const decltype(edm4eic::TrackPoint::momentum) momentum = edm4hep::utils::sphericalToVector(
-      static_cast<float>(1.0 / std::abs(parameter[Acts::eBoundQOverP])),
-      static_cast<float>(parameter[Acts::eBoundTheta]),
-      static_cast<float>(parameter[Acts::eBoundPhi]));
+      static_cast<float>(1.0 / std::abs(parameter[Acts::eBoundQOverP] * Acts::UnitConstants::GeV)),
+      static_cast<float>(parameter[Acts::eBoundTheta] / Acts::UnitConstants::rad),
+      static_cast<float>(parameter[Acts::eBoundPhi] / Acts::UnitConstants::rad));
   const decltype(edm4eic::TrackPoint::momentumError) momentumError{
-      static_cast<float>(covariance(Acts::eBoundTheta, Acts::eBoundTheta)),
-      static_cast<float>(covariance(Acts::eBoundPhi, Acts::eBoundPhi)),
-      static_cast<float>(covariance(Acts::eBoundQOverP, Acts::eBoundQOverP)),
-      static_cast<float>(covariance(Acts::eBoundTheta, Acts::eBoundPhi)),
-      static_cast<float>(covariance(Acts::eBoundTheta, Acts::eBoundQOverP)),
-      static_cast<float>(covariance(Acts::eBoundPhi, Acts::eBoundQOverP))};
+      static_cast<float>(covariance(Acts::eBoundTheta, Acts::eBoundTheta) /
+                         Acts::UnitConstants::rad / Acts::UnitConstants::rad),
+      static_cast<float>(covariance(Acts::eBoundPhi, Acts::eBoundPhi) / Acts::UnitConstants::rad /
+                         Acts::UnitConstants::rad),
+      static_cast<float>(covariance(Acts::eBoundQOverP, Acts::eBoundQOverP) *
+                         Acts::UnitConstants::GeV * Acts::UnitConstants::GeV),
+      static_cast<float>(covariance(Acts::eBoundTheta, Acts::eBoundPhi) / Acts::UnitConstants::rad /
+                         Acts::UnitConstants::rad),
+      static_cast<float>(covariance(Acts::eBoundTheta, Acts::eBoundQOverP) /
+                         Acts::UnitConstants::rad * Acts::UnitConstants::GeV),
+      static_cast<float>(covariance(Acts::eBoundPhi, Acts::eBoundQOverP) /
+                         Acts::UnitConstants::rad * Acts::UnitConstants::GeV)};
 
   // time
   const float time{static_cast<float>(parameter(Acts::eBoundTime) / Acts::UnitConstants::ns)};
@@ -351,24 +357,36 @@ TrackPropagation::propagate(const edm4eic::Track& /* track */,
   const float theta(parameter[Acts::eBoundTheta]);
   const float phi(parameter[Acts::eBoundPhi]);
   const decltype(edm4eic::TrackPoint::directionError) directionError{
-      static_cast<float>(covariance(Acts::eBoundTheta, Acts::eBoundTheta)),
-      static_cast<float>(covariance(Acts::eBoundPhi, Acts::eBoundPhi)),
-      static_cast<float>(covariance(Acts::eBoundTheta, Acts::eBoundPhi))};
+      static_cast<float>(covariance(Acts::eBoundTheta, Acts::eBoundTheta) /
+                         Acts::UnitConstants::rad / Acts::UnitConstants::rad),
+      static_cast<float>(covariance(Acts::eBoundPhi, Acts::eBoundPhi) / Acts::UnitConstants::rad /
+                         Acts::UnitConstants::rad),
+      static_cast<float>(covariance(Acts::eBoundTheta, Acts::eBoundPhi) / Acts::UnitConstants::rad /
+                         Acts::UnitConstants::rad)};
 
   // >oO debug print
-  trace("    loc 0   = {:.4f}", parameter[Acts::eBoundLoc0]);
-  trace("    loc 1   = {:.4f}", parameter[Acts::eBoundLoc1]);
-  trace("    phi     = {:.4f}", parameter[Acts::eBoundPhi]);
-  trace("    theta   = {:.4f}", parameter[Acts::eBoundTheta]);
-  trace("    q/p     = {:.4f}", parameter[Acts::eBoundQOverP]);
-  trace("    p       = {:.4f}", 1.0 / parameter[Acts::eBoundQOverP]);
-  trace("    err phi = {:.4f}", sqrt(covariance(Acts::eBoundPhi, Acts::eBoundPhi)));
-  trace("    err th  = {:.4f}", sqrt(covariance(Acts::eBoundTheta, Acts::eBoundTheta)));
-  trace("    err q/p = {:.4f}", sqrt(covariance(Acts::eBoundQOverP, Acts::eBoundQOverP)));
+  trace("    loc 0   = {:.4f} mm", parameter[Acts::eBoundLoc0] / Acts::UnitConstants::mm);
+  trace("    loc 1   = {:.4f} mm", parameter[Acts::eBoundLoc1] / Acts::UnitConstants::mm);
+  trace("    phi     = {:.4f} rad", parameter[Acts::eBoundPhi] / Acts::UnitConstants::rad);
+  trace("    theta   = {:.4f} rad", parameter[Acts::eBoundTheta] / Acts::UnitConstants::rad);
+  trace("    q/p     = {:.4f} / GeV", parameter[Acts::eBoundQOverP] * Acts::UnitConstants::GeV);
+  trace("    p       = {:.4f} GeV", 1.0 / parameter[Acts::eBoundQOverP] / Acts::UnitConstants::GeV);
+  trace("    err phi = {:.4f} rad", sqrt(covariance(Acts::eBoundPhi, Acts::eBoundPhi) /
+                                         Acts::UnitConstants::rad / Acts::UnitConstants::rad));
+  trace("    err th  = {:.4f} rad", sqrt(covariance(Acts::eBoundTheta, Acts::eBoundTheta) /
+                                         Acts::UnitConstants::rad / Acts::UnitConstants::rad));
+  trace("    err q/p = {:.4f} / GeV", sqrt(covariance(Acts::eBoundQOverP, Acts::eBoundQOverP) *
+                                           Acts::UnitConstants::GeV * Acts::UnitConstants::GeV));
   trace("    chi2    = {:.4f}", trajState.chi2Sum);
-  trace("    loc err = {:.4f}", static_cast<float>(covariance(Acts::eBoundLoc0, Acts::eBoundLoc0)));
-  trace("    loc err = {:.4f}", static_cast<float>(covariance(Acts::eBoundLoc1, Acts::eBoundLoc1)));
-  trace("    loc err = {:.4f}", static_cast<float>(covariance(Acts::eBoundLoc0, Acts::eBoundLoc1)));
+  trace("    loc err = {:.4f} mm^2",
+        static_cast<float>(covariance(Acts::eBoundLoc0, Acts::eBoundLoc0) /
+                           Acts::UnitConstants::mm / Acts::UnitConstants::mm));
+  trace("    loc err = {:.4f} mm^2",
+        static_cast<float>(covariance(Acts::eBoundLoc1, Acts::eBoundLoc1) /
+                           Acts::UnitConstants::mm / Acts::UnitConstants::mm));
+  trace("    loc err = {:.4f} mm^2",
+        static_cast<float>(covariance(Acts::eBoundLoc0, Acts::eBoundLoc1) /
+                           Acts::UnitConstants::mm / Acts::UnitConstants::mm));
 
   uint64_t surface = targetSurf->geometryId().value();
   uint32_t system  = 0; // default value...will be set in TrackPropagation factory

--- a/src/algorithms/tracking/TrackPropagation.h
+++ b/src/algorithms/tracking/TrackPropagation.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <Acts/EventData/TrackContainer.hpp>
 #include <Acts/EventData/TrackParameters.hpp>
 #include <Acts/EventData/TrackProxy.hpp>
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
@@ -23,6 +22,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <tuple>
 #include <vector>
 
 #include "algorithms/interfaces/ActsSvc.h"

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -255,7 +255,7 @@ TrackSeeding::estimateTrackParamsFromSeed(const Acts::Seed<SpacePoint>& seed) co
   cov(3, 3) = m_cfg.thetaError / Acts::UnitConstants::rad;  // theta
   cov(4, 4) = m_cfg.qOverPError * Acts::UnitConstants::GeV; // qOverP
   cov(5, 5) =
-      m_cfg.timeError / (Acts::UnitConstants::ns * Acts::UnitConstants::ns); // time variance in ns²
+      m_cfg.timeError / (Acts::UnitConstants::ns * Acts::UnitConstants::ns); // time variance in ns^2
   trackparam.setCovariance(cov);
 
   return trackparam;

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -253,7 +253,11 @@ TrackSeeding::estimateTrackParamsFromSeed(const Acts::Seed<SpacePoint>& seed) co
   cov(1, 1) = m_cfg.locbError / Acts::UnitConstants::mm;    // loc1
   cov(2, 2) = m_cfg.phiError / Acts::UnitConstants::rad;    // phi
   cov(3, 3) = m_cfg.thetaError / Acts::UnitConstants::rad;  // theta
-  cov(4, 4) = m_cfg.qOverPError * Acts::UnitConstants::GeV; // qOverP
+cov(0, 0) = m_cfg.locaError / Acts::UnitConstants::mm / Acts::UnitConstants::mm;    // loc0
+cov(1, 1) = m_cfg.locbError / Acts::UnitConstants::mm / Acts::UnitConstants::mm;    // loc1
+cov(2, 2) = m_cfg.phiError / Acts::UnitConstants::rad / Acts::UnitConstants::rad;    // phi
+cov(3, 3) = m_cfg.thetaError / Acts::UnitConstants::rad / Acts::UnitConstants::rad;  // theta
+cov(4, 4) = m_cfg.qOverPError * Acts::UnitConstants::GeV * Acts::UnitConstants::GeV; // qOverP
   cov(5, 5) = m_cfg.timeError /
               (Acts::UnitConstants::ns * Acts::UnitConstants::ns); // time variance in ns^2
   trackparam.setCovariance(cov);

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -249,15 +249,15 @@ TrackSeeding::estimateTrackParamsFromSeed(const Acts::Seed<SpacePoint>& seed) co
   trackparam.setQOverP(qOverP);                                            // Q/p [e/GeV]
   trackparam.setTime(10);                                                  // time in ns
   edm4eic::Cov6f cov;
-  cov(0, 0) = m_cfg.locaError / Acts::UnitConstants::mm;    // loc0
-  cov(1, 1) = m_cfg.locbError / Acts::UnitConstants::mm;    // loc1
-  cov(2, 2) = m_cfg.phiError / Acts::UnitConstants::rad;    // phi
-  cov(3, 3) = m_cfg.thetaError / Acts::UnitConstants::rad;  // theta
-cov(0, 0) = m_cfg.locaError / Acts::UnitConstants::mm / Acts::UnitConstants::mm;    // loc0
-cov(1, 1) = m_cfg.locbError / Acts::UnitConstants::mm / Acts::UnitConstants::mm;    // loc1
-cov(2, 2) = m_cfg.phiError / Acts::UnitConstants::rad / Acts::UnitConstants::rad;    // phi
-cov(3, 3) = m_cfg.thetaError / Acts::UnitConstants::rad / Acts::UnitConstants::rad;  // theta
-cov(4, 4) = m_cfg.qOverPError * Acts::UnitConstants::GeV * Acts::UnitConstants::GeV; // qOverP
+  cov(0, 0) = m_cfg.locaError / Acts::UnitConstants::mm;                               // loc0
+  cov(1, 1) = m_cfg.locbError / Acts::UnitConstants::mm;                               // loc1
+  cov(2, 2) = m_cfg.phiError / Acts::UnitConstants::rad;                               // phi
+  cov(3, 3) = m_cfg.thetaError / Acts::UnitConstants::rad;                             // theta
+  cov(0, 0) = m_cfg.locaError / Acts::UnitConstants::mm / Acts::UnitConstants::mm;     // loc0
+  cov(1, 1) = m_cfg.locbError / Acts::UnitConstants::mm / Acts::UnitConstants::mm;     // loc1
+  cov(2, 2) = m_cfg.phiError / Acts::UnitConstants::rad / Acts::UnitConstants::rad;    // phi
+  cov(3, 3) = m_cfg.thetaError / Acts::UnitConstants::rad / Acts::UnitConstants::rad;  // theta
+  cov(4, 4) = m_cfg.qOverPError * Acts::UnitConstants::GeV * Acts::UnitConstants::GeV; // qOverP
   cov(5, 5) = m_cfg.timeError /
               (Acts::UnitConstants::ns * Acts::UnitConstants::ns); // time variance in ns^2
   trackparam.setCovariance(cov);

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -254,7 +254,8 @@ TrackSeeding::estimateTrackParamsFromSeed(const Acts::Seed<SpacePoint>& seed) co
   cov(2, 2) = m_cfg.phiError / Acts::UnitConstants::rad;    // phi
   cov(3, 3) = m_cfg.thetaError / Acts::UnitConstants::rad;  // theta
   cov(4, 4) = m_cfg.qOverPError * Acts::UnitConstants::GeV; // qOverP
-  cov(5, 5) = m_cfg.timeError / Acts::UnitConstants::ns;    // time
+  cov(5, 5) =
+      m_cfg.timeError / (Acts::UnitConstants::ns * Acts::UnitConstants::ns); // time variance in ns²
   trackparam.setCovariance(cov);
 
   return trackparam;

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -249,17 +249,12 @@ TrackSeeding::estimateTrackParamsFromSeed(const Acts::Seed<SpacePoint>& seed) co
   trackparam.setQOverP(qOverP);                                            // Q/p [e/GeV]
   trackparam.setTime(10);                                                  // time in ns
   edm4eic::Cov6f cov;
-  cov(0, 0) = m_cfg.locaError / Acts::UnitConstants::mm;                               // loc0
-  cov(1, 1) = m_cfg.locbError / Acts::UnitConstants::mm;                               // loc1
-  cov(2, 2) = m_cfg.phiError / Acts::UnitConstants::rad;                               // phi
-  cov(3, 3) = m_cfg.thetaError / Acts::UnitConstants::rad;                             // theta
-  cov(0, 0) = m_cfg.locaError / Acts::UnitConstants::mm / Acts::UnitConstants::mm;     // loc0
-  cov(1, 1) = m_cfg.locbError / Acts::UnitConstants::mm / Acts::UnitConstants::mm;     // loc1
-  cov(2, 2) = m_cfg.phiError / Acts::UnitConstants::rad / Acts::UnitConstants::rad;    // phi
-  cov(3, 3) = m_cfg.thetaError / Acts::UnitConstants::rad / Acts::UnitConstants::rad;  // theta
-  cov(4, 4) = m_cfg.qOverPError * Acts::UnitConstants::GeV * Acts::UnitConstants::GeV; // qOverP
-  cov(5, 5) = m_cfg.timeError /
-              (Acts::UnitConstants::ns * Acts::UnitConstants::ns); // time variance in ns^2
+  cov(0, 0) = std::pow(m_cfg.locaError / Acts::UnitConstants::mm, 2);    // loc0
+  cov(1, 1) = std::pow(m_cfg.locbError / Acts::UnitConstants::mm, 2);    // loc1
+  cov(2, 2) = std::pow(m_cfg.phiError / Acts::UnitConstants::rad, 2);    // phi
+  cov(3, 3) = std::pow(m_cfg.thetaError / Acts::UnitConstants::rad, 2);  // theta
+  cov(4, 4) = std::pow(m_cfg.qOverPError * Acts::UnitConstants::GeV, 2); // qOverP
+  cov(5, 5) = std::pow(m_cfg.timeError / Acts::UnitConstants::ns, 2);    // time variance in ns^2
   trackparam.setCovariance(cov);
 
   return trackparam;

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -254,8 +254,8 @@ TrackSeeding::estimateTrackParamsFromSeed(const Acts::Seed<SpacePoint>& seed) co
   cov(2, 2) = m_cfg.phiError / Acts::UnitConstants::rad;    // phi
   cov(3, 3) = m_cfg.thetaError / Acts::UnitConstants::rad;  // theta
   cov(4, 4) = m_cfg.qOverPError * Acts::UnitConstants::GeV; // qOverP
-  cov(5, 5) =
-      m_cfg.timeError / (Acts::UnitConstants::ns * Acts::UnitConstants::ns); // time variance in ns^2
+  cov(5, 5) = m_cfg.timeError /
+              (Acts::UnitConstants::ns * Acts::UnitConstants::ns); // time variance in ns^2
   trackparam.setCovariance(cov);
 
   return trackparam;

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -237,15 +237,15 @@ TrackSeeding::estimateTrackParamsFromSeed(const Acts::Seed<SpacePoint>& seed) co
   trackparam.setQOverP(qOverP);                                            // Q/p [e/GeV]
   trackparam.setTime(10);                                                  // time in ns
   edm4eic::Cov6f cov;
-  cov(0, 0) = m_cfg.locaError / Acts::UnitConstants::mm;    // loc0
-  cov(1, 1) = m_cfg.locbError / Acts::UnitConstants::mm;    // loc1
-  cov(2, 2) = m_cfg.phiError / Acts::UnitConstants::rad;    // phi
-  cov(3, 3) = m_cfg.thetaError / Acts::UnitConstants::rad;  // theta
-cov(0, 0) = m_cfg.locaError / Acts::UnitConstants::mm / Acts::UnitConstants::mm;    // loc0
-cov(1, 1) = m_cfg.locbError / Acts::UnitConstants::mm / Acts::UnitConstants::mm;    // loc1
-cov(2, 2) = m_cfg.phiError / Acts::UnitConstants::rad / Acts::UnitConstants::rad;    // phi
-cov(3, 3) = m_cfg.thetaError / Acts::UnitConstants::rad / Acts::UnitConstants::rad;  // theta
-cov(4, 4) = m_cfg.qOverPError * Acts::UnitConstants::GeV * Acts::UnitConstants::GeV; // qOverP
+  cov(0, 0) = m_cfg.locaError / Acts::UnitConstants::mm;                               // loc0
+  cov(1, 1) = m_cfg.locbError / Acts::UnitConstants::mm;                               // loc1
+  cov(2, 2) = m_cfg.phiError / Acts::UnitConstants::rad;                               // phi
+  cov(3, 3) = m_cfg.thetaError / Acts::UnitConstants::rad;                             // theta
+  cov(0, 0) = m_cfg.locaError / Acts::UnitConstants::mm / Acts::UnitConstants::mm;     // loc0
+  cov(1, 1) = m_cfg.locbError / Acts::UnitConstants::mm / Acts::UnitConstants::mm;     // loc1
+  cov(2, 2) = m_cfg.phiError / Acts::UnitConstants::rad / Acts::UnitConstants::rad;    // phi
+  cov(3, 3) = m_cfg.thetaError / Acts::UnitConstants::rad / Acts::UnitConstants::rad;  // theta
+  cov(4, 4) = m_cfg.qOverPError * Acts::UnitConstants::GeV * Acts::UnitConstants::GeV; // qOverP
   cov(5, 5) = m_cfg.timeError /
               (Acts::UnitConstants::ns * Acts::UnitConstants::ns); // time variance in ns^2
   trackparam.setCovariance(cov);

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -242,7 +242,8 @@ TrackSeeding::estimateTrackParamsFromSeed(const Acts::Seed<SpacePoint>& seed) co
   cov(2, 2) = m_cfg.phiError / Acts::UnitConstants::rad;    // phi
   cov(3, 3) = m_cfg.thetaError / Acts::UnitConstants::rad;  // theta
   cov(4, 4) = m_cfg.qOverPError * Acts::UnitConstants::GeV; // qOverP
-  cov(5, 5) = m_cfg.timeError / Acts::UnitConstants::ns;    // time
+  cov(5, 5) =
+      m_cfg.timeError / (Acts::UnitConstants::ns * Acts::UnitConstants::ns); // time variance in ns²
   trackparam.setCovariance(cov);
 
   return trackparam;

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -242,8 +242,8 @@ TrackSeeding::estimateTrackParamsFromSeed(const Acts::Seed<SpacePoint>& seed) co
   cov(2, 2) = m_cfg.phiError / Acts::UnitConstants::rad;    // phi
   cov(3, 3) = m_cfg.thetaError / Acts::UnitConstants::rad;  // theta
   cov(4, 4) = m_cfg.qOverPError * Acts::UnitConstants::GeV; // qOverP
-  cov(5, 5) =
-      m_cfg.timeError / (Acts::UnitConstants::ns * Acts::UnitConstants::ns); // time variance in ns^2
+  cov(5, 5) = m_cfg.timeError /
+              (Acts::UnitConstants::ns * Acts::UnitConstants::ns); // time variance in ns^2
   trackparam.setCovariance(cov);
 
   return trackparam;

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -241,7 +241,11 @@ TrackSeeding::estimateTrackParamsFromSeed(const Acts::Seed<SpacePoint>& seed) co
   cov(1, 1) = m_cfg.locbError / Acts::UnitConstants::mm;    // loc1
   cov(2, 2) = m_cfg.phiError / Acts::UnitConstants::rad;    // phi
   cov(3, 3) = m_cfg.thetaError / Acts::UnitConstants::rad;  // theta
-  cov(4, 4) = m_cfg.qOverPError * Acts::UnitConstants::GeV; // qOverP
+cov(0, 0) = m_cfg.locaError / Acts::UnitConstants::mm / Acts::UnitConstants::mm;    // loc0
+cov(1, 1) = m_cfg.locbError / Acts::UnitConstants::mm / Acts::UnitConstants::mm;    // loc1
+cov(2, 2) = m_cfg.phiError / Acts::UnitConstants::rad / Acts::UnitConstants::rad;    // phi
+cov(3, 3) = m_cfg.thetaError / Acts::UnitConstants::rad / Acts::UnitConstants::rad;  // theta
+cov(4, 4) = m_cfg.qOverPError * Acts::UnitConstants::GeV * Acts::UnitConstants::GeV; // qOverP
   cov(5, 5) = m_cfg.timeError /
               (Acts::UnitConstants::ns * Acts::UnitConstants::ns); // time variance in ns^2
   trackparam.setCovariance(cov);

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -237,17 +237,12 @@ TrackSeeding::estimateTrackParamsFromSeed(const Acts::Seed<SpacePoint>& seed) co
   trackparam.setQOverP(qOverP);                                            // Q/p [e/GeV]
   trackparam.setTime(10);                                                  // time in ns
   edm4eic::Cov6f cov;
-  cov(0, 0) = m_cfg.locaError / Acts::UnitConstants::mm;                               // loc0
-  cov(1, 1) = m_cfg.locbError / Acts::UnitConstants::mm;                               // loc1
-  cov(2, 2) = m_cfg.phiError / Acts::UnitConstants::rad;                               // phi
-  cov(3, 3) = m_cfg.thetaError / Acts::UnitConstants::rad;                             // theta
-  cov(0, 0) = m_cfg.locaError / Acts::UnitConstants::mm / Acts::UnitConstants::mm;     // loc0
-  cov(1, 1) = m_cfg.locbError / Acts::UnitConstants::mm / Acts::UnitConstants::mm;     // loc1
-  cov(2, 2) = m_cfg.phiError / Acts::UnitConstants::rad / Acts::UnitConstants::rad;    // phi
-  cov(3, 3) = m_cfg.thetaError / Acts::UnitConstants::rad / Acts::UnitConstants::rad;  // theta
-  cov(4, 4) = m_cfg.qOverPError * Acts::UnitConstants::GeV * Acts::UnitConstants::GeV; // qOverP
-  cov(5, 5) = m_cfg.timeError /
-              (Acts::UnitConstants::ns * Acts::UnitConstants::ns); // time variance in ns^2
+  cov(0, 0) = std::pow(m_cfg.locaError / Acts::UnitConstants::mm, 2);    // loc0
+  cov(1, 1) = std::pow(m_cfg.locbError / Acts::UnitConstants::mm, 2);    // loc1
+  cov(2, 2) = std::pow(m_cfg.phiError / Acts::UnitConstants::rad, 2);    // phi
+  cov(3, 3) = std::pow(m_cfg.thetaError / Acts::UnitConstants::rad, 2);  // theta
+  cov(4, 4) = std::pow(m_cfg.qOverPError * Acts::UnitConstants::GeV, 2); // qOverP
+  cov(5, 5) = std::pow(m_cfg.timeError / Acts::UnitConstants::ns, 2);    // time variance in ns^2
   trackparam.setCovariance(cov);
 
   return trackparam;

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -243,7 +243,7 @@ TrackSeeding::estimateTrackParamsFromSeed(const Acts::Seed<SpacePoint>& seed) co
   cov(3, 3) = m_cfg.thetaError / Acts::UnitConstants::rad;  // theta
   cov(4, 4) = m_cfg.qOverPError * Acts::UnitConstants::GeV; // qOverP
   cov(5, 5) =
-      m_cfg.timeError / (Acts::UnitConstants::ns * Acts::UnitConstants::ns); // time variance in ns²
+      m_cfg.timeError / (Acts::UnitConstants::ns * Acts::UnitConstants::ns); // time variance in ns^2
   trackparam.setCovariance(cov);
 
   return trackparam;

--- a/src/algorithms/tracking/TrackSeeding.h
+++ b/src/algorithms/tracking/TrackSeeding.h
@@ -20,7 +20,6 @@
 #include <edm4eic/TrackParametersCollection.h>
 #include <edm4eic/TrackSeedCollection.h>
 #include <edm4eic/TrackerHitCollection.h>
-#include <cmath>
 #include <cstddef>
 #include <iterator>
 #include <memory>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Two time unit conversion issues between ACTS natural units and EDM4eic units.

#### Time values
ACTS stores time internally in mm/c (= 1/c in ACTS natural units where length is mm). `Acts::UnitConstants::ns = 299.792458`, so dividing the ACTS `eBoundTime` value by `UnitConstants::ns` converts to nanoseconds.

The input path in `CKFTracking.cc` already correctly multiplies by `Acts::UnitConstants::ns` when reading from EDM4eic (ns to ACTS units). However, the output paths in `ActsToTracks.cc`, `TrackPropagation.cc`, and `TrackProjector.cc` were missing the corresponding division, causing all stored times to be ~300x too large (in mm/c rather than ns).

Affected output collections:
- `CentralCKFTrackParameters.time` (was ~2998, should be ~10 ns)
- `CentralCKFTracks.time` (same issue)
- `_CalorimeterTrackProjections_points.time` (was ~6400 for normal tracks)
- `_CentralTrackSegments_points.time` (TrackProjector output)

Also fix the `timeError` fields to divide by `Acts::UnitConstants::ns` after taking the sqrt of the covariance element.

#### Covariances
The seed covariance `cov(5,5)` stores time variance in EDM4eic units (ns^2). `CKFTracking.cc` reads it back as: `cov_acts(t,t) = edm4eic_cov(t,t) * ns^2`.
    
The previous code stored:
```
cov(5,5) = timeError / ns
```
giving `cov_acts(t,t) = (timeError/ns) * ns^2 = timeError * ns` i.e. a variance of 0.1 * 299.8 ≈ 30 (mm/c)^2, σ_t ≈ 18 ps.
    
The correct formula divides by ns^2 to convert from (mm/c)^2 to ns^2:
```
cov(5,5) = timeError / (ns * ns)
```
giving `cov_acts(t,t) = timeError` ✓
    
Also update the default `timeError` from 0.1 * mm (σ_t ≈ 1 ps, much too tight) to ns^2 (σ_t = 1 ns), which is physically reasonable for a seeded track.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.