### PR TITLE
Conversion from energy deposit to the number of photoelectrons

### DIFF
--- a/src/algorithms/digi/PulseGeneration.cc
+++ b/src/algorithms/digi/PulseGeneration.cc
@@ -5,6 +5,7 @@
 // Convert energy deposition into ADC pulses
 // ADC pulses are assumed to follow the shape of landau function
 
+#include <DDSegmentation/BitFieldCoder.h>
 #include <RtypesCore.h>
 #include <TMath.h>
 #include <algorithms/service.h>
@@ -12,19 +13,21 @@
 #include <edm4hep/CaloHitContribution.h>
 #include <edm4hep/MCParticle.h>
 #include <edm4hep/Vector3f.h>
+#include <fmt/format.h>
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
-#include <cstdlib>
+#include <fstream>
 #include <functional>
+#include <memory>
 #include <optional>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
-#include <fmt/format.h>
-#include <memory>
 
 #include "PulseGeneration.h"
 #include "services/evaluator/EvaluatorSvc.h"

--- a/src/algorithms/digi/PulseGeneration.cc
+++ b/src/algorithms/digi/PulseGeneration.cc
@@ -37,281 +37,282 @@
 
 namespace eicrecon {
 
-	class SignalPulse {
+class SignalPulse {
 
-		public:
-			virtual ~SignalPulse() = default; // Virtual destructor
+public:
+  virtual ~SignalPulse() = default; // Virtual destructor
 
-			virtual double operator()(double time, double charge) = 0;
+  virtual double operator()(double time, double charge) = 0;
 
-			virtual double getMaximumTime() const = 0;
-	};
+  virtual double getMaximumTime() const = 0;
+};
 
-	// ----------------------------------------------------------------------------
-	// Landau Pulse Shape Functor
-	// ----------------------------------------------------------------------------
-	class LandauPulse : public SignalPulse {
-		public:
-			LandauPulse(std::vector<double> params) {
+// ----------------------------------------------------------------------------
+// Landau Pulse Shape Functor
+// ----------------------------------------------------------------------------
+class LandauPulse : public SignalPulse {
+public:
+  LandauPulse(std::vector<double> params) {
 
-				if ((params.size() != 2) && (params.size() != 3)) {
-					throw std::runtime_error(
-							"LandauPulse requires 2 or 3 parameters, gain, sigma_analog, [hit_sigma_offset], got " +
-							std::to_string(params.size()));
-				}
+    if ((params.size() != 2) && (params.size() != 3)) {
+      throw std::runtime_error(
+          "LandauPulse requires 2 or 3 parameters, gain, sigma_analog, [hit_sigma_offset], got " +
+          std::to_string(params.size()));
+    }
 
-				m_gain         = params[0];
-				m_sigma_analog = params[1];
-				if (params.size() == 3) {
-					m_hit_sigma_offset = params[2];
-				}
-			};
+    m_gain         = params[0];
+    m_sigma_analog = params[1];
+    if (params.size() == 3) {
+      m_hit_sigma_offset = params[2];
+    }
+  };
 
-			double operator()(double time, double charge) override {
-				return charge * m_gain *
-					TMath::Landau(time, m_hit_sigma_offset * m_sigma_analog, m_sigma_analog, kTRUE);
-			}
+  double operator()(double time, double charge) override {
+    return charge * m_gain *
+           TMath::Landau(time, m_hit_sigma_offset * m_sigma_analog, m_sigma_analog, kTRUE);
+  }
 
-			double getMaximumTime() const override { return m_hit_sigma_offset * m_sigma_analog; }
+  double getMaximumTime() const override { return m_hit_sigma_offset * m_sigma_analog; }
 
-		private:
-			double m_gain             = 1.0;
-			double m_sigma_analog     = 1.0;
-			double m_hit_sigma_offset = 3.5;
-	};
+private:
+  double m_gain             = 1.0;
+  double m_sigma_analog     = 1.0;
+  double m_hit_sigma_offset = 3.5;
+};
 
-	// EvaluatorSvc Pulse
-	class EvaluatorPulse : public SignalPulse {
-		public:
-			EvaluatorPulse(const std::string& expression, const std::vector<double>& params) {
+// EvaluatorSvc Pulse
+class EvaluatorPulse : public SignalPulse {
+public:
+  EvaluatorPulse(const std::string& expression, const std::vector<double>& params) {
 
-				std::vector<std::string> keys = {"time", "charge"};
-				for (std::size_t i = 0; i < params.size(); i++) {
-					std::string p = "param" + std::to_string(i);
-					//Check the expression contains the parameter
-					if (expression.find(p) == std::string::npos) {
-						throw std::runtime_error("Parameter " + p + " not found in expression");
-					}
-					keys.push_back(p);
-					param_map[p] = params[i];
-				}
+    std::vector<std::string> keys = {"time", "charge"};
+    for (std::size_t i = 0; i < params.size(); i++) {
+      std::string p = "param" + std::to_string(i);
+      //Check the expression contains the parameter
+      if (expression.find(p) == std::string::npos) {
+        throw std::runtime_error("Parameter " + p + " not found in expression");
+      }
+      keys.push_back(p);
+      param_map[p] = params[i];
+    }
 
-				// Check the expression is contains time and charge
-				if (expression.find("time") == std::string::npos) {
-					throw std::runtime_error("Parameter [time] not found in expression");
-				}
-				if (expression.find("charge") == std::string::npos) {
-					throw std::runtime_error("Parameter [charge] not found in expression");
-				}
+    // Check the expression is contains time and charge
+    if (expression.find("time") == std::string::npos) {
+      throw std::runtime_error("Parameter [time] not found in expression");
+    }
+    if (expression.find("charge") == std::string::npos) {
+      throw std::runtime_error("Parameter [charge] not found in expression");
+    }
 
-				auto& serviceSvc = algorithms::ServiceSvc::instance();
-				m_evaluator      = serviceSvc.service<EvaluatorSvc>("EvaluatorSvc")->_compile(expression, keys);
-			};
+    auto& serviceSvc = algorithms::ServiceSvc::instance();
+    m_evaluator      = serviceSvc.service<EvaluatorSvc>("EvaluatorSvc")->_compile(expression, keys);
+  };
 
-			double operator()(double time, double charge) override {
-				param_map["time"]   = time;
-				param_map["charge"] = charge;
-				return m_evaluator(param_map);
-			}
+  double operator()(double time, double charge) override {
+    param_map["time"]   = time;
+    param_map["charge"] = charge;
+    return m_evaluator(param_map);
+  }
 
-			double getMaximumTime() const override { return 0; }
+  double getMaximumTime() const override { return 0; }
 
-		private:
-			std::unordered_map<std::string, double> param_map;
-			std::function<double(const std::unordered_map<std::string, double>&)> m_evaluator;
-	};
+private:
+  std::unordered_map<std::string, double> param_map;
+  std::function<double(const std::unordered_map<std::string, double>&)> m_evaluator;
+};
 
-	class PulseShapeFactory {
-		public:
-			static std::unique_ptr<SignalPulse> createPulseShape(const std::string& type,
-					const std::vector<double>& params) {
-				if (type == "LandauPulse") {
-					return std::make_unique<LandauPulse>(params);
-				}
-				//
-				// Add more pulse shape variants here as needed
+class PulseShapeFactory {
+public:
+  static std::unique_ptr<SignalPulse> createPulseShape(const std::string& type,
+                                                       const std::vector<double>& params) {
+    if (type == "LandauPulse") {
+      return std::make_unique<LandauPulse>(params);
+    }
+    //
+    // Add more pulse shape variants here as needed
 
-				// If type not found, try and make a function using the ElavulatorSvc
-				try {
-					return std::make_unique<EvaluatorPulse>(type, params);
-				} catch (...) {
-					throw std::invalid_argument("Unable to make pulse shape type: " + type);
-				}
-			}
-	};
+    // If type not found, try and make a function using the ElavulatorSvc
+    try {
+      return std::make_unique<EvaluatorPulse>(type, params);
+    } catch (...) {
+      throw std::invalid_argument("Unable to make pulse shape type: " + type);
+    }
+  }
+};
 
-	std::tuple<double, double>
-		HitAdapter<edm4hep::SimTrackerHit>::getPulseSources(const edm4hep::SimTrackerHit& hit) {
-			return {hit.getTime(), hit.getEDep()};
-		}
-
-#if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
-	void HitAdapter<edm4hep::SimTrackerHit>::addRelations(MutablePulseType& pulse,
-			const edm4hep::SimTrackerHit& hit) {
-		pulse.addToTrackerHits(hit);
-		pulse.addToParticles(hit.getParticle());
-	}
-#endif
-
-	std::tuple<double, double>
-		HitAdapter<edm4hep::SimCalorimeterHit>::getPulseSources(const edm4hep::SimCalorimeterHit& hit) {
-			const auto& contribs  = hit.getContributions();
-			auto earliest_contrib = std::ranges::min_element(
-					contribs, [](const auto& a, const auto& b) { return a.getTime() < b.getTime(); });
-			return {earliest_contrib->getTime(), hit.getEnergy()};
-		}
+std::tuple<double, double>
+HitAdapter<edm4hep::SimTrackerHit>::getPulseSources(const edm4hep::SimTrackerHit& hit) {
+  return {hit.getTime(), hit.getEDep()};
+}
 
 #if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
-	void HitAdapter<edm4hep::SimCalorimeterHit>::addRelations(MutablePulseType& pulse,
-			const edm4hep::SimCalorimeterHit& hit) {
-		pulse.addToCalorimeterHits(hit);
-		pulse.addToParticles(hit.getContributions(0).getParticle());
-	}
+void HitAdapter<edm4hep::SimTrackerHit>::addRelations(MutablePulseType& pulse,
+                                                      const edm4hep::SimTrackerHit& hit) {
+  pulse.addToTrackerHits(hit);
+  pulse.addToParticles(hit.getParticle());
+}
 #endif
 
-	template <typename HitT> void PulseGeneration<HitT>::init() {
-		m_pulse =
-			PulseShapeFactory::createPulseShape(m_cfg.pulse_shape_function, m_cfg.pulse_shape_params);
-		m_min_sampling_time = m_cfg.min_sampling_time;
-
-		m_min_sampling_time = std::max<double>(m_pulse->getMaximumTime(), m_min_sampling_time);
-
-		m_ignore_thres = m_cfg.ignore_thres;
-
-		// For converting energy deposit to number of photoelectrons
-		if (m_cfg.edep_to_npe) {
-			m_edep_to_npe = m_cfg.edep_to_npe;
-			m_ignore_thres *= m_edep_to_npe.value();
-
-			// Get the field indices and field-dependent conversion factors if necessary
-			if (!m_cfg.readout.empty() && !m_cfg.edep_to_npe_fields.empty() && !m_cfg.edep_to_npe_filename.empty()) {
-				id_spec = m_detector->readout(m_cfg.readout).idSpec();
-				id_dec = id_spec.decoder();
-				for (const auto& field : m_cfg.edep_to_npe_fields) {
-					auto field_idx = id_dec->index(field);
-					m_field_idxs.push_back(field_idx);
-				}
-
-				std::string filename = fmt::format("calibrations/{}", m_cfg.edep_to_npe_filename);
-				std::ifstream infile(filename);
-				if (!infile) {
-					throw std::runtime_error(fmt::format("Unable to open LUT file: {}", 
-								m_cfg.edep_to_npe_filename));
-				}
-				std::string line;
-				while (std::getline(infile, line)) {
-					std::istringstream iss(line);
-					std::vector<int> keys;
-					for(std::size_t i = 0; i < m_cfg.edep_to_npe_fields.size(); i++) {
-						int value;
-						iss >> value;
-						keys.push_back(value);
-					}
-					double factor;
-					iss >> factor;
-					m_edep_to_npe_factors[keys] = factor;
-				}
-			}
-		}
-	}
-
-	template <typename HitT>
-		void PulseGeneration<HitT>::process(
-				const typename PulseGenerationAlgorithm<HitT>::Input& input,
-				const typename PulseGenerationAlgorithm<HitT>::Output& output) const {
-			const auto [simhits] = input;
-			auto [rawPulses]     = output;
-
-			for (const auto& hit : *simhits) {
-				const auto [time, raw_charge] = HitAdapter<HitT>::getPulseSources(hit);
-				double charge = raw_charge;
-
-				// Convert energy deposit to the number of photoelectrons if necessary
-				if (m_edep_to_npe) {
-					double npe = charge * m_edep_to_npe.value();
-
-					if (!m_edep_to_npe_factors.empty()) {
-						std::vector<int> field_values;
-						for (std::size_t i = 0; i < m_cfg.edep_to_npe_fields.size(); ++i) {
-							const int value = id_dec != nullptr && !m_cfg.edep_to_npe_fields[i].empty()
-								? static_cast<int>(id_dec->get(hit.getCellID(), m_field_idxs[i]))
-								: -1;
-							field_values.push_back(value);
-						}
-						auto it = m_edep_to_npe_factors.find(field_values);
-						if (it != m_edep_to_npe_factors.end()) {
-							npe *= it->second;
-						}
-					}
-
-					std::poisson_distribution<> poisson(npe);
-					charge = poisson(m_gen);
-				}
-
-				// Calculate nearest timestep to the hit time rounded down (assume clocks aligned with time 0)
-				double signal_time = m_cfg.timestep * std::floor(time / m_cfg.timestep);
-
-				bool passed_threshold   = false;
-				std::uint32_t skip_bins = 0;
-				float previous          = 0;
-				float integral          = 0;
-				std::vector<float> pulse;
-
-				for (std::uint32_t i = 0; i < m_cfg.max_time_bins; i++) {
-					double t    = signal_time + i * m_cfg.timestep - time;
-					auto signal = (*m_pulse)(t, charge);
-
-					// Early exit conditions: below threshold and falling, or min sampling time after threshold
-					if (std::abs(signal) < m_ignore_thres) {
-						if (!passed_threshold) {
-							// Before threshold crossed
-							auto diff = std::abs(signal) - std::abs(previous);
-							previous  = signal;
-							if (diff >= 0) {
-								// Rising before threshold crossed
-								skip_bins = i;
-								continue;
-							} else {
-								// Falling without threshold ever crossed
-								break;
-							}
-						} else {
-							// After threshold crossed, stop after min sampling time
-							if (t > m_min_sampling_time) {
-								break;
-							}
-						}
-					}
-
-					passed_threshold = true;
-					pulse.push_back(signal);
-					integral += signal;
-				}
-
-				if (!passed_threshold) {
-					continue;
-				}
-
-				auto time_series = rawPulses->create();
-				time_series.setCellID(hit.getCellID());
-				time_series.setInterval(m_cfg.timestep);
-				time_series.setTime(signal_time + skip_bins * m_cfg.timestep);
-
-				for (const auto& value : pulse) {
-					time_series.addToAmplitude(value);
-				}
+std::tuple<double, double>
+HitAdapter<edm4hep::SimCalorimeterHit>::getPulseSources(const edm4hep::SimCalorimeterHit& hit) {
+  const auto& contribs  = hit.getContributions();
+  auto earliest_contrib = std::ranges::min_element(
+      contribs, [](const auto& a, const auto& b) { return a.getTime() < b.getTime(); });
+  return {earliest_contrib->getTime(), hit.getEnergy()};
+}
 
 #if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
-				time_series.setIntegral(integral);
-				time_series.setPosition(
-						edm4hep::Vector3f(hit.getPosition().x, hit.getPosition().y, hit.getPosition().z));
-				HitAdapter<HitT>::addRelations(time_series, hit);
+void HitAdapter<edm4hep::SimCalorimeterHit>::addRelations(MutablePulseType& pulse,
+                                                          const edm4hep::SimCalorimeterHit& hit) {
+  pulse.addToCalorimeterHits(hit);
+  pulse.addToParticles(hit.getContributions(0).getParticle());
+}
 #endif
-			}
 
-		} // PulseGeneration:process
+template <typename HitT> void PulseGeneration<HitT>::init() {
+  m_pulse =
+      PulseShapeFactory::createPulseShape(m_cfg.pulse_shape_function, m_cfg.pulse_shape_params);
+  m_min_sampling_time = m_cfg.min_sampling_time;
 
-	template class PulseGeneration<edm4hep::SimTrackerHit>;
-	template class PulseGeneration<edm4hep::SimCalorimeterHit>;
+  m_min_sampling_time = std::max<double>(m_pulse->getMaximumTime(), m_min_sampling_time);
+
+  m_ignore_thres = m_cfg.ignore_thres;
+
+  // For converting energy deposit to number of photoelectrons
+  if (m_cfg.edep_to_npe) {
+    m_edep_to_npe = m_cfg.edep_to_npe;
+    m_ignore_thres *= m_edep_to_npe.value();
+
+    // Get the field indices and field-dependent conversion factors if necessary
+    if (!m_cfg.readout.empty() && !m_cfg.edep_to_npe_fields.empty() &&
+        !m_cfg.edep_to_npe_filename.empty()) {
+      id_spec = m_detector->readout(m_cfg.readout).idSpec();
+      id_dec  = id_spec.decoder();
+      for (const auto& field : m_cfg.edep_to_npe_fields) {
+        auto field_idx = id_dec->index(field);
+        m_field_idxs.push_back(field_idx);
+      }
+
+      std::string filename = fmt::format("calibrations/{}", m_cfg.edep_to_npe_filename);
+      std::ifstream infile(filename);
+      if (!infile) {
+        throw std::runtime_error(
+            fmt::format("Unable to open LUT file: {}", m_cfg.edep_to_npe_filename));
+      }
+      std::string line;
+      while (std::getline(infile, line)) {
+        std::istringstream iss(line);
+        std::vector<int> keys;
+        for (std::size_t i = 0; i < m_cfg.edep_to_npe_fields.size(); i++) {
+          int value;
+          iss >> value;
+          keys.push_back(value);
+        }
+        double factor;
+        iss >> factor;
+        m_edep_to_npe_factors[keys] = factor;
+      }
+    }
+  }
+}
+
+template <typename HitT>
+void PulseGeneration<HitT>::process(
+    const typename PulseGenerationAlgorithm<HitT>::Input& input,
+    const typename PulseGenerationAlgorithm<HitT>::Output& output) const {
+  const auto [simhits] = input;
+  auto [rawPulses]     = output;
+
+  for (const auto& hit : *simhits) {
+    const auto [time, raw_charge] = HitAdapter<HitT>::getPulseSources(hit);
+    double charge                 = raw_charge;
+
+    // Convert energy deposit to the number of photoelectrons if necessary
+    if (m_edep_to_npe) {
+      double npe = charge * m_edep_to_npe.value();
+
+      if (!m_edep_to_npe_factors.empty()) {
+        std::vector<int> field_values;
+        for (std::size_t i = 0; i < m_cfg.edep_to_npe_fields.size(); ++i) {
+          const int value = id_dec != nullptr && !m_cfg.edep_to_npe_fields[i].empty()
+                                ? static_cast<int>(id_dec->get(hit.getCellID(), m_field_idxs[i]))
+                                : -1;
+          field_values.push_back(value);
+        }
+        auto it = m_edep_to_npe_factors.find(field_values);
+        if (it != m_edep_to_npe_factors.end()) {
+          npe *= it->second;
+        }
+      }
+
+      std::poisson_distribution<> poisson(npe);
+      charge = poisson(m_gen);
+    }
+
+    // Calculate nearest timestep to the hit time rounded down (assume clocks aligned with time 0)
+    double signal_time = m_cfg.timestep * std::floor(time / m_cfg.timestep);
+
+    bool passed_threshold   = false;
+    std::uint32_t skip_bins = 0;
+    float previous          = 0;
+    float integral          = 0;
+    std::vector<float> pulse;
+
+    for (std::uint32_t i = 0; i < m_cfg.max_time_bins; i++) {
+      double t    = signal_time + i * m_cfg.timestep - time;
+      auto signal = (*m_pulse)(t, charge);
+
+      // Early exit conditions: below threshold and falling, or min sampling time after threshold
+      if (std::abs(signal) < m_ignore_thres) {
+        if (!passed_threshold) {
+          // Before threshold crossed
+          auto diff = std::abs(signal) - std::abs(previous);
+          previous  = signal;
+          if (diff >= 0) {
+            // Rising before threshold crossed
+            skip_bins = i;
+            continue;
+          } else {
+            // Falling without threshold ever crossed
+            break;
+          }
+        } else {
+          // After threshold crossed, stop after min sampling time
+          if (t > m_min_sampling_time) {
+            break;
+          }
+        }
+      }
+
+      passed_threshold = true;
+      pulse.push_back(signal);
+      integral += signal;
+    }
+
+    if (!passed_threshold) {
+      continue;
+    }
+
+    auto time_series = rawPulses->create();
+    time_series.setCellID(hit.getCellID());
+    time_series.setInterval(m_cfg.timestep);
+    time_series.setTime(signal_time + skip_bins * m_cfg.timestep);
+
+    for (const auto& value : pulse) {
+      time_series.addToAmplitude(value);
+    }
+
+#if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
+    time_series.setIntegral(integral);
+    time_series.setPosition(
+        edm4hep::Vector3f(hit.getPosition().x, hit.getPosition().y, hit.getPosition().z));
+    HitAdapter<HitT>::addRelations(time_series, hit);
+#endif
+  }
+
+} // PulseGeneration:process
+
+template class PulseGeneration<edm4hep::SimTrackerHit>;
+template class PulseGeneration<edm4hep::SimCalorimeterHit>;
 
 } // namespace eicrecon

