### PR TITLE
Add EICrecon-specific PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,4 +18,4 @@
 - [ ] This PR requires changes to EDM4eic (EDM PR: __)
 - [ ] This PR introduces breaking changes. Please describe changes users need to make below.
 - [ ] This PR changes default behavior. Please describe changes below.
-- [ ] (Optional) AI was used in preparing this PR. Please describe usage below.
+- [ ] AI was used in preparing this PR. Please describe usage below.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,4 +19,3 @@
 - [ ] This PR introduces breaking changes. Please describe changes users need to make below.
 - [ ] This PR changes default behavior. Please describe changes below.
 - [ ] (Optional) AI was used in preparing this PR. Please describe usage below.
-

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
+
+### What is the urgency of this PR?
+- [ ] High
+- [ ] Medium
+- [ ] Low
+
+### What kind of change does this PR introduce?
+- [ ] Bug fix (issue #__)
+- [ ] New feature (issue #__)
+- [ ] Optimization (issue #__)
+- [ ] Updated parameters, constants (issue #__)
+- [ ] Updated documentation
+- [ ] other: __
+
+### Please check if any of the following apply
+- [ ] This PR requires changes to geometry (epic PR: __)
+- [ ] This PR requires changes to EDM4eic (EDM PR: __)
+- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
+- [ ] This PR changes default behavior. Please describe changes below.
+- [ ] (Optional) AI was used in preparing this PR. Please describe usage below.
+


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This PR implements an EICrecon-specific PR template. It extends the default template introduced in [.github#9](https://github.com/eic/.github/pull/9) with options unique to EICrecon as per the discussion in the ePIC Review Team.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [x] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No.

### Does this PR change default behavior?

Yes. The default EICrecon PR template will now be different.