### PR TITLE
[v1.35] fix: add 130 and 250 GeV to hadron beam pz_set; centralize beam pz allowlists; improve round_beam_four_momentum matching

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -540,6 +540,44 @@ jobs:
         path: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
         if-no-files-found: error
 
+  npsim-pythia6:
+    runs-on: ubuntu-24.04
+    needs:
+    - detector-info
+    strategy:
+      matrix:
+        include:
+          - beam: 10x130
+            minq2: 1
+            detector_config: craterlake_10x130
+          - beam: 10x250
+            minq2: 1
+            detector_config: craterlake_10x250
+    steps:
+    - name: Retrieve simulation files
+      id: retrieve_simulation_files
+      uses: actions/cache@v5
+      with:
+        path: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
+        key: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root-${{ needs.detector-info.outputs.hash }}
+    - uses: cvmfs-contrib/github-action-cvmfs@v5
+      if: steps.retrieve_simulation_files.outputs.cache-hit != 'true'
+    - name: Produce simulation files
+      uses: eic/run-cvmfs-osg-eic-shell@main
+      if: steps.retrieve_simulation_files.outputs.cache-hit != 'true'
+      with:
+        organization: "${{ env.organization }}"
+        platform-release: "${{ env.platform }}:${{ env.release }}"
+        setup: "/opt/detector/epic-${{ env.detector-version }}/bin/thisepic.sh"
+        run: |
+          url=root://dtn-eic.jlab.org//volatile/eic/EPIC/EVGEN/DIS/pythia6.428-1.0/NC/noRad/ep/${{matrix.beam}}/q2_${{matrix.minq2}}to${{matrix.minq2}}0/pythia6.428-1.0_NC_noRad_ep_${{matrix.beam}}_q2_${{matrix.minq2}}to${{matrix.minq2}}0_ab.hepmc3.tree.root
+          npsim --compactFile ${DETECTOR_PATH}/${DETECTOR}_${{ matrix.detector_config }}.xml -N 100 --inputFiles ${url} --random.seed 1 --outputFile sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root -v WARNING
+    - uses: actions/upload-artifact@v7
+      with:
+        name: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
+        path: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
+        if-no-files-found: error
+
   npsim-minbias:
     runs-on: ubuntu-24.04
     needs:
@@ -916,6 +954,7 @@ jobs:
     needs:
     - build
     - npsim-dis
+    - npsim-pythia6
     - npsim-minbias
     strategy:
       matrix:
@@ -946,6 +985,16 @@ jobs:
           beam: 10x100
           minq2: 1000
           detector_config: craterlake_tracking_only
+          sanitizer: ASAN
+        - CXX: clang++
+          beam: 10x130
+          minq2: 1
+          detector_config: craterlake_10x130
+          sanitizer: ASAN
+        - CXX: clang++
+          beam: 10x250
+          minq2: 1
+          detector_config: craterlake_10x250
           sanitizer: ASAN
         - CXX: clang++
           beam: 18x275

--- a/src/algorithms/reco/Beam.h
+++ b/src/algorithms/reco/Beam.h
@@ -7,7 +7,9 @@
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <algorithm>
+#include <fmt/format.h>
 #include <set>
+#include <stdexcept>
 #include <vector>
 #include <cmath>
 
@@ -56,17 +58,36 @@ inline auto find_first_scattered_electron(const edm4eic::ReconstructedParticleCo
   return find_first_with_pdg(rcparts, {11});
 }
 
