### PR TITLE
fix: allow for EDM4hep v1.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,7 +197,9 @@ find_package(Eigen3 ${Eigen3_VERSION_MIN} REQUIRED)
 find_package(podio ${podio_VERSION_MIN} REQUIRED)
 find_package(EDM4HEP REQUIRED)
 if(${EDM4HEP_VERSION} VERSION_LESS ${EDM4HEP_VERSION_MIN})
-  message(FATAL_ERROR "EDM4HEP ${EDM4HEP_VERSION} is less than minimum ${EDM4HEP_VERSION_MIN}")
+  message(
+    FATAL_ERROR
+      "EDM4HEP ${EDM4HEP_VERSION} is less than minimum ${EDM4HEP_VERSION_MIN}")
 endif()
 find_package(EDM4EIC ${EDM4EIC_VERSION_MIN} REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,7 @@ find_package(algorithms ${algorithms_VERSION_MIN} REQUIRED Core)
 find_package(Eigen3 ${Eigen3_VERSION_MIN} REQUIRED)
 find_package(podio ${podio_VERSION_MIN} REQUIRED)
 find_package(EDM4HEP REQUIRED)
-if(${EDM4HEP_VERSION} VERSION_LESS ${EDM4HEP_VERSION_MIN})
+if(EDM4HEP_VERSION VERSION_LESS EDM4HEP_VERSION_MIN)
   message(
     FATAL_ERROR
       "EDM4HEP ${EDM4HEP_VERSION} is less than minimum ${EDM4HEP_VERSION_MIN}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,10 @@ find_package(algorithms ${algorithms_VERSION_MIN} REQUIRED Core)
 # PODIO, EDM4HEP, EDM4EIC event models
 find_package(Eigen3 ${Eigen3_VERSION_MIN} REQUIRED)
 find_package(podio ${podio_VERSION_MIN} REQUIRED)
-find_package(EDM4HEP ${EDM4HEP_VERSION_MIN} REQUIRED)
+find_package(EDM4HEP REQUIRED)
+if(${EDM4HEP_VERSION} VERSION_LESS ${EDM4HEP_VERSION_MIN})
+  message(FATAL_ERROR "EDM4HEP ${EDM4HEP_VERSION} is less than minimum ${EDM4HEP_VERSION_MIN}")
+endif()
 find_package(EDM4EIC ${EDM4EIC_VERSION_MIN} REQUIRED)
 
 # fmt


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes the version detection in CMakeLists.txt to allow for both pre-v1 and post-v1 versions of EDM4hep.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: EICrecon can't be configured with EDM4hep v1.0.0)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.