--- a/src/algorithms/digi/PulseGeneration.cc
+++ b/src/algorithms/digi/PulseGeneration.cc
@@ -23,15 +23,8 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
-
-#include <TDirectory.h>
-#include <TGraph2D.h>
 #include <fmt/format.h>
-#include <filesystem>
 #include <memory>
-#include <string>
-#include <stdexcept>
-#include <fstream>
 
 #include "services/evaluator/EvaluatorSvc.h"
 
@@ -176,42 +169,52 @@ template <typename HitT> void PulseGeneration<HitT>::init() {
 
   m_min_sampling_time = std::max<double>(m_pulse->getMaximumTime(), m_min_sampling_time);
 
-  m_ignore_thres = m_cfg.ignore_thres;
-
-  // For converting energy deposit to number of photoelectrons
-  if (m_cfg.edep_to_npe) {
-    m_edep_to_npe = m_cfg.edep_to_npe;
-    m_ignore_thres *= m_edep_to_npe.value();
-
-    // Get the field indices and field-dependent conversion factors if necessary
-    if (!m_cfg.readout.empty() && !m_cfg.edep_to_npe_fields.empty() &&
-        !m_cfg.edep_to_npe_filename.empty()) {
+  // Get the field indices and field-dependent conversion factors if necessary
+  if (!m_cfg.readout.empty() && !m_cfg.edep_to_npe_fields.empty() &&
+      !m_cfg.edep_to_npe_filename.empty()) {
+    try {
       id_spec = m_detector->readout(m_cfg.readout).idSpec();
-      id_dec  = id_spec.decoder();
+    } catch (...) {
+      this->warning("Failed to get idSpec for {}", m_cfg.readout);
+      return;
+    }
+    try {
+      id_dec = id_spec.decoder();
       for (const auto& field : m_cfg.edep_to_npe_fields) {
         auto field_idx = id_dec->index(field);
         m_field_idxs.push_back(field_idx);
       }
+    } catch (...) {
+      if (id_dec == nullptr) {
+        this->warning("Failed to load ID decoder for {}", m_cfg.readout);
+      } else {
+        this->warning("Failed to find edep-to-npe field indices for {}.", m_cfg.readout);
+      }
+      return;
+    }
 
-      std::string filename = fmt::format("calibrations/{}", m_cfg.edep_to_npe_filename);
-      std::ifstream infile(filename);
-      if (!infile) {
-        throw std::runtime_error(
-            fmt::format("Unable to open LUT file: {}", m_cfg.edep_to_npe_filename));
+    std::string filename = fmt::format("calibrations/{}", m_cfg.edep_to_npe_filename);
+    std::ifstream infile(filename);
+    if (!infile) {
+      this->warning("Unable to open LUT file: {}", filename);
+      return;
+    }
+    std::string line;
+    while (std::getline(infile, line)) {
+      std::istringstream iss(line);
+      std::vector<int> keys;
+      for (std::size_t i = 0; i < m_cfg.edep_to_npe_fields.size(); i++) {
+        int value;
+        iss >> value;
+        keys.push_back(value);
       }
-      std::string line;
-      while (std::getline(infile, line)) {
-        std::istringstream iss(line);
-        std::vector<int> keys;
-        for (std::size_t i = 0; i < m_cfg.edep_to_npe_fields.size(); i++) {
-          int value;
-          iss >> value;
-          keys.push_back(value);
-        }
-        double factor;
-        iss >> factor;
-        m_edep_to_npe_factors[keys] = factor;
+      double factor;
+      if (!(iss >> factor)) {
+        this->warning("Malformed LUT file: {}", filename);
+        m_edep_to_npe_lut.clear();
+        return;
       }
+      m_edep_to_npe_lut[keys] = factor;
     }
   }
 }
@@ -228,23 +231,8 @@ void PulseGeneration<HitT>::process(
     double charge                 = raw_charge;
 
     // Convert energy deposit to the number of photoelectrons if necessary
-    if (m_edep_to_npe) {
-      double npe = charge * m_edep_to_npe.value();
-
-      if (!m_edep_to_npe_factors.empty()) {
-        std::vector<int> field_values;
-        for (std::size_t i = 0; i < m_cfg.edep_to_npe_fields.size(); ++i) {
-          const int value = id_dec != nullptr && !m_cfg.edep_to_npe_fields[i].empty()
-                                ? static_cast<int>(id_dec->get(hit.getCellID(), m_field_idxs[i]))
-                                : -1;
-          field_values.push_back(value);
-        }
-        auto it = m_edep_to_npe_factors.find(field_values);
-        if (it != m_edep_to_npe_factors.end()) {
-          npe *= it->second;
-        }
-      }
-
+    if (m_cfg.edep_to_npe || !m_edep_to_npe_lut.empty()) {
+      double npe = charge * get_edep_to_npe_factor(hit);
       std::poisson_distribution<> poisson(npe);
       charge = poisson(m_gen);
     }
@@ -263,7 +251,7 @@ void PulseGeneration<HitT>::process(
       auto signal = (*m_pulse)(t, charge);
 
       // Early exit conditions: below threshold and falling, or min sampling time after threshold
-      if (std::abs(signal) < m_ignore_thres) {
+      if (std::abs(signal) < m_cfg.ignore_thres) {
         if (!passed_threshold) {
           // Before threshold crossed
           auto diff = std::abs(signal) - std::abs(previous);
@@ -311,6 +299,26 @@ void PulseGeneration<HitT>::process(
   }
 
 } // PulseGeneration:process
+
+template <typename HitT>
+double PulseGeneration<HitT>::get_edep_to_npe_factor(const HitT& hit) const {
+  if (m_cfg.edep_to_npe) {
+    return m_cfg.edep_to_npe;
+  } else if (!m_edep_to_npe_lut.empty()) {
+    std::vector<int> field_values;
+    for (std::size_t i = 0; i < m_cfg.edep_to_npe_fields.size(); ++i) {
+      const int value = id_dec != nullptr && !m_cfg.edep_to_npe_fields[i].empty()
+                            ? static_cast<int>(id_dec->get(hit.getCellID(), m_field_idxs[i]))
+                            : -1;
+      field_values.push_back(value);
+    }
+    auto it = m_edep_to_npe_lut.find(field_values);
+    if (it != m_edep_to_npe_lut.end()) {
+      return it->second;
+    }
+  }
+  return 1.;
+}
 
 template class PulseGeneration<edm4hep::SimTrackerHit>;
 template class PulseGeneration<edm4hep::SimCalorimeterHit>;

--- a/src/algorithms/digi/PulseGeneration.cc
+++ b/src/algorithms/digi/PulseGeneration.cc
@@ -24,224 +24,294 @@
 #include <unordered_map>
 #include <vector>
 
+#include <TDirectory.h>
+#include <TGraph2D.h>
+#include <fmt/format.h>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <stdexcept>
+#include <fstream>
+
 #include "services/evaluator/EvaluatorSvc.h"
 
 namespace eicrecon {
 
-class SignalPulse {
+	class SignalPulse {
 
-public:
-  virtual ~SignalPulse() = default; // Virtual destructor
+		public:
+			virtual ~SignalPulse() = default; // Virtual destructor
 
-  virtual double operator()(double time, double charge) = 0;
+			virtual double operator()(double time, double charge) = 0;
 
-  virtual double getMaximumTime() const = 0;
-};
+			virtual double getMaximumTime() const = 0;
+	};
 
-// ----------------------------------------------------------------------------
-// Landau Pulse Shape Functor
-// ----------------------------------------------------------------------------
-class LandauPulse : public SignalPulse {
-public:
-  LandauPulse(std::vector<double> params) {
+	// ----------------------------------------------------------------------------
+	// Landau Pulse Shape Functor
+	// ----------------------------------------------------------------------------
+	class LandauPulse : public SignalPulse {
+		public:
+			LandauPulse(std::vector<double> params) {
 
-    if ((params.size() != 2) && (params.size() != 3)) {
-      throw std::runtime_error(
-          "LandauPulse requires 2 or 3 parameters, gain, sigma_analog, [hit_sigma_offset], got " +
-          std::to_string(params.size()));
-    }
+				if ((params.size() != 2) && (params.size() != 3)) {
+					throw std::runtime_error(
+							"LandauPulse requires 2 or 3 parameters, gain, sigma_analog, [hit_sigma_offset], got " +
+							std::to_string(params.size()));
+				}
 
-    m_gain         = params[0];
-    m_sigma_analog = params[1];
-    if (params.size() == 3) {
-      m_hit_sigma_offset = params[2];
-    }
-  };
+				m_gain         = params[0];
+				m_sigma_analog = params[1];
+				if (params.size() == 3) {
+					m_hit_sigma_offset = params[2];
+				}
+			};
 
-  double operator()(double time, double charge) override {
-    return charge * m_gain *
-           TMath::Landau(time, m_hit_sigma_offset * m_sigma_analog, m_sigma_analog, kTRUE);
-  }
+			double operator()(double time, double charge) override {
+				return charge * m_gain *
+					TMath::Landau(time, m_hit_sigma_offset * m_sigma_analog, m_sigma_analog, kTRUE);
+			}
 
-  double getMaximumTime() const override { return m_hit_sigma_offset * m_sigma_analog; }
+			double getMaximumTime() const override { return m_hit_sigma_offset * m_sigma_analog; }
 
-private:
-  double m_gain             = 1.0;
-  double m_sigma_analog     = 1.0;
-  double m_hit_sigma_offset = 3.5;
-};
+		private:
+			double m_gain             = 1.0;
+			double m_sigma_analog     = 1.0;
+			double m_hit_sigma_offset = 3.5;
+	};
 
-// EvaluatorSvc Pulse
-class EvaluatorPulse : public SignalPulse {
-public:
-  EvaluatorPulse(const std::string& expression, const std::vector<double>& params) {
+	// EvaluatorSvc Pulse
+	class EvaluatorPulse : public SignalPulse {
+		public:
+			EvaluatorPulse(const std::string& expression, const std::vector<double>& params) {
 
-    std::vector<std::string> keys = {"time", "charge"};
-    for (std::size_t i = 0; i < params.size(); i++) {
-      std::string p = "param" + std::to_string(i);
-      //Check the expression contains the parameter
-      if (expression.find(p) == std::string::npos) {
-        throw std::runtime_error("Parameter " + p + " not found in expression");
-      }
-      keys.push_back(p);
-      param_map[p] = params[i];
-    }
+				std::vector<std::string> keys = {"time", "charge"};
+				for (std::size_t i = 0; i < params.size(); i++) {
+					std::string p = "param" + std::to_string(i);
+					//Check the expression contains the parameter
+					if (expression.find(p) == std::string::npos) {
+						throw std::runtime_error("Parameter " + p + " not found in expression");
+					}
+					keys.push_back(p);
+					param_map[p] = params[i];
+				}
 
-    // Check the expression is contains time and charge
-    if (expression.find("time") == std::string::npos) {
-      throw std::runtime_error("Parameter [time] not found in expression");
-    }
-    if (expression.find("charge") == std::string::npos) {
-      throw std::runtime_error("Parameter [charge] not found in expression");
-    }
+				// Check the expression is contains time and charge
+				if (expression.find("time") == std::string::npos) {
+					throw std::runtime_error("Parameter [time] not found in expression");
+				}
+				if (expression.find("charge") == std::string::npos) {
+					throw std::runtime_error("Parameter [charge] not found in expression");
+				}
 
-    auto& serviceSvc = algorithms::ServiceSvc::instance();
-    m_evaluator      = serviceSvc.service<EvaluatorSvc>("EvaluatorSvc")->_compile(expression, keys);
-  };
+				auto& serviceSvc = algorithms::ServiceSvc::instance();
+				m_evaluator      = serviceSvc.service<EvaluatorSvc>("EvaluatorSvc")->_compile(expression, keys);
+			};
 
-  double operator()(double time, double charge) override {
-    param_map["time"]   = time;
-    param_map["charge"] = charge;
-    return m_evaluator(param_map);
-  }
+			double operator()(double time, double charge) override {
+				param_map["time"]   = time;
+				param_map["charge"] = charge;
+				return m_evaluator(param_map);
+			}
 
-  double getMaximumTime() const override { return 0; }
+			double getMaximumTime() const override { return 0; }
 
-private:
-  std::unordered_map<std::string, double> param_map;
-  std::function<double(const std::unordered_map<std::string, double>&)> m_evaluator;
-};
+		private:
+			std::unordered_map<std::string, double> param_map;
+			std::function<double(const std::unordered_map<std::string, double>&)> m_evaluator;
+	};
 
-class PulseShapeFactory {
-public:
-  static std::unique_ptr<SignalPulse> createPulseShape(const std::string& type,
-                                                       const std::vector<double>& params) {
-    if (type == "LandauPulse") {
-      return std::make_unique<LandauPulse>(params);
-    }
-    //
-    // Add more pulse shape variants here as needed
+	class PulseShapeFactory {
+		public:
+			static std::unique_ptr<SignalPulse> createPulseShape(const std::string& type,
+					const std::vector<double>& params) {
+				if (type == "LandauPulse") {
+					return std::make_unique<LandauPulse>(params);
+				}
+				//
+				// Add more pulse shape variants here as needed
 
-    // If type not found, try and make a function using the ElavulatorSvc
-    try {
-      return std::make_unique<EvaluatorPulse>(type, params);
-    } catch (...) {
-      throw std::invalid_argument("Unable to make pulse shape type: " + type);
-    }
-  }
-};
+				// If type not found, try and make a function using the ElavulatorSvc
+				try {
+					return std::make_unique<EvaluatorPulse>(type, params);
+				} catch (...) {
+					throw std::invalid_argument("Unable to make pulse shape type: " + type);
+				}
+			}
+	};
 
-std::tuple<double, double>
-HitAdapter<edm4hep::SimTrackerHit>::getPulseSources(const edm4hep::SimTrackerHit& hit) {
-  return {hit.getTime(), hit.getEDep()};
-}
-
-#if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
-void HitAdapter<edm4hep::SimTrackerHit>::addRelations(MutablePulseType& pulse,
-                                                      const edm4hep::SimTrackerHit& hit) {
-  pulse.addToTrackerHits(hit);
-  pulse.addToParticles(hit.getParticle());
-}
-#endif
-
-std::tuple<double, double>
-HitAdapter<edm4hep::SimCalorimeterHit>::getPulseSources(const edm4hep::SimCalorimeterHit& hit) {
-  const auto& contribs  = hit.getContributions();
-  auto earliest_contrib = std::ranges::min_element(
-      contribs, [](const auto& a, const auto& b) { return a.getTime() < b.getTime(); });
-  return {earliest_contrib->getTime(), hit.getEnergy()};
-}
+	std::tuple<double, double>
+		HitAdapter<edm4hep::SimTrackerHit>::getPulseSources(const edm4hep::SimTrackerHit& hit) {
+			return {hit.getTime(), hit.getEDep()};
+		}
 
 #if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
-void HitAdapter<edm4hep::SimCalorimeterHit>::addRelations(MutablePulseType& pulse,
-                                                          const edm4hep::SimCalorimeterHit& hit) {
-  pulse.addToCalorimeterHits(hit);
-  pulse.addToParticles(hit.getContributions(0).getParticle());
-}
+	void HitAdapter<edm4hep::SimTrackerHit>::addRelations(MutablePulseType& pulse,
+			const edm4hep::SimTrackerHit& hit) {
+		pulse.addToTrackerHits(hit);
+		pulse.addToParticles(hit.getParticle());
+	}
 #endif
 
-template <typename HitT> void PulseGeneration<HitT>::init() {
-  m_pulse =
-      PulseShapeFactory::createPulseShape(m_cfg.pulse_shape_function, m_cfg.pulse_shape_params);
-  m_min_sampling_time = m_cfg.min_sampling_time;
-
-  m_min_sampling_time = std::max<double>(m_pulse->getMaximumTime(), m_min_sampling_time);
-}
-
-template <typename HitT>
-void PulseGeneration<HitT>::process(
-    const typename PulseGenerationAlgorithm<HitT>::Input& input,
-    const typename PulseGenerationAlgorithm<HitT>::Output& output) const {
-  const auto [simhits] = input;
-  auto [rawPulses]     = output;
-
-  for (const auto& hit : *simhits) {
-    const auto [time, charge] = HitAdapter<HitT>::getPulseSources(hit);
-
-    // Calculate nearest timestep to the hit time rounded down (assume clocks aligned with time 0)
-    double signal_time = m_cfg.timestep * std::floor(time / m_cfg.timestep);
-
-    bool passed_threshold   = false;
-    std::uint32_t skip_bins = 0;
-    float previous          = 0;
-    float integral          = 0;
-    std::vector<float> pulse;
-
-    for (std::uint32_t i = 0; i < m_cfg.max_time_bins; i++) {
-      double t    = signal_time + i * m_cfg.timestep - time;
-      auto signal = (*m_pulse)(t, charge);
-
-      // Early exit conditions: below threshold and falling, or min sampling time after threshold
-      if (std::abs(signal) < m_cfg.ignore_thres) {
-        if (!passed_threshold) {
-          // Before threshold crossed
-          auto diff = std::abs(signal) - std::abs(previous);
-          previous  = signal;
-          if (diff >= 0) {
-            // Rising before threshold crossed
-            skip_bins = i;
-            continue;
-          } else {
-            // Falling without threshold ever crossed
-            break;
-          }
-        } else {
-          // After threshold crossed, stop after min sampling time
-          if (t > m_min_sampling_time) {
-            break;
-          }
-        }
-      }
-
-      passed_threshold = true;
-      pulse.push_back(signal);
-      integral += signal;
-    }
-
-    if (!passed_threshold) {
-      continue;
-    }
-
-    auto time_series = rawPulses->create();
-    time_series.setCellID(hit.getCellID());
-    time_series.setInterval(m_cfg.timestep);
-    time_series.setTime(signal_time + skip_bins * m_cfg.timestep);
-
-    for (const auto& value : pulse) {
-      time_series.addToAmplitude(value);
-    }
+	std::tuple<double, double>
+		HitAdapter<edm4hep::SimCalorimeterHit>::getPulseSources(const edm4hep::SimCalorimeterHit& hit) {
+			const auto& contribs  = hit.getContributions();
+			auto earliest_contrib = std::ranges::min_element(
+					contribs, [](const auto& a, const auto& b) { return a.getTime() < b.getTime(); });
+			return {earliest_contrib->getTime(), hit.getEnergy()};
+		}
 
 #if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
-    time_series.setIntegral(integral);
-    time_series.setPosition(
-        edm4hep::Vector3f(hit.getPosition().x, hit.getPosition().y, hit.getPosition().z));
-    HitAdapter<HitT>::addRelations(time_series, hit);
+	void HitAdapter<edm4hep::SimCalorimeterHit>::addRelations(MutablePulseType& pulse,
+			const edm4hep::SimCalorimeterHit& hit) {
+		pulse.addToCalorimeterHits(hit);
+		pulse.addToParticles(hit.getContributions(0).getParticle());
+	}
 #endif
-  }
 
-} // PulseGeneration:process
+	template <typename HitT> void PulseGeneration<HitT>::init() {
+		m_pulse =
+			PulseShapeFactory::createPulseShape(m_cfg.pulse_shape_function, m_cfg.pulse_shape_params);
+		m_min_sampling_time = m_cfg.min_sampling_time;
 
-template class PulseGeneration<edm4hep::SimTrackerHit>;
-template class PulseGeneration<edm4hep::SimCalorimeterHit>;
+		m_min_sampling_time = std::max<double>(m_pulse->getMaximumTime(), m_min_sampling_time);
+
+		m_ignore_thres = m_cfg.ignore_thres;
+
+		// For converting energy deposit to number of photoelectrons
+		if (m_cfg.edep_to_npe) {
+			m_edep_to_npe = m_cfg.edep_to_npe;
+			m_ignore_thres *= m_edep_to_npe.value();
+
+			// Get the field indices and field-dependent conversion factors if necessary
+			if (!m_cfg.readout.empty() && !m_cfg.edep_to_npe_fields.empty() && !m_cfg.edep_to_npe_filename.empty()) {
+				id_spec = m_detector->readout(m_cfg.readout).idSpec();
+				id_dec = id_spec.decoder();
+				for (const auto& field : m_cfg.edep_to_npe_fields) {
+					auto field_idx = id_dec->index(field);
+					m_field_idxs.push_back(field_idx);
+				}
+
+				std::string filename = fmt::format("calibrations/{}", m_cfg.edep_to_npe_filename);
+				std::ifstream infile(filename);
+				if (!infile) {
+					throw std::runtime_error(fmt::format("Unable to open LUT file: {}", 
+								m_cfg.edep_to_npe_filename));
+				}
+				std::string line;
+				while (std::getline(infile, line)) {
+					std::istringstream iss(line);
+					std::vector<int> keys;
+					for(std::size_t i = 0; i < m_cfg.edep_to_npe_fields.size(); i++) {
+						int value;
+						iss >> value;
+						keys.push_back(value);
+					}
+					double factor;
+					iss >> factor;
+					m_edep_to_npe_factors[keys] = factor;
+				}
+			}
+		}
+	}
+
+	template <typename HitT>
+		void PulseGeneration<HitT>::process(
+				const typename PulseGenerationAlgorithm<HitT>::Input& input,
+				const typename PulseGenerationAlgorithm<HitT>::Output& output) const {
+			const auto [simhits] = input;
+			auto [rawPulses]     = output;
+
+			for (const auto& hit : *simhits) {
+				const auto [time, raw_charge] = HitAdapter<HitT>::getPulseSources(hit);
+				double charge = raw_charge;
+
+				// Convert energy deposit to the number of photoelectrons if necessary
+				if (m_edep_to_npe) {
+					double npe = charge * m_edep_to_npe.value();
+
+					if (!m_edep_to_npe_factors.empty()) {
+						std::vector<int> field_values;
+						for (std::size_t i = 0; i < m_cfg.edep_to_npe_fields.size(); ++i) {
+							const int value = id_dec != nullptr && !m_cfg.edep_to_npe_fields[i].empty()
+								? static_cast<int>(id_dec->get(hit.getCellID(), m_field_idxs[i]))
+								: -1;
+							field_values.push_back(value);
+						}
+						auto it = m_edep_to_npe_factors.find(field_values);
+						if (it != m_edep_to_npe_factors.end()) {
+							npe *= it->second;
+						}
+					}
+
+					std::poisson_distribution<> poisson(npe);
+					charge = poisson(m_gen);
+				}
+
+				// Calculate nearest timestep to the hit time rounded down (assume clocks aligned with time 0)
+				double signal_time = m_cfg.timestep * std::floor(time / m_cfg.timestep);
+
+				bool passed_threshold   = false;
+				std::uint32_t skip_bins = 0;
+				float previous          = 0;
+				float integral          = 0;
+				std::vector<float> pulse;
+
+				for (std::uint32_t i = 0; i < m_cfg.max_time_bins; i++) {
+					double t    = signal_time + i * m_cfg.timestep - time;
+					auto signal = (*m_pulse)(t, charge);
+
+					// Early exit conditions: below threshold and falling, or min sampling time after threshold
+					if (std::abs(signal) < m_ignore_thres) {
+						if (!passed_threshold) {
+							// Before threshold crossed
+							auto diff = std::abs(signal) - std::abs(previous);
+							previous  = signal;
+							if (diff >= 0) {
+								// Rising before threshold crossed
+								skip_bins = i;
+								continue;
+							} else {
+								// Falling without threshold ever crossed
+								break;
+							}
+						} else {
+							// After threshold crossed, stop after min sampling time
+							if (t > m_min_sampling_time) {
+								break;
+							}
+						}
+					}
+
+					passed_threshold = true;
+					pulse.push_back(signal);
+					integral += signal;
+				}
+
+				if (!passed_threshold) {
+					continue;
+				}
+
+				auto time_series = rawPulses->create();
+				time_series.setCellID(hit.getCellID());
+				time_series.setInterval(m_cfg.timestep);
+				time_series.setTime(signal_time + skip_bins * m_cfg.timestep);
+
+				for (const auto& value : pulse) {
+					time_series.addToAmplitude(value);
+				}
+
+#if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 1)
+				time_series.setIntegral(integral);
+				time_series.setPosition(
+						edm4hep::Vector3f(hit.getPosition().x, hit.getPosition().y, hit.getPosition().z));
+				HitAdapter<HitT>::addRelations(time_series, hit);
+#endif
+			}
+
+		} // PulseGeneration:process
+
+	template class PulseGeneration<edm4hep::SimTrackerHit>;
+	template class PulseGeneration<edm4hep::SimCalorimeterHit>;
 
 } // namespace eicrecon

--- a/src/algorithms/digi/PulseGeneration.h
+++ b/src/algorithms/digi/PulseGeneration.h
@@ -6,17 +6,9 @@
 
 #pragma once
 
-#include <DD4hep/Alignments.h>
-#include <DD4hep/Handle.h>
 #include <DD4hep/IDDescriptor.h>
-#include <DD4hep/Objects.h>
 #include <DD4hep/Readout.h>
-#include <DD4hep/Segmentations.h>
-#include <DD4hep/Shapes.h>
-#include <DD4hep/VolumeManager.h>
-#include <DD4hep/Volumes.h>
 #include <algorithms/algorithm.h>
-#include <algorithms/service.h>
 #include <algorithms/geo.h>
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/unit_system.h>
@@ -31,7 +23,6 @@
 #include <string_view>
 #include <tuple>
 #include <variant>
-#include <optional>
 #include <random>
 
 #include "algorithms/digi/PulseGenerationConfig.h"
@@ -87,16 +78,16 @@ private:
   std::shared_ptr<SignalPulse> m_pulse;
   float m_min_sampling_time = 0 * edm4eic::unit::ns;
 
-  // Members for converting energy deposit to number of photoelectrons
+  // Members for converting energy deposit to the number of photoelectrons
   dd4hep::IDDescriptor id_spec;
   dd4hep::BitFieldCoder* id_dec = nullptr;
   const dd4hep::Detector* m_detector{algorithms::GeoSvc::instance().detector()};
-  std::vector<std::size_t> m_field_idxs{};
-
   mutable std::mt19937 m_gen{};
-  double m_ignore_thres = 10;
-  std::optional<double> m_edep_to_npe;
-  std::map<std::vector<int>, double> m_edep_to_npe_factors{};
+  std::vector<std::size_t> m_field_idxs{};
+  std::map<std::vector<int>, double> m_edep_to_npe_lut{};
+
+private:
+  double get_edep_to_npe_factor(const HitT& hit) const;
 };
 
 } // namespace eicrecon

--- a/src/algorithms/digi/PulseGeneration.h
+++ b/src/algorithms/digi/PulseGeneration.h
@@ -6,7 +6,18 @@
 
 #pragma once
 
+#include <DD4hep/Alignments.h>
+#include <DD4hep/Handle.h>
+#include <DD4hep/IDDescriptor.h>
+#include <DD4hep/Objects.h>
+#include <DD4hep/Readout.h>
+#include <DD4hep/Segmentations.h>
+#include <DD4hep/Shapes.h>
+#include <DD4hep/VolumeManager.h>
+#include <DD4hep/Volumes.h>
 #include <algorithms/algorithm.h>
+#include <algorithms/service.h>
+#include <algorithms/geo.h>
 #include <edm4eic/EDM4eicVersion.h>
 #include <edm4eic/unit_system.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
@@ -20,9 +31,13 @@
 #include <string_view>
 #include <tuple>
 #include <variant>
+#include <optional>
+#include <random>
 
 #include "algorithms/digi/PulseGenerationConfig.h"
 #include "algorithms/interfaces/WithPodConfig.h"
+
+using namespace dd4hep;
 
 namespace eicrecon {
 
@@ -71,6 +86,17 @@ public:
 private:
   std::shared_ptr<SignalPulse> m_pulse;
   float m_min_sampling_time = 0 * edm4eic::unit::ns;
+
+  // Members for converting energy deposit to number of photoelectrons
+  dd4hep::IDDescriptor id_spec;
+  dd4hep::BitFieldCoder* id_dec = nullptr;
+  const dd4hep::Detector* m_detector{algorithms::GeoSvc::instance().detector()};
+  std::vector<std::size_t> m_field_idxs{};
+
+  mutable std::mt19937 m_gen{};
+  double m_ignore_thres = 10;
+  std::optional<double> m_edep_to_npe;
+  std::map<std::vector<int>, double> m_edep_to_npe_factors{};
 };
 
 } // namespace eicrecon

--- a/src/algorithms/digi/PulseGeneration.h
+++ b/src/algorithms/digi/PulseGeneration.h
@@ -6,8 +6,9 @@
 
 #pragma once
 
+#include <DD4hep/Detector.h>
 #include <DD4hep/IDDescriptor.h>
-#include <DD4hep/Readout.h>
+#include <Parsers/Primitives.h>
 #include <algorithms/algorithm.h>
 #include <algorithms/geo.h>
 #include <edm4eic/EDM4eicVersion.h>
@@ -19,11 +20,15 @@
 #else
 #include <edm4hep/TimeSeriesCollection.h>
 #endif
+#include <cstddef>
+#include <gsl/pointers>
+#include <map>
 #include <memory>
+#include <random>
 #include <string_view>
 #include <tuple>
 #include <variant>
-#include <random>
+#include <vector>
 
 #include "algorithms/digi/PulseGenerationConfig.h"
 #include "algorithms/interfaces/WithPodConfig.h"

--- a/src/algorithms/digi/PulseGenerationConfig.h
+++ b/src/algorithms/digi/PulseGenerationConfig.h
@@ -20,8 +20,10 @@ struct PulseGenerationConfig {
 
   // Parameters for converting energy deposit to the number of photoelectrons
   std::string readout{};
-  std::vector<std::string> edep_to_npe_fields{}; // Fields the edep-to-npe conversion factor depends on
-  std::string edep_to_npe_filename{}; // Lookup table name to get the field-dependent edep-to-npe conversion factors
+  std::vector<std::string>
+      edep_to_npe_fields{}; // Fields the edep-to-npe conversion factor depends on
+  std::string
+      edep_to_npe_filename{}; // Lookup table name to get the field-dependent edep-to-npe conversion factors
   double edep_to_npe{}; // Constant edep-to-npe conversion factor
 };
 

--- a/src/algorithms/digi/PulseGenerationConfig.h
+++ b/src/algorithms/digi/PulseGenerationConfig.h
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2025 Simon Gardner
+// Copyright (C) 2025 Simon Gardner, Minho Kim
 
 #pragma once
 
+#include <string>
+#include <vector>
 #include <edm4eic/unit_system.h>
 
 namespace eicrecon {
@@ -15,6 +17,12 @@ struct PulseGenerationConfig {
   double timestep          = 0.2 * edm4eic::unit::ns; // Minimum digitization time step
   double min_sampling_time = 0 * edm4eic::unit::ns;   // Minimum sampling time
   uint32_t max_time_bins   = 10000;
+
+  // Parameters for converting energy deposit to number of photoelectrons
+  std::string readout{};
+  std::vector<std::string> edep_to_npe_fields{};
+  std::string edep_to_npe_filename{};
+  double edep_to_npe{};
 };
 
 } // namespace eicrecon

--- a/src/algorithms/digi/PulseGenerationConfig.h
+++ b/src/algorithms/digi/PulseGenerationConfig.h
@@ -18,11 +18,11 @@ struct PulseGenerationConfig {
   double min_sampling_time = 0 * edm4eic::unit::ns;   // Minimum sampling time
   uint32_t max_time_bins   = 10000;
 
-  // Parameters for converting energy deposit to number of photoelectrons
+  // Parameters for converting energy deposit to the number of photoelectrons
   std::string readout{};
-  std::vector<std::string> edep_to_npe_fields{};
-  std::string edep_to_npe_filename{};
-  double edep_to_npe{};
+  std::vector<std::string> edep_to_npe_fields{}; // Fields the edep-to-npe conversion factor depends on
+  std::string edep_to_npe_filename{}; // Lookup table name to get the field-dependent edep-to-npe conversion factors
+  double edep_to_npe{}; // Constant edep-to-npe conversion factor
 };
 
 } // namespace eicrecon

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -63,6 +63,8 @@ void InitPlugin(JApplication* app) {
       1.0, 2 * edm4eic::unit::ns};
   decltype(PulseGenerationConfig::ignore_thres) EcalBarrelScFi_ignore_thres = {5.0e-5};
   decltype(PulseGenerationConfig::timestep) EcalBarrelScFi_timestep = {0.5 * edm4eic::unit::ns};
+  decltype(PulseGenerationConfig::edep_to_npe) EcalBarrelScFi_edep_to_npe =
+      1773.26 / edm4eic::unit::GeV;
 
   decltype(PulseCombinerConfig::combine_field) EcalBarrelScFi_combine_field           = {"grid"};
   decltype(PulseCombinerConfig::minimum_separation) EcalBarrelScFi_minimum_separation = {
@@ -117,6 +119,7 @@ void InitPlugin(JApplication* app) {
           .pulse_shape_params   = EcalBarrelScFi_pulse_shape_params,
           .ignore_thres         = EcalBarrelScFi_ignore_thres,
           .timestep             = EcalBarrelScFi_timestep,
+	  .edep_to_npe          = EcalBarrelScFi_edep_to_npe,
       },
       app // TODO: Remove me once fixed
       ));
@@ -127,6 +130,7 @@ void InitPlugin(JApplication* app) {
           .pulse_shape_params   = EcalBarrelScFi_pulse_shape_params,
           .ignore_thres         = EcalBarrelScFi_ignore_thres,
           .timestep             = EcalBarrelScFi_timestep,
+	  .edep_to_npe          = EcalBarrelScFi_edep_to_npe,
       },
       app // TODO: Remove me once fixed
       ));

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -119,7 +119,7 @@ void InitPlugin(JApplication* app) {
           .pulse_shape_params   = EcalBarrelScFi_pulse_shape_params,
           .ignore_thres         = EcalBarrelScFi_ignore_thres,
           .timestep             = EcalBarrelScFi_timestep,
-	  .edep_to_npe          = EcalBarrelScFi_edep_to_npe,
+          .edep_to_npe          = EcalBarrelScFi_edep_to_npe,
       },
       app // TODO: Remove me once fixed
       ));
