### PR TITLE
ActsGeometryProvider: remove dependency on DetectorElementBase for Acts 45+

### DIFF
--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022 - 2024 Whitney Armstrong, Wouter Deconinck, Dmitry Romanov
 
+#if Acts_VERSION_MAJOR < 45
 #include <Acts/Geometry/DetectorElementBase.hpp>
+#endif
 #include <Acts/Geometry/GeometryIdentifier.hpp>
 #include <Acts/Geometry/TrackingGeometry.hpp>
 #include <Acts/Geometry/TrackingVolume.hpp>


### PR DESCRIPTION
That header was removed entirely in https://github.com/acts-project/acts/pull/5176