+// Canonical beam momentum allowlists used by all kinematics algorithms.
+// Electron beam: negative pz (beam goes in -z direction).
+inline const std::vector<float> electron_beam_pz_set{-5.0, -10.0, -18.0};
+// Hadron beam: positive pz (beam goes in +z direction).
+inline const std::vector<float> hadron_beam_pz_set{41.0, 100.0, 130.0, 250.0, 275.0};
+
 template <typename Vector3>
 PxPyPzEVector round_beam_four_momentum(const Vector3& p_in, const float mass,
                                        const std::vector<float>& pz_set,
                                        const float crossing_angle = 0.0) {
-  PxPyPzEVector p_out;
+  // Find the closest pz within 10% relative tolerance
+  float best_pz    = 0.0F;
+  float best_err   = 0.1F; // 10% tolerance — entries above this are not accepted
+  bool found_match = false;
   for (const auto& pz : pz_set) {
-    if (std::abs(p_in.z / pz - 1) < 0.1) {
-      p_out.SetPz(pz);
-      break;
+    const float err = std::abs(p_in.z / pz - 1);
+    if (err < best_err) {
+      best_err    = err;
+      best_pz     = pz;
+      found_match = true;
     }
   }
+  if (!found_match) {
+    throw std::runtime_error(
+        fmt::format("round_beam_four_momentum: no match for beam momentum {:.3f} GeV within 10%% "
+                    "of any of the allowed values",
+                    p_in.z));
+  }
+  PxPyPzEVector p_out;
+  p_out.SetPz(best_pz);
   p_out.SetPx(p_out.Pz() * sin(crossing_angle));
   p_out.SetPz(p_out.Pz() * cos(crossing_angle));
   p_out.SetE(std::hypot(p_out.Px(), p_out.Pz(), mass));

--- a/src/algorithms/reco/HadronicFinalState.cc
+++ b/src/algorithms/reco/HadronicFinalState.cc
@@ -12,8 +12,7 @@
 #include <podio/ObjectID.h>
 #include <algorithm>
 #include <cmath>
-#include <gsl/pointers>
-#include <vector>
+#include <tuple>
 
 #include "Beam.h"
 #include "Boost.h"
@@ -39,7 +38,7 @@ void HadronicFinalState::process(const HadronicFinalState::Input& input,
   const auto& ei_particle = (*mc_beam_electrons)[0];
   const PxPyPzEVector ei(round_beam_four_momentum(ei_particle.getMomentum(),
                                                   m_particleSvc.particle(ei_particle.getPDG()).mass,
-                                                  {-5.0, -10.0, -18.0}, 0.0));
+                                                  electron_beam_pz_set, 0.0));
 
   // Get first (should be only) beam proton
   if (mc_beam_protons->empty()) {
@@ -49,7 +48,7 @@ void HadronicFinalState::process(const HadronicFinalState::Input& input,
   const auto& pi_particle = (*mc_beam_protons)[0];
   const PxPyPzEVector pi(round_beam_four_momentum(pi_particle.getMomentum(),
                                                   m_particleSvc.particle(pi_particle.getPDG()).mass,
-                                                  {41.0, 100.0, 275.0}, m_crossingAngle));
+                                                  hadron_beam_pz_set, m_crossingAngle));
 
   // Get first scattered electron from full MCParticles collection
   if (mcparts == nullptr) {

--- a/src/algorithms/reco/InclusiveKinematicsDA.cc
+++ b/src/algorithms/reco/InclusiveKinematicsDA.cc
@@ -10,7 +10,6 @@
 #include <edm4hep/Vector3f.h>
 #include <cmath>
 #include <tuple>
-#include <vector>
 
 #include "Beam.h"
 #include "Boost.h"
@@ -36,7 +35,7 @@ void InclusiveKinematicsDA::process(const InclusiveKinematicsDA::Input& input,
   const auto& ei_particle = (*mc_beam_electrons)[0];
   const PxPyPzEVector ei(round_beam_four_momentum(ei_particle.getMomentum(),
                                                   m_particleSvc.particle(ei_particle.getPDG()).mass,
-                                                  {-5.0, -10.0, -18.0}, 0.0));
+                                                  electron_beam_pz_set, 0.0));
 
   // Get first (should be only) beam proton
   if (mc_beam_protons->empty()) {
@@ -46,7 +45,7 @@ void InclusiveKinematicsDA::process(const InclusiveKinematicsDA::Input& input,
   const auto& pi_particle = (*mc_beam_protons)[0];
   const PxPyPzEVector pi(round_beam_four_momentum(pi_particle.getMomentum(),
                                                   m_particleSvc.particle(pi_particle.getPDG()).mass,
-                                                  {41.0, 100.0, 275.0}, m_crossingAngle));
+                                                  hadron_beam_pz_set, m_crossingAngle));
 
   // Get boost to colinear frame
   auto boost = determine_boost(ei, pi);

--- a/src/algorithms/reco/InclusiveKinematicsESigma.cc
+++ b/src/algorithms/reco/InclusiveKinematicsESigma.cc
@@ -10,7 +10,6 @@
 #include <edm4hep/Vector3f.h>
 #include <cmath>
 #include <tuple>
-#include <vector>
 
 #include "Beam.h"
 #include "Boost.h"
@@ -36,7 +35,7 @@ void InclusiveKinematicsESigma::process(const InclusiveKinematicsESigma::Input& 
   const auto& ei_particle = (*mc_beam_electrons)[0];
   const PxPyPzEVector ei(round_beam_four_momentum(ei_particle.getMomentum(),
                                                   m_particleSvc.particle(ei_particle.getPDG()).mass,
-                                                  {-5.0, -10.0, -18.0}, 0.0));
+                                                  electron_beam_pz_set, 0.0));
 
   // Get first (should be only) beam proton
   if (mc_beam_protons->empty()) {
@@ -46,7 +45,7 @@ void InclusiveKinematicsESigma::process(const InclusiveKinematicsESigma::Input& 
   const auto& pi_particle = (*mc_beam_protons)[0];
   const PxPyPzEVector pi(round_beam_four_momentum(pi_particle.getMomentum(),
                                                   m_particleSvc.particle(pi_particle.getPDG()).mass,
-                                                  {41.0, 100.0, 275.0}, m_crossingAngle));
+                                                  hadron_beam_pz_set, m_crossingAngle));
 
   // Get boost to colinear frame
   auto boost = determine_boost(ei, pi);