@@ -130,7 +130,7 @@ void InitPlugin(JApplication* app) {
           .pulse_shape_params   = EcalBarrelScFi_pulse_shape_params,
           .ignore_thres         = EcalBarrelScFi_ignore_thres,
           .timestep             = EcalBarrelScFi_timestep,
-	  .edep_to_npe          = EcalBarrelScFi_edep_to_npe,
+          .edep_to_npe          = EcalBarrelScFi_edep_to_npe,
       },
       app // TODO: Remove me once fixed
       ));

--- a/src/factories/digi/PulseGeneration_factory.h
+++ b/src/factories/digi/PulseGeneration_factory.h
@@ -41,14 +41,14 @@ private:
       this, "minSamplingTime", this->config().min_sampling_time};
   typename FactoryT::template ParameterRef<uint32_t> m_max_time_bins{this, "maxTimeBins",
                                                                      this->config().max_time_bins};
-  typename FactoryT::template ParameterRef<std::string> m_readout{
-      this, "readout", this->config().readout};
+  typename FactoryT::template ParameterRef<std::string> m_readout{this, "readout",
+                                                                  this->config().readout};
   typename FactoryT::template ParameterRef<std::vector<std::string>> m_edep_to_npe_fields{
       this, "edepToNpeFields", this->config().edep_to_npe_fields};
   typename FactoryT::template ParameterRef<std::string> m_edep_to_npe_filename{
       this, "fileName", this->config().edep_to_npe_filename};
