### PR TITLE
Implement ObjectID comparator

### DIFF
--- a/src/algorithms/interfaces/CompareObjectID.h
+++ b/src/algorithms/interfaces/CompareObjectID.h
@@ -11,8 +11,7 @@ namespace eicrecon {
  *  their ObjectID's in decreasing collection ID first, and second by
  *  decreasing index second.
  */
-template <typename T>
-struct CompareObjectID {
+template <typename T> struct CompareObjectID {
   bool operator()(const T& lhs, const T& rhs) const {
     if (lhs.getObjectID().collectionID == rhs.getObjectID().collectionID) {
       return (lhs.getObjectID().index < rhs.getObjectID().index);


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This PR follows the suggestion from [EICrecon#1627](https://github.com/eic/EICrecon/pull/1627#discussion_r2780065499) and implements a `podio::ObjectID` comparator for use in `std::set`s, `std::map`s, etc. in algorithms.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #2573 )
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No.

### Does this PR change default behavior?

No.