### PR TITLE
Increase requirement on minimum number of track measurements to 4

### DIFF
--- a/src/algorithms/tracking/AmbiguitySolverConfig.h
+++ b/src/algorithms/tracking/AmbiguitySolverConfig.h
@@ -12,6 +12,6 @@ struct AmbiguitySolverConfig {
   /// Maximum number of iterations
   std::uint32_t maximum_iterations = 100000;
   /// Minimum number of measurement to form a track.
-  std::size_t n_measurements_min = 3;
+  std::size_t n_measurements_min = 4;
 };
 } // namespace eicrecon

--- a/src/algorithms/tracking/CKFTrackingConfig.h
+++ b/src/algorithms/tracking/CKFTrackingConfig.h
@@ -12,6 +12,6 @@ struct CKFTrackingConfig {
   std::vector<double> chi2CutOff                 = {15.};
   std::vector<std::size_t> numMeasurementsCutOff = {10};
 
-  std::size_t numMeasurementsMin = 3;
+  std::size_t numMeasurementsMin = 4;
 };
 } // namespace eicrecon

--- a/src/algorithms/tracking/IterativeVertexFinderConfig.h
+++ b/src/algorithms/tracking/IterativeVertexFinderConfig.h
@@ -5,7 +5,7 @@ namespace eicrecon {
 struct IterativeVertexFinderConfig {
   int maxVertices                  = 10;
   bool reassignTracksAfterFirstFit = true;
-  unsigned int minTrackHits        = 3;
+  unsigned int minTrackHits        = 4;
 };
 
 } // namespace eicrecon

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -277,10 +277,6 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<PrimaryVertices_factory>(
       "PrimaryVertices", {"CentralTrackVertices"}, {"PrimaryVertices"}, {}, app));
 
-  app->Add(new JOmniFactoryGeneratorT<PrimaryVertices_factory>(
-      "Primary4HitCutVertices", {"CentralTrack4HitCutVertices"}, {"Primary4HitCutVertices"}, {},
-      app));
-
   app->Add(new JOmniFactoryGeneratorT<SecondaryVerticesHelix_factory>(
       "SecondaryVerticesHelix", {"PrimaryVertices", "ReconstructedParticles"},
       {"SecondaryVerticesHelix"}, {}, app));

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -318,6 +318,9 @@ void InitPlugin(JApplication* app) {
           "B0TrackerCKFTruthSeededActsTrackStatesUnfiltered",
           "B0TrackerCKFTruthSeededActsTracksUnfiltered",
       },
+    {
+      .numMeasurementsMin = 3,
+    },
       app));
 
   app->Add(new JOmniFactoryGeneratorT<ActsToTracks_factory>(
@@ -348,7 +351,10 @@ void InitPlugin(JApplication* app) {
           "B0TrackerCKFTruthSeededActsTrackStates",
           "B0TrackerCKFTruthSeededActsTracks",
       },
-      app));
+          {
+      .n_measurements_min = 3,
+    },
+    app));
 
   app->Add(new JOmniFactoryGeneratorT<ActsToTracks_factory>(
       "B0TrackerCKFTruthSeededTracks",

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -247,18 +247,6 @@ void InitPlugin(JApplication* app) {
                                                                 },
                                                                 {}, app));
 
-  app->Add(
-      new JOmniFactoryGeneratorT<IterativeVertexFinder_factory>("CentralTrack4HitCutVertices",
-                                                                {
-                                                                    "CentralCKFActsTrackStates",
-                                                                    "CentralCKFActsTracks",
-                                                                    "ReconstructedChargedParticles",
-                                                                },
-                                                                {
-                                                                    "CentralTrack4HitCutVertices",
-                                                                },
-                                                                {.minTrackHits = 4}, app));
-
   app->Add(new JOmniFactoryGeneratorT<TrackPropagation_factory>(
       "CalorimeterTrackPropagator",
       {"CentralCKFTracks", "CentralCKFActsTrackStates", "CentralCKFActsTracks"},

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -318,9 +318,9 @@ void InitPlugin(JApplication* app) {
           "B0TrackerCKFTruthSeededActsTrackStatesUnfiltered",
           "B0TrackerCKFTruthSeededActsTracksUnfiltered",
       },
-    {
-      .numMeasurementsMin = 3,
-    },
+      {
+          .numMeasurementsMin = 3,
+      },
       app));
 
   app->Add(new JOmniFactoryGeneratorT<ActsToTracks_factory>(
@@ -351,10 +351,10 @@ void InitPlugin(JApplication* app) {
           "B0TrackerCKFTruthSeededActsTrackStates",
           "B0TrackerCKFTruthSeededActsTracks",
       },
-          {
-      .n_measurements_min = 3,
-    },
-    app));
+      {
+          .n_measurements_min = 3,
+      },
+      app));
 
   app->Add(new JOmniFactoryGeneratorT<ActsToTracks_factory>(
       "B0TrackerCKFTruthSeededTracks",

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -459,18 +459,6 @@ void InitPlugin(JApplication* app) {
       },
       {}, app));
 
-  app->Add(new JOmniFactoryGeneratorT<IterativeVertexFinder_factory>(
-      "CentralAndB0Track4HitCutVertices",
-      {
-          "CentralAndB0TrackerCKFActsTrackStates",
-          "CentralAndB0TrackerCKFActsTracks",
-          "ReconstructedChargedParticles",
-      },
-      {
-          "CentralAndB0Track4HitCutVertices",
-      },
-      {.minTrackHits = 4}, app));
-
   // Add central and B0 tracks
   app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::Track, true>>(
       "CombinedTracks", {"CentralCKFTracks", "B0TrackerCKFTracks"}, {"CombinedTracks"}, app));

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -281,7 +281,6 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       // Central tracking
       "CentralTrackSegments",
       "CentralTrackVertices",
-      "CentralTrack4HitCutVertices",
       "CentralCKFTruthSeededTrajectories",
       "CentralCKFTruthSeededTracks",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
@@ -346,7 +345,6 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       "B0TrackerCKFTrackUnfilteredAssociations",
 
       "CentralAndB0TrackVertices",
-      "CentralAndB0Track4HitCutVertices",
 
       // Inclusive kinematics
       "InclusiveKinematicsDA",
@@ -367,7 +365,6 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       "ScatteredElectronsTruth",
       "ScatteredElectronsEMinusPz",
       "PrimaryVertices",
-      "Primary4HitCutVertices",
       "SecondaryVerticesHelix",
       "BarrelClusters",
       "HadronicFinalState",


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This increases the minimum number of measurements required in the CKF for a given track from 3 to 4. This follows extensive studies by the tracking/vertexing group with beam-induced backgrounds, as well as studies by the PWGs.

The minimum number of hits per track in the Ambiguity Solver and Iterative Vertex Finder/Fitter is also increased to 4. This is done so that we always have 

```numMeasurementsMin_CKF <= numMeasurementsMin_AmbiguitySolver <= numMeasurementsMin_VertexFinder```

The extra vertexing factories that were created for the tests done in March are now redundant and have been removed.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @ShujieL @Simple-Shyam @rachel-m @sfazio

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
Yes. It impacts what tracks (and therefore ReconstructedParticles) will be saved