-  typename FactoryT::template ParameterRef<double> m_edep_to_npe{
-      this, "edepToNpe", this->config().edep_to_npe};
+  typename FactoryT::template ParameterRef<double> m_edep_to_npe{this, "edepToNpe",
+                                                                 this->config().edep_to_npe};
 
   typename FactoryT::template Service<AlgorithmsInit_service> m_algorithmsInit{this};
 

--- a/src/factories/digi/PulseGeneration_factory.h
+++ b/src/factories/digi/PulseGeneration_factory.h
@@ -44,8 +44,8 @@ private:
       this, "readout", this->config().readout};
   typename FactoryT::template ParameterRef<std::vector<std::string>> m_edep_to_npe_fields{
       this, "edepToNpeFields", this->config().edep_to_npe_fields};
-  typename FactoryT::template ParameterRef<std::string> m_filename{
-      this, "fileName", this->config().filename};
+  typename FactoryT::template ParameterRef<std::string> m_edep_to_npe_filename{
+      this, "fileName", this->config().edep_to_npe_filename};
   typename FactoryT::template ParameterRef<double> m_edep_to_npe{
       this, "edepToNpe", this->config().edep_to_npe};
 

--- a/src/factories/digi/PulseGeneration_factory.h
+++ b/src/factories/digi/PulseGeneration_factory.h
@@ -40,6 +40,14 @@ private:
       this, "minSamplingTime", this->config().min_sampling_time};
   typename FactoryT::template ParameterRef<uint32_t> m_max_time_bins{this, "maxTimeBins",
                                                                      this->config().max_time_bins};
+  typename FactoryT::template ParameterRef<std::string> m_readout{
+      this, "readout", this->config().readout};
+  typename FactoryT::template ParameterRef<std::vector<std::string>> m_edep_to_npe_fields{
+      this, "edepToNpeFields", this->config().edep_to_npe_fields};
+  typename FactoryT::template ParameterRef<std::string> m_filename{
+      this, "fileName", this->config().filename};
+  typename FactoryT::template ParameterRef<double> m_edep_to_npe{
+      this, "edepToNpe", this->config().edep_to_npe};
 
   typename FactoryT::template Service<AlgorithmsInit_service> m_algorithmsInit{this};
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds a conversion from energy deposit to the number of photoelectrons in the `PulseGeneration` algorithm. If the conversion factor is a constant and doesn't depend on any field, `edep_to_npe` is used for conversion. It the conversion factor depends on certain fields, the algorithm gets the field-dependent conversion factors from a lookup table using `m_edep_to_npe_fields` and `m_edep_to_npe_filename`. Poisson smearing is also applied after the conversion.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #2467)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No