--- a/src/algorithms/reco/InclusiveKinematicsElectron.cc
+++ b/src/algorithms/reco/InclusiveKinematicsElectron.cc
@@ -9,7 +9,7 @@
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <cmath>
-#include <gsl/pointers>
+#include <tuple>
 #include <vector>
 
 #include "Beam.h"
@@ -35,7 +35,7 @@ void InclusiveKinematicsElectron::process(const InclusiveKinematicsElectron::Inp
   const auto& ei_particle = (*mc_beam_electrons)[0];
   const PxPyPzEVector ei(round_beam_four_momentum(ei_particle.getMomentum(),
                                                   m_particleSvc.particle(ei_particle.getPDG()).mass,
-                                                  {-5.0, -10.0, -18.0}, 0.0));
+                                                  electron_beam_pz_set, 0.0));
 
   // Get first (should be only) beam proton
   if (mc_beam_protons->empty()) {
@@ -45,7 +45,7 @@ void InclusiveKinematicsElectron::process(const InclusiveKinematicsElectron::Inp
   const auto& pi_particle = (*mc_beam_protons)[0];
   const PxPyPzEVector pi(round_beam_four_momentum(pi_particle.getMomentum(),
                                                   m_particleSvc.particle(pi_particle.getPDG()).mass,
-                                                  {41.0, 100.0, 275.0}, m_crossingAngle));
+                                                  hadron_beam_pz_set, m_crossingAngle));
 
   // Get scattered electron
   std::vector<PxPyPzEVector> electrons;

--- a/src/algorithms/reco/InclusiveKinematicsJB.cc
+++ b/src/algorithms/reco/InclusiveKinematicsJB.cc
@@ -7,8 +7,7 @@
 #include <edm4eic/HadronicFinalStateCollection.h>
 #include <edm4eic/InclusiveKinematicsCollection.h>
 #include <cmath>
-#include <gsl/pointers>
-#include <vector>
+#include <tuple>
 
 #include "Beam.h"
 #include "InclusiveKinematicsJB.h"
