### PR TITLE
Link pf algorithms against datamodel, don't override cmake min version

### DIFF
--- a/src/algorithms/particle_flow/CMakeLists.txt
+++ b/src/algorithms/particle_flow/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
-
 set(PLUGIN_NAME "algorithms_particle_flow")
 
 # Function creates ${PLUGIN_NAME}_plugin and ${PLUGIN_NAME}_library targets
@@ -11,6 +9,5 @@ plugin_add(${PLUGIN_NAME} WITH_SHARED_LIBRARY WITHOUT_PLUGIN)
 # headers to the correct installation directory
 plugin_glob_all(${PLUGIN_NAME})
 
-# Find dependencies plugin_add_algorithms(${PLUGIN_NAME})
-# plugin_add_dd4hep(${PLUGIN_NAME}) plugin_add_event_model(${PLUGIN_NAME})
-# plugin_add_eigen3(${PLUGIN_NAME})
+# Find dependencies
+plugin_add_event_model(${PLUGIN_NAME})

--- a/src/global/particle_flow/CMakeLists.txt
+++ b/src/global/particle_flow/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
-
 # Automatically set plugin name the same as the directory name Don't forget
 # string(REPLACE " " "_" PLUGIN_NAME ${PLUGIN_NAME}) if this dir has spaces in
 # its name


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This PR implements 2 fixes to CMake files for #2195 :
- `particle_flow` algorithms library is now linked against the datamodel, and
- the `algorithms` and `global` `CMakeLists.txt` no longer override minimum required CMake version.

### What kind of change does this PR introduce?
- [x] Bug fix (issue # n/a)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No.

### Does this PR change default behavior?

No.