### PR TITLE
[Backport v1.36] Add TrackTruthSeeds to PODIO output to fix segfault in podio-dump

### DIFF
--- a/docs/design/tracking.md
+++ b/docs/design/tracking.md
@@ -272,9 +272,9 @@ flowchart TB
     TrackerHitsConverter ---> TrackerHitsOnSurface[CentralTrackerMeasurements]:::col
 
     MCParticles --> TrackParamTruthInit:::alg
-    TrackParamTruthInit --> TrackTruthSeeds:::col
+    TrackParamTruthInit --> TrackerTruthSeeds:::col
 
-    TrackTruthSeeds --> SubDivideCollection:::alg
+    TrackerTruthSeeds --> SubDivideCollection:::alg
     SubDivideCollection --> CentralTrackerTruthSeeds:::col
 
     CKFTracking:::alg

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -50,13 +50,13 @@ void InitPlugin(JApplication* app) {
   using namespace eicrecon;
 
   app->Add(new JOmniFactoryGeneratorT<TrackParamTruthInit_factory>(
-      "TrackTruthSeeds", {"EventHeader", "MCParticles"},
-      {"TrackTruthSeeds", "TrackTruthSeedParameters"}, {}, app));
+      "TrackerTruthSeeds", {"EventHeader", "MCParticles"},
+      {"TrackerTruthSeeds", "TrackerTruthSeedParameters"}, {}, app));
 
   std::vector<std::pair<double, double>> thetaRanges{{0, 50 * dd4hep::mrad},
                                                      {50 * dd4hep::mrad, 180 * dd4hep::deg}};
   app->Add(new JOmniFactoryGeneratorT<SubDivideCollection_factory<edm4eic::TrackSeed>>(
-      "CentralB0TrackTruthSeeds", {"TrackTruthSeeds"},
+      "CentralB0TrackerTruthSeeds", {"TrackerTruthSeeds"},
       {"B0TrackerTruthSeeds", "CentralTrackerTruthSeeds"},
       {
           .function = RangeSplit<

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -63,6 +63,8 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       "MCParticlesHeadOnFrameNoBeamFX",
 
       // Central tracking hits combined
+      "TrackerTruthSeeds",
+      "TrackerTruthSeedParameters",
       "CentralTrackerTruthSeeds",
       "CentralTrackingRecHits",
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)


### PR DESCRIPTION
# Description
Backport of #2596 to `v1.36`.