@@ -33,7 +32,7 @@ void InclusiveKinematicsJB::process(const InclusiveKinematicsJB::Input& input,
   const auto& ei_particle = (*mc_beam_electrons)[0];
   const PxPyPzEVector ei(round_beam_four_momentum(ei_particle.getMomentum(),
                                                   m_particleSvc.particle(ei_particle.getPDG()).mass,
-                                                  {-5.0, -10.0, -18.0}, 0.0));
+                                                  electron_beam_pz_set, 0.0));
 
   // Get first (should be only) beam proton
   if (mc_beam_protons->empty()) {
@@ -43,7 +42,7 @@ void InclusiveKinematicsJB::process(const InclusiveKinematicsJB::Input& input,
   const auto& pi_particle = (*mc_beam_protons)[0];
   const PxPyPzEVector pi(round_beam_four_momentum(pi_particle.getMomentum(),
                                                   m_particleSvc.particle(pi_particle.getPDG()).mass,
-                                                  {41.0, 100.0, 275.0}, m_crossingAngle));
+                                                  hadron_beam_pz_set, m_crossingAngle));
 
   // Get hadronic final state variables
   if (hfs->empty()) {

--- a/src/algorithms/reco/InclusiveKinematicsSigma.cc
+++ b/src/algorithms/reco/InclusiveKinematicsSigma.cc
@@ -8,8 +8,7 @@
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <cmath>
-#include <gsl/pointers>
-#include <vector>
+#include <tuple>
 
 #include "Beam.h"
 #include "Boost.h"
@@ -35,7 +34,7 @@ void InclusiveKinematicsSigma::process(const InclusiveKinematicsSigma::Input& in
   const auto& ei_particle = (*mc_beam_electrons)[0];
   const PxPyPzEVector ei(round_beam_four_momentum(ei_particle.getMomentum(),
                                                   m_particleSvc.particle(ei_particle.getPDG()).mass,
-                                                  {-5.0, -10.0, -18.0}, 0.0));
+                                                  electron_beam_pz_set, 0.0));
 
   // Get first (should be only) beam proton
   if (mc_beam_protons->empty()) {
@@ -45,7 +44,7 @@ void InclusiveKinematicsSigma::process(const InclusiveKinematicsSigma::Input& in
   const auto& pi_particle = (*mc_beam_protons)[0];
   const PxPyPzEVector pi(round_beam_four_momentum(pi_particle.getMomentum(),
                                                   m_particleSvc.particle(pi_particle.getPDG()).mass,
-                                                  {41.0, 100.0, 275.0}, m_crossingAngle));
+                                                  hadron_beam_pz_set, m_crossingAngle));
 
   // Get boost to colinear frame
   auto boost = determine_boost(ei, pi);

--- a/src/algorithms/reco/TransformBreitFrame.cc
+++ b/src/algorithms/reco/TransformBreitFrame.cc
@@ -11,13 +11,10 @@
 #include <Math/GenVector/PxPyPzE4D.h>
 #include <Math/GenVector/Rotation3D.h>
 #include <Math/Vector4Dfwd.h>
-#include <edm4eic/Cov4f.h>
 #include <edm4eic/Vertex.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/kinematics.h>
-#include <fmt/core.h>
-#include <gsl/pointers>
-#include <vector>
+#include <tuple>
 
 #include "Beam.h"
 
@@ -40,7 +37,7 @@ void TransformBreitFrame::process(const TransformBreitFrame::Input& input,
   }
   const PxPyPzEVector e_initial(round_beam_four_momentum(
       ei_coll[0].getMomentum(), m_particleSvc.particle(ei_coll[0].getPDG()).mass,
-      {-5.0, -10.0, -18.0}, 0.0));
+      electron_beam_pz_set, 0.0));
 
   // Get incoming hadron beam
   const auto pi_coll = find_first_beam_hadron(mcpart);
@@ -50,7 +47,7 @@ void TransformBreitFrame::process(const TransformBreitFrame::Input& input,
   }
   const PxPyPzEVector p_initial(round_beam_four_momentum(
       pi_coll[0].getMomentum(), m_particleSvc.particle(pi_coll[0].getPDG()).mass,
-      {41.0, 100.0, 275.0}, m_crossingAngle));
+      hadron_beam_pz_set, m_crossingAngle));
 
   debug("electron energy, proton energy = {},{}", e_initial.E(), p_initial.E());
 


### PR DESCRIPTION
Backport #2543

(cherry picked from commit https://github.com/eic/EICrecon/commit/8ffe0bc26e8f063e66f29ccda0dc4825520423d8)