### PR TITLE
Add FF Lambda multi-calorimeter reconstruction

### DIFF
--- a/src/algorithms/reco/FarForwardLambdaReconstruction.cc
+++ b/src/algorithms/reco/FarForwardLambdaReconstruction.cc
@@ -1,182 +1,376 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2025 Sebouh Paul
+// Update/modification 2026 by Baptiste Fraisse
 
 #include <Evaluator/DD4hepUnits.h>
 #include <TVector3.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/Vector3f.h>
-#include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
 #include <cmath>
 #include <cstddef>
 #include <gsl/pointers>
 #include <stdexcept>
 #include <vector>
+#include <type_traits>
 
 #include "FarForwardLambdaReconstruction.h"
 #include "TLorentzVector.h"
-/**
-Creates Lambda candidates from a neutron and two photons from a pi0 decay
- */
 
 namespace eicrecon {
 
-void FarForwardLambdaReconstruction::init() {
+// helpers 
 
+static inline void toTVector3(TVector3& v1, const edm4hep::Vector3f& v2) {
+  v1.SetXYZ(v2.x, v2.y, v2.z);
+}
+
+void FarForwardLambdaReconstruction::init() {
   try {
     m_zMax = m_detector->constant<double>(m_cfg.offsetPositionName);
   } catch (std::runtime_error&) {
-    m_zMax = 35800; // default value
-    trace("Failed to get {} from the detector, using default value of {}", m_cfg.offsetPositionName,
-          m_zMax);
+    m_zMax = 35800;
+    trace("Failed to get {} from the detector, using default value of {}", m_cfg.offsetPositionName, m_zMax);
   }
 }
 
-/* converts one type of vector format to another */
-void toTVector3(TVector3& v1, const edm4hep::Vector3f& v2) { v1.SetXYZ(v2.x, v2.y, v2.z); }
+// reconstruction machinery from n+g+g
 
-void FarForwardLambdaReconstruction::process(
-    const FarForwardLambdaReconstruction::Input& input,
-    const FarForwardLambdaReconstruction::Output& output) const {
-  const auto [neutrals]                                = input;
-  auto [out_lambdas, out_decay_products]               = output;
-  std::vector<edm4eic::ReconstructedParticle> neutrons = {};
-  std::vector<edm4eic::ReconstructedParticle> gammas   = {};
-  for (auto part : *neutrals) {
-    if (part.getPDG() == 2112) {
-      neutrons.push_back(part);
-    }
-    if (part.getPDG() == 22) {
-      gammas.push_back(part);
-    }
-  }
-
-  if (neutrons.empty() || gammas.size() < 2) {
-    return;
-  }
-
+bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
+    const edm4eic::ReconstructedParticle& n_in,
+    const edm4eic::ReconstructedParticle& g1_in,
+    const edm4eic::ReconstructedParticle& g2_in,
+    edm4eic::ReconstructedParticleCollection* out_lambdas,
+    edm4eic::ReconstructedParticleCollection* out_decay_products) const
+{
   static const double m_neutron = m_particleSvc.particle(2112).mass;
   static const double m_pi0     = m_particleSvc.particle(111).mass;
   static const double m_lambda  = m_particleSvc.particle(3122).mass;
 
-  for (std::size_t i_n = 0; i_n < neutrons.size(); i_n++) {
-    for (std::size_t i_1 = 0; i_1 < gammas.size() - 1; i_1++) {
-      for (std::size_t i_2 = i_1 + 1; i_2 < gammas.size(); i_2++) {
+  const double En = n_in.getEnergy();
+  const double E1 = g1_in.getEnergy();
+  const double E2 = g2_in.getEnergy();
 
-        double En = neutrons[i_n].getEnergy();
-        double pn = sqrt(En * En - m_neutron * m_neutron);
-        double E1 = gammas[i_1].getEnergy();
-        double E2 = gammas[i_2].getEnergy();
-        TVector3 xn;
-        TVector3 x1;
-        TVector3 x2;
+  if (En <= m_neutron) return false;
+  const double pn = std::sqrt(std::max(0.0, En*En - m_neutron*m_neutron));
 
-        toTVector3(xn, neutrons[0].getReferencePoint() * dd4hep::mm);
-        toTVector3(x1, gammas[0].getReferencePoint() * dd4hep::mm);
-        toTVector3(x2, gammas[1].getReferencePoint() * dd4hep::mm);
+  TVector3 xn, x1, x2;
 
-        xn.RotateY(-m_cfg.globalToProtonRotation);
-        x1.RotateY(-m_cfg.globalToProtonRotation);
-        x2.RotateY(-m_cfg.globalToProtonRotation);
+  const auto& rn  = n_in.getReferencePoint();
+  const auto& rg1 = g1_in.getReferencePoint();
+  const auto& rg2 = g2_in.getReferencePoint();
 
-        debug("nx recon = {}, g1x recon = {}, g2x recon = {}", xn.X(), x1.X(), x2.X());
-        debug("nz recon = {}, g1z recon = {}, g2z recon = {}, z face = {}", xn.Z(), x1.Z(), x2.Z(),
-              m_zMax);
+  xn.SetXYZ(rn.x * dd4hep::mm,
+            rn.y * dd4hep::mm,
+            rn.z * dd4hep::mm);
 
-        TVector3 vtx(0, 0, 0);
-        double f                   = 0;
-        double df                  = 0.5;
-        double theta_open_expected = 2 * asin(m_pi0 / (2 * sqrt(E1 * E2)));
-        TLorentzVector n;
-        TLorentzVector g1;
-        TLorentzVector g2;
-        TLorentzVector lambda;
-        for (int i = 0; i < m_cfg.iterations; i++) {
-          n                 = {pn * (xn - vtx).Unit(), En};
-          g1                = {E1 * (x1 - vtx).Unit(), E1};
-          g2                = {E2 * (x2 - vtx).Unit(), E2};
-          double theta_open = g1.Angle(g2.Vect());
-          lambda            = n + g1 + g2;
-          if (theta_open > theta_open_expected) {
-            f -= df;
-          } else if (theta_open < theta_open_expected) {
-            f += df;
-          }
+  x1.SetXYZ(rg1.x * dd4hep::mm,
+            rg1.y * dd4hep::mm,
+            rg1.z * dd4hep::mm);
 
-          vtx = lambda.Vect() * (f * m_zMax / lambda.Z());
-          df /= 2;
-        }
+  x2.SetXYZ(rg2.x * dd4hep::mm,
+            rg2.y * dd4hep::mm,
+            rg2.z * dd4hep::mm);
 
-        double mass_rec = lambda.M();
-        if (std::abs(mass_rec - m_lambda) > m_cfg.lambdaMaxMassDev) {
-          continue;
-        }
+  xn.RotateY(-m_cfg.globalToProtonRotation);
+  x1.RotateY(-m_cfg.globalToProtonRotation);
+  x2.RotateY(-m_cfg.globalToProtonRotation);
 
-        // rotate everything back to the lab coordinates.
-        vtx.RotateY(m_cfg.globalToProtonRotation);
-        lambda.RotateY(m_cfg.globalToProtonRotation);
-        n.RotateY(m_cfg.globalToProtonRotation);
-        g1.RotateY(m_cfg.globalToProtonRotation);
-        g2.RotateY(m_cfg.globalToProtonRotation);
+  TVector3 vtx(0, 0, 0);
+  double f  = 0.0;
+  double df = 0.5;
 
-        auto b = -lambda.BoostVector();
-        n.Boost(b);
-        g1.Boost(b);
-        g2.Boost(b);
+  const double theta_open_expected = 2 * std::asin(m_pi0 / (2 * std::sqrt(E1 * E2)));
 
-        //convert vertex to mm:
-        vtx = vtx * (1 / dd4hep::mm);
+  TLorentzVector n, g1, g2, lambda;
 
-        auto rec_lambda = out_lambdas->create();
-        rec_lambda.setPDG(3122);
+  for (int i = 0; i < m_cfg.iterations; i++) {
+    n      = { pn * (xn - vtx).Unit(), En };
+    g1     = { E1 * (x1 - vtx).Unit(), E1 };
+    g2     = { E2 * (x2 - vtx).Unit(), E2 };
+    lambda = n + g1 + g2;
 
-        rec_lambda.setEnergy(lambda.E());
-        rec_lambda.setMomentum({static_cast<float>(lambda.X()), static_cast<float>(lambda.Y()),
-                                static_cast<float>(lambda.Z())});
-        rec_lambda.setReferencePoint({static_cast<float>(vtx.X()), static_cast<float>(vtx.Y()),
-                                      static_cast<float>(vtx.Z())});
-        rec_lambda.setCharge(0);
-        rec_lambda.setMass(mass_rec);
+    const double theta_open = g1.Angle(g2.Vect());
+    if (theta_open > theta_open_expected)      f -= df;
+    else if (theta_open < theta_open_expected) f += df;
 
-        auto neutron_cm = out_decay_products->create();
-        neutron_cm.setPDG(2112);
-        neutron_cm.setEnergy(n.E());
-        neutron_cm.setMomentum(
-            {static_cast<float>(n.X()), static_cast<float>(n.Y()), static_cast<float>(n.Z())});
-        neutron_cm.setReferencePoint({static_cast<float>(vtx.X()), static_cast<float>(vtx.Y()),
-                                      static_cast<float>(vtx.Z())});
-        neutron_cm.setCharge(0);
-        neutron_cm.setMass(m_neutron);
-        //link the reconstructed lambda to the input neutron,
-        // and the cm neutron to the input neutron
-        rec_lambda.addToParticles(neutrons[i_n]);
-        neutron_cm.addToParticles(neutrons[i_n]);
+    vtx = lambda.Vect() * (f * m_zMax / lambda.Z());
+    df /= 2.0;
+  }
 
-        auto gamma1_cm = out_decay_products->create();
-        gamma1_cm.setPDG(22);
-        gamma1_cm.setEnergy(g1.E());
-        gamma1_cm.setMomentum(
-            {static_cast<float>(g1.X()), static_cast<float>(g1.Y()), static_cast<float>(g1.Z())});
-        gamma1_cm.setReferencePoint({static_cast<float>(vtx.X()), static_cast<float>(vtx.Y()),
-                                     static_cast<float>(vtx.Z())});
-        gamma1_cm.setCharge(0);
-        gamma1_cm.setMass(0);
-        rec_lambda.addToParticles(gammas[i_1]);
-        gamma1_cm.addToParticles(gammas[i_1]);
+  const double mass_rec = lambda.M();
+  if (std::abs(mass_rec - m_lambda) > m_cfg.lambdaMassWindow) return false;
 
-        auto gamma2_cm = out_decay_products->create();
-        gamma2_cm.setPDG(22);
-        gamma2_cm.setEnergy(g2.E());
-        gamma2_cm.setMomentum(
-            {static_cast<float>(g2.X()), static_cast<float>(g2.Y()), static_cast<float>(g2.Z())});
-        gamma2_cm.setReferencePoint({static_cast<float>(vtx.X()), static_cast<float>(vtx.Y()),
-                                     static_cast<float>(vtx.Z())});
-        gamma2_cm.setCharge(0);
-        gamma2_cm.setMass(0);
-        rec_lambda.addToParticles(gammas[i_2]);
-        gamma2_cm.addToParticles(gammas[i_2]);
-      }
+  // rotate everything back to lab coordinates
+  vtx.RotateY(m_cfg.globalToProtonRotation);
+  lambda.RotateY(m_cfg.globalToProtonRotation);
+  n.RotateY(m_cfg.globalToProtonRotation);
+  g1.RotateY(m_cfg.globalToProtonRotation);
+  g2.RotateY(m_cfg.globalToProtonRotation);
+
+  // boost decay products to Lambda rest frame
+  auto b = -lambda.BoostVector();
+  n.Boost(b);
+  g1.Boost(b);
+  g2.Boost(b);
+
+  // vertex back to EDM units (mm)
+  vtx = vtx * (1.0 / dd4hep::mm);
+
+  // saving reco lambda
+  auto rec_lambda = out_lambdas->create();
+  rec_lambda.setPDG(3122);
+  rec_lambda.setEnergy(lambda.E());
+  rec_lambda.setMomentum({static_cast<float>(lambda.X()),
+                          static_cast<float>(lambda.Y()),
+                          static_cast<float>(lambda.Z())});
+  rec_lambda.setReferencePoint({static_cast<float>(vtx.X()),
+                                static_cast<float>(vtx.Y()),
+                                static_cast<float>(vtx.Z())});
+  rec_lambda.setCharge(0);
+  rec_lambda.setMass(mass_rec);
+
+  // --- cm neutron
+  auto neutron_cm = out_decay_products->create();
+  neutron_cm.setPDG(2112);
+  neutron_cm.setEnergy(n.E());
+  neutron_cm.setMomentum({static_cast<float>(n.X()),
+                          static_cast<float>(n.Y()),
+                          static_cast<float>(n.Z())});
+  neutron_cm.setReferencePoint({static_cast<float>(vtx.X()),
+                                static_cast<float>(vtx.Y()),
+                                static_cast<float>(vtx.Z())});
+  neutron_cm.setCharge(0);
+  neutron_cm.setMass(m_neutron);
+
+  // --- cm gammas
+  auto gamma1_cm = out_decay_products->create();
+  gamma1_cm.setPDG(22);
+  gamma1_cm.setEnergy(g1.E());
+  gamma1_cm.setMomentum({static_cast<float>(g1.X()),
+                         static_cast<float>(g1.Y()),
+                         static_cast<float>(g1.Z())});
+  gamma1_cm.setReferencePoint({static_cast<float>(vtx.X()),
+                               static_cast<float>(vtx.Y()),
+                               static_cast<float>(vtx.Z())});
+  gamma1_cm.setCharge(0);
+  gamma1_cm.setMass(0);
+
+  auto gamma2_cm = out_decay_products->create();
+  gamma2_cm.setPDG(22);
+  gamma2_cm.setEnergy(g2.E());
+  gamma2_cm.setMomentum({static_cast<float>(g2.X()),
+                         static_cast<float>(g2.Y()),
+                         static_cast<float>(g2.Z())});
+  gamma2_cm.setReferencePoint({static_cast<float>(vtx.X()),
+                               static_cast<float>(vtx.Y()),
+                               static_cast<float>(vtx.Z())});
+  gamma2_cm.setCharge(0);
+  gamma2_cm.setMass(0);
+
+  // --- links
+  rec_lambda.addToParticles(n_in);
+  rec_lambda.addToParticles(g1_in);
+  rec_lambda.addToParticles(g2_in);
+
+  neutron_cm.addToParticles(n_in);
+  gamma1_cm.addToParticles(g1_in);
+  gamma2_cm.addToParticles(g2_in);
+
+  return true;
+}
+
+// selection of the best triplets n+g+g
+
+void FarForwardLambdaReconstruction::process(
+    const FarForwardLambdaReconstruction::Input& input,
+    const FarForwardLambdaReconstruction::Output& output) const
+{
+  const auto [neutralsHcal, neutralsB0, neutralsEcalEndcapP, neutralsLFHCAL] = input;
+  auto [out_lambdas, out_decay_products] = output;
+
+  const double m_pi0    = m_particleSvc.particle(111).mass;
+  const double m_lambda = m_particleSvc.particle(3122).mass;
+
+  // (A) collect by detector category
+  std::vector<edm4eic::ReconstructedParticle> neutrons_zdc, neutrons_other;
+  std::vector<edm4eic::ReconstructedParticle> gammas_zdc, gammas_other;
+
+  // ZDC Hcal
+  for (auto part : *neutralsHcal) {
+    if (part.getPDG() == 2112) neutrons_zdc.push_back(part);
+    if (part.getPDG() == 22)   gammas_zdc.push_back(part);
+  }
+
+  // B0 Ecal photons
+  for (auto part : *neutralsB0) {
+    if (part.getPDG() == 22) gammas_other.push_back(part);
+  }
+
+  // EndcapP Ecal photons
+  for (auto part : *neutralsEcalEndcapP) {
+    if (part.getPDG() == 22) gammas_other.push_back(part);
+  }
+
+  // LFHCAL neutrons
+  for (auto part : *neutralsLFHCAL) {
+    if (part.getPDG() == 2112) neutrons_other.push_back(part);
+  }
+
+  if (neutrons_zdc.empty() && neutrons_other.empty()) return;
+
+  // gamma pool
+  using GammaT = typename std::decay_t<decltype(gammas_zdc)>::value_type;
+  std::vector<GammaT> gamma_pool;
+  std::vector<uint8_t> gamma_is_zdc;
+
+  gamma_pool.reserve(gammas_zdc.size() + gammas_other.size());
+  gamma_is_zdc.reserve(gammas_zdc.size() + gammas_other.size());
+
+  for (const auto& g : gammas_zdc)   { gamma_pool.push_back(g); gamma_is_zdc.push_back(1); }
+  for (const auto& g : gammas_other) { gamma_pool.push_back(g); gamma_is_zdc.push_back(0); }
+
+  if (gamma_pool.size() < 2) return;
+
+  // invariant mass helpers (ranking only)
+
+  auto invMass2 = [](const edm4eic::ReconstructedParticle& a,
+                     const edm4eic::ReconstructedParticle& b) {
+    const auto pa = a.getMomentum();
+    const auto pb = b.getMomentum();
+    const double Ea = a.getEnergy();
+    const double Eb = b.getEnergy();
+    const double px = pa.x + pb.x;
+    const double py = pa.y + pb.y;
+    const double pz = pa.z + pb.z;
+    const double E  = Ea + Eb;
+    return E*E - (px*px + py*py + pz*pz);
+  };
+
+  auto invMass2_3 = [](const edm4eic::ReconstructedParticle& a,
+                       const edm4eic::ReconstructedParticle& b,
+                       const edm4eic::ReconstructedParticle& c) {
+    const auto pa = a.getMomentum();
+    const auto pb = b.getMomentum();
+    const auto pc = c.getMomentum();
+    const double Ea = a.getEnergy();
+    const double Eb = b.getEnergy();
+    const double Ec = c.getEnergy();
+    const double px = pa.x + pb.x + pc.x;
+    const double py = pa.y + pb.y + pc.y;
+    const double pz = pa.z + pb.z + pc.z;
+    const double E  = Ea + Eb + Ec;
+    return E*E - (px*px + py*py + pz*pz);
+  };
+
+  // (1) pi0 candidates
+  struct Pi0Pair {
+    int i, j;
+    int cat;             // 0:2ZDC, 1:1ZDC, 2:0ZDC
+    double dmpi0_cand;
+  };
+
+  std::vector<Pi0Pair> pi0_pairs;
+  pi0_pairs.reserve(gamma_pool.size() * (gamma_pool.size() - 1) / 2);
+
+  for (size_t i = 0; i < gamma_pool.size(); ++i) {
+    for (size_t j = i + 1; j < gamma_pool.size(); ++j) {
+      const auto& g1 = gamma_pool[i];
+      const auto& g2 = gamma_pool[j];
+
+      const double m2 = invMass2(g1, g2);
+      if (m2 <= 0.0) continue;
+
+      const double m  = std::sqrt(m2);
+      const double dm = std::abs(m - m_pi0);
+      if (dm > m_cfg.pi0Window * m_pi0) continue;
+
+      const bool z1 = gamma_is_zdc[i];
+      const bool z2 = gamma_is_zdc[j];
+      const int cat = (z1 && z2) ? 0 : ((z1 || z2) ? 1 : 2);
+
+      pi0_pairs.push_back({(int)i, (int)j, cat, dm});
     }
   }
+  if (pi0_pairs.empty()) return;
+
+  // (2) Lambda candidates pool
+  struct LambdaCand {
+    int g_i, g_j;
+    int n_idx;
+    int n_cat;   // 0: ZDC neutron, 1: other neutron
+    int g_cat;   // 0:2ZDC, 1:1ZDC, 2:0ZDC
+    double chi2;
+    double E;
+    double pz;
+  };
+
+  std::vector<LambdaCand> cands;
+  cands.reserve(64);
+
+  auto try_neutrons = [&](const auto& neutron_list, int n_cat) {
+    for (const auto& pp : pi0_pairs) {
+      const auto& g1 = gamma_pool[pp.i];
+      const auto& g2 = gamma_pool[pp.j];
+
+      for (size_t in = 0; in < neutron_list.size(); ++in) {
+        const auto& n = neutron_list[in];
+
+        const double m2L = invMass2_3(n, g1, g2);
+        if (m2L <= 0.0) continue;
+
+        const double mL = std::sqrt(m2L);
+        if (std::abs(mL - m_lambda) > m_cfg.lambdaMassWindow * m_lambda) continue;
+
+        const double dL = (mL - m_lambda);
+
+        // same score as your new code
+        const double chi2 =
+          (pp.dmpi0_cand / (m_cfg.pi0Window * m_pi0)) * (pp.dmpi0_cand / (m_cfg.pi0Window * m_pi0)) +
+          (dL / (m_cfg.lambdaMassWindow * m_lambda)) * (dL / (m_cfg.lambdaMassWindow * m_lambda));
+
+        const double E  = n.getEnergy() + g1.getEnergy() + g2.getEnergy();
+
+        const auto pn  = n.getMomentum();
+        const auto pg1 = g1.getMomentum();
+        const auto pg2 = g2.getMomentum();
+
+        const double px = pn.x + pg1.x + pg2.x;
+        const double py = pn.y + pg1.y + pg2.y;
+        const double pz = pn.z + pg1.z + pg2.z;
+
+        cands.push_back({pp.i, pp.j, (int)in, n_cat, pp.cat, chi2, E, pz});
+      }
+    }
+  };
+
+  if (!neutrons_zdc.empty())   try_neutrons(neutrons_zdc,   0);
+  if (!neutrons_other.empty()) try_neutrons(neutrons_other, 1);
+
+  if (cands.empty()) return;
+
+  // (3) best candidate selection (your policy)
+  auto better = [&](const LambdaCand& a, const LambdaCand& b) -> bool {
+    if (a.n_cat != b.n_cat) return a.n_cat < b.n_cat;  // prefer ZDC neutron
+    if (a.g_cat != b.g_cat) return a.g_cat < b.g_cat;  // prefer 2ZDC gammas
+    if (a.chi2  != b.chi2)  return a.chi2  < b.chi2;
+    if (a.pz    != b.pz)    return a.pz > b.pz;
+    return a.E > b.E;
+  };
+
+  int best_k = 0;
+  for (int k = 1; k < (int)cands.size(); ++k) {
+    if (better(cands[k], cands[best_k])) best_k = k;
+  }
+
+  const auto& best = cands[best_k];
+
+  const auto& g1 = gamma_pool[best.g_i];
+  const auto& g2 = gamma_pool[best.g_j];
+  const auto& n  = (best.n_cat == 0) ? neutrons_zdc[best.n_idx] : neutrons_other[best.n_idx];
+
+  // (4) lambda reconstruction machinery
+  reconstruct_from_triplet(n, g1, g2, out_lambdas, out_decay_products);
 }
+
 } // namespace eicrecon

--- a/src/algorithms/reco/FarForwardLambdaReconstruction.cc
+++ b/src/algorithms/reco/FarForwardLambdaReconstruction.cc
@@ -19,7 +19,7 @@
 
 namespace eicrecon {
 
-// helpers 
+// helpers
 
 static inline void toTVector3(TVector3& v1, const edm4hep::Vector3f& v2) {
   v1.SetXYZ(v2.x, v2.y, v2.z);
@@ -30,19 +30,18 @@ void FarForwardLambdaReconstruction::init() {
     m_zMax = m_detector->constant<double>(m_cfg.offsetPositionName);
   } catch (std::runtime_error&) {
     m_zMax = 35800;
-    trace("Failed to get {} from the detector, using default value of {}", m_cfg.offsetPositionName, m_zMax);
+    trace("Failed to get {} from the detector, using default value of {}", m_cfg.offsetPositionName,
+          m_zMax);
   }
 }
 
 // reconstruction machinery from n+g+g
 
 bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
-    const edm4eic::ReconstructedParticle& n_in,
-    const edm4eic::ReconstructedParticle& g1_in,
+    const edm4eic::ReconstructedParticle& n_in, const edm4eic::ReconstructedParticle& g1_in,
     const edm4eic::ReconstructedParticle& g2_in,
     edm4eic::ReconstructedParticleCollection* out_lambdas,
-    edm4eic::ReconstructedParticleCollection* out_decay_products) const
-{
+    edm4eic::ReconstructedParticleCollection* out_decay_products) const {
   static const double m_neutron = m_particleSvc.particle(2112).mass;
   static const double m_pi0     = m_particleSvc.particle(111).mass;
   static const double m_lambda  = m_particleSvc.particle(3122).mass;
@@ -51,8 +50,9 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
   const double E1 = g1_in.getEnergy();
   const double E2 = g2_in.getEnergy();
 
-  if (En <= m_neutron) return false;
-  const double pn = std::sqrt(std::max(0.0, En*En - m_neutron*m_neutron));
+  if (En <= m_neutron)
+    return false;
+  const double pn = std::sqrt(std::max(0.0, En * En - m_neutron * m_neutron));
 
   TVector3 xn, x1, x2;
 
@@ -60,17 +60,11 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
   const auto& rg1 = g1_in.getReferencePoint();
   const auto& rg2 = g2_in.getReferencePoint();
 
-  xn.SetXYZ(rn.x * dd4hep::mm,
-            rn.y * dd4hep::mm,
-            rn.z * dd4hep::mm);
+  xn.SetXYZ(rn.x * dd4hep::mm, rn.y * dd4hep::mm, rn.z * dd4hep::mm);
 
-  x1.SetXYZ(rg1.x * dd4hep::mm,
-            rg1.y * dd4hep::mm,
-            rg1.z * dd4hep::mm);
+  x1.SetXYZ(rg1.x * dd4hep::mm, rg1.y * dd4hep::mm, rg1.z * dd4hep::mm);
 
-  x2.SetXYZ(rg2.x * dd4hep::mm,
-            rg2.y * dd4hep::mm,
-            rg2.z * dd4hep::mm);
+  x2.SetXYZ(rg2.x * dd4hep::mm, rg2.y * dd4hep::mm, rg2.z * dd4hep::mm);
 
   xn.RotateY(-m_cfg.globalToProtonRotation);
   x1.RotateY(-m_cfg.globalToProtonRotation);
@@ -85,21 +79,24 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
   TLorentzVector n, g1, g2, lambda;
 
   for (int i = 0; i < m_cfg.iterations; i++) {
-    n      = { pn * (xn - vtx).Unit(), En };
-    g1     = { E1 * (x1 - vtx).Unit(), E1 };
-    g2     = { E2 * (x2 - vtx).Unit(), E2 };
+    n      = {pn * (xn - vtx).Unit(), En};
+    g1     = {E1 * (x1 - vtx).Unit(), E1};
+    g2     = {E2 * (x2 - vtx).Unit(), E2};
     lambda = n + g1 + g2;
 
     const double theta_open = g1.Angle(g2.Vect());
-    if (theta_open > theta_open_expected)      f -= df;
-    else if (theta_open < theta_open_expected) f += df;
+    if (theta_open > theta_open_expected)
+      f -= df;
+    else if (theta_open < theta_open_expected)
+      f += df;
 
     vtx = lambda.Vect() * (f * m_zMax / lambda.Z());
     df /= 2.0;
   }
 
   const double mass_rec = lambda.M();
-  if (std::abs(mass_rec - m_lambda) > m_cfg.lambdaMassWindow) return false;
+  if (std::abs(mass_rec - m_lambda) > m_cfg.lambdaMassWindow)
+    return false;
 
   // rotate everything back to lab coordinates
   vtx.RotateY(m_cfg.globalToProtonRotation);
@@ -121,12 +118,10 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
   auto rec_lambda = out_lambdas->create();
   rec_lambda.setPDG(3122);
   rec_lambda.setEnergy(lambda.E());
-  rec_lambda.setMomentum({static_cast<float>(lambda.X()),
-                          static_cast<float>(lambda.Y()),
+  rec_lambda.setMomentum({static_cast<float>(lambda.X()), static_cast<float>(lambda.Y()),
                           static_cast<float>(lambda.Z())});
-  rec_lambda.setReferencePoint({static_cast<float>(vtx.X()),
-                                static_cast<float>(vtx.Y()),
-                                static_cast<float>(vtx.Z())});
+  rec_lambda.setReferencePoint(
+      {static_cast<float>(vtx.X()), static_cast<float>(vtx.Y()), static_cast<float>(vtx.Z())});
   rec_lambda.setCharge(0);
   rec_lambda.setMass(mass_rec);
 
@@ -134,12 +129,10 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
   auto neutron_cm = out_decay_products->create();
   neutron_cm.setPDG(2112);
   neutron_cm.setEnergy(n.E());
-  neutron_cm.setMomentum({static_cast<float>(n.X()),
-                          static_cast<float>(n.Y()),
-                          static_cast<float>(n.Z())});
-  neutron_cm.setReferencePoint({static_cast<float>(vtx.X()),
-                                static_cast<float>(vtx.Y()),
-                                static_cast<float>(vtx.Z())});
+  neutron_cm.setMomentum(
+      {static_cast<float>(n.X()), static_cast<float>(n.Y()), static_cast<float>(n.Z())});
+  neutron_cm.setReferencePoint(
+      {static_cast<float>(vtx.X()), static_cast<float>(vtx.Y()), static_cast<float>(vtx.Z())});
   neutron_cm.setCharge(0);
   neutron_cm.setMass(m_neutron);
 
@@ -147,24 +140,20 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
   auto gamma1_cm = out_decay_products->create();
   gamma1_cm.setPDG(22);
   gamma1_cm.setEnergy(g1.E());
-  gamma1_cm.setMomentum({static_cast<float>(g1.X()),
-                         static_cast<float>(g1.Y()),
-                         static_cast<float>(g1.Z())});
-  gamma1_cm.setReferencePoint({static_cast<float>(vtx.X()),
-                               static_cast<float>(vtx.Y()),
-                               static_cast<float>(vtx.Z())});
+  gamma1_cm.setMomentum(
+      {static_cast<float>(g1.X()), static_cast<float>(g1.Y()), static_cast<float>(g1.Z())});
+  gamma1_cm.setReferencePoint(
+      {static_cast<float>(vtx.X()), static_cast<float>(vtx.Y()), static_cast<float>(vtx.Z())});
   gamma1_cm.setCharge(0);
   gamma1_cm.setMass(0);
 
   auto gamma2_cm = out_decay_products->create();
   gamma2_cm.setPDG(22);
   gamma2_cm.setEnergy(g2.E());
-  gamma2_cm.setMomentum({static_cast<float>(g2.X()),
-                         static_cast<float>(g2.Y()),
-                         static_cast<float>(g2.Z())});
-  gamma2_cm.setReferencePoint({static_cast<float>(vtx.X()),
-                               static_cast<float>(vtx.Y()),
-                               static_cast<float>(vtx.Z())});
+  gamma2_cm.setMomentum(
+      {static_cast<float>(g2.X()), static_cast<float>(g2.Y()), static_cast<float>(g2.Z())});
+  gamma2_cm.setReferencePoint(
+      {static_cast<float>(vtx.X()), static_cast<float>(vtx.Y()), static_cast<float>(vtx.Z())});
   gamma2_cm.setCharge(0);
   gamma2_cm.setMass(0);
 
@@ -184,10 +173,9 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
 
 void FarForwardLambdaReconstruction::process(
     const FarForwardLambdaReconstruction::Input& input,
-    const FarForwardLambdaReconstruction::Output& output) const
-{
+    const FarForwardLambdaReconstruction::Output& output) const {
   const auto [neutralsHcal, neutralsB0, neutralsEcalEndcapP, neutralsLFHCAL] = input;
-  auto [out_lambdas, out_decay_products] = output;
+  auto [out_lambdas, out_decay_products]                                     = output;
 
   const double m_pi0    = m_particleSvc.particle(111).mass;
   const double m_lambda = m_particleSvc.particle(3122).mass;
@@ -198,26 +186,32 @@ void FarForwardLambdaReconstruction::process(
 
   // ZDC Hcal
   for (auto part : *neutralsHcal) {
-    if (part.getPDG() == 2112) neutrons_zdc.push_back(part);
-    if (part.getPDG() == 22)   gammas_zdc.push_back(part);
+    if (part.getPDG() == 2112)
+      neutrons_zdc.push_back(part);
+    if (part.getPDG() == 22)
+      gammas_zdc.push_back(part);
   }
 
   // B0 Ecal photons
   for (auto part : *neutralsB0) {
-    if (part.getPDG() == 22) gammas_other.push_back(part);
+    if (part.getPDG() == 22)
+      gammas_other.push_back(part);
   }
 
   // EndcapP Ecal photons
   for (auto part : *neutralsEcalEndcapP) {
-    if (part.getPDG() == 22) gammas_other.push_back(part);
+    if (part.getPDG() == 22)
+      gammas_other.push_back(part);
   }
 
   // LFHCAL neutrons
   for (auto part : *neutralsLFHCAL) {
-    if (part.getPDG() == 2112) neutrons_other.push_back(part);
+    if (part.getPDG() == 2112)
+      neutrons_other.push_back(part);
   }
 
-  if (neutrons_zdc.empty() && neutrons_other.empty()) return;
+  if (neutrons_zdc.empty() && neutrons_other.empty())
+    return;
 
   // gamma pool
   using GammaT = typename std::decay_t<decltype(gammas_zdc)>::value_type;
@@ -227,32 +221,39 @@ void FarForwardLambdaReconstruction::process(
   gamma_pool.reserve(gammas_zdc.size() + gammas_other.size());
   gamma_is_zdc.reserve(gammas_zdc.size() + gammas_other.size());
 
-  for (const auto& g : gammas_zdc)   { gamma_pool.push_back(g); gamma_is_zdc.push_back(1); }
-  for (const auto& g : gammas_other) { gamma_pool.push_back(g); gamma_is_zdc.push_back(0); }
+  for (const auto& g : gammas_zdc) {
+    gamma_pool.push_back(g);
+    gamma_is_zdc.push_back(1);
+  }
+  for (const auto& g : gammas_other) {
+    gamma_pool.push_back(g);
+    gamma_is_zdc.push_back(0);
+  }
 
-  if (gamma_pool.size() < 2) return;
+  if (gamma_pool.size() < 2)
+    return;
 
   // invariant mass helpers (ranking only)
 
   auto invMass2 = [](const edm4eic::ReconstructedParticle& a,
                      const edm4eic::ReconstructedParticle& b) {
-    const auto pa = a.getMomentum();
-    const auto pb = b.getMomentum();
+    const auto pa   = a.getMomentum();
+    const auto pb   = b.getMomentum();
     const double Ea = a.getEnergy();
     const double Eb = b.getEnergy();
     const double px = pa.x + pb.x;
     const double py = pa.y + pb.y;
     const double pz = pa.z + pb.z;
     const double E  = Ea + Eb;
-    return E*E - (px*px + py*py + pz*pz);
+    return E * E - (px * px + py * py + pz * pz);
   };
 
   auto invMass2_3 = [](const edm4eic::ReconstructedParticle& a,
                        const edm4eic::ReconstructedParticle& b,
                        const edm4eic::ReconstructedParticle& c) {
-    const auto pa = a.getMomentum();
-    const auto pb = b.getMomentum();
-    const auto pc = c.getMomentum();
+    const auto pa   = a.getMomentum();
+    const auto pb   = b.getMomentum();
+    const auto pc   = c.getMomentum();
     const double Ea = a.getEnergy();
     const double Eb = b.getEnergy();
     const double Ec = c.getEnergy();
@@ -260,13 +261,13 @@ void FarForwardLambdaReconstruction::process(
     const double py = pa.y + pb.y + pc.y;
     const double pz = pa.z + pb.z + pc.z;
     const double E  = Ea + Eb + Ec;
-    return E*E - (px*px + py*py + pz*pz);
+    return E * E - (px * px + py * py + pz * pz);
   };
 
   // (1) pi0 candidates
   struct Pi0Pair {
     int i, j;
-    int cat;             // 0:2ZDC, 1:1ZDC, 2:0ZDC
+    int cat; // 0:2ZDC, 1:1ZDC, 2:0ZDC
     double dmpi0_cand;
   };
 
@@ -279,11 +280,13 @@ void FarForwardLambdaReconstruction::process(
       const auto& g2 = gamma_pool[j];
 
       const double m2 = invMass2(g1, g2);
-      if (m2 <= 0.0) continue;
+      if (m2 <= 0.0)
+        continue;
 
       const double m  = std::sqrt(m2);
       const double dm = std::abs(m - m_pi0);
-      if (dm > m_cfg.pi0Window * m_pi0) continue;
+      if (dm > m_cfg.pi0Window * m_pi0)
+        continue;
 
       const bool z1 = gamma_is_zdc[i];
       const bool z2 = gamma_is_zdc[j];
@@ -292,14 +295,15 @@ void FarForwardLambdaReconstruction::process(
       pi0_pairs.push_back({(int)i, (int)j, cat, dm});
     }
   }
-  if (pi0_pairs.empty()) return;
+  if (pi0_pairs.empty())
+    return;
 
   // (2) Lambda candidates pool
   struct LambdaCand {
     int g_i, g_j;
     int n_idx;
-    int n_cat;   // 0: ZDC neutron, 1: other neutron
-    int g_cat;   // 0:2ZDC, 1:1ZDC, 2:0ZDC
+    int n_cat; // 0: ZDC neutron, 1: other neutron
+    int g_cat; // 0:2ZDC, 1:1ZDC, 2:0ZDC
     double chi2;
     double E;
     double pz;
@@ -317,19 +321,22 @@ void FarForwardLambdaReconstruction::process(
         const auto& n = neutron_list[in];
 
         const double m2L = invMass2_3(n, g1, g2);
-        if (m2L <= 0.0) continue;
+        if (m2L <= 0.0)
+          continue;
 
         const double mL = std::sqrt(m2L);
-        if (std::abs(mL - m_lambda) > m_cfg.lambdaMassWindow * m_lambda) continue;
+        if (std::abs(mL - m_lambda) > m_cfg.lambdaMassWindow * m_lambda)
+          continue;
 
         const double dL = (mL - m_lambda);
 
         // same score as your new code
         const double chi2 =
-          (pp.dmpi0_cand / (m_cfg.pi0Window * m_pi0)) * (pp.dmpi0_cand / (m_cfg.pi0Window * m_pi0)) +
-          (dL / (m_cfg.lambdaMassWindow * m_lambda)) * (dL / (m_cfg.lambdaMassWindow * m_lambda));
+            (pp.dmpi0_cand / (m_cfg.pi0Window * m_pi0)) *
+                (pp.dmpi0_cand / (m_cfg.pi0Window * m_pi0)) +
+            (dL / (m_cfg.lambdaMassWindow * m_lambda)) * (dL / (m_cfg.lambdaMassWindow * m_lambda));
 
-        const double E  = n.getEnergy() + g1.getEnergy() + g2.getEnergy();
+        const double E = n.getEnergy() + g1.getEnergy() + g2.getEnergy();
 
         const auto pn  = n.getMomentum();
         const auto pg1 = g1.getMomentum();
@@ -344,23 +351,31 @@ void FarForwardLambdaReconstruction::process(
     }
   };
 
-  if (!neutrons_zdc.empty())   try_neutrons(neutrons_zdc,   0);
-  if (!neutrons_other.empty()) try_neutrons(neutrons_other, 1);
+  if (!neutrons_zdc.empty())
+    try_neutrons(neutrons_zdc, 0);
+  if (!neutrons_other.empty())
+    try_neutrons(neutrons_other, 1);
 
-  if (cands.empty()) return;
+  if (cands.empty())
+    return;
 
   // (3) best candidate selection (your policy)
   auto better = [&](const LambdaCand& a, const LambdaCand& b) -> bool {
-    if (a.n_cat != b.n_cat) return a.n_cat < b.n_cat;  // prefer ZDC neutron
-    if (a.g_cat != b.g_cat) return a.g_cat < b.g_cat;  // prefer 2ZDC gammas
-    if (a.chi2  != b.chi2)  return a.chi2  < b.chi2;
-    if (a.pz    != b.pz)    return a.pz > b.pz;
+    if (a.n_cat != b.n_cat)
+      return a.n_cat < b.n_cat; // prefer ZDC neutron
+    if (a.g_cat != b.g_cat)
+      return a.g_cat < b.g_cat; // prefer 2ZDC gammas
+    if (a.chi2 != b.chi2)
+      return a.chi2 < b.chi2;
+    if (a.pz != b.pz)
+      return a.pz > b.pz;
     return a.E > b.E;
   };
 
   int best_k = 0;
   for (int k = 1; k < (int)cands.size(); ++k) {
-    if (better(cands[k], cands[best_k])) best_k = k;
+    if (better(cands[k], cands[best_k]))
+      best_k = k;
   }
 
   const auto& best = cands[best_k];

--- a/src/algorithms/reco/FarForwardLambdaReconstruction.cc
+++ b/src/algorithms/reco/FarForwardLambdaReconstruction.cc
@@ -342,8 +342,6 @@ void FarForwardLambdaReconstruction::process(
         const auto pg1 = g1.getMomentum();
         const auto pg2 = g2.getMomentum();
 
-        const double px = pn.x + pg1.x + pg2.x;
-        const double py = pn.y + pg1.y + pg2.y;
         const double pz = pn.z + pg1.z + pg2.z;
 
         cands.push_back({pp.i, pp.j, (int)in, n_cat, pp.cat, chi2, E, pz});

--- a/src/algorithms/reco/FarForwardLambdaReconstruction.cc
+++ b/src/algorithms/reco/FarForwardLambdaReconstruction.cc
@@ -19,12 +19,6 @@
 
 namespace eicrecon {
 
-// helpers
-
-static inline void toTVector3(TVector3& v1, const edm4hep::Vector3f& v2) {
-  v1.SetXYZ(v2.x, v2.y, v2.z);
-}
-
 void FarForwardLambdaReconstruction::init() {
   try {
     m_zMax = m_detector->constant<double>(m_cfg.offsetPositionName);

--- a/src/algorithms/reco/FarForwardLambdaReconstruction.h
+++ b/src/algorithms/reco/FarForwardLambdaReconstruction.h
@@ -19,7 +19,10 @@
 namespace eicrecon {
 
 using FarForwardLambdaReconstructionAlgorithm = algorithms::Algorithm<
-    algorithms::Input<const edm4eic::ReconstructedParticleCollection>,
+    algorithms::Input<const edm4eic::ReconstructedParticleCollection,
+                      const edm4eic::ReconstructedParticleCollection,
+                      const edm4eic::ReconstructedParticleCollection,
+                      const edm4eic::ReconstructedParticleCollection>,
     /*output collections contain the lambda candidates and their decay products in the CM frame*/
     algorithms::Output<edm4eic::ReconstructedParticleCollection,
                        edm4eic::ReconstructedParticleCollection>>;
@@ -29,10 +32,16 @@ public:
   FarForwardLambdaReconstruction(std::string_view name)
       : FarForwardLambdaReconstructionAlgorithm{
             name,
-            {"inputNeutrals"},
-            {"outputLambdas", "outputLambdaDecayProductsCM"},
-            "Reconstructs lambda candidates and their decay products (in the CM frame) from the "
-            "reconstructed neutrons and photons"} {}
+
+            {"inputNeutralsHcal",
+             "inputNeutralsB0", 
+             "inputNeutralsEcalEndCapP",
+             "inputNeutralsLFHCAL"},
+
+            {"outputLambdas", 
+             "outputLambdaDecayProductsCM"},
+
+            "Reconstructs lambda candidates and their decay products (in the CM frame) from the reconstructed neutrons and photons"} {}
 
   void init() final;
   void process(const Input&, const Output&) const final;
@@ -42,5 +51,12 @@ private:
   const algorithms::ParticleSvc& m_particleSvc = algorithms::ParticleSvc::instance();
   const dd4hep::Detector* m_detector{algorithms::GeoSvc::instance().detector()};
   double m_zMax{0};
+
+  bool reconstruct_from_triplet(
+      const edm4eic::ReconstructedParticle& n_in,
+      const edm4eic::ReconstructedParticle& g1_in,
+      const edm4eic::ReconstructedParticle& g2_in,
+      edm4eic::ReconstructedParticleCollection* out_lambdas,
+      edm4eic::ReconstructedParticleCollection* out_decay_products) const;
 };
 } // namespace eicrecon

--- a/src/algorithms/reco/FarForwardLambdaReconstruction.h
+++ b/src/algorithms/reco/FarForwardLambdaReconstruction.h
@@ -33,15 +33,13 @@ public:
       : FarForwardLambdaReconstructionAlgorithm{
             name,
 
-            {"inputNeutralsHcal",
-             "inputNeutralsB0", 
-             "inputNeutralsEcalEndCapP",
+            {"inputNeutralsHcal", "inputNeutralsB0", "inputNeutralsEcalEndCapP",
              "inputNeutralsLFHCAL"},
 
-            {"outputLambdas", 
-             "outputLambdaDecayProductsCM"},
+            {"outputLambdas", "outputLambdaDecayProductsCM"},
 
-            "Reconstructs lambda candidates and their decay products (in the CM frame) from the reconstructed neutrons and photons"} {}
+            "Reconstructs lambda candidates and their decay products (in the CM frame) from the "
+            "reconstructed neutrons and photons"} {}
 
   void init() final;
   void process(const Input&, const Output&) const final;
@@ -52,11 +50,10 @@ private:
   const dd4hep::Detector* m_detector{algorithms::GeoSvc::instance().detector()};
   double m_zMax{0};
 
-  bool reconstruct_from_triplet(
-      const edm4eic::ReconstructedParticle& n_in,
-      const edm4eic::ReconstructedParticle& g1_in,
-      const edm4eic::ReconstructedParticle& g2_in,
-      edm4eic::ReconstructedParticleCollection* out_lambdas,
-      edm4eic::ReconstructedParticleCollection* out_decay_products) const;
+  bool reconstruct_from_triplet(const edm4eic::ReconstructedParticle& n_in,
+                                const edm4eic::ReconstructedParticle& g1_in,
+                                const edm4eic::ReconstructedParticle& g2_in,
+                                edm4eic::ReconstructedParticleCollection* out_lambdas,
+                                edm4eic::ReconstructedParticleCollection* out_decay_products) const;
 };
 } // namespace eicrecon

--- a/src/algorithms/reco/FarForwardLambdaReconstructionConfig.h
+++ b/src/algorithms/reco/FarForwardLambdaReconstructionConfig.h
@@ -13,7 +13,8 @@ struct FarForwardLambdaReconstructionConfig {
   /** transformation from global coordinates to proton-frame coordinates*/
   double globalToProtonRotation = -0.025;
   /** maximum deviation between reconstructed mass and PDG mass */
-  double lambdaMaxMassDev = 0.030 * dd4hep::GeV;
+  double lambdaMassWindow = 0.30;
+  double pi0Window = 0.30;
   /** number of iterations for the IDOLA algorithm */
   int iterations = 10;
 };

--- a/src/algorithms/reco/FarForwardLambdaReconstructionConfig.h
+++ b/src/algorithms/reco/FarForwardLambdaReconstructionConfig.h
@@ -14,7 +14,7 @@ struct FarForwardLambdaReconstructionConfig {
   double globalToProtonRotation = -0.025;
   /** maximum deviation between reconstructed mass and PDG mass */
   double lambdaMassWindow = 0.30;
-  double pi0Window = 0.30;
+  double pi0Window        = 0.30;
   /** number of iterations for the IDOLA algorithm */
   int iterations = 10;
 };

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
@@ -69,246 +69,243 @@ void FarForwardNeutralsReconstruction::process(
     const FarForwardNeutralsReconstruction::Output& output) const {
 
   // Unpacking
-  const auto [clustersHcal, clustersB0, clustersEcalEndcapP, clustersLFHCAL] = input;
+  const auto [clustersHcal, clustersB0, clustersEcalEndcapP, clustersLFHCAL]           = input;
   auto [out_neutralsHcal, out_neutralsB0, out_neutralsEcalEndcapP, out_neutralsLFHCAL] = output;
 
   // Global
   const double m_neutron = m_particleSvc.particle(2112).mass;
-  int n_neutrons = 0;
+  int n_neutrons         = 0;
 
   // neutron-gamma separation method
-  enum class GammaMode   { None, LeaderOnly, AllPassing };
+  enum class GammaMode { None, LeaderOnly, AllPassing };
   enum class NeutronMode { None, SumAll, LeaderOnly };
 
   using CorrFunc = std::function<double(double, const std::vector<double>&)>;
 
   CorrFunc corr_power = [](double E, const std::vector<double>& coeffs) {
-    if (coeffs.size() < 2) return E;
+    if (coeffs.size() < 2)
+      return E;
     return coeffs[0] * std::pow(E, coeffs[1]);
   };
 
   // helper for processing detectors
   auto processNeutralCalo =
-    [&](auto clusters,
-        auto out_neutrals,
-        const std::vector<double>& gammaScaleCoeff,
-        const std::vector<double>& neutronScaleCoeff,
-        bool canDetectGammas,
-        bool canDetectNeutrons,
-        const CorrFunc& gammaCorr,
-        const CorrFunc& neutronCorr,
-        GammaMode gammaMode,
-        double gammaLeaderFracMin,
-        double clusterEmin,
-        NeutronMode neutronMode,
-        bool associateAllClustersToNeutron) -> int {
+      [&](auto clusters, auto out_neutrals, const std::vector<double>& gammaScaleCoeff,
+          const std::vector<double>& neutronScaleCoeff, bool canDetectGammas,
+          bool canDetectNeutrons, const CorrFunc& gammaCorr, const CorrFunc& neutronCorr,
+          GammaMode gammaMode, double gammaLeaderFracMin, double clusterEmin,
+          NeutronMode neutronMode, bool associateAllClustersToNeutron) -> int {
+    (void)gammaLeaderFracMin;
 
-      (void)gammaLeaderFracMin;
+    if (!clusters || clusters->empty())
+      return 0;
+    if (!canDetectGammas)
+      gammaMode = GammaMode::None;
 
-      if (!clusters || clusters->empty()) return 0;
-      if (!canDetectGammas) gammaMode = GammaMode::None;
+    // gammas from clusters
+    auto makeGamma = [&](const edm4eic::Cluster& cl) {
+      auto rec = out_neutrals->create();
+      rec.setPDG(22);
 
-      // gammas from clusters
-      auto makeGamma = [&](const edm4eic::Cluster& cl){
-        auto rec = out_neutrals->create();
-        rec.setPDG(22);
+      const auto pos = cl.getPosition();
+      const double E = gammaCorr(cl.getEnergy(), gammaScaleCoeff);
 
-        const auto pos = cl.getPosition();
-        const double E = gammaCorr(cl.getEnergy(), gammaScaleCoeff);
+      const double r = edm4hep::utils::magnitude(pos);
+      if (r > 0)
+        rec.setMomentum(pos * (E / r));
 
-        const double r = edm4hep::utils::magnitude(pos);
-        if (r > 0) rec.setMomentum(pos * (E / r));
+      rec.setEnergy(E);
+      rec.setReferencePoint(pos);
+      rec.setCharge(0);
+      rec.setMass(0);
+      rec.addToClusters(cl);
+    };
 
-        rec.setEnergy(E);
-        rec.setReferencePoint(pos);
-        rec.setCharge(0);
-        rec.setMass(0);
-        rec.addToClusters(cl);
-      };
+    std::vector<const edm4eic::Cluster*> gamma_used;
+    gamma_used.reserve(clusters->size());
 
-      std::vector<const edm4eic::Cluster*> gamma_used;
-      gamma_used.reserve(clusters->size());
+    // gammaMode == LeaderOnly
+    if (gammaMode == GammaMode::LeaderOnly) {
 
-      // gammaMode == LeaderOnly
-      if (gammaMode == GammaMode::LeaderOnly) {
+      std::vector<int> idx;
+      idx.reserve(clusters->size());
 
-        std::vector<int> idx;
-        idx.reserve(clusters->size());
+      double Esum = 0.0;
+      for (int i = 0, n = (int)clusters->size(); i < n; ++i) {
+        const double E = (*clusters)[i].getEnergy();
+        if (E < clusterEmin)
+          continue;
+        Esum += E;
+        idx.push_back(i);
+      }
 
-        double Esum = 0.0;
-        for (int i = 0, n = (int)clusters->size(); i < n; ++i) {
-          const double E = (*clusters)[i].getEnergy();
-          if (E < clusterEmin) continue;
-          Esum += E;
-          idx.push_back(i);
-        }
+      if (idx.empty() || Esum <= 0.0)
+        return 0;
 
-        if (idx.empty() || Esum <= 0.0) return 0;
+      const size_t Nkeep = 4;
+      for (size_t k = 0; k < std::min(Nkeep, idx.size()); ++k) {
+        const auto& cl = (*clusters)[idx[k]];
+        makeGamma(cl);
+        gamma_used.push_back(&cl);
+      }
 
-        const size_t Nkeep = 4;
-        for (size_t k = 0; k < std::min(Nkeep, idx.size()); ++k) {
-          const auto& cl = (*clusters)[idx[k]];
+    }
+
+    // gammaMode == AllPassing
+    else if (gammaMode == GammaMode::AllPassing) {
+      for (const auto& cl : *clusters) {
+        const double E = cl.getEnergy();
+        if (E < clusterEmin)
+          continue;
+        if (isGamma(cl)) {
           makeGamma(cl);
           gamma_used.push_back(&cl);
         }
-
       }
+    }
 
-      // gammaMode == AllPassing
-      else if (gammaMode == GammaMode::AllPassing) {
-        for (const auto& cl : *clusters) {
-          const double E = cl.getEnergy();
-          if (E < clusterEmin) continue;
-          if (isGamma(cl)) {
-            makeGamma(cl);
-            gamma_used.push_back(&cl);
-          }
-        }
-      }
-
-      // gammaMode == None => nothing
-      auto is_used_as_gamma = [&](const edm4eic::Cluster& cl)
-      {
-        for (auto* p : gamma_used) if (p == &cl) return true;
-        return false;
-      };
-
-      // neutrons from clusters
-      const edm4eic::Cluster* leaderN = nullptr;
-      double E_leader = -1.0;
-
-      double E_sum = 0.0;
-      std::vector<const edm4eic::Cluster*> kept;
-      kept.reserve(clusters->size());
-
-      for (const auto& cl : *clusters) {
-        if (gammaMode != GammaMode::None && is_used_as_gamma(cl)) continue;
-
-        const double E = cl.getEnergy();
-        if (E < clusterEmin) continue;
-
-        E_sum += E;
-        kept.push_back(&cl);
-
-        if (E > E_leader) {
-          E_leader = E;
-          leaderN  = &cl;
-        }
-      }
-
-      if (!canDetectNeutrons) return 0;
-
-      double En_raw = 0.0;
-      edm4hep::Vector3f n_pos{0,0,0};
-
-      if (neutronMode == NeutronMode::LeaderOnly) {
-        if (!leaderN || E_leader <= 0.0) return 0;
-        En_raw = E_leader;
-        n_pos  = leaderN->getPosition();
-
-        kept.clear();
-        kept.push_back(leaderN);
-      }
-      else if (neutronMode == NeutronMode::SumAll) {
-        if (E_sum <= 0.0 || kept.empty()) return 0;
-        En_raw = E_sum;
-        if (!leaderN || E_leader <= 0.0) return 0;
-        n_pos = leaderN->getPosition();
-      }
-      else {
-        return 0;
-      }
-
-      // apply calibration laws
-      const double En = neutronCorr(En_raw, neutronScaleCoeff);
-
-      auto rec = out_neutrals->create();
-      rec.setPDG(2112);
-      rec.setEnergy(En);
-      rec.setCharge(0);
-      rec.setMass(m_neutron);
-
-      const double r = edm4hep::utils::magnitude(n_pos);
-      if (r > 0) {
-        const double psq = std::max(0.0, En*En - m_neutron*m_neutron);
-        rec.setMomentum(n_pos * (std::sqrt(psq) / r));
-      }
-      rec.setReferencePoint(n_pos);
-
-      if (associateAllClustersToNeutron) {
-        for (const auto& cl : *clusters) rec.addToClusters(cl);
-      } else {
-        for (auto* clp : kept) rec.addToClusters(*clp);
-      }
-
-      return 1;
+    // gammaMode == None => nothing
+    auto is_used_as_gamma = [&](const edm4eic::Cluster& cl) {
+      for (auto* p : gamma_used)
+        if (p == &cl)
+          return true;
+      return false;
     };
+
+    // neutrons from clusters
+    const edm4eic::Cluster* leaderN = nullptr;
+    double E_leader                 = -1.0;
+
+    double E_sum = 0.0;
+    std::vector<const edm4eic::Cluster*> kept;
+    kept.reserve(clusters->size());
+
+    for (const auto& cl : *clusters) {
+      if (gammaMode != GammaMode::None && is_used_as_gamma(cl))
+        continue;
+
+      const double E = cl.getEnergy();
+      if (E < clusterEmin)
+        continue;
+
+      E_sum += E;
+      kept.push_back(&cl);
+
+      if (E > E_leader) {
+        E_leader = E;
+        leaderN  = &cl;
+      }
+    }
+
+    if (!canDetectNeutrons)
+      return 0;
+
+    double En_raw = 0.0;
+    edm4hep::Vector3f n_pos{0, 0, 0};
+
+    if (neutronMode == NeutronMode::LeaderOnly) {
+      if (!leaderN || E_leader <= 0.0)
+        return 0;
+      En_raw = E_leader;
+      n_pos  = leaderN->getPosition();
+
+      kept.clear();
+      kept.push_back(leaderN);
+    } else if (neutronMode == NeutronMode::SumAll) {
+      if (E_sum <= 0.0 || kept.empty())
+        return 0;
+      En_raw = E_sum;
+      if (!leaderN || E_leader <= 0.0)
+        return 0;
+      n_pos = leaderN->getPosition();
+    } else {
+      return 0;
+    }
+
+    // apply calibration laws
+    const double En = neutronCorr(En_raw, neutronScaleCoeff);
+
+    auto rec = out_neutrals->create();
+    rec.setPDG(2112);
+    rec.setEnergy(En);
+    rec.setCharge(0);
+    rec.setMass(m_neutron);
+
+    const double r = edm4hep::utils::magnitude(n_pos);
+    if (r > 0) {
+      const double psq = std::max(0.0, En * En - m_neutron * m_neutron);
+      rec.setMomentum(n_pos * (std::sqrt(psq) / r));
+    }
+    rec.setReferencePoint(n_pos);
+
+    if (associateAllClustersToNeutron) {
+      for (const auto& cl : *clusters)
+        rec.addToClusters(cl);
+    } else {
+      for (auto* clp : kept)
+        rec.addToClusters(*clp);
+    }
+
+    return 1;
+  };
 
   // --- processing of detectors
 
   // ZDC-Hcal
-  n_neutrons += processNeutralCalo(
-                                    clustersHcal, out_neutralsHcal,
-                                    /*gammaCorrCoefs=*/   m_cfg.gammaScaleCorrCoeffHcal,
-                                    /*neutronCorrCoefs=*/ m_cfg.neutronScaleCorrCoeffHcal,
-                                    /*canDetectGammas=*/  true,
-                                    /*canDetectNeutrons=*/true,
-                                    /*gammaCorr=*/        corr_power,
-                                    /*neutronCorr=*/      corr_power,
-                                    /*gammaMode=*/        GammaMode::AllPassing,
-                                    /*gammaLeaderFracMin=*/0.0,
-                                    /*clusterEmin=*/      0.0,
-                                    /*neutronMode=*/      NeutronMode::SumAll,
-                                    /*associateAllClustersToNeutron=*/true
-  );
+  n_neutrons += processNeutralCalo(clustersHcal, out_neutralsHcal,
+                                   /*gammaCorrCoefs=*/m_cfg.gammaScaleCorrCoeffHcal,
+                                   /*neutronCorrCoefs=*/m_cfg.neutronScaleCorrCoeffHcal,
+                                   /*canDetectGammas=*/true,
+                                   /*canDetectNeutrons=*/true,
+                                   /*gammaCorr=*/corr_power,
+                                   /*neutronCorr=*/corr_power,
+                                   /*gammaMode=*/GammaMode::AllPassing,
+                                   /*gammaLeaderFracMin=*/0.0,
+                                   /*clusterEmin=*/0.0,
+                                   /*neutronMode=*/NeutronMode::SumAll,
+                                   /*associateAllClustersToNeutron=*/true);
 
   // B0-Ecal
-  n_neutrons += processNeutralCalo(
-                                    clustersB0, out_neutralsB0,
-                                    /*gammaCorrCoefs=*/   m_cfg.gammaScaleCorrCoeffB0Ecal,
-                                    /*neutronCorrCoefs=*/ m_cfg.neutronScaleCorrCoeffB0Ecal,
-                                    /*canDetectGammas=*/  true,
-                                    /*canDetectNeutrons=*/false,
-                                    /*gammaCorr=*/        corr_power,
-                                    /*neutronCorr=*/      corr_power,
-                                    /*gammaMode=*/        GammaMode::LeaderOnly,
-                                    /*gammaLeaderFracMin=*/0.0,
-                                    /*clusterEmin=*/      1.0,
-                                    /*neutronMode=*/      NeutronMode::None,
-                                    /*associateAllClustersToNeutron=*/false
-  );
+  n_neutrons += processNeutralCalo(clustersB0, out_neutralsB0,
+                                   /*gammaCorrCoefs=*/m_cfg.gammaScaleCorrCoeffB0Ecal,
+                                   /*neutronCorrCoefs=*/m_cfg.neutronScaleCorrCoeffB0Ecal,
+                                   /*canDetectGammas=*/true,
+                                   /*canDetectNeutrons=*/false,
+                                   /*gammaCorr=*/corr_power,
+                                   /*neutronCorr=*/corr_power,
+                                   /*gammaMode=*/GammaMode::LeaderOnly,
+                                   /*gammaLeaderFracMin=*/0.0,
+                                   /*clusterEmin=*/1.0,
+                                   /*neutronMode=*/NeutronMode::None,
+                                   /*associateAllClustersToNeutron=*/false);
 
   // EndcapP-Ecal
-  n_neutrons += processNeutralCalo(
-                                    clustersEcalEndcapP, out_neutralsEcalEndcapP,
-                                    /*gammaCorrCoefs=*/   m_cfg.gammaScaleCorrCoeffEcalEndcapP,
-                                    /*neutronCorrCoefs=*/ m_cfg.neutronScaleCorrCoeffEcalEndcapP,
-                                    /*canDetectGammas=*/  true,
-                                    /*canDetectNeutrons=*/false,
-                                    /*gammaCorr=*/        corr_power,
-                                    /*neutronCorr=*/      corr_power,
-                                    /*gammaMode=*/        GammaMode::LeaderOnly,
-                                    /*gammaLeaderFracMin=*/0.0,
-                                    /*clusterEmin=*/      1.0,
-                                    /*neutronMode=*/      NeutronMode::None,
-                                    /*associateAllClustersToNeutron=*/false
-  );
+  n_neutrons += processNeutralCalo(clustersEcalEndcapP, out_neutralsEcalEndcapP,
+                                   /*gammaCorrCoefs=*/m_cfg.gammaScaleCorrCoeffEcalEndcapP,
+                                   /*neutronCorrCoefs=*/m_cfg.neutronScaleCorrCoeffEcalEndcapP,
+                                   /*canDetectGammas=*/true,
+                                   /*canDetectNeutrons=*/false,
+                                   /*gammaCorr=*/corr_power,
+                                   /*neutronCorr=*/corr_power,
+                                   /*gammaMode=*/GammaMode::LeaderOnly,
+                                   /*gammaLeaderFracMin=*/0.0,
+                                   /*clusterEmin=*/1.0,
+                                   /*neutronMode=*/NeutronMode::None,
+                                   /*associateAllClustersToNeutron=*/false);
 
   // LFHCAL
-  n_neutrons += processNeutralCalo(
-                                    clustersLFHCAL, out_neutralsLFHCAL,
-                                    /*gammaCorrCoefs=*/   m_cfg.gammaScaleCorrCoeffLFHCAL,
-                                    /*neutronCorrCoefs=*/ m_cfg.neutronScaleCorrCoeffLFHCAL,
-                                    /*canDetectGammas=*/  false,
-                                    /*canDetectNeutrons=*/true,
-                                    /*gammaCorr=*/        corr_power,
-                                    /*neutronCorr=*/      corr_power,
-                                    /*gammaMode=*/        GammaMode::None,
-                                    /*gammaLeaderFracMin=*/0.0,
-                                    /*clusterEmin=*/      7.0,
-                                    /*neutronMode=*/      NeutronMode::LeaderOnly,
-                                    /*associateAllClustersToNeutron=*/false
-  );
+  n_neutrons += processNeutralCalo(clustersLFHCAL, out_neutralsLFHCAL,
+                                   /*gammaCorrCoefs=*/m_cfg.gammaScaleCorrCoeffLFHCAL,
+                                   /*neutronCorrCoefs=*/m_cfg.neutronScaleCorrCoeffLFHCAL,
+                                   /*canDetectGammas=*/false,
+                                   /*canDetectNeutrons=*/true,
+                                   /*gammaCorr=*/corr_power,
+                                   /*neutronCorr=*/corr_power,
+                                   /*gammaMode=*/GammaMode::None,
+                                   /*gammaLeaderFracMin=*/0.0,
+                                   /*clusterEmin=*/7.0,
+                                   /*neutronMode=*/NeutronMode::LeaderOnly,
+                                   /*associateAllClustersToNeutron=*/false);
 
   debug("Found {} neutron candidates", n_neutrons);
 }

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.h
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.h
@@ -21,18 +21,34 @@
 namespace eicrecon {
 
 using FarForwardNeutralsReconstructionAlgorithm =
-    algorithms::Algorithm<algorithms::Input<const edm4eic::ClusterCollection>,
-                          algorithms::Output<edm4eic::ReconstructedParticleCollection>>;
+
+    algorithms::Algorithm<algorithms::Input<const edm4eic::ClusterCollection,            // clusters ZDC-Hcal
+                                            const edm4eic::ClusterCollection,            // clusters B0-Ecal
+                                            const edm4eic::ClusterCollection,            // clusters EndcapP-Ecal
+                                            const edm4eic::ClusterCollection>,           // clusters LFHCAL
+
+                          algorithms::Output<edm4eic::ReconstructedParticleCollection,   // neutrons/gamma in ZDC-Hcal
+                                             edm4eic::ReconstructedParticleCollection,   // neutrons/gamma in B0-Ecal
+                                             edm4eic::ReconstructedParticleCollection,   // neutrons/gamma in EndcapP-Ecal
+                                             edm4eic::ReconstructedParticleCollection>>; // neutrons/gamma in LFHCAL
 class FarForwardNeutralsReconstruction
     : public FarForwardNeutralsReconstructionAlgorithm,
       public WithPodConfig<FarForwardNeutralsReconstructionConfig> {
 public:
   FarForwardNeutralsReconstruction(std::string_view name)
       : FarForwardNeutralsReconstructionAlgorithm{name,
-                                                  {"inputClustersHcal"},
-                                                  {"outputNeutrals"},
-                                                  "Merges all HCAL clusters in a collection into a "
-                                                  "neutron candidate and photon candidates "} {}
+        
+                                                  {"clustersHcal", 
+                                                   "clustersB0", 
+                                                   "clustersEcalEndCapP",
+                                                   "clustersLFHCAL"},
+
+                                                  {"outputNeutralsHcal", 
+                                                   "outputNeutralsB0", 
+                                                   "outputNeutralsEcalEndCapP",
+                                                   "outputNeutralsLFHCAL"},
+
+                                                  "Merges all HCAL clusters in a collection into a neutron candidate and photon candidates "} {}
 
   void init() final;
   void process(const Input&, const Output&) const final;
@@ -46,4 +62,4 @@ private:
   const dd4hep::Detector* m_detector{algorithms::GeoSvc::instance().detector()};
   double m_gammaZMax{0};
 };
-} // namespace eicrecon
+}

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.h
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.h
@@ -22,33 +22,32 @@ namespace eicrecon {
 
 using FarForwardNeutralsReconstructionAlgorithm =
 
-    algorithms::Algorithm<algorithms::Input<const edm4eic::ClusterCollection,            // clusters ZDC-Hcal
-                                            const edm4eic::ClusterCollection,            // clusters B0-Ecal
-                                            const edm4eic::ClusterCollection,            // clusters EndcapP-Ecal
-                                            const edm4eic::ClusterCollection>,           // clusters LFHCAL
+    algorithms::Algorithm<
+        algorithms::Input<const edm4eic::ClusterCollection,  // clusters ZDC-Hcal
+                          const edm4eic::ClusterCollection,  // clusters B0-Ecal
+                          const edm4eic::ClusterCollection,  // clusters EndcapP-Ecal
+                          const edm4eic::ClusterCollection>, // clusters LFHCAL
 
-                          algorithms::Output<edm4eic::ReconstructedParticleCollection,   // neutrons/gamma in ZDC-Hcal
-                                             edm4eic::ReconstructedParticleCollection,   // neutrons/gamma in B0-Ecal
-                                             edm4eic::ReconstructedParticleCollection,   // neutrons/gamma in EndcapP-Ecal
-                                             edm4eic::ReconstructedParticleCollection>>; // neutrons/gamma in LFHCAL
+        algorithms::Output<
+            edm4eic::ReconstructedParticleCollection,   // neutrons/gamma in ZDC-Hcal
+            edm4eic::ReconstructedParticleCollection,   // neutrons/gamma in B0-Ecal
+            edm4eic::ReconstructedParticleCollection,   // neutrons/gamma in EndcapP-Ecal
+            edm4eic::ReconstructedParticleCollection>>; // neutrons/gamma in LFHCAL
 class FarForwardNeutralsReconstruction
     : public FarForwardNeutralsReconstructionAlgorithm,
       public WithPodConfig<FarForwardNeutralsReconstructionConfig> {
 public:
   FarForwardNeutralsReconstruction(std::string_view name)
-      : FarForwardNeutralsReconstructionAlgorithm{name,
-        
-                                                  {"clustersHcal", 
-                                                   "clustersB0", 
-                                                   "clustersEcalEndCapP",
-                                                   "clustersLFHCAL"},
+      : FarForwardNeutralsReconstructionAlgorithm{
+            name,
 
-                                                  {"outputNeutralsHcal", 
-                                                   "outputNeutralsB0", 
-                                                   "outputNeutralsEcalEndCapP",
-                                                   "outputNeutralsLFHCAL"},
+            {"clustersHcal", "clustersB0", "clustersEcalEndCapP", "clustersLFHCAL"},
 
-                                                  "Merges all HCAL clusters in a collection into a neutron candidate and photon candidates "} {}
+            {"outputNeutralsHcal", "outputNeutralsB0", "outputNeutralsEcalEndCapP",
+             "outputNeutralsLFHCAL"},
+
+            "Merges all HCAL clusters in a collection into a neutron candidate and photon "
+            "candidates "} {}
 
   void init() final;
   void process(const Input&, const Output&) const final;
@@ -62,4 +61,4 @@ private:
   const dd4hep::Detector* m_detector{algorithms::GeoSvc::instance().detector()};
   double m_gammaZMax{0};
 };
-}
+} // namespace eicrecon

--- a/src/algorithms/reco/FarForwardNeutralsReconstructionConfig.h
+++ b/src/algorithms/reco/FarForwardNeutralsReconstructionConfig.h
@@ -29,8 +29,8 @@ struct FarForwardNeutralsReconstructionConfig {
   double globalToProtonRotation = -0.025;
   /** Neutron-photon separation in HcalFarForwardZDC */
   double gammaZMaxOffset = 400 * dd4hep::mm;
-  double gammaMaxLength = 100 * dd4hep::mm;
-  double gammaMaxWidth  = 12 * dd4hep::mm;
+  double gammaMaxLength  = 100 * dd4hep::mm;
+  double gammaMaxWidth   = 12 * dd4hep::mm;
 };
 
 } // namespace eicrecon

--- a/src/algorithms/reco/FarForwardNeutralsReconstructionConfig.h
+++ b/src/algorithms/reco/FarForwardNeutralsReconstructionConfig.h
@@ -9,15 +9,26 @@ namespace eicrecon {
 struct FarForwardNeutralsReconstructionConfig {
   /** detector constant describing distance to the ZDC */
   std::string offsetPositionName = "HcalFarForwardZDC_SiPMonTile_r_pos";
-  /** Correction factors for neutrons in the Hcal */
-  std::vector<double> neutronScaleCorrCoeffHcal = {-0.11, -1.5, 0};
-  /** Correction factors for gammas in the Hcal */
-  std::vector<double> gammaScaleCorrCoeffHcal = {0, -0.13, 0};
+  /** Correction factors for neutrons in the Hcal (ZDC) */
+  std::vector<double> neutronScaleCorrCoeffHcal = {2.4, 0.89};
+  /** Correction factors for gammas in the Hcal (ZDC) */
+  std::vector<double> gammaScaleCorrCoeffHcal = {1.1, 0.98};
+  /** Correction factors for neutrons in the LFHCAL */
+  std::vector<double> neutronScaleCorrCoeffLFHCAL = {2.55, 0.95};
+  /** Correction factors for gammas in the LFHCAL */
+  std::vector<double> gammaScaleCorrCoeffLFHCAL = {0., 0.};
+  /** Correction factors for neutrons in the B0-Ecal */
+  std::vector<double> neutronScaleCorrCoeffB0Ecal = {0., 0.};
+  /** Correction factors for gammas in the B0-Ecal */
+  std::vector<double> gammaScaleCorrCoeffB0Ecal = {0.99, 1.14};
+  /** Correction factors for neutrons in the Endcap-Ecal */
+  std::vector<double> neutronScaleCorrCoeffEcalEndcapP = {0., 0.};
+  /** Correction factors for gammas in the Endcap-Ecal */
+  std::vector<double> gammaScaleCorrCoeffEcalEndcapP = {1.05, 1.01};
   /** rotation from global to local coordinates */
   double globalToProtonRotation = -0.025;
-  /** position cuts for the clusters identified as photons */
-  double gammaZMaxOffset = 300 * dd4hep::mm;
-  /** cuts for the sqrts of the largest and second largest eigenvalues of the moment matrix */
+  /** Neutron-photon separation in HcalFarForwardZDC */
+  double gammaZMaxOffset = 400 * dd4hep::mm;
   double gammaMaxLength = 100 * dd4hep::mm;
   double gammaMaxWidth  = 12 * dd4hep::mm;
 };

--- a/src/factories/reco/FarForwardLambdaReconstruction_factory.h
+++ b/src/factories/reco/FarForwardLambdaReconstruction_factory.h
@@ -48,18 +48,11 @@ public:
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process(
-      
-      {
-        m_hcal_neutrals_input(),
-        m_b0_neutrals_input(), 
-        m_ecalendcapp_neutrals_input(),
-        m_lfhcal_neutrals_input()
-      },
-      
-      {
-        m_lambda_output().get(), 
-        m_lambda_decay_products_cm_output().get()
-      });
+
+        {m_hcal_neutrals_input(), m_b0_neutrals_input(), m_ecalendcapp_neutrals_input(),
+         m_lfhcal_neutrals_input()},
+
+        {m_lambda_output().get(), m_lambda_decay_products_cm_output().get()});
   }
 };
 

--- a/src/factories/reco/FarForwardLambdaReconstruction_factory.h
+++ b/src/factories/reco/FarForwardLambdaReconstruction_factory.h
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2025 Sebouh Paul
+// Update/modification 2026 by Baptiste Fraisse
 
 #pragma once
 
@@ -19,14 +20,20 @@ public:
 
 private:
   std::unique_ptr<AlgoT> m_algo;
-  PodioInput<edm4eic::ReconstructedParticle> m_neutrals_input{this};
+
+  PodioInput<edm4eic::ReconstructedParticle> m_hcal_neutrals_input{this};
+  PodioInput<edm4eic::ReconstructedParticle> m_b0_neutrals_input{this};
+  PodioInput<edm4eic::ReconstructedParticle> m_ecalendcapp_neutrals_input{this};
+  PodioInput<edm4eic::ReconstructedParticle> m_lfhcal_neutrals_input{this};
+
   PodioOutput<edm4eic::ReconstructedParticle> m_lambda_output{this};
   PodioOutput<edm4eic::ReconstructedParticle> m_lambda_decay_products_cm_output{this};
 
   ParameterRef<std::string> m_offset_position_name{this, "offsetPositionName",
                                                    config().offsetPositionName};
   ParameterRef<double> m_rot_y{this, "globalToProtonRotation", config().globalToProtonRotation};
-  ParameterRef<double> m_lambda_max_mass_dev{this, "lambdaMaxMassDev", config().lambdaMaxMassDev};
+  ParameterRef<double> m_lambda_max_mass_dev{this, "lambdaMassWindow", config().lambdaMassWindow};
+  ParameterRef<double> m_pi0_max_mass_dev{this, "pi0Window", config().pi0Window};
   ParameterRef<int> m_iterations{this, "iterations", config().iterations};
   Service<AlgorithmsInit_service> m_algorithmsInit{this};
 
@@ -40,8 +47,19 @@ public:
   }
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
-    m_algo->process({m_neutrals_input()},
-                    {m_lambda_output().get(), m_lambda_decay_products_cm_output().get()});
+    m_algo->process(
+      
+      {
+        m_hcal_neutrals_input(),
+        m_b0_neutrals_input(), 
+        m_ecalendcapp_neutrals_input(),
+        m_lfhcal_neutrals_input()
+      },
+      
+      {
+        m_lambda_output().get(), 
+        m_lambda_decay_products_cm_output().get()
+      });
   }
 };
 

--- a/src/factories/reco/FarForwardNeutralsReconstruction_factory.h
+++ b/src/factories/reco/FarForwardNeutralsReconstruction_factory.h
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2025 Sebouh Paul
+// Update/modification 2026 by Baptiste Fraisse
 
 #pragma once
 
@@ -19,8 +20,16 @@ public:
 
 private:
   std::unique_ptr<AlgoT> m_algo;
+
   PodioInput<edm4eic::Cluster> m_clusters_hcal_input{this};
-  PodioOutput<edm4eic::ReconstructedParticle> m_neutrals_output{this};
+  PodioInput<edm4eic::Cluster> m_clusters_b0_input{this};
+  PodioInput<edm4eic::Cluster> m_clusters_ecalendcapp_input{this};
+  PodioInput<edm4eic::Cluster> m_clusters_lfhcal_input{this};
+
+  PodioOutput<edm4eic::ReconstructedParticle> m_hcal_neutrals_output{this};
+  PodioOutput<edm4eic::ReconstructedParticle> m_b0_neutrals_output{this};
+  PodioOutput<edm4eic::ReconstructedParticle> m_ecalendcapp_neutrals_output{this};
+  PodioOutput<edm4eic::ReconstructedParticle> m_lfhcal_neutrals_output{this};
 
   ParameterRef<std::string> m_offset_position_name{this, "offsetPositionName",
                                                    config().offsetPositionName};
@@ -28,6 +37,18 @@ private:
                                                               config().neutronScaleCorrCoeffHcal};
   ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_hcal{this, "gammaScaleCorrCoeffHcal",
                                                                   config().gammaScaleCorrCoeffHcal};
+  ParameterRef<std::vector<double>> m_n_scale_corr_coeff_b0ecal{this, "neutronScaleCorrCoeffB0Ecal",
+                                                                  config().neutronScaleCorrCoeffB0Ecal};
+  ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_b0ecal{this, "gammaScaleCorrCoeffB0Ecal",
+                                                                  config().gammaScaleCorrCoeffB0Ecal};
+  ParameterRef<std::vector<double>> m_n_scale_corr_coeff_ecalendcapp{this, "neutronScaleCorrCoeffEcalEndcapP",
+                                                                  config().neutronScaleCorrCoeffEcalEndcapP};
+  ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_ecalendcapp{this, "gammaScaleCorrCoeffEcalEndcapP",
+                                                                  config().gammaScaleCorrCoeffEcalEndcapP};
+  ParameterRef<std::vector<double>> m_n_scale_corr_coeff_lfhcal{this, "neutronScaleCorrCoeffLFHCAL",
+                                                                  config().neutronScaleCorrCoeffLFHCAL};
+  ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_lfhcal{this, "gammaScaleCorrCoeffLFHCAL",
+                                                                  config().gammaScaleCorrCoeffLFHCAL};
   ParameterRef<double> m_global_to_proton_rotation{this, "globalToProtonRotation",
                                                    config().globalToProtonRotation};
   ParameterRef<double> m_gamma_zmax_offset{this, "gammaZMaxOffset", config().gammaZMaxOffset};
@@ -50,9 +71,17 @@ public:
     m_algo->process(
         {
             m_clusters_hcal_input(),
+            m_clusters_b0_input(),
+            m_clusters_ecalendcapp_input(),
+            m_clusters_lfhcal_input(),
+
         },
         {
-            m_neutrals_output().get(),
+            m_hcal_neutrals_output().get(),
+            m_b0_neutrals_output().get(),
+            m_ecalendcapp_neutrals_output().get(),
+            m_lfhcal_neutrals_output().get(),
+
         });
   }
 };

--- a/src/factories/reco/FarForwardNeutralsReconstruction_factory.h
+++ b/src/factories/reco/FarForwardNeutralsReconstruction_factory.h
@@ -37,18 +37,18 @@ private:
                                                               config().neutronScaleCorrCoeffHcal};
   ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_hcal{this, "gammaScaleCorrCoeffHcal",
                                                                   config().gammaScaleCorrCoeffHcal};
-  ParameterRef<std::vector<double>> m_n_scale_corr_coeff_b0ecal{this, "neutronScaleCorrCoeffB0Ecal",
-                                                                  config().neutronScaleCorrCoeffB0Ecal};
-  ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_b0ecal{this, "gammaScaleCorrCoeffB0Ecal",
-                                                                  config().gammaScaleCorrCoeffB0Ecal};
-  ParameterRef<std::vector<double>> m_n_scale_corr_coeff_ecalendcapp{this, "neutronScaleCorrCoeffEcalEndcapP",
-                                                                  config().neutronScaleCorrCoeffEcalEndcapP};
-  ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_ecalendcapp{this, "gammaScaleCorrCoeffEcalEndcapP",
-                                                                  config().gammaScaleCorrCoeffEcalEndcapP};
-  ParameterRef<std::vector<double>> m_n_scale_corr_coeff_lfhcal{this, "neutronScaleCorrCoeffLFHCAL",
-                                                                  config().neutronScaleCorrCoeffLFHCAL};
-  ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_lfhcal{this, "gammaScaleCorrCoeffLFHCAL",
-                                                                  config().gammaScaleCorrCoeffLFHCAL};
+  ParameterRef<std::vector<double>> m_n_scale_corr_coeff_b0ecal{
+      this, "neutronScaleCorrCoeffB0Ecal", config().neutronScaleCorrCoeffB0Ecal};
+  ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_b0ecal{
+      this, "gammaScaleCorrCoeffB0Ecal", config().gammaScaleCorrCoeffB0Ecal};
+  ParameterRef<std::vector<double>> m_n_scale_corr_coeff_ecalendcapp{
+      this, "neutronScaleCorrCoeffEcalEndcapP", config().neutronScaleCorrCoeffEcalEndcapP};
+  ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_ecalendcapp{
+      this, "gammaScaleCorrCoeffEcalEndcapP", config().gammaScaleCorrCoeffEcalEndcapP};
+  ParameterRef<std::vector<double>> m_n_scale_corr_coeff_lfhcal{
+      this, "neutronScaleCorrCoeffLFHCAL", config().neutronScaleCorrCoeffLFHCAL};
+  ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_lfhcal{
+      this, "gammaScaleCorrCoeffLFHCAL", config().gammaScaleCorrCoeffLFHCAL};
   ParameterRef<double> m_global_to_proton_rotation{this, "globalToProtonRotation",
                                                    config().globalToProtonRotation};
   ParameterRef<double> m_gamma_zmax_offset{this, "gammaZMaxOffset", config().gammaZMaxOffset};

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -216,27 +216,43 @@ void InitPlugin(JApplication* app) {
       {"ReconstructedBreitFrameParticles"}, {}, app));
 
   app->Add(new JOmniFactoryGeneratorT<FarForwardNeutralsReconstruction_factory>(
-      "ReconstructedFarForwardZDCNeutrons",
-      {"HcalFarForwardZDCClusters"},          // edm4eic::ClusterCollection
-      {"ReconstructedFarForwardZDCNeutrals"}, // edm4eic::ReconstrutedParticleCollection,
-      {.offsetPositionName        = "HcalFarForwardZDC_SiPMonTile_r_pos",
-       .neutronScaleCorrCoeffHcal = {-0.11, -1.5, 0},
-       .gammaScaleCorrCoeffHcal   = {0, -.13, 0},
-       .globalToProtonRotation    = -0.025,
-       .gammaZMaxOffset           = 300 * dd4hep::mm,
-       .gammaMaxLength            = 100 * dd4hep::mm,
-       .gammaMaxWidth             = 12 * dd4hep::mm},
+      "ReconstructedFarForwardZDCNeutrals",
+      {"HcalFarForwardZDCClusters", 
+        "B0ECalClusters", 
+        "EcalEndcapPClusters", 
+        "LFHCALClusters"},
+      {"ReconstructedHcalFarForwardZDCNeutrals", 
+        "ReconstructedB0EcalNeutrals", 
+        "ReconstructedEcalEndcapPNeutrals",
+        "ReconstructedLFHCALNeutrals"},
+      {.offsetPositionName               = "HcalFarForwardZDC_SiPMonTile_r_pos",
+       .neutronScaleCorrCoeffHcal        = {2.4, 0.89},
+       .gammaScaleCorrCoeffHcal          = {1.1, 0.98},
+       .neutronScaleCorrCoeffLFHCAL      = {2.55, 0.95},
+       .gammaScaleCorrCoeffLFHCAL        = {0., 0.},
+       .neutronScaleCorrCoeffB0Ecal      = {0., 0.},
+       .gammaScaleCorrCoeffB0Ecal        = {0.99, 1.14},
+       .neutronScaleCorrCoeffEcalEndcapP = {0., 0.},
+       .gammaScaleCorrCoeffEcalEndcapP   = {1.05, 1.01},
+       .globalToProtonRotation           = -0.025,
+       .gammaZMaxOffset                  = 400 * dd4hep::mm,
+       .gammaMaxLength                   = 100 * dd4hep::mm,
+       .gammaMaxWidth                    = 12 * dd4hep::mm},
       app // TODO: Remove me once fixed
       ));
 
   app->Add(new JOmniFactoryGeneratorT<FarForwardLambdaReconstruction_factory>(
-      "ReconstructedFarForwardZDCLambdas",
-      {"ReconstructedFarForwardZDCNeutrals"}, // edm4eic::ReconstrutedParticleCollection,
-      {"ReconstructedFarForwardZDCLambdas", "ReconstructedFarForwardZDCLambdaDecayProductsC"
-                                            "M"}, // edm4eic::ReconstrutedParticleCollection,
+      "ReconstructedFarForwardLambdas",
+      {"ReconstructedHcalFarForwardZDCNeutrals", 
+        "ReconstructedB0EcalNeutrals", 
+        "ReconstructedEcalEndcapPNeutrals", 
+        "ReconstructedLFHCALNeutrals"},
+      {"ReconstructedFarForwardLambdas", 
+        "ReconstructedFarForwardLambdaDecayProductsCM"},
       {.offsetPositionName     = "HcalFarForwardZDC_SiPMonTile_r_pos",
        .globalToProtonRotation = -0.025,
-       .lambdaMaxMassDev       = 0.030 * dd4hep::GeV,
+       .lambdaMassWindow       = 0.30,
+       .pi0Window              = 0.30,
        .iterations             = 10},
       app // TODO: Remove me once fixed
       ));

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -217,14 +217,9 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<FarForwardNeutralsReconstruction_factory>(
       "ReconstructedFarForwardZDCNeutrals",
-      {"HcalFarForwardZDCClusters", 
-        "B0ECalClusters", 
-        "EcalEndcapPClusters", 
-        "LFHCALClusters"},
-      {"ReconstructedHcalFarForwardZDCNeutrals", 
-        "ReconstructedB0EcalNeutrals", 
-        "ReconstructedEcalEndcapPNeutrals",
-        "ReconstructedLFHCALNeutrals"},
+      {"HcalFarForwardZDCClusters", "B0ECalClusters", "EcalEndcapPClusters", "LFHCALClusters"},
+      {"ReconstructedHcalFarForwardZDCNeutrals", "ReconstructedB0EcalNeutrals",
+       "ReconstructedEcalEndcapPNeutrals", "ReconstructedLFHCALNeutrals"},
       {.offsetPositionName               = "HcalFarForwardZDC_SiPMonTile_r_pos",
        .neutronScaleCorrCoeffHcal        = {2.4, 0.89},
        .gammaScaleCorrCoeffHcal          = {1.1, 0.98},
@@ -243,12 +238,9 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<FarForwardLambdaReconstruction_factory>(
       "ReconstructedFarForwardLambdas",
-      {"ReconstructedHcalFarForwardZDCNeutrals", 
-        "ReconstructedB0EcalNeutrals", 
-        "ReconstructedEcalEndcapPNeutrals", 
-        "ReconstructedLFHCALNeutrals"},
-      {"ReconstructedFarForwardLambdas", 
-        "ReconstructedFarForwardLambdaDecayProductsCM"},
+      {"ReconstructedHcalFarForwardZDCNeutrals", "ReconstructedB0EcalNeutrals",
+       "ReconstructedEcalEndcapPNeutrals", "ReconstructedLFHCALNeutrals"},
+      {"ReconstructedFarForwardLambdas", "ReconstructedFarForwardLambdaDecayProductsCM"},
       {.offsetPositionName     = "HcalFarForwardZDC_SiPMonTile_r_pos",
        .globalToProtonRotation = -0.025,
        .lambdaMassWindow       = 0.30,

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -558,9 +558,12 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       "HcalFarForwardZDCTruthClusterLinks",
 #endif
       "HcalFarForwardZDCTruthClusterAssociations",
-      "ReconstructedFarForwardZDCNeutrals",
-      "ReconstructedFarForwardZDCLambdas",
-      "ReconstructedFarForwardZDCLambdaDecayProductsCM",
+      "ReconstructedHcalFarForwardZDCNeutrals",
+      "ReconstructedB0EcalNeutrals",
+      "ReconstructedEcalEndcapPNeutrals",
+      "ReconstructedLFHCALNeutrals",
+      "ReconstructedFarForwardLambdas",
+      "ReconstructedFarForwardLambdaDecayProductsCM",
 
       // DIRC
       "DIRCRawHits",


### PR DESCRIPTION
## Summary
This PR adds far-forward Lambda reconstruction using multi-calorimeter inputs (improving the previous ZDC-only approach).

## Main changes
- improve far-forward Lambda reconstruction algorithms (from ZDC-only to multi-calorimeters)
- add far-forward neutrals reconstruction for EcalEndCapP, LFHCAL, B0-Ecal.
- integrate new components into the reco chain
- update related factories and configuration

## Motivation
This extends the far-forward Lambda reconstruction beyond the previous setup and makes it available from `main`.

## Notes
- rebased on the latest `main`
- resolved conflict in `JEventProcessorPODIO.cc` by keeping upstream logic