### PR TITLE
Add multi-calorimeter reconstruction for Lambdas

### DIFF
--- a/src/algorithms/reco/FarForwardLambdaReconstruction.cc
+++ b/src/algorithms/reco/FarForwardLambdaReconstruction.cc
@@ -1,182 +1,376 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2025 Sebouh Paul
+// Update/modification 2026 by Baptiste Fraisse
 
 #include <Evaluator/DD4hepUnits.h>
 #include <TVector3.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/Vector3f.h>
-#include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
 #include <cmath>
 #include <cstddef>
 #include <gsl/pointers>
 #include <stdexcept>
 #include <vector>
+#include <type_traits>
 
 #include "FarForwardLambdaReconstruction.h"
 #include "TLorentzVector.h"
-/**
-Creates Lambda candidates from a neutron and two photons from a pi0 decay
- */
 
 namespace eicrecon {
 
-void FarForwardLambdaReconstruction::init() {
+// helpers 
 
+static inline void toTVector3(TVector3& v1, const edm4hep::Vector3f& v2) {
+  v1.SetXYZ(v2.x, v2.y, v2.z);
+}
+
+void FarForwardLambdaReconstruction::init() {
   try {
     m_zMax = m_detector->constant<double>(m_cfg.offsetPositionName);
   } catch (std::runtime_error&) {
-    m_zMax = 35800; // default value
-    trace("Failed to get {} from the detector, using default value of {}", m_cfg.offsetPositionName,
-          m_zMax);
+    m_zMax = 35800;
+    trace("Failed to get {} from the detector, using default value of {}", m_cfg.offsetPositionName, m_zMax);
   }
 }
 
-/* converts one type of vector format to another */
-void toTVector3(TVector3& v1, const edm4hep::Vector3f& v2) { v1.SetXYZ(v2.x, v2.y, v2.z); }
+// reconstruction machinery from n+g+g
 
-void FarForwardLambdaReconstruction::process(
-    const FarForwardLambdaReconstruction::Input& input,
-    const FarForwardLambdaReconstruction::Output& output) const {
-  const auto [neutrals]                                = input;
-  auto [out_lambdas, out_decay_products]               = output;
-  std::vector<edm4eic::ReconstructedParticle> neutrons = {};
-  std::vector<edm4eic::ReconstructedParticle> gammas   = {};
-  for (auto part : *neutrals) {
-    if (part.getPDG() == 2112) {
-      neutrons.push_back(part);
-    }
-    if (part.getPDG() == 22) {
-      gammas.push_back(part);
-    }
-  }
-
-  if (neutrons.empty() || gammas.size() < 2) {
-    return;
-  }
-
+bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
+    const edm4eic::ReconstructedParticle& n_in,
+    const edm4eic::ReconstructedParticle& g1_in,
+    const edm4eic::ReconstructedParticle& g2_in,
+    edm4eic::ReconstructedParticleCollection* out_lambdas,
+    edm4eic::ReconstructedParticleCollection* out_decay_products) const
+{
   static const double m_neutron = m_particleSvc.particle(2112).mass;
   static const double m_pi0     = m_particleSvc.particle(111).mass;
   static const double m_lambda  = m_particleSvc.particle(3122).mass;
 
-  for (std::size_t i_n = 0; i_n < neutrons.size(); i_n++) {
-    for (std::size_t i_1 = 0; i_1 < gammas.size() - 1; i_1++) {
-      for (std::size_t i_2 = i_1 + 1; i_2 < gammas.size(); i_2++) {
+  const double En = n_in.getEnergy();
+  const double E1 = g1_in.getEnergy();
+  const double E2 = g2_in.getEnergy();
 
-        double En = neutrons[i_n].getEnergy();
-        double pn = sqrt(En * En - m_neutron * m_neutron);
-        double E1 = gammas[i_1].getEnergy();
-        double E2 = gammas[i_2].getEnergy();
-        TVector3 xn;
-        TVector3 x1;
-        TVector3 x2;
+  if (En <= m_neutron) return false;
+  const double pn = std::sqrt(std::max(0.0, En*En - m_neutron*m_neutron));
 
-        toTVector3(xn, neutrons[0].getReferencePoint() * dd4hep::mm);
-        toTVector3(x1, gammas[0].getReferencePoint() * dd4hep::mm);
-        toTVector3(x2, gammas[1].getReferencePoint() * dd4hep::mm);
+  TVector3 xn, x1, x2;
 
-        xn.RotateY(-m_cfg.globalToProtonRotation);
-        x1.RotateY(-m_cfg.globalToProtonRotation);
-        x2.RotateY(-m_cfg.globalToProtonRotation);
+  const auto& rn  = n_in.getReferencePoint();
+  const auto& rg1 = g1_in.getReferencePoint();
+  const auto& rg2 = g2_in.getReferencePoint();
 
-        debug("nx recon = {}, g1x recon = {}, g2x recon = {}", xn.X(), x1.X(), x2.X());
-        debug("nz recon = {}, g1z recon = {}, g2z recon = {}, z face = {}", xn.Z(), x1.Z(), x2.Z(),
-              m_zMax);
+  xn.SetXYZ(rn.x * dd4hep::mm,
+            rn.y * dd4hep::mm,
+            rn.z * dd4hep::mm);
 
-        TVector3 vtx(0, 0, 0);
-        double f                   = 0;
-        double df                  = 0.5;
-        double theta_open_expected = 2 * asin(m_pi0 / (2 * sqrt(E1 * E2)));
-        TLorentzVector n;
-        TLorentzVector g1;
-        TLorentzVector g2;
-        TLorentzVector lambda;
-        for (int i = 0; i < m_cfg.iterations; i++) {
-          n                 = {pn * (xn - vtx).Unit(), En};
-          g1                = {E1 * (x1 - vtx).Unit(), E1};
-          g2                = {E2 * (x2 - vtx).Unit(), E2};
-          double theta_open = g1.Angle(g2.Vect());
-          lambda            = n + g1 + g2;
-          if (theta_open > theta_open_expected) {
-            f -= df;
-          } else if (theta_open < theta_open_expected) {
-            f += df;
-          }
+  x1.SetXYZ(rg1.x * dd4hep::mm,
+            rg1.y * dd4hep::mm,
+            rg1.z * dd4hep::mm);
 
-          vtx = lambda.Vect() * (f * m_zMax / lambda.Z());
-          df /= 2;
-        }
+  x2.SetXYZ(rg2.x * dd4hep::mm,
+            rg2.y * dd4hep::mm,
+            rg2.z * dd4hep::mm);
 
-        double mass_rec = lambda.M();
-        if (std::abs(mass_rec - m_lambda) > m_cfg.lambdaMaxMassDev) {
-          continue;
-        }
+  xn.RotateY(-m_cfg.globalToProtonRotation);
+  x1.RotateY(-m_cfg.globalToProtonRotation);
+  x2.RotateY(-m_cfg.globalToProtonRotation);
 
-        // rotate everything back to the lab coordinates.
-        vtx.RotateY(m_cfg.globalToProtonRotation);
-        lambda.RotateY(m_cfg.globalToProtonRotation);
-        n.RotateY(m_cfg.globalToProtonRotation);
-        g1.RotateY(m_cfg.globalToProtonRotation);
-        g2.RotateY(m_cfg.globalToProtonRotation);
+  TVector3 vtx(0, 0, 0);
+  double f  = 0.0;
+  double df = 0.5;
 
-        auto b = -lambda.BoostVector();
-        n.Boost(b);
-        g1.Boost(b);
-        g2.Boost(b);
+  const double theta_open_expected = 2 * std::asin(m_pi0 / (2 * std::sqrt(E1 * E2)));
 
-        //convert vertex to mm:
-        vtx = vtx * (1 / dd4hep::mm);
+  TLorentzVector n, g1, g2, lambda;
 
-        auto rec_lambda = out_lambdas->create();
-        rec_lambda.setPDG(3122);
+  for (int i = 0; i < m_cfg.iterations; i++) {
+    n      = { pn * (xn - vtx).Unit(), En };
+    g1     = { E1 * (x1 - vtx).Unit(), E1 };
+    g2     = { E2 * (x2 - vtx).Unit(), E2 };
+    lambda = n + g1 + g2;
 
-        rec_lambda.setEnergy(lambda.E());
-        rec_lambda.setMomentum({static_cast<float>(lambda.X()), static_cast<float>(lambda.Y()),
-                                static_cast<float>(lambda.Z())});
-        rec_lambda.setReferencePoint({static_cast<float>(vtx.X()), static_cast<float>(vtx.Y()),
-                                      static_cast<float>(vtx.Z())});
-        rec_lambda.setCharge(0);
-        rec_lambda.setMass(mass_rec);
+    const double theta_open = g1.Angle(g2.Vect());
+    if (theta_open > theta_open_expected)      f -= df;
+    else if (theta_open < theta_open_expected) f += df;
 
-        auto neutron_cm = out_decay_products->create();
-        neutron_cm.setPDG(2112);
-        neutron_cm.setEnergy(n.E());
-        neutron_cm.setMomentum(
-            {static_cast<float>(n.X()), static_cast<float>(n.Y()), static_cast<float>(n.Z())});
-        neutron_cm.setReferencePoint({static_cast<float>(vtx.X()), static_cast<float>(vtx.Y()),
-                                      static_cast<float>(vtx.Z())});
-        neutron_cm.setCharge(0);
-        neutron_cm.setMass(m_neutron);
-        //link the reconstructed lambda to the input neutron,
-        // and the cm neutron to the input neutron
-        rec_lambda.addToParticles(neutrons[i_n]);
-        neutron_cm.addToParticles(neutrons[i_n]);
+    vtx = lambda.Vect() * (f * m_zMax / lambda.Z());
+    df /= 2.0;
+  }
 
-        auto gamma1_cm = out_decay_products->create();
-        gamma1_cm.setPDG(22);
-        gamma1_cm.setEnergy(g1.E());
-        gamma1_cm.setMomentum(
-            {static_cast<float>(g1.X()), static_cast<float>(g1.Y()), static_cast<float>(g1.Z())});
-        gamma1_cm.setReferencePoint({static_cast<float>(vtx.X()), static_cast<float>(vtx.Y()),
-                                     static_cast<float>(vtx.Z())});
-        gamma1_cm.setCharge(0);
-        gamma1_cm.setMass(0);
-        rec_lambda.addToParticles(gammas[i_1]);
-        gamma1_cm.addToParticles(gammas[i_1]);
+  const double mass_rec = lambda.M();
+  if (std::abs(mass_rec - m_lambda) > m_cfg.lambdaMassWindow) return false;
 
-        auto gamma2_cm = out_decay_products->create();
-        gamma2_cm.setPDG(22);
-        gamma2_cm.setEnergy(g2.E());
-        gamma2_cm.setMomentum(
-            {static_cast<float>(g2.X()), static_cast<float>(g2.Y()), static_cast<float>(g2.Z())});
-        gamma2_cm.setReferencePoint({static_cast<float>(vtx.X()), static_cast<float>(vtx.Y()),
-                                     static_cast<float>(vtx.Z())});
-        gamma2_cm.setCharge(0);
-        gamma2_cm.setMass(0);
-        rec_lambda.addToParticles(gammas[i_2]);
-        gamma2_cm.addToParticles(gammas[i_2]);
-      }
+  // rotate everything back to lab coordinates
+  vtx.RotateY(m_cfg.globalToProtonRotation);
+  lambda.RotateY(m_cfg.globalToProtonRotation);
+  n.RotateY(m_cfg.globalToProtonRotation);
+  g1.RotateY(m_cfg.globalToProtonRotation);
+  g2.RotateY(m_cfg.globalToProtonRotation);
+
+  // boost decay products to Lambda rest frame
+  auto b = -lambda.BoostVector();
+  n.Boost(b);
+  g1.Boost(b);
+  g2.Boost(b);
+
+  // vertex back to EDM units (mm)
+  vtx = vtx * (1.0 / dd4hep::mm);
+
+  // saving reco lambda
+  auto rec_lambda = out_lambdas->create();
+  rec_lambda.setPDG(3122);
+  rec_lambda.setEnergy(lambda.E());
+  rec_lambda.setMomentum({static_cast<float>(lambda.X()),
+                          static_cast<float>(lambda.Y()),
+                          static_cast<float>(lambda.Z())});
+  rec_lambda.setReferencePoint({static_cast<float>(vtx.X()),
+                                static_cast<float>(vtx.Y()),
+                                static_cast<float>(vtx.Z())});
+  rec_lambda.setCharge(0);
+  rec_lambda.setMass(mass_rec);
+
+  // --- cm neutron
+  auto neutron_cm = out_decay_products->create();
+  neutron_cm.setPDG(2112);
+  neutron_cm.setEnergy(n.E());
+  neutron_cm.setMomentum({static_cast<float>(n.X()),
+                          static_cast<float>(n.Y()),
+                          static_cast<float>(n.Z())});
+  neutron_cm.setReferencePoint({static_cast<float>(vtx.X()),
+                                static_cast<float>(vtx.Y()),
+                                static_cast<float>(vtx.Z())});
+  neutron_cm.setCharge(0);
+  neutron_cm.setMass(m_neutron);
+
+  // --- cm gammas
+  auto gamma1_cm = out_decay_products->create();
+  gamma1_cm.setPDG(22);
+  gamma1_cm.setEnergy(g1.E());
+  gamma1_cm.setMomentum({static_cast<float>(g1.X()),
+                         static_cast<float>(g1.Y()),
+                         static_cast<float>(g1.Z())});
+  gamma1_cm.setReferencePoint({static_cast<float>(vtx.X()),
+                               static_cast<float>(vtx.Y()),
+                               static_cast<float>(vtx.Z())});
+  gamma1_cm.setCharge(0);
+  gamma1_cm.setMass(0);
+
+  auto gamma2_cm = out_decay_products->create();
+  gamma2_cm.setPDG(22);
+  gamma2_cm.setEnergy(g2.E());
+  gamma2_cm.setMomentum({static_cast<float>(g2.X()),
+                         static_cast<float>(g2.Y()),
+                         static_cast<float>(g2.Z())});
+  gamma2_cm.setReferencePoint({static_cast<float>(vtx.X()),
+                               static_cast<float>(vtx.Y()),
+                               static_cast<float>(vtx.Z())});
+  gamma2_cm.setCharge(0);
+  gamma2_cm.setMass(0);
+
+  // --- links
+  rec_lambda.addToParticles(n_in);
+  rec_lambda.addToParticles(g1_in);
+  rec_lambda.addToParticles(g2_in);
+
+  neutron_cm.addToParticles(n_in);
+  gamma1_cm.addToParticles(g1_in);
+  gamma2_cm.addToParticles(g2_in);
+
+  return true;
+}
+
+// selection of the best triplets n+g+g
+
+void FarForwardLambdaReconstruction::process(
+    const FarForwardLambdaReconstruction::Input& input,
+    const FarForwardLambdaReconstruction::Output& output) const
+{
+  const auto [neutralsHcal, neutralsB0, neutralsEcalEndcapP, neutralsLFHCAL] = input;
+  auto [out_lambdas, out_decay_products] = output;
+
+  const double m_pi0    = m_particleSvc.particle(111).mass;
+  const double m_lambda = m_particleSvc.particle(3122).mass;
+
+  // (A) collect by detector category
+  std::vector<edm4eic::ReconstructedParticle> neutrons_zdc, neutrons_other;
+  std::vector<edm4eic::ReconstructedParticle> gammas_zdc, gammas_other;
+
+  // ZDC Hcal
+  for (auto part : *neutralsHcal) {
+    if (part.getPDG() == 2112) neutrons_zdc.push_back(part);
+    if (part.getPDG() == 22)   gammas_zdc.push_back(part);
+  }
+
+  // B0 Ecal photons
+  for (auto part : *neutralsB0) {
+    if (part.getPDG() == 22) gammas_other.push_back(part);
+  }
+
+  // EndcapP Ecal photons
+  for (auto part : *neutralsEcalEndcapP) {
+    if (part.getPDG() == 22) gammas_other.push_back(part);
+  }
+
+  // LFHCAL neutrons
+  for (auto part : *neutralsLFHCAL) {
+    if (part.getPDG() == 2112) neutrons_other.push_back(part);
+  }
+
+  if (neutrons_zdc.empty() && neutrons_other.empty()) return;
+
+  // gamma pool
+  using GammaT = typename std::decay_t<decltype(gammas_zdc)>::value_type;
+  std::vector<GammaT> gamma_pool;
+  std::vector<uint8_t> gamma_is_zdc;
+
+  gamma_pool.reserve(gammas_zdc.size() + gammas_other.size());
+  gamma_is_zdc.reserve(gammas_zdc.size() + gammas_other.size());
+
+  for (const auto& g : gammas_zdc)   { gamma_pool.push_back(g); gamma_is_zdc.push_back(1); }
+  for (const auto& g : gammas_other) { gamma_pool.push_back(g); gamma_is_zdc.push_back(0); }
+
+  if (gamma_pool.size() < 2) return;
+
+  // invariant mass helpers (ranking only)
+
+  auto invMass2 = [](const edm4eic::ReconstructedParticle& a,
+                     const edm4eic::ReconstructedParticle& b) {
+    const auto pa = a.getMomentum();
+    const auto pb = b.getMomentum();
+    const double Ea = a.getEnergy();
+    const double Eb = b.getEnergy();
+    const double px = pa.x + pb.x;
+    const double py = pa.y + pb.y;
+    const double pz = pa.z + pb.z;
+    const double E  = Ea + Eb;
+    return E*E - (px*px + py*py + pz*pz);
+  };
+
+  auto invMass2_3 = [](const edm4eic::ReconstructedParticle& a,
+                       const edm4eic::ReconstructedParticle& b,
+                       const edm4eic::ReconstructedParticle& c) {
+    const auto pa = a.getMomentum();
+    const auto pb = b.getMomentum();
+    const auto pc = c.getMomentum();
+    const double Ea = a.getEnergy();
+    const double Eb = b.getEnergy();
+    const double Ec = c.getEnergy();
+    const double px = pa.x + pb.x + pc.x;
+    const double py = pa.y + pb.y + pc.y;
+    const double pz = pa.z + pb.z + pc.z;
+    const double E  = Ea + Eb + Ec;
+    return E*E - (px*px + py*py + pz*pz);
+  };
+
+  // (1) pi0 candidates
+  struct Pi0Pair {
+    int i, j;
+    int cat;             // 0:2ZDC, 1:1ZDC, 2:0ZDC
+    double dmpi0_cand;
+  };
+
+  std::vector<Pi0Pair> pi0_pairs;
+  pi0_pairs.reserve(gamma_pool.size() * (gamma_pool.size() - 1) / 2);
+
+  for (size_t i = 0; i < gamma_pool.size(); ++i) {
+    for (size_t j = i + 1; j < gamma_pool.size(); ++j) {
+      const auto& g1 = gamma_pool[i];
+      const auto& g2 = gamma_pool[j];
+
+      const double m2 = invMass2(g1, g2);
+      if (m2 <= 0.0) continue;
+
+      const double m  = std::sqrt(m2);
+      const double dm = std::abs(m - m_pi0);
+      if (dm > m_cfg.pi0Window * m_pi0) continue;
+
+      const bool z1 = gamma_is_zdc[i];
+      const bool z2 = gamma_is_zdc[j];
+      const int cat = (z1 && z2) ? 0 : ((z1 || z2) ? 1 : 2);
+
+      pi0_pairs.push_back({(int)i, (int)j, cat, dm});
     }
   }
+  if (pi0_pairs.empty()) return;
+
+  // (2) Lambda candidates pool
+  struct LambdaCand {
+    int g_i, g_j;
+    int n_idx;
+    int n_cat;   // 0: ZDC neutron, 1: other neutron
+    int g_cat;   // 0:2ZDC, 1:1ZDC, 2:0ZDC
+    double chi2;
+    double E;
+    double pz;
+  };
+
+  std::vector<LambdaCand> cands;
+  cands.reserve(64);
+
+  auto try_neutrons = [&](const auto& neutron_list, int n_cat) {
+    for (const auto& pp : pi0_pairs) {
+      const auto& g1 = gamma_pool[pp.i];
+      const auto& g2 = gamma_pool[pp.j];
+
+      for (size_t in = 0; in < neutron_list.size(); ++in) {
+        const auto& n = neutron_list[in];
+
+        const double m2L = invMass2_3(n, g1, g2);
+        if (m2L <= 0.0) continue;
+
+        const double mL = std::sqrt(m2L);
+        if (std::abs(mL - m_lambda) > m_cfg.lambdaMassWindow * m_lambda) continue;
+
+        const double dL = (mL - m_lambda);
+
+        // same score as your new code
+        const double chi2 =
+          (pp.dmpi0_cand / (m_cfg.pi0Window * m_pi0)) * (pp.dmpi0_cand / (m_cfg.pi0Window * m_pi0)) +
+          (dL / (m_cfg.lambdaMassWindow * m_lambda)) * (dL / (m_cfg.lambdaMassWindow * m_lambda));
+
+        const double E  = n.getEnergy() + g1.getEnergy() + g2.getEnergy();
+
+        const auto pn  = n.getMomentum();
+        const auto pg1 = g1.getMomentum();
+        const auto pg2 = g2.getMomentum();
+
+        const double px = pn.x + pg1.x + pg2.x;
+        const double py = pn.y + pg1.y + pg2.y;
+        const double pz = pn.z + pg1.z + pg2.z;
+
+        cands.push_back({pp.i, pp.j, (int)in, n_cat, pp.cat, chi2, E, pz});
+      }
+    }
+  };
+
+  if (!neutrons_zdc.empty())   try_neutrons(neutrons_zdc,   0);
+  if (!neutrons_other.empty()) try_neutrons(neutrons_other, 1);
+
+  if (cands.empty()) return;
+
+  // (3) best candidate selection (your policy)
+  auto better = [&](const LambdaCand& a, const LambdaCand& b) -> bool {
+    if (a.n_cat != b.n_cat) return a.n_cat < b.n_cat;  // prefer ZDC neutron
+    if (a.g_cat != b.g_cat) return a.g_cat < b.g_cat;  // prefer 2ZDC gammas
+    if (a.chi2  != b.chi2)  return a.chi2  < b.chi2;
+    if (a.pz    != b.pz)    return a.pz > b.pz;
+    return a.E > b.E;
+  };
+
+  int best_k = 0;
+  for (int k = 1; k < (int)cands.size(); ++k) {
+    if (better(cands[k], cands[best_k])) best_k = k;
+  }
+
+  const auto& best = cands[best_k];
+
+  const auto& g1 = gamma_pool[best.g_i];
+  const auto& g2 = gamma_pool[best.g_j];
+  const auto& n  = (best.n_cat == 0) ? neutrons_zdc[best.n_idx] : neutrons_other[best.n_idx];
+
+  // (4) lambda reconstruction machinery
+  reconstruct_from_triplet(n, g1, g2, out_lambdas, out_decay_products);
 }
+
 } // namespace eicrecon

--- a/src/algorithms/reco/FarForwardLambdaReconstruction.cc
+++ b/src/algorithms/reco/FarForwardLambdaReconstruction.cc
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2025 Sebouh Paul
-// Update/modification 2026 by Baptiste Fraisse
+// Copyright (C) 2025 Sebouh Paul, Baptiste Fraisse
 
 #include <Evaluator/DD4hepUnits.h>
 #include <TVector3.h>
@@ -63,11 +62,9 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
   xn.SetXYZ(rn.x * dd4hep::mm,
             rn.y * dd4hep::mm,
             rn.z * dd4hep::mm);
-
   x1.SetXYZ(rg1.x * dd4hep::mm,
             rg1.y * dd4hep::mm,
             rg1.z * dd4hep::mm);
-
   x2.SetXYZ(rg2.x * dd4hep::mm,
             rg2.y * dd4hep::mm,
             rg2.z * dd4hep::mm);
@@ -168,7 +165,6 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
   gamma2_cm.setCharge(0);
   gamma2_cm.setMass(0);
 
-  // --- links
   rec_lambda.addToParticles(n_in);
   rec_lambda.addToParticles(g1_in);
   rec_lambda.addToParticles(g2_in);
@@ -180,8 +176,6 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
   return true;
 }
 
-// selection of the best triplets n+g+g
-
 void FarForwardLambdaReconstruction::process(
     const FarForwardLambdaReconstruction::Input& input,
     const FarForwardLambdaReconstruction::Output& output) const
@@ -192,81 +186,124 @@ void FarForwardLambdaReconstruction::process(
   const double m_pi0    = m_particleSvc.particle(111).mass;
   const double m_lambda = m_particleSvc.particle(3122).mass;
 
-  // (A) collect by detector category
+  // --------------------------------------------------------------------------
+  // Step 1: collect neutral candidates by broad detector category
+  //
+  // We keep two categories for ranking purposes:
+  //   - ZDC-preferred neutrals
+  //   - other far-forward neutrals
+  // while centralizing the detector-specific collection handling in a single
+  // local table to avoid duplicating hardcoded loops throughout the algorithm.
+  // --------------------------------------------------------------------------
+
   std::vector<edm4eic::ReconstructedParticle> neutrons_zdc, neutrons_other;
   std::vector<edm4eic::ReconstructedParticle> gammas_zdc, gammas_other;
 
-  // ZDC Hcal
-  for (auto part : *neutralsHcal) {
-    if (part.getPDG() == 2112) neutrons_zdc.push_back(part);
-    if (part.getPDG() == 22)   gammas_zdc.push_back(part);
+  struct NeutralInputDesc {
+    const edm4eic::ReconstructedParticleCollection* coll;
+    bool use_gamma;
+    bool use_neutron;
+    bool is_zdc;
+  };
+
+  const std::array<NeutralInputDesc, 4> input_descs{{
+      {neutralsHcal,        true,  true,  true },
+      {neutralsB0,          true,  false, false},
+      {neutralsEcalEndcapP, true,  false, false},
+      {neutralsLFHCAL,      false, true,  false},
+  }};
+
+  for (const auto& desc : input_descs) {
+    for (const auto& part : *desc.coll) {
+      if (desc.use_neutron && part.getPDG() == 2112) {
+        (desc.is_zdc ? neutrons_zdc : neutrons_other).push_back(part);
+      }
+      if (desc.use_gamma && part.getPDG() == 22) {
+        (desc.is_zdc ? gammas_zdc : gammas_other).push_back(part);
+      }
+    }
   }
 
-  // B0 Ecal photons
-  for (auto part : *neutralsB0) {
-    if (part.getPDG() == 22) gammas_other.push_back(part);
+  if (neutrons_zdc.empty() && neutrons_other.empty()) {
+    return;
   }
 
-  // EndcapP Ecal photons
-  for (auto part : *neutralsEcalEndcapP) {
-    if (part.getPDG() == 22) gammas_other.push_back(part);
-  }
+  // --------------------------------------------------------------------------
+  // Step 2: build a unified photon pool while retaining whether each photon
+  // comes from the ZDC-preferred category.
+  // --------------------------------------------------------------------------
 
-  // LFHCAL neutrons
-  for (auto part : *neutralsLFHCAL) {
-    if (part.getPDG() == 2112) neutrons_other.push_back(part);
-  }
+  using ParticleT = edm4eic::ReconstructedParticle;
 
-  if (neutrons_zdc.empty() && neutrons_other.empty()) return;
-
-  // gamma pool
-  using GammaT = typename std::decay_t<decltype(gammas_zdc)>::value_type;
-  std::vector<GammaT> gamma_pool;
+  std::vector<ParticleT> gamma_pool;
   std::vector<uint8_t> gamma_is_zdc;
 
   gamma_pool.reserve(gammas_zdc.size() + gammas_other.size());
   gamma_is_zdc.reserve(gammas_zdc.size() + gammas_other.size());
 
-  for (const auto& g : gammas_zdc)   { gamma_pool.push_back(g); gamma_is_zdc.push_back(1); }
-  for (const auto& g : gammas_other) { gamma_pool.push_back(g); gamma_is_zdc.push_back(0); }
+  for (const auto& g : gammas_zdc) {
+    gamma_pool.push_back(g);
+    gamma_is_zdc.push_back(1);
+  }
+  for (const auto& g : gammas_other) {
+    gamma_pool.push_back(g);
+    gamma_is_zdc.push_back(0);
+  }
 
-  if (gamma_pool.size() < 2) return;
+  if (gamma_pool.size() < 2) {
+    return;
+  }
 
-  // invariant mass helpers (ranking only)
+  // --------------------------------------------------------------------------
+  // Invariant-mass helpers
+  // --------------------------------------------------------------------------
 
-  auto invMass2 = [](const edm4eic::ReconstructedParticle& a,
-                     const edm4eic::ReconstructedParticle& b) {
+  auto invMass2 = [](const ParticleT& a, const ParticleT& b) {
     const auto pa = a.getMomentum();
     const auto pb = b.getMomentum();
+
     const double Ea = a.getEnergy();
     const double Eb = b.getEnergy();
+
     const double px = pa.x + pb.x;
     const double py = pa.y + pb.y;
     const double pz = pa.z + pb.z;
     const double E  = Ea + Eb;
-    return E*E - (px*px + py*py + pz*pz);
+
+    return E * E - (px * px + py * py + pz * pz);
   };
 
-  auto invMass2_3 = [](const edm4eic::ReconstructedParticle& a,
-                       const edm4eic::ReconstructedParticle& b,
-                       const edm4eic::ReconstructedParticle& c) {
+  auto invMass2_3 = [](const ParticleT& a, const ParticleT& b, const ParticleT& c) {
     const auto pa = a.getMomentum();
     const auto pb = b.getMomentum();
     const auto pc = c.getMomentum();
+
     const double Ea = a.getEnergy();
     const double Eb = b.getEnergy();
     const double Ec = c.getEnergy();
+
     const double px = pa.x + pb.x + pc.x;
     const double py = pa.y + pb.y + pc.y;
     const double pz = pa.z + pb.z + pc.z;
     const double E  = Ea + Eb + Ec;
-    return E*E - (px*px + py*py + pz*pz);
+
+    return E * E - (px * px + py * py + pz * pz);
   };
 
-  // (1) pi0 candidates
+  // --------------------------------------------------------------------------
+  // Step 3: build pi0 candidates from photon pairs
+  // --------------------------------------------------------------------------
+
+  enum class GammaCategory : uint8_t {
+    TwoZDC  = 0,
+    OneZDC  = 1,
+    ZeroZDC = 2
+  };
+
   struct Pi0Pair {
-    int i, j;
-    int cat;             // 0:2ZDC, 1:1ZDC, 2:0ZDC
+    int i;
+    int j;
+    GammaCategory cat;
     double dmpi0_cand;
   };
 
@@ -279,27 +316,47 @@ void FarForwardLambdaReconstruction::process(
       const auto& g2 = gamma_pool[j];
 
       const double m2 = invMass2(g1, g2);
-      if (m2 <= 0.0) continue;
+      if (m2 <= 0.0) {
+        continue;
+      }
 
       const double m  = std::sqrt(m2);
       const double dm = std::abs(m - m_pi0);
-      if (dm > m_cfg.pi0Window * m_pi0) continue;
+      if (dm > m_cfg.pi0Window * m_pi0) {
+        continue;
+      }
 
       const bool z1 = gamma_is_zdc[i];
       const bool z2 = gamma_is_zdc[j];
-      const int cat = (z1 && z2) ? 0 : ((z1 || z2) ? 1 : 2);
 
-      pi0_pairs.push_back({(int)i, (int)j, cat, dm});
+      const GammaCategory cat =
+          (z1 && z2) ? GammaCategory::TwoZDC
+        : (z1 || z2) ? GammaCategory::OneZDC
+                     : GammaCategory::ZeroZDC;
+
+      pi0_pairs.push_back({static_cast<int>(i), static_cast<int>(j), cat, dm});
     }
   }
-  if (pi0_pairs.empty()) return;
 
-  // (2) Lambda candidates pool
+  if (pi0_pairs.empty()) {
+    return;
+  }
+
+  // --------------------------------------------------------------------------
+  // Step 4: build Lambda candidate pool from pi0-neutron combinations
+  // --------------------------------------------------------------------------
+
+  enum class NeutronCategory : uint8_t {
+    ZDC   = 0,
+    Other = 1
+  };
+
   struct LambdaCand {
-    int g_i, g_j;
+    int g_i;
+    int g_j;
     int n_idx;
-    int n_cat;   // 0: ZDC neutron, 1: other neutron
-    int g_cat;   // 0:2ZDC, 1:1ZDC, 2:0ZDC
+    NeutronCategory n_cat;
+    GammaCategory g_cat;
     double chi2;
     double E;
     double pz;
@@ -308,7 +365,7 @@ void FarForwardLambdaReconstruction::process(
   std::vector<LambdaCand> cands;
   cands.reserve(64);
 
-  auto try_neutrons = [&](const auto& neutron_list, int n_cat) {
+  auto try_neutrons = [&](const auto& neutron_list, NeutronCategory n_cat) {
     for (const auto& pp : pi0_pairs) {
       const auto& g1 = gamma_pool[pp.i];
       const auto& g2 = gamma_pool[pp.j];
@@ -317,59 +374,99 @@ void FarForwardLambdaReconstruction::process(
         const auto& n = neutron_list[in];
 
         const double m2L = invMass2_3(n, g1, g2);
-        if (m2L <= 0.0) continue;
+        if (m2L <= 0.0) {
+          continue;
+        }
 
         const double mL = std::sqrt(m2L);
-        if (std::abs(mL - m_lambda) > m_cfg.lambdaMassWindow * m_lambda) continue;
+        const double dL = mL - m_lambda;
 
-        const double dL = (mL - m_lambda);
+        if (std::abs(dL) > m_cfg.lambdaMassWindow * m_lambda) {
+          continue;
+        }
 
-        // same score as your new code
-        const double chi2 =
-          (pp.dmpi0_cand / (m_cfg.pi0Window * m_pi0)) * (pp.dmpi0_cand / (m_cfg.pi0Window * m_pi0)) +
-          (dL / (m_cfg.lambdaMassWindow * m_lambda)) * (dL / (m_cfg.lambdaMassWindow * m_lambda));
+        const double pi0_term =
+            pp.dmpi0_cand / (m_cfg.pi0Window * m_pi0);
+        const double lambda_term =
+            dL / (m_cfg.lambdaMassWindow * m_lambda);
 
-        const double E  = n.getEnergy() + g1.getEnergy() + g2.getEnergy();
+        const double chi2 = pi0_term * pi0_term + lambda_term * lambda_term;
+
+        const double E = n.getEnergy() + g1.getEnergy() + g2.getEnergy();
 
         const auto pn  = n.getMomentum();
         const auto pg1 = g1.getMomentum();
         const auto pg2 = g2.getMomentum();
 
-        const double px = pn.x + pg1.x + pg2.x;
-        const double py = pn.y + pg1.y + pg2.y;
         const double pz = pn.z + pg1.z + pg2.z;
 
-        cands.push_back({pp.i, pp.j, (int)in, n_cat, pp.cat, chi2, E, pz});
+        cands.push_back({
+            pp.i,
+            pp.j,
+            static_cast<int>(in),
+            n_cat,
+            pp.cat,
+            chi2,
+            E,
+            pz
+        });
       }
     }
   };
 
-  if (!neutrons_zdc.empty())   try_neutrons(neutrons_zdc,   0);
-  if (!neutrons_other.empty()) try_neutrons(neutrons_other, 1);
+  if (!neutrons_zdc.empty()) {
+    try_neutrons(neutrons_zdc, NeutronCategory::ZDC);
+  }
+  if (!neutrons_other.empty()) {
+    try_neutrons(neutrons_other, NeutronCategory::Other);
+  }
 
-  if (cands.empty()) return;
+  if (cands.empty()) {
+    return;
+  }
 
-  // (3) best candidate selection (your policy)
+  // --------------------------------------------------------------------------
+  // Step 5: rank candidates and keep the best one
+  // Preference order:
+  //   1. ZDC neutron over other neutron
+  //   2. more ZDC photons in the pi0 candidate
+  //   3. lower combined mass-based chi2
+  //   4. larger forward momentum pz
+  //   5. larger total energy
+  // --------------------------------------------------------------------------
+
   auto better = [&](const LambdaCand& a, const LambdaCand& b) -> bool {
-    if (a.n_cat != b.n_cat) return a.n_cat < b.n_cat;  // prefer ZDC neutron
-    if (a.g_cat != b.g_cat) return a.g_cat < b.g_cat;  // prefer 2ZDC gammas
-    if (a.chi2  != b.chi2)  return a.chi2  < b.chi2;
-    if (a.pz    != b.pz)    return a.pz > b.pz;
+    if (a.n_cat != b.n_cat) {
+      return static_cast<int>(a.n_cat) < static_cast<int>(b.n_cat);
+    }
+    if (a.g_cat != b.g_cat) {
+      return static_cast<int>(a.g_cat) < static_cast<int>(b.g_cat);
+    }
+    if (a.chi2 != b.chi2) {
+      return a.chi2 < b.chi2;
+    }
+    if (a.pz != b.pz) {
+      return a.pz > b.pz;
+    }
     return a.E > b.E;
   };
 
   int best_k = 0;
-  for (int k = 1; k < (int)cands.size(); ++k) {
-    if (better(cands[k], cands[best_k])) best_k = k;
+  for (int k = 1; k < static_cast<int>(cands.size()); ++k) {
+    if (better(cands[k], cands[best_k])) {
+      best_k = k;
+    }
   }
 
   const auto& best = cands[best_k];
 
   const auto& g1 = gamma_pool[best.g_i];
   const auto& g2 = gamma_pool[best.g_j];
-  const auto& n  = (best.n_cat == 0) ? neutrons_zdc[best.n_idx] : neutrons_other[best.n_idx];
+  const auto& n =
+      (best.n_cat == NeutronCategory::ZDC)
+          ? neutrons_zdc[best.n_idx]
+          : neutrons_other[best.n_idx];
 
-  // (4) lambda reconstruction machinery
   reconstruct_from_triplet(n, g1, g2, out_lambdas, out_decay_products);
 }
 

--- a/src/algorithms/reco/FarForwardLambdaReconstruction.cc
+++ b/src/algorithms/reco/FarForwardLambdaReconstruction.cc
@@ -4,14 +4,16 @@
 #include <Evaluator/DD4hepUnits.h>
 #include <TVector3.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
+#include <edm4eic/Vertex.h>
 #include <edm4hep/Vector3f.h>
-#include <fmt/core.h>
+#include <stdint.h>
+#include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstddef>
-#include <gsl/pointers>
 #include <stdexcept>
+#include <tuple>
 #include <vector>
-#include <type_traits>
 
 #include "FarForwardLambdaReconstruction.h"
 #include "TLorentzVector.h"

--- a/src/algorithms/reco/FarForwardLambdaReconstruction.cc
+++ b/src/algorithms/reco/FarForwardLambdaReconstruction.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2025 Sebouh Paul, Baptiste Fraisse
+// Copyright (C) 2026 Sebouh Paul, Baptiste Fraisse
 
 #include <Evaluator/DD4hepUnits.h>
 #include <TVector3.h>
@@ -50,14 +50,22 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
   const double E1 = g1_in.getEnergy();
   const double E2 = g2_in.getEnergy();
 
-  if (En <= m_neutron) return false;
+  if (En <= m_neutron){ return false; }
   const double pn = std::sqrt(std::max(0.0, En*En - m_neutron*m_neutron));
 
-  TVector3 xn, x1, x2;
+  TVector3 xn;
+  TVector3 x1;
+  TVector3 x2;
 
-  const auto& rn  = n_in.getReferencePoint();
-  const auto& rg1 = g1_in.getReferencePoint();
-  const auto& rg2 = g2_in.getReferencePoint();
+  if (n_in.clusters_size() == 0 ||
+      g1_in.clusters_size() == 0 ||
+      g2_in.clusters_size() == 0) {
+    return false;
+  }
+
+  const auto rn  = n_in.getClusters(0).getPosition();
+  const auto rg1 = g1_in.getClusters(0).getPosition();
+  const auto rg2 = g2_in.getClusters(0).getPosition();
 
   xn.SetXYZ(rn.x * dd4hep::mm,
             rn.y * dd4hep::mm,
@@ -79,7 +87,10 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
 
   const double theta_open_expected = 2 * std::asin(m_pi0 / (2 * std::sqrt(E1 * E2)));
 
-  TLorentzVector n, g1, g2, lambda;
+  TLorentzVector n;
+  TLorentzVector g1;
+  TLorentzVector g2;
+  TLorentzVector lambda;
 
   for (int i = 0; i < m_cfg.iterations; i++) {
     n      = { pn * (xn - vtx).Unit(), En };
@@ -88,15 +99,20 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
     lambda = n + g1 + g2;
 
     const double theta_open = g1.Angle(g2.Vect());
-    if (theta_open > theta_open_expected)      f -= df;
-    else if (theta_open < theta_open_expected) f += df;
+    if (theta_open > theta_open_expected) {
+      f -= df;
+    } else if (theta_open < theta_open_expected) {
+      f += df;
+    }
 
     vtx = lambda.Vect() * (f * m_zMax / lambda.Z());
     df /= 2.0;
   }
 
   const double mass_rec = lambda.M();
-  if (std::abs(mass_rec - m_lambda) > m_cfg.lambdaMassWindow) return false;
+  if (std::abs(mass_rec - m_lambda) > m_cfg.lambdaMassWindow * m_lambda) {
+    return false;
+  }
 
   // rotate everything back to lab coordinates
   vtx.RotateY(m_cfg.globalToProtonRotation);
@@ -196,17 +212,19 @@ void FarForwardLambdaReconstruction::process(
   // local table to avoid duplicating hardcoded loops throughout the algorithm.
   // --------------------------------------------------------------------------
 
-  std::vector<edm4eic::ReconstructedParticle> neutrons_zdc, neutrons_other;
-  std::vector<edm4eic::ReconstructedParticle> gammas_zdc, gammas_other;
+  std::vector<edm4eic::ReconstructedParticle> neutrons_zdc;
+  std::vector<edm4eic::ReconstructedParticle> neutrons_other;
+  std::vector<edm4eic::ReconstructedParticle> gammas_zdc;
+  std::vector<edm4eic::ReconstructedParticle> gammas_other;
 
-  struct NeutralInputDesc {
+  struct NeutralInputDescription {
     const edm4eic::ReconstructedParticleCollection* coll;
     bool use_gamma;
     bool use_neutron;
     bool is_zdc;
   };
 
-  const std::array<NeutralInputDesc, 4> input_descs{{
+  const std::array<NeutralInputDescription, 4> input_descs{{
       {neutralsHcal,        true,  true,  true },
       {neutralsB0,          true,  false, false},
       {neutralsEcalEndcapP, true,  false, false},
@@ -225,6 +243,7 @@ void FarForwardLambdaReconstruction::process(
   }
 
   if (neutrons_zdc.empty() && neutrons_other.empty()) {
+    debug("No neutrons in input collection");
     return;
   }
 
@@ -236,7 +255,7 @@ void FarForwardLambdaReconstruction::process(
   using ParticleT = edm4eic::ReconstructedParticle;
 
   std::vector<ParticleT> gamma_pool;
-  std::vector<uint8_t> gamma_is_zdc;
+  std::vector<bool> gamma_is_zdc;
 
   gamma_pool.reserve(gammas_zdc.size() + gammas_other.size());
   gamma_is_zdc.reserve(gammas_zdc.size() + gammas_other.size());
@@ -251,6 +270,7 @@ void FarForwardLambdaReconstruction::process(
   }
 
   if (gamma_pool.size() < 2) {
+    debug("Less than 2 gammas found ({})", gamma_pool.size());
     return;
   }
 

--- a/src/algorithms/reco/FarForwardLambdaReconstruction.cc
+++ b/src/algorithms/reco/FarForwardLambdaReconstruction.cc
@@ -18,12 +18,6 @@
 
 namespace eicrecon {
 
-// helpers
-
-static inline void toTVector3(TVector3& v1, const edm4hep::Vector3f& v2) {
-  v1.SetXYZ(v2.x, v2.y, v2.z);
-}
-
 void FarForwardLambdaReconstruction::init() {
   try {
     m_zMax = m_detector->constant<double>(m_cfg.offsetPositionName);

--- a/src/algorithms/reco/FarForwardLambdaReconstruction.cc
+++ b/src/algorithms/reco/FarForwardLambdaReconstruction.cc
@@ -6,7 +6,7 @@
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4eic/Vertex.h>
 #include <edm4hep/Vector3f.h>
-#include <stdint.h>
+#include <cstdint>
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -45,11 +45,14 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
   const double E1 = g1_in.getEnergy();
   const double E2 = g2_in.getEnergy();
 
-  if (En <= m_neutron)
+  if (En <= m_neutron) {
     return false;
+}
   const double pn = std::sqrt(std::max(0.0, En * En - m_neutron * m_neutron));
 
-  TVector3 xn, x1, x2;
+  TVector3 xn;
+  TVector3 x1;
+  TVector3 x2;
 
   const auto& rn  = n_in.getReferencePoint();
   const auto& rg1 = g1_in.getReferencePoint();
@@ -69,7 +72,10 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
 
   const double theta_open_expected = 2 * std::asin(m_pi0 / (2 * std::sqrt(E1 * E2)));
 
-  TLorentzVector n, g1, g2, lambda;
+  TLorentzVector n;
+  TLorentzVector g1;
+  TLorentzVector g2;
+  TLorentzVector lambda;
 
   for (int i = 0; i < m_cfg.iterations; i++) {
     n      = {pn * (xn - vtx).Unit(), En};
@@ -78,18 +84,20 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
     lambda = n + g1 + g2;
 
     const double theta_open = g1.Angle(g2.Vect());
-    if (theta_open > theta_open_expected)
+    if (theta_open > theta_open_expected) {
       f -= df;
-    else if (theta_open < theta_open_expected)
+    } else if (theta_open < theta_open_expected) {
       f += df;
+}
 
     vtx = lambda.Vect() * (f * m_zMax / lambda.Z());
     df /= 2.0;
   }
 
   const double mass_rec = lambda.M();
-  if (std::abs(mass_rec - m_lambda) > m_cfg.lambdaMassWindow)
+  if (std::abs(mass_rec - m_lambda) > m_cfg.lambdaMassWindow) {
     return false;
+}
 
   // rotate everything back to lab coordinates
   vtx.RotateY(m_cfg.globalToProtonRotation);
@@ -180,8 +188,10 @@ void FarForwardLambdaReconstruction::process(
   // local table to avoid duplicating hardcoded loops throughout the algorithm.
   // --------------------------------------------------------------------------
 
-  std::vector<edm4eic::ReconstructedParticle> neutrons_zdc, neutrons_other;
-  std::vector<edm4eic::ReconstructedParticle> gammas_zdc, gammas_other;
+  std::vector<edm4eic::ReconstructedParticle> neutrons_zdc;
+  std::vector<edm4eic::ReconstructedParticle> neutrons_other;
+  std::vector<edm4eic::ReconstructedParticle> gammas_zdc;
+  std::vector<edm4eic::ReconstructedParticle> gammas_other;
 
   struct NeutralInputDesc {
     const edm4eic::ReconstructedParticleCollection* coll;

--- a/src/algorithms/reco/FarForwardLambdaReconstruction.cc
+++ b/src/algorithms/reco/FarForwardLambdaReconstruction.cc
@@ -18,7 +18,7 @@
 
 namespace eicrecon {
 
-// helpers 
+// helpers
 
 static inline void toTVector3(TVector3& v1, const edm4hep::Vector3f& v2) {
   v1.SetXYZ(v2.x, v2.y, v2.z);
@@ -29,19 +29,18 @@ void FarForwardLambdaReconstruction::init() {
     m_zMax = m_detector->constant<double>(m_cfg.offsetPositionName);
   } catch (std::runtime_error&) {
     m_zMax = 35800;
-    trace("Failed to get {} from the detector, using default value of {}", m_cfg.offsetPositionName, m_zMax);
+    trace("Failed to get {} from the detector, using default value of {}", m_cfg.offsetPositionName,
+          m_zMax);
   }
 }
 
 // reconstruction machinery from n+g+g
 
 bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
-    const edm4eic::ReconstructedParticle& n_in,
-    const edm4eic::ReconstructedParticle& g1_in,
+    const edm4eic::ReconstructedParticle& n_in, const edm4eic::ReconstructedParticle& g1_in,
     const edm4eic::ReconstructedParticle& g2_in,
     edm4eic::ReconstructedParticleCollection* out_lambdas,
-    edm4eic::ReconstructedParticleCollection* out_decay_products) const
-{
+    edm4eic::ReconstructedParticleCollection* out_decay_products) const {
   static const double m_neutron = m_particleSvc.particle(2112).mass;
   static const double m_pi0     = m_particleSvc.particle(111).mass;
   static const double m_lambda  = m_particleSvc.particle(3122).mass;
@@ -50,8 +49,9 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
   const double E1 = g1_in.getEnergy();
   const double E2 = g2_in.getEnergy();
 
-  if (En <= m_neutron) return false;
-  const double pn = std::sqrt(std::max(0.0, En*En - m_neutron*m_neutron));
+  if (En <= m_neutron)
+    return false;
+  const double pn = std::sqrt(std::max(0.0, En * En - m_neutron * m_neutron));
 
   TVector3 xn, x1, x2;
 
@@ -59,15 +59,9 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
   const auto& rg1 = g1_in.getReferencePoint();
   const auto& rg2 = g2_in.getReferencePoint();
 
-  xn.SetXYZ(rn.x * dd4hep::mm,
-            rn.y * dd4hep::mm,
-            rn.z * dd4hep::mm);
-  x1.SetXYZ(rg1.x * dd4hep::mm,
-            rg1.y * dd4hep::mm,
-            rg1.z * dd4hep::mm);
-  x2.SetXYZ(rg2.x * dd4hep::mm,
-            rg2.y * dd4hep::mm,
-            rg2.z * dd4hep::mm);
+  xn.SetXYZ(rn.x * dd4hep::mm, rn.y * dd4hep::mm, rn.z * dd4hep::mm);
+  x1.SetXYZ(rg1.x * dd4hep::mm, rg1.y * dd4hep::mm, rg1.z * dd4hep::mm);
+  x2.SetXYZ(rg2.x * dd4hep::mm, rg2.y * dd4hep::mm, rg2.z * dd4hep::mm);
 
   xn.RotateY(-m_cfg.globalToProtonRotation);
   x1.RotateY(-m_cfg.globalToProtonRotation);
@@ -82,21 +76,24 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
   TLorentzVector n, g1, g2, lambda;
 
   for (int i = 0; i < m_cfg.iterations; i++) {
-    n      = { pn * (xn - vtx).Unit(), En };
-    g1     = { E1 * (x1 - vtx).Unit(), E1 };
-    g2     = { E2 * (x2 - vtx).Unit(), E2 };
+    n      = {pn * (xn - vtx).Unit(), En};
+    g1     = {E1 * (x1 - vtx).Unit(), E1};
+    g2     = {E2 * (x2 - vtx).Unit(), E2};
     lambda = n + g1 + g2;
 
     const double theta_open = g1.Angle(g2.Vect());
-    if (theta_open > theta_open_expected)      f -= df;
-    else if (theta_open < theta_open_expected) f += df;
+    if (theta_open > theta_open_expected)
+      f -= df;
+    else if (theta_open < theta_open_expected)
+      f += df;
 
     vtx = lambda.Vect() * (f * m_zMax / lambda.Z());
     df /= 2.0;
   }
 
   const double mass_rec = lambda.M();
-  if (std::abs(mass_rec - m_lambda) > m_cfg.lambdaMassWindow) return false;
+  if (std::abs(mass_rec - m_lambda) > m_cfg.lambdaMassWindow)
+    return false;
 
   // rotate everything back to lab coordinates
   vtx.RotateY(m_cfg.globalToProtonRotation);
@@ -118,12 +115,10 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
   auto rec_lambda = out_lambdas->create();
   rec_lambda.setPDG(3122);
   rec_lambda.setEnergy(lambda.E());
-  rec_lambda.setMomentum({static_cast<float>(lambda.X()),
-                          static_cast<float>(lambda.Y()),
+  rec_lambda.setMomentum({static_cast<float>(lambda.X()), static_cast<float>(lambda.Y()),
                           static_cast<float>(lambda.Z())});
-  rec_lambda.setReferencePoint({static_cast<float>(vtx.X()),
-                                static_cast<float>(vtx.Y()),
-                                static_cast<float>(vtx.Z())});
+  rec_lambda.setReferencePoint(
+      {static_cast<float>(vtx.X()), static_cast<float>(vtx.Y()), static_cast<float>(vtx.Z())});
   rec_lambda.setCharge(0);
   rec_lambda.setMass(mass_rec);
 
@@ -131,12 +126,10 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
   auto neutron_cm = out_decay_products->create();
   neutron_cm.setPDG(2112);
   neutron_cm.setEnergy(n.E());
-  neutron_cm.setMomentum({static_cast<float>(n.X()),
-                          static_cast<float>(n.Y()),
-                          static_cast<float>(n.Z())});
-  neutron_cm.setReferencePoint({static_cast<float>(vtx.X()),
-                                static_cast<float>(vtx.Y()),
-                                static_cast<float>(vtx.Z())});
+  neutron_cm.setMomentum(
+      {static_cast<float>(n.X()), static_cast<float>(n.Y()), static_cast<float>(n.Z())});
+  neutron_cm.setReferencePoint(
+      {static_cast<float>(vtx.X()), static_cast<float>(vtx.Y()), static_cast<float>(vtx.Z())});
   neutron_cm.setCharge(0);
   neutron_cm.setMass(m_neutron);
 
@@ -144,24 +137,20 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
   auto gamma1_cm = out_decay_products->create();
   gamma1_cm.setPDG(22);
   gamma1_cm.setEnergy(g1.E());
-  gamma1_cm.setMomentum({static_cast<float>(g1.X()),
-                         static_cast<float>(g1.Y()),
-                         static_cast<float>(g1.Z())});
-  gamma1_cm.setReferencePoint({static_cast<float>(vtx.X()),
-                               static_cast<float>(vtx.Y()),
-                               static_cast<float>(vtx.Z())});
+  gamma1_cm.setMomentum(
+      {static_cast<float>(g1.X()), static_cast<float>(g1.Y()), static_cast<float>(g1.Z())});
+  gamma1_cm.setReferencePoint(
+      {static_cast<float>(vtx.X()), static_cast<float>(vtx.Y()), static_cast<float>(vtx.Z())});
   gamma1_cm.setCharge(0);
   gamma1_cm.setMass(0);
 
   auto gamma2_cm = out_decay_products->create();
   gamma2_cm.setPDG(22);
   gamma2_cm.setEnergy(g2.E());
-  gamma2_cm.setMomentum({static_cast<float>(g2.X()),
-                         static_cast<float>(g2.Y()),
-                         static_cast<float>(g2.Z())});
-  gamma2_cm.setReferencePoint({static_cast<float>(vtx.X()),
-                               static_cast<float>(vtx.Y()),
-                               static_cast<float>(vtx.Z())});
+  gamma2_cm.setMomentum(
+      {static_cast<float>(g2.X()), static_cast<float>(g2.Y()), static_cast<float>(g2.Z())});
+  gamma2_cm.setReferencePoint(
+      {static_cast<float>(vtx.X()), static_cast<float>(vtx.Y()), static_cast<float>(vtx.Z())});
   gamma2_cm.setCharge(0);
   gamma2_cm.setMass(0);
 
@@ -178,10 +167,9 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
 
 void FarForwardLambdaReconstruction::process(
     const FarForwardLambdaReconstruction::Input& input,
-    const FarForwardLambdaReconstruction::Output& output) const
-{
+    const FarForwardLambdaReconstruction::Output& output) const {
   const auto [neutralsHcal, neutralsB0, neutralsEcalEndcapP, neutralsLFHCAL] = input;
-  auto [out_lambdas, out_decay_products] = output;
+  auto [out_lambdas, out_decay_products]                                     = output;
 
   const double m_pi0    = m_particleSvc.particle(111).mass;
   const double m_lambda = m_particleSvc.particle(3122).mass;
@@ -207,10 +195,10 @@ void FarForwardLambdaReconstruction::process(
   };
 
   const std::array<NeutralInputDesc, 4> input_descs{{
-      {neutralsHcal,        true,  true,  true },
-      {neutralsB0,          true,  false, false},
-      {neutralsEcalEndcapP, true,  false, false},
-      {neutralsLFHCAL,      false, true,  false},
+      {neutralsHcal, true, true, true},
+      {neutralsB0, true, false, false},
+      {neutralsEcalEndcapP, true, false, false},
+      {neutralsLFHCAL, false, true, false},
   }};
 
   for (const auto& desc : input_descs) {
@@ -294,11 +282,7 @@ void FarForwardLambdaReconstruction::process(
   // Step 3: build pi0 candidates from photon pairs
   // --------------------------------------------------------------------------
 
-  enum class GammaCategory : uint8_t {
-    TwoZDC  = 0,
-    OneZDC  = 1,
-    ZeroZDC = 2
-  };
+  enum class GammaCategory : uint8_t { TwoZDC = 0, OneZDC = 1, ZeroZDC = 2 };
 
   struct Pi0Pair {
     int i;
@@ -329,10 +313,9 @@ void FarForwardLambdaReconstruction::process(
       const bool z1 = gamma_is_zdc[i];
       const bool z2 = gamma_is_zdc[j];
 
-      const GammaCategory cat =
-          (z1 && z2) ? GammaCategory::TwoZDC
-        : (z1 || z2) ? GammaCategory::OneZDC
-                     : GammaCategory::ZeroZDC;
+      const GammaCategory cat = (z1 && z2)   ? GammaCategory::TwoZDC
+                                : (z1 || z2) ? GammaCategory::OneZDC
+                                             : GammaCategory::ZeroZDC;
 
       pi0_pairs.push_back({static_cast<int>(i), static_cast<int>(j), cat, dm});
     }
@@ -346,10 +329,7 @@ void FarForwardLambdaReconstruction::process(
   // Step 4: build Lambda candidate pool from pi0-neutron combinations
   // --------------------------------------------------------------------------
 
-  enum class NeutronCategory : uint8_t {
-    ZDC   = 0,
-    Other = 1
-  };
+  enum class NeutronCategory : uint8_t { ZDC = 0, Other = 1 };
 
   struct LambdaCand {
     int g_i;
@@ -385,10 +365,8 @@ void FarForwardLambdaReconstruction::process(
           continue;
         }
 
-        const double pi0_term =
-            pp.dmpi0_cand / (m_cfg.pi0Window * m_pi0);
-        const double lambda_term =
-            dL / (m_cfg.lambdaMassWindow * m_lambda);
+        const double pi0_term    = pp.dmpi0_cand / (m_cfg.pi0Window * m_pi0);
+        const double lambda_term = dL / (m_cfg.lambdaMassWindow * m_lambda);
 
         const double chi2 = pi0_term * pi0_term + lambda_term * lambda_term;
 
@@ -400,16 +378,7 @@ void FarForwardLambdaReconstruction::process(
 
         const double pz = pn.z + pg1.z + pg2.z;
 
-        cands.push_back({
-            pp.i,
-            pp.j,
-            static_cast<int>(in),
-            n_cat,
-            pp.cat,
-            chi2,
-            E,
-            pz
-        });
+        cands.push_back({pp.i, pp.j, static_cast<int>(in), n_cat, pp.cat, chi2, E, pz});
       }
     }
   };
@@ -463,9 +432,7 @@ void FarForwardLambdaReconstruction::process(
   const auto& g1 = gamma_pool[best.g_i];
   const auto& g2 = gamma_pool[best.g_j];
   const auto& n =
-      (best.n_cat == NeutronCategory::ZDC)
-          ? neutrons_zdc[best.n_idx]
-          : neutrons_other[best.n_idx];
+      (best.n_cat == NeutronCategory::ZDC) ? neutrons_zdc[best.n_idx] : neutrons_other[best.n_idx];
 
   reconstruct_from_triplet(n, g1, g2, out_lambdas, out_decay_products);
 }

--- a/src/algorithms/reco/FarForwardLambdaReconstruction.cc
+++ b/src/algorithms/reco/FarForwardLambdaReconstruction.cc
@@ -47,7 +47,7 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
 
   if (En <= m_neutron) {
     return false;
-}
+  }
   const double pn = std::sqrt(std::max(0.0, En * En - m_neutron * m_neutron));
 
   TVector3 xn;
@@ -88,7 +88,7 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
       f -= df;
     } else if (theta_open < theta_open_expected) {
       f += df;
-}
+    }
 
     vtx = lambda.Vect() * (f * m_zMax / lambda.Z());
     df /= 2.0;
@@ -97,7 +97,7 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
   const double mass_rec = lambda.M();
   if (std::abs(mass_rec - m_lambda) > m_cfg.lambdaMassWindow) {
     return false;
-}
+  }
 
   // rotate everything back to lab coordinates
   vtx.RotateY(m_cfg.globalToProtonRotation);

--- a/src/algorithms/reco/FarForwardLambdaReconstruction.cc
+++ b/src/algorithms/reco/FarForwardLambdaReconstruction.cc
@@ -18,7 +18,7 @@
 
 namespace eicrecon {
 
-// helpers 
+// helpers
 
 static inline void toTVector3(TVector3& v1, const edm4hep::Vector3f& v2) {
   v1.SetXYZ(v2.x, v2.y, v2.z);
@@ -29,19 +29,18 @@ void FarForwardLambdaReconstruction::init() {
     m_zMax = m_detector->constant<double>(m_cfg.offsetPositionName);
   } catch (std::runtime_error&) {
     m_zMax = 35800;
-    trace("Failed to get {} from the detector, using default value of {}", m_cfg.offsetPositionName, m_zMax);
+    trace("Failed to get {} from the detector, using default value of {}", m_cfg.offsetPositionName,
+          m_zMax);
   }
 }
 
 // reconstruction machinery from n+g+g
 
 bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
-    const edm4eic::ReconstructedParticle& n_in,
-    const edm4eic::ReconstructedParticle& g1_in,
+    const edm4eic::ReconstructedParticle& n_in, const edm4eic::ReconstructedParticle& g1_in,
     const edm4eic::ReconstructedParticle& g2_in,
     edm4eic::ReconstructedParticleCollection* out_lambdas,
-    edm4eic::ReconstructedParticleCollection* out_decay_products) const
-{
+    edm4eic::ReconstructedParticleCollection* out_decay_products) const {
   static const double m_neutron = m_particleSvc.particle(2112).mass;
   static const double m_pi0     = m_particleSvc.particle(111).mass;
   static const double m_lambda  = m_particleSvc.particle(3122).mass;
@@ -50,16 +49,16 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
   const double E1 = g1_in.getEnergy();
   const double E2 = g2_in.getEnergy();
 
-  if (En <= m_neutron){ return false; }
-  const double pn = std::sqrt(std::max(0.0, En*En - m_neutron*m_neutron));
+  if (En <= m_neutron) {
+    return false;
+  }
+  const double pn = std::sqrt(std::max(0.0, En * En - m_neutron * m_neutron));
 
   TVector3 xn;
   TVector3 x1;
   TVector3 x2;
 
-  if (n_in.clusters_size() == 0 ||
-      g1_in.clusters_size() == 0 ||
-      g2_in.clusters_size() == 0) {
+  if (n_in.clusters_size() == 0 || g1_in.clusters_size() == 0 || g2_in.clusters_size() == 0) {
     return false;
   }
 
@@ -67,15 +66,9 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
   const auto rg1 = g1_in.getClusters(0).getPosition();
   const auto rg2 = g2_in.getClusters(0).getPosition();
 
-  xn.SetXYZ(rn.x * dd4hep::mm,
-            rn.y * dd4hep::mm,
-            rn.z * dd4hep::mm);
-  x1.SetXYZ(rg1.x * dd4hep::mm,
-            rg1.y * dd4hep::mm,
-            rg1.z * dd4hep::mm);
-  x2.SetXYZ(rg2.x * dd4hep::mm,
-            rg2.y * dd4hep::mm,
-            rg2.z * dd4hep::mm);
+  xn.SetXYZ(rn.x * dd4hep::mm, rn.y * dd4hep::mm, rn.z * dd4hep::mm);
+  x1.SetXYZ(rg1.x * dd4hep::mm, rg1.y * dd4hep::mm, rg1.z * dd4hep::mm);
+  x2.SetXYZ(rg2.x * dd4hep::mm, rg2.y * dd4hep::mm, rg2.z * dd4hep::mm);
 
   xn.RotateY(-m_cfg.globalToProtonRotation);
   x1.RotateY(-m_cfg.globalToProtonRotation);
@@ -93,9 +86,9 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
   TLorentzVector lambda;
 
   for (int i = 0; i < m_cfg.iterations; i++) {
-    n      = { pn * (xn - vtx).Unit(), En };
-    g1     = { E1 * (x1 - vtx).Unit(), E1 };
-    g2     = { E2 * (x2 - vtx).Unit(), E2 };
+    n      = {pn * (xn - vtx).Unit(), En};
+    g1     = {E1 * (x1 - vtx).Unit(), E1};
+    g2     = {E2 * (x2 - vtx).Unit(), E2};
     lambda = n + g1 + g2;
 
     const double theta_open = g1.Angle(g2.Vect());
@@ -134,12 +127,10 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
   auto rec_lambda = out_lambdas->create();
   rec_lambda.setPDG(3122);
   rec_lambda.setEnergy(lambda.E());
-  rec_lambda.setMomentum({static_cast<float>(lambda.X()),
-                          static_cast<float>(lambda.Y()),
+  rec_lambda.setMomentum({static_cast<float>(lambda.X()), static_cast<float>(lambda.Y()),
                           static_cast<float>(lambda.Z())});
-  rec_lambda.setReferencePoint({static_cast<float>(vtx.X()),
-                                static_cast<float>(vtx.Y()),
-                                static_cast<float>(vtx.Z())});
+  rec_lambda.setReferencePoint(
+      {static_cast<float>(vtx.X()), static_cast<float>(vtx.Y()), static_cast<float>(vtx.Z())});
   rec_lambda.setCharge(0);
   rec_lambda.setMass(mass_rec);
 
@@ -147,12 +138,10 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
   auto neutron_cm = out_decay_products->create();
   neutron_cm.setPDG(2112);
   neutron_cm.setEnergy(n.E());
-  neutron_cm.setMomentum({static_cast<float>(n.X()),
-                          static_cast<float>(n.Y()),
-                          static_cast<float>(n.Z())});
-  neutron_cm.setReferencePoint({static_cast<float>(vtx.X()),
-                                static_cast<float>(vtx.Y()),
-                                static_cast<float>(vtx.Z())});
+  neutron_cm.setMomentum(
+      {static_cast<float>(n.X()), static_cast<float>(n.Y()), static_cast<float>(n.Z())});
+  neutron_cm.setReferencePoint(
+      {static_cast<float>(vtx.X()), static_cast<float>(vtx.Y()), static_cast<float>(vtx.Z())});
   neutron_cm.setCharge(0);
   neutron_cm.setMass(m_neutron);
 
@@ -160,24 +149,20 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
   auto gamma1_cm = out_decay_products->create();
   gamma1_cm.setPDG(22);
   gamma1_cm.setEnergy(g1.E());
-  gamma1_cm.setMomentum({static_cast<float>(g1.X()),
-                         static_cast<float>(g1.Y()),
-                         static_cast<float>(g1.Z())});
-  gamma1_cm.setReferencePoint({static_cast<float>(vtx.X()),
-                               static_cast<float>(vtx.Y()),
-                               static_cast<float>(vtx.Z())});
+  gamma1_cm.setMomentum(
+      {static_cast<float>(g1.X()), static_cast<float>(g1.Y()), static_cast<float>(g1.Z())});
+  gamma1_cm.setReferencePoint(
+      {static_cast<float>(vtx.X()), static_cast<float>(vtx.Y()), static_cast<float>(vtx.Z())});
   gamma1_cm.setCharge(0);
   gamma1_cm.setMass(0);
 
   auto gamma2_cm = out_decay_products->create();
   gamma2_cm.setPDG(22);
   gamma2_cm.setEnergy(g2.E());
-  gamma2_cm.setMomentum({static_cast<float>(g2.X()),
-                         static_cast<float>(g2.Y()),
-                         static_cast<float>(g2.Z())});
-  gamma2_cm.setReferencePoint({static_cast<float>(vtx.X()),
-                               static_cast<float>(vtx.Y()),
-                               static_cast<float>(vtx.Z())});
+  gamma2_cm.setMomentum(
+      {static_cast<float>(g2.X()), static_cast<float>(g2.Y()), static_cast<float>(g2.Z())});
+  gamma2_cm.setReferencePoint(
+      {static_cast<float>(vtx.X()), static_cast<float>(vtx.Y()), static_cast<float>(vtx.Z())});
   gamma2_cm.setCharge(0);
   gamma2_cm.setMass(0);
 
@@ -194,10 +179,9 @@ bool FarForwardLambdaReconstruction::reconstruct_from_triplet(
 
 void FarForwardLambdaReconstruction::process(
     const FarForwardLambdaReconstruction::Input& input,
-    const FarForwardLambdaReconstruction::Output& output) const
-{
+    const FarForwardLambdaReconstruction::Output& output) const {
   const auto [neutralsHcal, neutralsB0, neutralsEcalEndcapP, neutralsLFHCAL] = input;
-  auto [out_lambdas, out_decay_products] = output;
+  auto [out_lambdas, out_decay_products]                                     = output;
 
   const double m_pi0    = m_particleSvc.particle(111).mass;
   const double m_lambda = m_particleSvc.particle(3122).mass;
@@ -225,10 +209,10 @@ void FarForwardLambdaReconstruction::process(
   };
 
   const std::array<NeutralInputDescription, 4> input_descs{{
-      {neutralsHcal,        true,  true,  true },
-      {neutralsB0,          true,  false, false},
-      {neutralsEcalEndcapP, true,  false, false},
-      {neutralsLFHCAL,      false, true,  false},
+      {neutralsHcal, true, true, true},
+      {neutralsB0, true, false, false},
+      {neutralsEcalEndcapP, true, false, false},
+      {neutralsLFHCAL, false, true, false},
   }};
 
   for (const auto& desc : input_descs) {
@@ -314,11 +298,7 @@ void FarForwardLambdaReconstruction::process(
   // Step 3: build pi0 candidates from photon pairs
   // --------------------------------------------------------------------------
 
-  enum class GammaCategory : uint8_t {
-    TwoZDC  = 0,
-    OneZDC  = 1,
-    ZeroZDC = 2
-  };
+  enum class GammaCategory : uint8_t { TwoZDC = 0, OneZDC = 1, ZeroZDC = 2 };
 
   struct Pi0Pair {
     int i;
@@ -349,10 +329,9 @@ void FarForwardLambdaReconstruction::process(
       const bool z1 = gamma_is_zdc[i];
       const bool z2 = gamma_is_zdc[j];
 
-      const GammaCategory cat =
-          (z1 && z2) ? GammaCategory::TwoZDC
-        : (z1 || z2) ? GammaCategory::OneZDC
-                     : GammaCategory::ZeroZDC;
+      const GammaCategory cat = (z1 && z2)   ? GammaCategory::TwoZDC
+                                : (z1 || z2) ? GammaCategory::OneZDC
+                                             : GammaCategory::ZeroZDC;
 
       pi0_pairs.push_back({static_cast<int>(i), static_cast<int>(j), cat, dm});
     }
@@ -366,10 +345,7 @@ void FarForwardLambdaReconstruction::process(
   // Step 4: build Lambda candidate pool from pi0-neutron combinations
   // --------------------------------------------------------------------------
 
-  enum class NeutronCategory : uint8_t {
-    ZDC   = 0,
-    Other = 1
-  };
+  enum class NeutronCategory : uint8_t { ZDC = 0, Other = 1 };
 
   struct LambdaCandidate {
     int g_i;
@@ -405,10 +381,8 @@ void FarForwardLambdaReconstruction::process(
           continue;
         }
 
-        const double pi0_term =
-            pp.dmpi0_cand / (m_cfg.pi0Window * m_pi0);
-        const double lambda_term =
-            dL / (m_cfg.lambdaMassWindow * m_lambda);
+        const double pi0_term    = pp.dmpi0_cand / (m_cfg.pi0Window * m_pi0);
+        const double lambda_term = dL / (m_cfg.lambdaMassWindow * m_lambda);
 
         const double chi2 = pi0_term * pi0_term + lambda_term * lambda_term;
 
@@ -420,16 +394,7 @@ void FarForwardLambdaReconstruction::process(
 
         const double pz = pn.z + pg1.z + pg2.z;
 
-        cands.push_back({
-            pp.i,
-            pp.j,
-            static_cast<int>(in),
-            n_cat,
-            pp.cat,
-            chi2,
-            E,
-            pz
-        });
+        cands.push_back({pp.i, pp.j, static_cast<int>(in), n_cat, pp.cat, chi2, E, pz});
       }
     }
   };
@@ -483,9 +448,7 @@ void FarForwardLambdaReconstruction::process(
   const auto& g1 = gamma_pool[best.g_i];
   const auto& g2 = gamma_pool[best.g_j];
   const auto& n =
-      (best.n_cat == NeutronCategory::ZDC)
-          ? neutrons_zdc[best.n_idx]
-          : neutrons_other[best.n_idx];
+      (best.n_cat == NeutronCategory::ZDC) ? neutrons_zdc[best.n_idx] : neutrons_other[best.n_idx];
 
   reconstruct_from_triplet(n, g1, g2, out_lambdas, out_decay_products);
 }

--- a/src/algorithms/reco/FarForwardLambdaReconstruction.cc
+++ b/src/algorithms/reco/FarForwardLambdaReconstruction.cc
@@ -3,15 +3,18 @@
 
 #include <Evaluator/DD4hepUnits.h>
 #include <TVector3.h>
+#include <edm4eic/Cluster.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
+#include <edm4eic/Vertex.h>
 #include <edm4hep/Vector3f.h>
-#include <fmt/core.h>
+#include <stdint.h>
+#include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstddef>
-#include <gsl/pointers>
 #include <stdexcept>
+#include <tuple>
 #include <vector>
-#include <type_traits>
 
 #include "FarForwardLambdaReconstruction.h"
 #include "TLorentzVector.h"

--- a/src/algorithms/reco/FarForwardLambdaReconstruction.cc
+++ b/src/algorithms/reco/FarForwardLambdaReconstruction.cc
@@ -371,7 +371,7 @@ void FarForwardLambdaReconstruction::process(
     Other = 1
   };
 
-  struct LambdaCand {
+  struct LambdaCandidate {
     int g_i;
     int g_j;
     int n_idx;
@@ -382,8 +382,8 @@ void FarForwardLambdaReconstruction::process(
     double pz;
   };
 
-  std::vector<LambdaCand> cands;
-  cands.reserve(64);
+  std::vector<LambdaCandidate> cands;
+  cands.reserve(64); // NB <= 4^3 candidates when searching for 3 daughters across 4 calos
 
   auto try_neutrons = [&](const auto& neutron_list, NeutronCategory n_cat) {
     for (const auto& pp : pi0_pairs) {
@@ -455,7 +455,7 @@ void FarForwardLambdaReconstruction::process(
   //   5. larger total energy
   // --------------------------------------------------------------------------
 
-  auto better = [&](const LambdaCand& a, const LambdaCand& b) -> bool {
+  auto better = [&](const LambdaCandidate& a, const LambdaCandidate& b) -> bool {
     if (a.n_cat != b.n_cat) {
       return static_cast<int>(a.n_cat) < static_cast<int>(b.n_cat);
     }

--- a/src/algorithms/reco/FarForwardLambdaReconstruction.h
+++ b/src/algorithms/reco/FarForwardLambdaReconstruction.h
@@ -19,7 +19,10 @@
 namespace eicrecon {
 
 using FarForwardLambdaReconstructionAlgorithm = algorithms::Algorithm<
-    algorithms::Input<const edm4eic::ReconstructedParticleCollection>,
+    algorithms::Input<const edm4eic::ReconstructedParticleCollection,
+                      const edm4eic::ReconstructedParticleCollection,
+                      const edm4eic::ReconstructedParticleCollection,
+                      const edm4eic::ReconstructedParticleCollection>,
     /*output collections contain the lambda candidates and their decay products in the CM frame*/
     algorithms::Output<edm4eic::ReconstructedParticleCollection,
                        edm4eic::ReconstructedParticleCollection>>;
@@ -29,10 +32,16 @@ public:
   FarForwardLambdaReconstruction(std::string_view name)
       : FarForwardLambdaReconstructionAlgorithm{
             name,
-            {"inputNeutrals"},
-            {"outputLambdas", "outputLambdaDecayProductsCM"},
-            "Reconstructs lambda candidates and their decay products (in the CM frame) from the "
-            "reconstructed neutrons and photons"} {}
+
+            {"inputNeutralsHcal",
+             "inputNeutralsB0", 
+             "inputNeutralsEcalEndCapP",
+             "inputNeutralsLFHCAL"},
+
+            {"outputLambdas", 
+             "outputLambdaDecayProductsCM"},
+
+            "Reconstructs lambda candidates and their decay products (in the CM frame) from the reconstructed neutrons and photons"} {}
 
   void init() final;
   void process(const Input&, const Output&) const final;
@@ -42,5 +51,12 @@ private:
   const algorithms::ParticleSvc& m_particleSvc = algorithms::ParticleSvc::instance();
   const dd4hep::Detector* m_detector{algorithms::GeoSvc::instance().detector()};
   double m_zMax{0};
+
+  bool reconstruct_from_triplet(
+      const edm4eic::ReconstructedParticle& n_in,
+      const edm4eic::ReconstructedParticle& g1_in,
+      const edm4eic::ReconstructedParticle& g2_in,
+      edm4eic::ReconstructedParticleCollection* out_lambdas,
+      edm4eic::ReconstructedParticleCollection* out_decay_products) const;
 };
 } // namespace eicrecon

--- a/src/algorithms/reco/FarForwardLambdaReconstruction.h
+++ b/src/algorithms/reco/FarForwardLambdaReconstruction.h
@@ -52,15 +52,13 @@ public:
       : FarForwardLambdaReconstructionAlgorithm{
             name,
 
-            {"inputNeutralsHcal",
-             "inputNeutralsB0", 
-             "inputNeutralsEcalEndCapP",
+            {"inputNeutralsHcal", "inputNeutralsB0", "inputNeutralsEcalEndCapP",
              "inputNeutralsLFHCAL"},
 
-            {"outputLambdas", 
-             "outputLambdaDecayProductsCM"},
+            {"outputLambdas", "outputLambdaDecayProductsCM"},
 
-            "Reconstructs lambda candidates and their decay products (in the CM frame) from the reconstructed neutrons and photons"} {}
+            "Reconstructs lambda candidates and their decay products (in the CM frame) from the "
+            "reconstructed neutrons and photons"} {}
 
   void init() final;
   void process(const Input&, const Output&) const final;
@@ -71,11 +69,10 @@ private:
   const dd4hep::Detector* m_detector{algorithms::GeoSvc::instance().detector()};
   double m_zMax{0};
 
-  bool reconstruct_from_triplet(
-      const edm4eic::ReconstructedParticle& n_in,
-      const edm4eic::ReconstructedParticle& g1_in,
-      const edm4eic::ReconstructedParticle& g2_in,
-      edm4eic::ReconstructedParticleCollection* out_lambdas,
-      edm4eic::ReconstructedParticleCollection* out_decay_products) const;
+  bool reconstruct_from_triplet(const edm4eic::ReconstructedParticle& n_in,
+                                const edm4eic::ReconstructedParticle& g1_in,
+                                const edm4eic::ReconstructedParticle& g2_in,
+                                edm4eic::ReconstructedParticleCollection* out_lambdas,
+                                edm4eic::ReconstructedParticleCollection* out_decay_products) const;
 };
 } // namespace eicrecon

--- a/src/algorithms/reco/FarForwardLambdaReconstruction.h
+++ b/src/algorithms/reco/FarForwardLambdaReconstruction.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2025 Sebouh Paul
+// Copyright (C) 2025 Sebouh Paul, Baptiste Fraisse
 
 #pragma once
 #include <DD4hep/Detector.h>
@@ -26,6 +26,25 @@ using FarForwardLambdaReconstructionAlgorithm = algorithms::Algorithm<
     /*output collections contain the lambda candidates and their decay products in the CM frame*/
     algorithms::Output<edm4eic::ReconstructedParticleCollection,
                        edm4eic::ReconstructedParticleCollection>>;
+/**
+ * Reconstruct far-forward Lambda candidates from neutral reconstructed particles.
+ *
+ * The reconstruction proceeds in five stages:
+ * - collect photon and neutron candidates from the configured far-forward
+ *   neutral collections and split them into detector categories;
+ * - build pi0 candidates from all photon pairs passing the configured pi0
+ *   invariant-mass window;
+ * - combine accepted pi0 candidates with neutron candidates to form Lambda
+ *   candidates passing the configured Lambda invariant-mass window;
+ * - rank the surviving candidates according to detector-preference and
+ *   mass-compatibility criteria;
+ * - run the final Lambda reconstruction on the best candidate and store the
+ *   resulting Lambda and decay products.
+ *
+ * The current ranking gives priority to candidates containing a ZDC neutron,
+ * then to candidates containing more ZDC photons, followed by the combined
+ * pi0/Lambda mass residual score and forward kinematics.
+ */
 class FarForwardLambdaReconstruction : public FarForwardLambdaReconstructionAlgorithm,
                                        public WithPodConfig<FarForwardLambdaReconstructionConfig> {
 public:

--- a/src/algorithms/reco/FarForwardLambdaReconstruction.h
+++ b/src/algorithms/reco/FarForwardLambdaReconstruction.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2025 Sebouh Paul, Baptiste Fraisse
+// Copyright (C) 2026 Sebouh Paul, Baptiste Fraisse
 
 #pragma once
 #include <DD4hep/Detector.h>
@@ -30,15 +30,15 @@ using FarForwardLambdaReconstructionAlgorithm = algorithms::Algorithm<
  * Reconstruct far-forward Lambda candidates from neutral reconstructed particles.
  *
  * The reconstruction proceeds in five stages:
- * - collect photon and neutron candidates from the configured far-forward
+ * 1. collect photon and neutron candidates from the configured far-forward
  *   neutral collections and split them into detector categories;
- * - build pi0 candidates from all photon pairs passing the configured pi0
+ * 2. build pi0 candidates from all photon pairs passing the configured pi0
  *   invariant-mass window;
- * - combine accepted pi0 candidates with neutron candidates to form Lambda
+ * 3. combine accepted pi0 candidates with neutron candidates to form Lambda
  *   candidates passing the configured Lambda invariant-mass window;
- * - rank the surviving candidates according to detector-preference and
+ * 4. rank the surviving candidates according to detector-preference and
  *   mass-compatibility criteria;
- * - run the final Lambda reconstruction on the best candidate and store the
+ * 5. run the final Lambda reconstruction on the best candidate and store the
  *   resulting Lambda and decay products.
  *
  * The current ranking gives priority to candidates containing a ZDC neutron,

--- a/src/algorithms/reco/FarForwardLambdaReconstructionConfig.h
+++ b/src/algorithms/reco/FarForwardLambdaReconstructionConfig.h
@@ -13,7 +13,8 @@ struct FarForwardLambdaReconstructionConfig {
   /** transformation from global coordinates to proton-frame coordinates*/
   double globalToProtonRotation = -0.025;
   /** maximum deviation between reconstructed mass and PDG mass */
-  double lambdaMaxMassDev = 0.030 * dd4hep::GeV;
+  double lambdaMassWindow = 0.30;
+  double pi0Window = 0.30;
   /** number of iterations for the IDOLA algorithm */
   int iterations = 10;
 };

--- a/src/algorithms/reco/FarForwardLambdaReconstructionConfig.h
+++ b/src/algorithms/reco/FarForwardLambdaReconstructionConfig.h
@@ -14,7 +14,7 @@ struct FarForwardLambdaReconstructionConfig {
   double globalToProtonRotation = -0.025;
   /** maximum deviation between reconstructed mass and PDG mass */
   double lambdaMassWindow = 0.30;
-  double pi0Window = 0.30;
+  double pi0Window        = 0.30;
   /** number of iterations for the IDOLA algorithm */
   int iterations = 10;
 };

--- a/src/algorithms/reco/FarForwardLambdaReconstructionConfig.h
+++ b/src/algorithms/reco/FarForwardLambdaReconstructionConfig.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2025 Sebouh Paul, Baptiste Fraisse
+// Copyright (C) 2026 Sebouh Paul, Baptiste Fraisse
 #pragma once
 #include <float.h>
 #include <DD4hep/Detector.h>
@@ -13,8 +13,8 @@ struct FarForwardLambdaReconstructionConfig {
   /** transformation from global coordinates to proton-frame coordinates*/
   double globalToProtonRotation = -0.025;
   /** maximum deviation between reconstructed mass and PDG mass */
-  double lambdaMassWindow = 0.30;
-  double pi0Window = 0.30;
+  double lambdaMassWindow = 0.1;
+  double pi0Window = 0.1;
   /** number of iterations for the IDOLA algorithm */
   int iterations = 10;
 };

--- a/src/algorithms/reco/FarForwardLambdaReconstructionConfig.h
+++ b/src/algorithms/reco/FarForwardLambdaReconstructionConfig.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2025 Sebouh Paul
+// Copyright (C) 2025 Sebouh Paul, Baptiste Fraisse
 #pragma once
 #include <float.h>
 #include <DD4hep/Detector.h>

--- a/src/algorithms/reco/FarForwardLambdaReconstructionConfig.h
+++ b/src/algorithms/reco/FarForwardLambdaReconstructionConfig.h
@@ -14,7 +14,7 @@ struct FarForwardLambdaReconstructionConfig {
   double globalToProtonRotation = -0.025;
   /** maximum deviation between reconstructed mass and PDG mass */
   double lambdaMassWindow = 0.1;
-  double pi0Window = 0.1;
+  double pi0Window        = 0.1;
   /** number of iterations for the IDOLA algorithm */
   int iterations = 10;
 };

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2025 Sebouh Paul, Baptiste Fraisse
+// Copyright (C) 2026 Sebouh Paul, Baptiste Fraisse
 
 #include <Evaluator/DD4hepUnits.h>
 #include <edm4eic/ClusterCollection.h>
@@ -20,22 +20,20 @@
 namespace eicrecon {
 
 void FarForwardNeutralsReconstruction::init() {
-
   try {
     m_gammaZMax =
-        400 * dd4hep::mm + m_detector->constant<double>(m_cfg.offsetPositionName) / dd4hep::mm;
+        m_cfg.gammaZMaxOffset +
+        m_detector->constant<double>(m_cfg.offsetPositionName) / dd4hep::mm;
   } catch (std::runtime_error&) {
-    m_gammaZMax = m_cfg.gammaZMaxOffset + 35800;
-    trace("Failed to get {} from the detector, using default value of {}", m_cfg.offsetPositionName,
+    m_gammaZMax = m_cfg.gammaZMaxOffset + 35800.0;
+    trace("Failed to get {} from the detector, using default value of {}",
+          m_cfg.offsetPositionName,
           m_gammaZMax);
   }
-
-  trace("gamma detection params:   max length={},   max width={},   max z={}", m_cfg.gammaMaxLength,
-        m_cfg.gammaMaxWidth, m_gammaZMax);
-}
-
-double FarForwardNeutralsReconstruction::calc_corr(double Etot, const std::vector<double>& coeffs) {
-  return coeffs[0] + coeffs[1] / sqrt(Etot) + coeffs[2] / Etot;
+  trace("gamma detection params:   max length={},   max width={},   max z={}",
+        m_cfg.gammaMaxLength,
+        m_cfg.gammaMaxWidth,
+        m_gammaZMax);
 }
 
 /*
@@ -87,7 +85,9 @@ void FarForwardNeutralsReconstruction::process(
   using CorrFunc = std::function<double(double, const std::vector<double>&)>;
 
   CorrFunc corr_power = [](double E, const std::vector<double>& coeffs) {
-    if (coeffs.size() < 2) return E;
+    if (coeffs.size() < 2) {
+      return E;
+    }
     return coeffs[0] * std::pow(E, coeffs[1]);
   };
 
@@ -109,8 +109,12 @@ void FarForwardNeutralsReconstruction::process(
 
       (void)gammaLeaderFracMin;
 
-      if (!clusters || clusters->empty()) return 0;
-      if (!canDetectGammas) gammaMode = GammaMode::None;
+      if (!clusters || clusters->empty()) {
+        return 0;
+      }
+      if (!canDetectGammas) {
+        gammaMode = GammaMode::None;
+      }
 
       // gammas from clusters
       auto makeGamma = [&](const edm4eic::Cluster& cl){
@@ -121,10 +125,11 @@ void FarForwardNeutralsReconstruction::process(
         const double E = gammaCorr(cl.getEnergy(), gammaScaleCoeff);
 
         const double r = edm4hep::utils::magnitude(pos);
-        if (r > 0) rec.setMomentum(pos * (E / r));
+        if (r > 0) {
+          rec.setMomentum(pos * (E / r));
+        }
 
         rec.setEnergy(E);
-        rec.setReferencePoint(pos);
         rec.setCharge(0);
         rec.setMass(0);
         rec.addToClusters(cl);
@@ -142,13 +147,23 @@ void FarForwardNeutralsReconstruction::process(
         double Esum = 0.0;
         for (int i = 0, n = (int)clusters->size(); i < n; ++i) {
           const double E = (*clusters)[i].getEnergy();
-          if (E < clusterEmin) continue;
+          if (E < clusterEmin) {
+            continue;
+          }
           Esum += E;
           idx.push_back(i);
         }
 
-        if (idx.empty() || Esum <= 0.0) return 0;
+        if (idx.empty() || Esum <= 0.0) {
+          return 0;
+        }
 
+        // Sort clusters by decreasing energy before keeping the leading ones.
+        std::sort(idx.begin(), idx.end(), [&](int a, int b) {
+          return (*clusters)[a].getEnergy() > (*clusters)[b].getEnergy();
+        });
+
+        // Keep only the leading clusters in order to limit combinatorial
         const size_t Nkeep = 4;
         for (size_t k = 0; k < std::min(Nkeep, idx.size()); ++k) {
           const auto& cl = (*clusters)[idx[k]];
@@ -253,15 +268,15 @@ void FarForwardNeutralsReconstruction::process(
   // ZDC-Hcal
   n_neutrons += processNeutralCalo(
                                     clustersHcal, out_neutralsHcal,
-                                    /*gammaCorrCoefs=*/   m_cfg.gammaScaleCorrCoeffHcal,
-                                    /*neutronCorrCoefs=*/ m_cfg.neutronScaleCorrCoeffHcal,
+                                    /*gammaCorrCoefs=*/   m_cfg.gammaScaleCorrCoeffHcalZDC,
+                                    /*neutronCorrCoefs=*/ m_cfg.neutronScaleCorrCoeffHcalZDC,
                                     /*canDetectGammas=*/  true,
                                     /*canDetectNeutrons=*/true,
                                     /*gammaCorr=*/        corr_power,
                                     /*neutronCorr=*/      corr_power,
                                     /*gammaMode=*/        GammaMode::AllPassing,
                                     /*gammaLeaderFracMin=*/0.0,
-                                    /*clusterEmin=*/      0.0,
+                                    /*clusterEmin=*/      m_cfg.clusterEminHcalZDC,
                                     /*neutronMode=*/      NeutronMode::SumAll,
                                     /*associateAllClustersToNeutron=*/true
   );
@@ -277,7 +292,7 @@ void FarForwardNeutralsReconstruction::process(
                                     /*neutronCorr=*/      corr_power,
                                     /*gammaMode=*/        GammaMode::LeaderOnly,
                                     /*gammaLeaderFracMin=*/0.0,
-                                    /*clusterEmin=*/      1.0,
+                                    /*clusterEmin=*/      m_cfg.clusterEminB0Ecal,
                                     /*neutronMode=*/      NeutronMode::None,
                                     /*associateAllClustersToNeutron=*/false
   );
@@ -293,7 +308,7 @@ void FarForwardNeutralsReconstruction::process(
                                     /*neutronCorr=*/      corr_power,
                                     /*gammaMode=*/        GammaMode::LeaderOnly,
                                     /*gammaLeaderFracMin=*/0.0,
-                                    /*clusterEmin=*/      1.0,
+                                    /*clusterEmin=*/      m_cfg.clusterEminEcalEndcapP,
                                     /*neutronMode=*/      NeutronMode::None,
                                     /*associateAllClustersToNeutron=*/false
   );
@@ -309,7 +324,7 @@ void FarForwardNeutralsReconstruction::process(
                                     /*neutronCorr=*/      corr_power,
                                     /*gammaMode=*/        GammaMode::None,
                                     /*gammaLeaderFracMin=*/0.0,
-                                    /*clusterEmin=*/      7.0,
+                                    /*clusterEmin=*/      m_cfg.clusterEminLFHCAL,
                                     /*neutronMode=*/      NeutronMode::LeaderOnly,
                                     /*associateAllClustersToNeutron=*/false
   );

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2025 Sebouh Paul
-// Update/modification 2026 by Baptiste Fraisse
+// Copyright (C) 2025 Sebouh Paul, Baptiste Fraisse
 
 #include <Evaluator/DD4hepUnits.h>
 #include <edm4eic/ClusterCollection.h>
@@ -39,6 +38,11 @@ double FarForwardNeutralsReconstruction::calc_corr(double Etot, const std::vecto
   return coeffs[0] + coeffs[1] / sqrt(Etot) + coeffs[2] / Etot;
 }
 
+/*
+     check that the cluster position is within the correct range into ZDC,
+     and that the sqrt(largest eigenvalue) is less than gamma_max_length,
+     and that the sqrt(second largest eigenvalue) is less than gamma_max_width
+*/
 bool FarForwardNeutralsReconstruction::isGamma(const edm4eic::Cluster& cluster) const {
 
   double l1 = sqrt(cluster.getShapeParameters(4)) * dd4hep::mm;

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
@@ -3,17 +3,16 @@
 
 #include <Evaluator/DD4hepUnits.h>
 #include <edm4eic/ClusterCollection.h>
-#include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <fmt/core.h>
+#include <stddef.h>
+#include <algorithm>
 #include <cmath>
+#include <functional>
 #include <gsl/pointers>
 #include <stdexcept>
+#include <tuple>
 #include <vector>
-#include <functional>
-#include <limits>
-#include <algorithm>
 
 #include "FarForwardNeutralsReconstruction.h"
 

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
@@ -88,7 +88,7 @@ void FarForwardNeutralsReconstruction::process(
   CorrFunc corr_power = [](double E, const std::vector<double>& coeffs) {
     if (coeffs.size() < 2) {
       return E;
-}
+    }
     return coeffs[0] * std::pow(E, coeffs[1]);
   };
 
@@ -103,10 +103,10 @@ void FarForwardNeutralsReconstruction::process(
 
     if (!clusters || clusters->empty()) {
       return 0;
-}
+    }
     if (!canDetectGammas) {
       gammaMode = GammaMode::None;
-}
+    }
 
     // gammas from clusters
     auto makeGamma = [&](const edm4eic::Cluster& cl) {
@@ -119,7 +119,7 @@ void FarForwardNeutralsReconstruction::process(
       const double r = edm4hep::utils::magnitude(pos);
       if (r > 0) {
         rec.setMomentum(pos * (E / r));
-}
+      }
 
       rec.setEnergy(E);
       rec.setReferencePoint(pos);
@@ -142,14 +142,14 @@ void FarForwardNeutralsReconstruction::process(
         const double E = (*clusters)[i].getEnergy();
         if (E < clusterEmin) {
           continue;
-}
+        }
         Esum += E;
         idx.push_back(i);
       }
 
       if (idx.empty() || Esum <= 0.0) {
         return 0;
-}
+      }
 
       const size_t Nkeep = 4;
       for (size_t k = 0; k < std::min(Nkeep, idx.size()); ++k) {

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
@@ -73,246 +73,243 @@ void FarForwardNeutralsReconstruction::process(
     const FarForwardNeutralsReconstruction::Output& output) const {
 
   // Unpacking
-  const auto [clustersHcal, clustersB0, clustersEcalEndcapP, clustersLFHCAL] = input;
+  const auto [clustersHcal, clustersB0, clustersEcalEndcapP, clustersLFHCAL]           = input;
   auto [out_neutralsHcal, out_neutralsB0, out_neutralsEcalEndcapP, out_neutralsLFHCAL] = output;
 
   // Global
   const double m_neutron = m_particleSvc.particle(2112).mass;
-  int n_neutrons = 0;
+  int n_neutrons         = 0;
 
   // neutron-gamma separation method
-  enum class GammaMode   { None, LeaderOnly, AllPassing };
+  enum class GammaMode { None, LeaderOnly, AllPassing };
   enum class NeutronMode { None, SumAll, LeaderOnly };
 
   using CorrFunc = std::function<double(double, const std::vector<double>&)>;
 
   CorrFunc corr_power = [](double E, const std::vector<double>& coeffs) {
-    if (coeffs.size() < 2) return E;
+    if (coeffs.size() < 2)
+      return E;
     return coeffs[0] * std::pow(E, coeffs[1]);
   };
 
   // helper for processing detectors
   auto processNeutralCalo =
-    [&](auto clusters,
-        auto out_neutrals,
-        const std::vector<double>& gammaScaleCoeff,
-        const std::vector<double>& neutronScaleCoeff,
-        bool canDetectGammas,
-        bool canDetectNeutrons,
-        const CorrFunc& gammaCorr,
-        const CorrFunc& neutronCorr,
-        GammaMode gammaMode,
-        double gammaLeaderFracMin,
-        double clusterEmin,
-        NeutronMode neutronMode,
-        bool associateAllClustersToNeutron) -> int {
+      [&](auto clusters, auto out_neutrals, const std::vector<double>& gammaScaleCoeff,
+          const std::vector<double>& neutronScaleCoeff, bool canDetectGammas,
+          bool canDetectNeutrons, const CorrFunc& gammaCorr, const CorrFunc& neutronCorr,
+          GammaMode gammaMode, double gammaLeaderFracMin, double clusterEmin,
+          NeutronMode neutronMode, bool associateAllClustersToNeutron) -> int {
+    (void)gammaLeaderFracMin;
 
-      (void)gammaLeaderFracMin;
+    if (!clusters || clusters->empty())
+      return 0;
+    if (!canDetectGammas)
+      gammaMode = GammaMode::None;
 
-      if (!clusters || clusters->empty()) return 0;
-      if (!canDetectGammas) gammaMode = GammaMode::None;
+    // gammas from clusters
+    auto makeGamma = [&](const edm4eic::Cluster& cl) {
+      auto rec = out_neutrals->create();
+      rec.setPDG(22);
 
-      // gammas from clusters
-      auto makeGamma = [&](const edm4eic::Cluster& cl){
-        auto rec = out_neutrals->create();
-        rec.setPDG(22);
+      const auto pos = cl.getPosition();
+      const double E = gammaCorr(cl.getEnergy(), gammaScaleCoeff);
 
-        const auto pos = cl.getPosition();
-        const double E = gammaCorr(cl.getEnergy(), gammaScaleCoeff);
+      const double r = edm4hep::utils::magnitude(pos);
+      if (r > 0)
+        rec.setMomentum(pos * (E / r));
 
-        const double r = edm4hep::utils::magnitude(pos);
-        if (r > 0) rec.setMomentum(pos * (E / r));
+      rec.setEnergy(E);
+      rec.setReferencePoint(pos);
+      rec.setCharge(0);
+      rec.setMass(0);
+      rec.addToClusters(cl);
+    };
 
-        rec.setEnergy(E);
-        rec.setReferencePoint(pos);
-        rec.setCharge(0);
-        rec.setMass(0);
-        rec.addToClusters(cl);
-      };
+    std::vector<const edm4eic::Cluster*> gamma_used;
+    gamma_used.reserve(clusters->size());
 
-      std::vector<const edm4eic::Cluster*> gamma_used;
-      gamma_used.reserve(clusters->size());
+    // gammaMode == LeaderOnly
+    if (gammaMode == GammaMode::LeaderOnly) {
 
-      // gammaMode == LeaderOnly
-      if (gammaMode == GammaMode::LeaderOnly) {
+      std::vector<int> idx;
+      idx.reserve(clusters->size());
 
-        std::vector<int> idx;
-        idx.reserve(clusters->size());
+      double Esum = 0.0;
+      for (int i = 0, n = (int)clusters->size(); i < n; ++i) {
+        const double E = (*clusters)[i].getEnergy();
+        if (E < clusterEmin)
+          continue;
+        Esum += E;
+        idx.push_back(i);
+      }
 
-        double Esum = 0.0;
-        for (int i = 0, n = (int)clusters->size(); i < n; ++i) {
-          const double E = (*clusters)[i].getEnergy();
-          if (E < clusterEmin) continue;
-          Esum += E;
-          idx.push_back(i);
-        }
+      if (idx.empty() || Esum <= 0.0)
+        return 0;
 
-        if (idx.empty() || Esum <= 0.0) return 0;
+      const size_t Nkeep = 4;
+      for (size_t k = 0; k < std::min(Nkeep, idx.size()); ++k) {
+        const auto& cl = (*clusters)[idx[k]];
+        makeGamma(cl);
+        gamma_used.push_back(&cl);
+      }
 
-        const size_t Nkeep = 4;
-        for (size_t k = 0; k < std::min(Nkeep, idx.size()); ++k) {
-          const auto& cl = (*clusters)[idx[k]];
+    }
+
+    // gammaMode == AllPassing
+    else if (gammaMode == GammaMode::AllPassing) {
+      for (const auto& cl : *clusters) {
+        const double E = cl.getEnergy();
+        if (E < clusterEmin)
+          continue;
+        if (isGamma(cl)) {
           makeGamma(cl);
           gamma_used.push_back(&cl);
         }
-
       }
+    }
 
-      // gammaMode == AllPassing
-      else if (gammaMode == GammaMode::AllPassing) {
-        for (const auto& cl : *clusters) {
-          const double E = cl.getEnergy();
-          if (E < clusterEmin) continue;
-          if (isGamma(cl)) {
-            makeGamma(cl);
-            gamma_used.push_back(&cl);
-          }
-        }
-      }
-
-      // gammaMode == None => nothing
-      auto is_used_as_gamma = [&](const edm4eic::Cluster& cl)
-      {
-        for (auto* p : gamma_used) if (p == &cl) return true;
-        return false;
-      };
-
-      // neutrons from clusters
-      const edm4eic::Cluster* leaderN = nullptr;
-      double E_leader = -1.0;
-
-      double E_sum = 0.0;
-      std::vector<const edm4eic::Cluster*> kept;
-      kept.reserve(clusters->size());
-
-      for (const auto& cl : *clusters) {
-        if (gammaMode != GammaMode::None && is_used_as_gamma(cl)) continue;
-
-        const double E = cl.getEnergy();
-        if (E < clusterEmin) continue;
-
-        E_sum += E;
-        kept.push_back(&cl);
-
-        if (E > E_leader) {
-          E_leader = E;
-          leaderN  = &cl;
-        }
-      }
-
-      if (!canDetectNeutrons) return 0;
-
-      double En_raw = 0.0;
-      edm4hep::Vector3f n_pos{0,0,0};
-
-      if (neutronMode == NeutronMode::LeaderOnly) {
-        if (!leaderN || E_leader <= 0.0) return 0;
-        En_raw = E_leader;
-        n_pos  = leaderN->getPosition();
-
-        kept.clear();
-        kept.push_back(leaderN);
-      }
-      else if (neutronMode == NeutronMode::SumAll) {
-        if (E_sum <= 0.0 || kept.empty()) return 0;
-        En_raw = E_sum;
-        if (!leaderN || E_leader <= 0.0) return 0;
-        n_pos = leaderN->getPosition();
-      }
-      else {
-        return 0;
-      }
-
-      // apply calibration laws
-      const double En = neutronCorr(En_raw, neutronScaleCoeff);
-
-      auto rec = out_neutrals->create();
-      rec.setPDG(2112);
-      rec.setEnergy(En);
-      rec.setCharge(0);
-      rec.setMass(m_neutron);
-
-      const double r = edm4hep::utils::magnitude(n_pos);
-      if (r > 0) {
-        const double psq = std::max(0.0, En*En - m_neutron*m_neutron);
-        rec.setMomentum(n_pos * (std::sqrt(psq) / r));
-      }
-      rec.setReferencePoint(n_pos);
-
-      if (associateAllClustersToNeutron) {
-        for (const auto& cl : *clusters) rec.addToClusters(cl);
-      } else {
-        for (auto* clp : kept) rec.addToClusters(*clp);
-      }
-
-      return 1;
+    // gammaMode == None => nothing
+    auto is_used_as_gamma = [&](const edm4eic::Cluster& cl) {
+      for (auto* p : gamma_used)
+        if (p == &cl)
+          return true;
+      return false;
     };
+
+    // neutrons from clusters
+    const edm4eic::Cluster* leaderN = nullptr;
+    double E_leader                 = -1.0;
+
+    double E_sum = 0.0;
+    std::vector<const edm4eic::Cluster*> kept;
+    kept.reserve(clusters->size());
+
+    for (const auto& cl : *clusters) {
+      if (gammaMode != GammaMode::None && is_used_as_gamma(cl))
+        continue;
+
+      const double E = cl.getEnergy();
+      if (E < clusterEmin)
+        continue;
+
+      E_sum += E;
+      kept.push_back(&cl);
+
+      if (E > E_leader) {
+        E_leader = E;
+        leaderN  = &cl;
+      }
+    }
+
+    if (!canDetectNeutrons)
+      return 0;
+
+    double En_raw = 0.0;
+    edm4hep::Vector3f n_pos{0, 0, 0};
+
+    if (neutronMode == NeutronMode::LeaderOnly) {
+      if (!leaderN || E_leader <= 0.0)
+        return 0;
+      En_raw = E_leader;
+      n_pos  = leaderN->getPosition();
+
+      kept.clear();
+      kept.push_back(leaderN);
+    } else if (neutronMode == NeutronMode::SumAll) {
+      if (E_sum <= 0.0 || kept.empty())
+        return 0;
+      En_raw = E_sum;
+      if (!leaderN || E_leader <= 0.0)
+        return 0;
+      n_pos = leaderN->getPosition();
+    } else {
+      return 0;
+    }
+
+    // apply calibration laws
+    const double En = neutronCorr(En_raw, neutronScaleCoeff);
+
+    auto rec = out_neutrals->create();
+    rec.setPDG(2112);
+    rec.setEnergy(En);
+    rec.setCharge(0);
+    rec.setMass(m_neutron);
+
+    const double r = edm4hep::utils::magnitude(n_pos);
+    if (r > 0) {
+      const double psq = std::max(0.0, En * En - m_neutron * m_neutron);
+      rec.setMomentum(n_pos * (std::sqrt(psq) / r));
+    }
+    rec.setReferencePoint(n_pos);
+
+    if (associateAllClustersToNeutron) {
+      for (const auto& cl : *clusters)
+        rec.addToClusters(cl);
+    } else {
+      for (auto* clp : kept)
+        rec.addToClusters(*clp);
+    }
+
+    return 1;
+  };
 
   // --- processing of detectors
 
   // ZDC-Hcal
-  n_neutrons += processNeutralCalo(
-                                    clustersHcal, out_neutralsHcal,
-                                    /*gammaCorrCoefs=*/   m_cfg.gammaScaleCorrCoeffHcal,
-                                    /*neutronCorrCoefs=*/ m_cfg.neutronScaleCorrCoeffHcal,
-                                    /*canDetectGammas=*/  true,
-                                    /*canDetectNeutrons=*/true,
-                                    /*gammaCorr=*/        corr_power,
-                                    /*neutronCorr=*/      corr_power,
-                                    /*gammaMode=*/        GammaMode::AllPassing,
-                                    /*gammaLeaderFracMin=*/0.0,
-                                    /*clusterEmin=*/      0.0,
-                                    /*neutronMode=*/      NeutronMode::SumAll,
-                                    /*associateAllClustersToNeutron=*/true
-  );
+  n_neutrons += processNeutralCalo(clustersHcal, out_neutralsHcal,
+                                   /*gammaCorrCoefs=*/m_cfg.gammaScaleCorrCoeffHcal,
+                                   /*neutronCorrCoefs=*/m_cfg.neutronScaleCorrCoeffHcal,
+                                   /*canDetectGammas=*/true,
+                                   /*canDetectNeutrons=*/true,
+                                   /*gammaCorr=*/corr_power,
+                                   /*neutronCorr=*/corr_power,
+                                   /*gammaMode=*/GammaMode::AllPassing,
+                                   /*gammaLeaderFracMin=*/0.0,
+                                   /*clusterEmin=*/0.0,
+                                   /*neutronMode=*/NeutronMode::SumAll,
+                                   /*associateAllClustersToNeutron=*/true);
 
   // B0-Ecal
-  n_neutrons += processNeutralCalo(
-                                    clustersB0, out_neutralsB0,
-                                    /*gammaCorrCoefs=*/   m_cfg.gammaScaleCorrCoeffB0Ecal,
-                                    /*neutronCorrCoefs=*/ m_cfg.neutronScaleCorrCoeffB0Ecal,
-                                    /*canDetectGammas=*/  true,
-                                    /*canDetectNeutrons=*/false,
-                                    /*gammaCorr=*/        corr_power,
-                                    /*neutronCorr=*/      corr_power,
-                                    /*gammaMode=*/        GammaMode::LeaderOnly,
-                                    /*gammaLeaderFracMin=*/0.0,
-                                    /*clusterEmin=*/      1.0,
-                                    /*neutronMode=*/      NeutronMode::None,
-                                    /*associateAllClustersToNeutron=*/false
-  );
+  n_neutrons += processNeutralCalo(clustersB0, out_neutralsB0,
+                                   /*gammaCorrCoefs=*/m_cfg.gammaScaleCorrCoeffB0Ecal,
+                                   /*neutronCorrCoefs=*/m_cfg.neutronScaleCorrCoeffB0Ecal,
+                                   /*canDetectGammas=*/true,
+                                   /*canDetectNeutrons=*/false,
+                                   /*gammaCorr=*/corr_power,
+                                   /*neutronCorr=*/corr_power,
+                                   /*gammaMode=*/GammaMode::LeaderOnly,
+                                   /*gammaLeaderFracMin=*/0.0,
+                                   /*clusterEmin=*/1.0,
+                                   /*neutronMode=*/NeutronMode::None,
+                                   /*associateAllClustersToNeutron=*/false);
 
   // EndcapP-Ecal
-  n_neutrons += processNeutralCalo(
-                                    clustersEcalEndcapP, out_neutralsEcalEndcapP,
-                                    /*gammaCorrCoefs=*/   m_cfg.gammaScaleCorrCoeffEcalEndcapP,
-                                    /*neutronCorrCoefs=*/ m_cfg.neutronScaleCorrCoeffEcalEndcapP,
-                                    /*canDetectGammas=*/  true,
-                                    /*canDetectNeutrons=*/false,
-                                    /*gammaCorr=*/        corr_power,
-                                    /*neutronCorr=*/      corr_power,
-                                    /*gammaMode=*/        GammaMode::LeaderOnly,
-                                    /*gammaLeaderFracMin=*/0.0,
-                                    /*clusterEmin=*/      1.0,
-                                    /*neutronMode=*/      NeutronMode::None,
-                                    /*associateAllClustersToNeutron=*/false
-  );
+  n_neutrons += processNeutralCalo(clustersEcalEndcapP, out_neutralsEcalEndcapP,
+                                   /*gammaCorrCoefs=*/m_cfg.gammaScaleCorrCoeffEcalEndcapP,
+                                   /*neutronCorrCoefs=*/m_cfg.neutronScaleCorrCoeffEcalEndcapP,
+                                   /*canDetectGammas=*/true,
+                                   /*canDetectNeutrons=*/false,
+                                   /*gammaCorr=*/corr_power,
+                                   /*neutronCorr=*/corr_power,
+                                   /*gammaMode=*/GammaMode::LeaderOnly,
+                                   /*gammaLeaderFracMin=*/0.0,
+                                   /*clusterEmin=*/1.0,
+                                   /*neutronMode=*/NeutronMode::None,
+                                   /*associateAllClustersToNeutron=*/false);
 
   // LFHCAL
-  n_neutrons += processNeutralCalo(
-                                    clustersLFHCAL, out_neutralsLFHCAL,
-                                    /*gammaCorrCoefs=*/   m_cfg.gammaScaleCorrCoeffLFHCAL,
-                                    /*neutronCorrCoefs=*/ m_cfg.neutronScaleCorrCoeffLFHCAL,
-                                    /*canDetectGammas=*/  false,
-                                    /*canDetectNeutrons=*/true,
-                                    /*gammaCorr=*/        corr_power,
-                                    /*neutronCorr=*/      corr_power,
-                                    /*gammaMode=*/        GammaMode::None,
-                                    /*gammaLeaderFracMin=*/0.0,
-                                    /*clusterEmin=*/      7.0,
-                                    /*neutronMode=*/      NeutronMode::LeaderOnly,
-                                    /*associateAllClustersToNeutron=*/false
-  );
+  n_neutrons += processNeutralCalo(clustersLFHCAL, out_neutralsLFHCAL,
+                                   /*gammaCorrCoefs=*/m_cfg.gammaScaleCorrCoeffLFHCAL,
+                                   /*neutronCorrCoefs=*/m_cfg.neutronScaleCorrCoeffLFHCAL,
+                                   /*canDetectGammas=*/false,
+                                   /*canDetectNeutrons=*/true,
+                                   /*gammaCorr=*/corr_power,
+                                   /*neutronCorr=*/corr_power,
+                                   /*gammaMode=*/GammaMode::None,
+                                   /*gammaLeaderFracMin=*/0.0,
+                                   /*clusterEmin=*/7.0,
+                                   /*neutronMode=*/NeutronMode::LeaderOnly,
+                                   /*associateAllClustersToNeutron=*/false);
 
   debug("Found {} neutron candidates", n_neutrons);
 }

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
@@ -5,7 +5,7 @@
 #include <edm4eic/ClusterCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <stddef.h>
+#include <cstddef>
 #include <algorithm>
 #include <cmath>
 #include <functional>
@@ -86,8 +86,9 @@ void FarForwardNeutralsReconstruction::process(
   using CorrFunc = std::function<double(double, const std::vector<double>&)>;
 
   CorrFunc corr_power = [](double E, const std::vector<double>& coeffs) {
-    if (coeffs.size() < 2)
+    if (coeffs.size() < 2) {
       return E;
+}
     return coeffs[0] * std::pow(E, coeffs[1]);
   };
 
@@ -100,10 +101,12 @@ void FarForwardNeutralsReconstruction::process(
           NeutronMode neutronMode, bool associateAllClustersToNeutron) -> int {
     (void)gammaLeaderFracMin;
 
-    if (!clusters || clusters->empty())
+    if (!clusters || clusters->empty()) {
       return 0;
-    if (!canDetectGammas)
+}
+    if (!canDetectGammas) {
       gammaMode = GammaMode::None;
+}
 
     // gammas from clusters
     auto makeGamma = [&](const edm4eic::Cluster& cl) {
@@ -114,8 +117,9 @@ void FarForwardNeutralsReconstruction::process(
       const double E = gammaCorr(cl.getEnergy(), gammaScaleCoeff);
 
       const double r = edm4hep::utils::magnitude(pos);
-      if (r > 0)
+      if (r > 0) {
         rec.setMomentum(pos * (E / r));
+}
 
       rec.setEnergy(E);
       rec.setReferencePoint(pos);
@@ -136,14 +140,16 @@ void FarForwardNeutralsReconstruction::process(
       double Esum = 0.0;
       for (int i = 0, n = (int)clusters->size(); i < n; ++i) {
         const double E = (*clusters)[i].getEnergy();
-        if (E < clusterEmin)
+        if (E < clusterEmin) {
           continue;
+}
         Esum += E;
         idx.push_back(i);
       }
 
-      if (idx.empty() || Esum <= 0.0)
+      if (idx.empty() || Esum <= 0.0) {
         return 0;
+}
 
       const size_t Nkeep = 4;
       for (size_t k = 0; k < std::min(Nkeep, idx.size()); ++k) {

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
@@ -132,7 +132,7 @@ int FarForwardNeutralsReconstruction::processNeutralCalo(
     }
 
     // Sort clusters by decreasing energy before keeping the leading ones.
-    std::sort(idx.begin(), idx.end(), [&](int a, int b) {
+    std::ranges::sort(idx,, [&](int a, int b) {
       return (*clusters)[a].getEnergy() > (*clusters)[b].getEnergy();
     });
 

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
@@ -132,7 +132,7 @@ int FarForwardNeutralsReconstruction::processNeutralCalo(
     }
 
     // Sort clusters by decreasing energy before keeping the leading ones.
-    std::ranges::sort(idx,, [&](int a, int b) {
+    std::ranges::sort(idx, , [&](int a, int b) {
       return (*clusters)[a].getEnergy() > (*clusters)[b].getEnergy();
     });
 

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
@@ -22,18 +22,14 @@ namespace eicrecon {
 void FarForwardNeutralsReconstruction::init() {
   try {
     m_gammaZMax =
-        m_cfg.gammaZMaxOffset +
-        m_detector->constant<double>(m_cfg.offsetPositionName) / dd4hep::mm;
+        m_cfg.gammaZMaxOffset + m_detector->constant<double>(m_cfg.offsetPositionName) / dd4hep::mm;
   } catch (std::runtime_error&) {
     m_gammaZMax = m_cfg.gammaZMaxOffset + 35800.0;
-    trace("Failed to get {} from the detector, using default value of {}",
-          m_cfg.offsetPositionName,
+    trace("Failed to get {} from the detector, using default value of {}", m_cfg.offsetPositionName,
           m_gammaZMax);
   }
-  trace("gamma detection params:   max length={},   max width={},   max z={}",
-        m_cfg.gammaMaxLength,
-        m_cfg.gammaMaxWidth,
-        m_gammaZMax);
+  trace("gamma detection params:   max length={},   max width={},   max z={}", m_cfg.gammaMaxLength,
+        m_cfg.gammaMaxWidth, m_gammaZMax);
 }
 
 /*
@@ -66,14 +62,11 @@ bool FarForwardNeutralsReconstruction::isGamma(const edm4eic::Cluster& cluster) 
   return !(isZMoreThanMax || isLengthMoreThanMax || areWidthsMoreThanMax);
 }
 
-double FarForwardNeutralsReconstruction::corrPower(
-    double E,
-    const std::vector<double>& coeffs) {
+double FarForwardNeutralsReconstruction::corrPower(double E, const std::vector<double>& coeffs) {
 
   if (coeffs.size() != 2) {
     throw std::runtime_error(
-        "Energy correction for Lambda reconstruction requires 2 coefficients: a * E^b."
-    );
+        "Energy correction for Lambda reconstruction requires 2 coefficients: a * E^b.");
   }
 
   return coeffs[0] * std::pow(E, coeffs[1]);
@@ -82,174 +75,175 @@ double FarForwardNeutralsReconstruction::corrPower(
 int FarForwardNeutralsReconstruction::processNeutralCalo(
     const edm4eic::ClusterCollection* clusters,
     edm4eic::ReconstructedParticleCollection* out_neutrals,
-    const std::vector<double>& gammaScaleCoeff,
-    const std::vector<double>& neutronScaleCoeff,
-    bool canDetectGammas,
-    bool canDetectNeutrons,
-    const CorrFunc& gammaCorr,
-    const CorrFunc& neutronCorr,
-    GammaMode gammaMode,
-    double gammaLeaderFracMin,
-    double clusterEmin,
-    NeutronMode neutronMode,
-    bool associateAllClustersToNeutron) const {
+    const std::vector<double>& gammaScaleCoeff, const std::vector<double>& neutronScaleCoeff,
+    bool canDetectGammas, bool canDetectNeutrons, const CorrFunc& gammaCorr,
+    const CorrFunc& neutronCorr, GammaMode gammaMode, double gammaLeaderFracMin, double clusterEmin,
+    NeutronMode neutronMode, bool associateAllClustersToNeutron) const {
 
-    (void)gammaLeaderFracMin;
-    
-    const double m_neutron = m_particleSvc.particle(2112).mass;
+  (void)gammaLeaderFracMin;
 
-    if (!clusters || clusters->empty()) {
-        return 0;
+  const double m_neutron = m_particleSvc.particle(2112).mass;
+
+  if (!clusters || clusters->empty()) {
+    return 0;
+  }
+  if (!canDetectGammas) {
+    gammaMode = GammaMode::None;
+  }
+
+  // gammas from clusters
+  auto makeGamma = [&](const edm4eic::Cluster& cl) {
+    auto rec = out_neutrals->create();
+    rec.setPDG(22);
+
+    const auto pos = cl.getPosition();
+    const double E = gammaCorr(cl.getEnergy(), gammaScaleCoeff);
+
+    const double r = edm4hep::utils::magnitude(pos);
+    if (r > 0) {
+      rec.setMomentum(pos * (E / r));
+    }
+
+    rec.setEnergy(E);
+    rec.setCharge(0);
+    rec.setMass(0);
+    rec.addToClusters(cl);
+  };
+
+  std::vector<const edm4eic::Cluster*> gamma_used;
+  gamma_used.reserve(clusters->size());
+
+  // gammaMode == LeaderOnly
+  if (gammaMode == GammaMode::LeaderOnly) {
+
+    std::vector<int> idx;
+    idx.reserve(clusters->size());
+
+    double Esum = 0.0;
+    for (int i = 0, n = (int)clusters->size(); i < n; ++i) {
+      const double E = (*clusters)[i].getEnergy();
+      if (E < clusterEmin) {
+        continue;
       }
-      if (!canDetectGammas) {
-        gammaMode = GammaMode::None;
+      Esum += E;
+      idx.push_back(i);
+    }
+
+    if (idx.empty() || Esum <= 0.0) {
+      return 0;
+    }
+
+    // Sort clusters by decreasing energy before keeping the leading ones.
+    std::sort(idx.begin(), idx.end(), [&](int a, int b) {
+      return (*clusters)[a].getEnergy() > (*clusters)[b].getEnergy();
+    });
+
+    // Keep only the leading clusters in order to limit combinatorial
+    const size_t Nkeep = 4;
+    for (size_t k = 0; k < std::min(Nkeep, idx.size()); ++k) {
+      const auto& cl = (*clusters)[idx[k]];
+      makeGamma(cl);
+      gamma_used.push_back(&cl);
+    }
+
+  }
+
+  // gammaMode == AllPassing
+  else if (gammaMode == GammaMode::AllPassing) {
+    for (const auto& cl : *clusters) {
+      const double E = cl.getEnergy();
+      if (E < clusterEmin)
+        continue;
+      if (isGamma(cl)) {
+        makeGamma(cl);
+        gamma_used.push_back(&cl);
       }
+    }
+  }
 
-      // gammas from clusters
-      auto makeGamma = [&](const edm4eic::Cluster& cl){
-        auto rec = out_neutrals->create();
-        rec.setPDG(22);
+  // gammaMode == None => nothing
+  auto is_used_as_gamma = [&](const edm4eic::Cluster& cl) {
+    for (auto* p : gamma_used)
+      if (p == &cl)
+        return true;
+    return false;
+  };
 
-        const auto pos = cl.getPosition();
-        const double E = gammaCorr(cl.getEnergy(), gammaScaleCoeff);
+  // neutrons from clusters
+  const edm4eic::Cluster* leaderN = nullptr;
+  double E_leader                 = -1.0;
 
-        const double r = edm4hep::utils::magnitude(pos);
-        if (r > 0) {
-          rec.setMomentum(pos * (E / r));
-        }
+  double E_sum = 0.0;
+  std::vector<const edm4eic::Cluster*> kept;
+  kept.reserve(clusters->size());
 
-        rec.setEnergy(E);
-        rec.setCharge(0);
-        rec.setMass(0);
-        rec.addToClusters(cl);
-      };
+  for (const auto& cl : *clusters) {
+    if (gammaMode != GammaMode::None && is_used_as_gamma(cl))
+      continue;
 
-      std::vector<const edm4eic::Cluster*> gamma_used;
-      gamma_used.reserve(clusters->size());
+    const double E = cl.getEnergy();
+    if (E < clusterEmin)
+      continue;
 
-      // gammaMode == LeaderOnly
-      if (gammaMode == GammaMode::LeaderOnly) {
+    E_sum += E;
+    kept.push_back(&cl);
 
-        std::vector<int> idx;
-        idx.reserve(clusters->size());
+    if (E > E_leader) {
+      E_leader = E;
+      leaderN  = &cl;
+    }
+  }
 
-        double Esum = 0.0;
-        for (int i = 0, n = (int)clusters->size(); i < n; ++i) {
-          const double E = (*clusters)[i].getEnergy();
-          if (E < clusterEmin) {
-            continue;
-          }
-          Esum += E;
-          idx.push_back(i);
-        }
+  if (!canDetectNeutrons)
+    return 0;
 
-        if (idx.empty() || Esum <= 0.0) {
-          return 0;
-        }
+  double En_raw = 0.0;
+  edm4hep::Vector3f n_pos{0, 0, 0};
 
-        // Sort clusters by decreasing energy before keeping the leading ones.
-        std::sort(idx.begin(), idx.end(), [&](int a, int b) {
-          return (*clusters)[a].getEnergy() > (*clusters)[b].getEnergy();
-        });
+  if (neutronMode == NeutronMode::LeaderOnly) {
+    if (!leaderN || E_leader <= 0.0)
+      return 0;
+    En_raw = E_leader;
+    n_pos  = leaderN->getPosition();
 
-        // Keep only the leading clusters in order to limit combinatorial
-        const size_t Nkeep = 4;
-        for (size_t k = 0; k < std::min(Nkeep, idx.size()); ++k) {
-          const auto& cl = (*clusters)[idx[k]];
-          makeGamma(cl);
-          gamma_used.push_back(&cl);
-        }
+    kept.clear();
+    kept.push_back(leaderN);
+  } else if (neutronMode == NeutronMode::SumAll) {
+    if (E_sum <= 0.0 || kept.empty())
+      return 0;
+    En_raw = E_sum;
+    if (!leaderN || E_leader <= 0.0)
+      return 0;
+    n_pos = leaderN->getPosition();
+  } else {
+    return 0;
+  }
 
-      }
+  // apply calibration laws
+  const double En = neutronCorr(En_raw, neutronScaleCoeff);
 
-      // gammaMode == AllPassing
-      else if (gammaMode == GammaMode::AllPassing) {
-        for (const auto& cl : *clusters) {
-          const double E = cl.getEnergy();
-          if (E < clusterEmin) continue;
-          if (isGamma(cl)) {
-            makeGamma(cl);
-            gamma_used.push_back(&cl);
-          }
-        }
-      }
+  auto rec = out_neutrals->create();
+  rec.setPDG(2112);
+  rec.setEnergy(En);
+  rec.setCharge(0);
+  rec.setMass(m_neutron);
 
-      // gammaMode == None => nothing
-      auto is_used_as_gamma = [&](const edm4eic::Cluster& cl)
-      {
-        for (auto* p : gamma_used) if (p == &cl) return true;
-        return false;
-      };
+  const double r = edm4hep::utils::magnitude(n_pos);
+  if (r > 0) {
+    const double psq = std::max(0.0, En * En - m_neutron * m_neutron);
+    rec.setMomentum(n_pos * (std::sqrt(psq) / r));
+  }
+  rec.setReferencePoint(n_pos);
 
-      // neutrons from clusters
-      const edm4eic::Cluster* leaderN = nullptr;
-      double E_leader = -1.0;
+  if (associateAllClustersToNeutron) {
+    for (const auto& cl : *clusters)
+      rec.addToClusters(cl);
+  } else {
+    for (auto* clp : kept)
+      rec.addToClusters(*clp);
+  }
 
-      double E_sum = 0.0;
-      std::vector<const edm4eic::Cluster*> kept;
-      kept.reserve(clusters->size());
-
-      for (const auto& cl : *clusters) {
-        if (gammaMode != GammaMode::None && is_used_as_gamma(cl)) continue;
-
-        const double E = cl.getEnergy();
-        if (E < clusterEmin) continue;
-
-        E_sum += E;
-        kept.push_back(&cl);
-
-        if (E > E_leader) {
-          E_leader = E;
-          leaderN  = &cl;
-        }
-      }
-
-      if (!canDetectNeutrons) return 0;
-
-      double En_raw = 0.0;
-      edm4hep::Vector3f n_pos{0,0,0};
-
-      if (neutronMode == NeutronMode::LeaderOnly) {
-        if (!leaderN || E_leader <= 0.0) return 0;
-        En_raw = E_leader;
-        n_pos  = leaderN->getPosition();
-
-        kept.clear();
-        kept.push_back(leaderN);
-      }
-      else if (neutronMode == NeutronMode::SumAll) {
-        if (E_sum <= 0.0 || kept.empty()) return 0;
-        En_raw = E_sum;
-        if (!leaderN || E_leader <= 0.0) return 0;
-        n_pos = leaderN->getPosition();
-      }
-      else {
-        return 0;
-      }
-
-      // apply calibration laws
-      const double En = neutronCorr(En_raw, neutronScaleCoeff);
-
-      auto rec = out_neutrals->create();
-      rec.setPDG(2112);
-      rec.setEnergy(En);
-      rec.setCharge(0);
-      rec.setMass(m_neutron);
-
-      const double r = edm4hep::utils::magnitude(n_pos);
-      if (r > 0) {
-        const double psq = std::max(0.0, En*En - m_neutron*m_neutron);
-        rec.setMomentum(n_pos * (std::sqrt(psq) / r));
-      }
-      rec.setReferencePoint(n_pos);
-
-      if (associateAllClustersToNeutron) {
-        for (const auto& cl : *clusters) rec.addToClusters(cl);
-      } else {
-        for (auto* clp : kept) rec.addToClusters(*clp);
-      }
-
-      return 1;
+  return 1;
 }
 
 void FarForwardNeutralsReconstruction::process(
@@ -257,75 +251,67 @@ void FarForwardNeutralsReconstruction::process(
     const FarForwardNeutralsReconstruction::Output& output) const {
 
   // Unpacking
-  const auto [clustersHcal, clustersB0, clustersEcalEndcapP, clustersLFHCAL] = input;
+  const auto [clustersHcal, clustersB0, clustersEcalEndcapP, clustersLFHCAL]           = input;
   auto [out_neutralsHcal, out_neutralsB0, out_neutralsEcalEndcapP, out_neutralsLFHCAL] = output;
 
   // Global
   int n_neutrons = 0;
 
   // ZDC-Hcal
-  n_neutrons += processNeutralCalo(
-                                    clustersHcal, out_neutralsHcal,
-                                    /*gammaCorrCoefs=*/   m_cfg.gammaScaleCorrCoeffHcalZDC,
-                                    /*neutronCorrCoefs=*/ m_cfg.neutronScaleCorrCoeffHcalZDC,
-                                    /*canDetectGammas=*/  true,
-                                    /*canDetectNeutrons=*/true,
-                                    /*gammaCorr=*/        corrPower,
-                                    /*neutronCorr=*/      corrPower,
-                                    /*gammaMode=*/        GammaMode::AllPassing,
-                                    /*gammaLeaderFracMin=*/0.0,
-                                    /*clusterEmin=*/      m_cfg.clusterEminHcalZDC,
-                                    /*neutronMode=*/      NeutronMode::SumAll,
-                                    /*associateAllClustersToNeutron=*/true
-  );
+  n_neutrons += processNeutralCalo(clustersHcal, out_neutralsHcal,
+                                   /*gammaCorrCoefs=*/m_cfg.gammaScaleCorrCoeffHcalZDC,
+                                   /*neutronCorrCoefs=*/m_cfg.neutronScaleCorrCoeffHcalZDC,
+                                   /*canDetectGammas=*/true,
+                                   /*canDetectNeutrons=*/true,
+                                   /*gammaCorr=*/corrPower,
+                                   /*neutronCorr=*/corrPower,
+                                   /*gammaMode=*/GammaMode::AllPassing,
+                                   /*gammaLeaderFracMin=*/0.0,
+                                   /*clusterEmin=*/m_cfg.clusterEminHcalZDC,
+                                   /*neutronMode=*/NeutronMode::SumAll,
+                                   /*associateAllClustersToNeutron=*/true);
 
   // B0-Ecal
-  n_neutrons += processNeutralCalo(
-                                    clustersB0, out_neutralsB0,
-                                    /*gammaCorrCoefs=*/   m_cfg.gammaScaleCorrCoeffB0Ecal,
-                                    /*neutronCorrCoefs=*/ m_cfg.neutronScaleCorrCoeffB0Ecal,
-                                    /*canDetectGammas=*/  true,
-                                    /*canDetectNeutrons=*/false,
-                                    /*gammaCorr=*/        corrPower,
-                                    /*neutronCorr=*/      corrPower,
-                                    /*gammaMode=*/        GammaMode::LeaderOnly,
-                                    /*gammaLeaderFracMin=*/0.0,
-                                    /*clusterEmin=*/      m_cfg.clusterEminB0Ecal,
-                                    /*neutronMode=*/      NeutronMode::None,
-                                    /*associateAllClustersToNeutron=*/false
-  );
+  n_neutrons += processNeutralCalo(clustersB0, out_neutralsB0,
+                                   /*gammaCorrCoefs=*/m_cfg.gammaScaleCorrCoeffB0Ecal,
+                                   /*neutronCorrCoefs=*/m_cfg.neutronScaleCorrCoeffB0Ecal,
+                                   /*canDetectGammas=*/true,
+                                   /*canDetectNeutrons=*/false,
+                                   /*gammaCorr=*/corrPower,
+                                   /*neutronCorr=*/corrPower,
+                                   /*gammaMode=*/GammaMode::LeaderOnly,
+                                   /*gammaLeaderFracMin=*/0.0,
+                                   /*clusterEmin=*/m_cfg.clusterEminB0Ecal,
+                                   /*neutronMode=*/NeutronMode::None,
+                                   /*associateAllClustersToNeutron=*/false);
 
   // EndcapP-Ecal
-  n_neutrons += processNeutralCalo(
-                                    clustersEcalEndcapP, out_neutralsEcalEndcapP,
-                                    /*gammaCorrCoefs=*/   m_cfg.gammaScaleCorrCoeffEcalEndcapP,
-                                    /*neutronCorrCoefs=*/ m_cfg.neutronScaleCorrCoeffEcalEndcapP,
-                                    /*canDetectGammas=*/  true,
-                                    /*canDetectNeutrons=*/false,
-                                    /*gammaCorr=*/        corrPower,
-                                    /*neutronCorr=*/      corrPower,
-                                    /*gammaMode=*/        GammaMode::LeaderOnly,
-                                    /*gammaLeaderFracMin=*/0.0,
-                                    /*clusterEmin=*/      m_cfg.clusterEminEcalEndcapP,
-                                    /*neutronMode=*/      NeutronMode::None,
-                                    /*associateAllClustersToNeutron=*/false
-  );
+  n_neutrons += processNeutralCalo(clustersEcalEndcapP, out_neutralsEcalEndcapP,
+                                   /*gammaCorrCoefs=*/m_cfg.gammaScaleCorrCoeffEcalEndcapP,
+                                   /*neutronCorrCoefs=*/m_cfg.neutronScaleCorrCoeffEcalEndcapP,
+                                   /*canDetectGammas=*/true,
+                                   /*canDetectNeutrons=*/false,
+                                   /*gammaCorr=*/corrPower,
+                                   /*neutronCorr=*/corrPower,
+                                   /*gammaMode=*/GammaMode::LeaderOnly,
+                                   /*gammaLeaderFracMin=*/0.0,
+                                   /*clusterEmin=*/m_cfg.clusterEminEcalEndcapP,
+                                   /*neutronMode=*/NeutronMode::None,
+                                   /*associateAllClustersToNeutron=*/false);
 
   // LFHCAL
-  n_neutrons += processNeutralCalo(
-                                    clustersLFHCAL, out_neutralsLFHCAL,
-                                    /*gammaCorrCoefs=*/   m_cfg.gammaScaleCorrCoeffLFHCAL,
-                                    /*neutronCorrCoefs=*/ m_cfg.neutronScaleCorrCoeffLFHCAL,
-                                    /*canDetectGammas=*/  false,
-                                    /*canDetectNeutrons=*/true,
-                                    /*gammaCorr=*/        corrPower,
-                                    /*neutronCorr=*/      corrPower,
-                                    /*gammaMode=*/        GammaMode::None,
-                                    /*gammaLeaderFracMin=*/0.0,
-                                    /*clusterEmin=*/      m_cfg.clusterEminLFHCAL,
-                                    /*neutronMode=*/      NeutronMode::LeaderOnly,
-                                    /*associateAllClustersToNeutron=*/false
-  );
+  n_neutrons += processNeutralCalo(clustersLFHCAL, out_neutralsLFHCAL,
+                                   /*gammaCorrCoefs=*/m_cfg.gammaScaleCorrCoeffLFHCAL,
+                                   /*neutronCorrCoefs=*/m_cfg.neutronScaleCorrCoeffLFHCAL,
+                                   /*canDetectGammas=*/false,
+                                   /*canDetectNeutrons=*/true,
+                                   /*gammaCorr=*/corrPower,
+                                   /*neutronCorr=*/corrPower,
+                                   /*gammaMode=*/GammaMode::None,
+                                   /*gammaLeaderFracMin=*/0.0,
+                                   /*clusterEmin=*/m_cfg.clusterEminLFHCAL,
+                                   /*neutronMode=*/NeutronMode::LeaderOnly,
+                                   /*associateAllClustersToNeutron=*/false);
 
   debug("Found {} neutron candidates", n_neutrons);
 }

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
@@ -257,8 +257,8 @@ void FarForwardNeutralsReconstruction::process(
 
   // ZDC-Hcal
   n_neutrons += processNeutralCalo(clustersHcal, out_neutralsHcal,
-                                   /*gammaCorrCoefs=*/m_cfg.gammaScaleCorrCoeffHcalZDC,
-                                   /*neutronCorrCoefs=*/m_cfg.neutronScaleCorrCoeffHcalZDC,
+                                   /*gammaScaleCoeff=*/m_cfg.gammaScaleCorrCoeffHcalZDC,
+                                   /*neutronScaleCoeff=*/m_cfg.neutronScaleCorrCoeffHcalZDC,
                                    /*canDetectGammas=*/true,
                                    /*canDetectNeutrons=*/true,
                                    /*gammaCorr=*/corrPower,
@@ -271,8 +271,8 @@ void FarForwardNeutralsReconstruction::process(
 
   // B0-Ecal
   n_neutrons += processNeutralCalo(clustersB0, out_neutralsB0,
-                                   /*gammaCorrCoefs=*/m_cfg.gammaScaleCorrCoeffB0Ecal,
-                                   /*neutronCorrCoefs=*/m_cfg.neutronScaleCorrCoeffB0Ecal,
+                                   /*gammaScaleCoeff=*/m_cfg.gammaScaleCorrCoeffB0Ecal,
+                                   /*neutronScaleCoeff=*/m_cfg.neutronScaleCorrCoeffB0Ecal,
                                    /*canDetectGammas=*/true,
                                    /*canDetectNeutrons=*/false,
                                    /*gammaCorr=*/corrPower,
@@ -285,8 +285,8 @@ void FarForwardNeutralsReconstruction::process(
 
   // EndcapP-Ecal
   n_neutrons += processNeutralCalo(clustersEcalEndcapP, out_neutralsEcalEndcapP,
-                                   /*gammaCorrCoefs=*/m_cfg.gammaScaleCorrCoeffEcalEndcapP,
-                                   /*neutronCorrCoefs=*/m_cfg.neutronScaleCorrCoeffEcalEndcapP,
+                                   /*gammaScaleCoeff=*/m_cfg.gammaScaleCorrCoeffEcalEndcapP,
+                                   /*neutronScaleCoeff=*/m_cfg.neutronScaleCorrCoeffEcalEndcapP,
                                    /*canDetectGammas=*/true,
                                    /*canDetectNeutrons=*/false,
                                    /*gammaCorr=*/corrPower,
@@ -299,8 +299,8 @@ void FarForwardNeutralsReconstruction::process(
 
   // LFHCAL
   n_neutrons += processNeutralCalo(clustersLFHCAL, out_neutralsLFHCAL,
-                                   /*gammaCorrCoefs=*/m_cfg.gammaScaleCorrCoeffLFHCAL,
-                                   /*neutronCorrCoefs=*/m_cfg.neutronScaleCorrCoeffLFHCAL,
+                                   /*gammaScaleCoeff=*/m_cfg.gammaScaleCorrCoeffLFHCAL,
+                                   /*neutronScaleCoeff=*/m_cfg.neutronScaleCorrCoeffLFHCAL,
                                    /*canDetectGammas=*/false,
                                    /*canDetectNeutrons=*/true,
                                    /*gammaCorr=*/corrPower,

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
@@ -132,9 +132,8 @@ int FarForwardNeutralsReconstruction::processNeutralCalo(
     }
 
     // Sort clusters by decreasing energy before keeping the leading ones.
-    std::ranges::sort(idx, [&](int a, int b) {
-      return (*clusters)[a].getEnergy() > (*clusters)[b].getEnergy();
-    });
+    std::ranges::sort(
+        idx, [&](int a, int b) { return (*clusters)[a].getEnergy() > (*clusters)[b].getEnergy(); });
 
     // Keep only the leading clusters in order to limit combinatorial
     const size_t Nkeep = 4;

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
@@ -132,7 +132,7 @@ int FarForwardNeutralsReconstruction::processNeutralCalo(
     }
 
     // Sort clusters by decreasing energy before keeping the leading ones.
-    std::ranges::sort(idx, , [&](int a, int b) {
+    std::ranges::sort(idx, [&](int a, int b) {
       return (*clusters)[a].getEnergy() > (*clusters)[b].getEnergy();
     });
 

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
@@ -82,7 +82,7 @@ int FarForwardNeutralsReconstruction::processNeutralCalo(
 
   const double m_neutron = m_particleSvc.particle(2112).mass;
 
-  if (!clusters || clusters->empty()) {
+  if ((clusters == nullptr) || clusters->empty()) {
     return 0;
   }
   if (!canDetectGammas) {

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
@@ -66,50 +66,39 @@ bool FarForwardNeutralsReconstruction::isGamma(const edm4eic::Cluster& cluster) 
   return !(isZMoreThanMax || isLengthMoreThanMax || areWidthsMoreThanMax);
 }
 
-void FarForwardNeutralsReconstruction::process(
-    const FarForwardNeutralsReconstruction::Input& input,
-    const FarForwardNeutralsReconstruction::Output& output) const {
+double FarForwardNeutralsReconstruction::corrPower(
+    double E,
+    const std::vector<double>& coeffs) {
 
-  // Unpacking
-  const auto [clustersHcal, clustersB0, clustersEcalEndcapP, clustersLFHCAL] = input;
-  auto [out_neutralsHcal, out_neutralsB0, out_neutralsEcalEndcapP, out_neutralsLFHCAL] = output;
+  if (coeffs.size() != 2) {
+    throw std::runtime_error(
+        "Energy correction for Lambda reconstruction requires 2 coefficients: a * E^b."
+    );
+  }
 
-  // Global
-  const double m_neutron = m_particleSvc.particle(2112).mass;
-  int n_neutrons = 0;
+  return coeffs[0] * std::pow(E, coeffs[1]);
+}
 
-  // neutron-gamma separation method
-  enum class GammaMode   { None, LeaderOnly, AllPassing };
-  enum class NeutronMode { None, SumAll, LeaderOnly };
+int FarForwardNeutralsReconstruction::processNeutralCalo(
+    const edm4eic::ClusterCollection* clusters,
+    edm4eic::ReconstructedParticleCollection* out_neutrals,
+    const std::vector<double>& gammaScaleCoeff,
+    const std::vector<double>& neutronScaleCoeff,
+    bool canDetectGammas,
+    bool canDetectNeutrons,
+    const CorrFunc& gammaCorr,
+    const CorrFunc& neutronCorr,
+    GammaMode gammaMode,
+    double gammaLeaderFracMin,
+    double clusterEmin,
+    NeutronMode neutronMode,
+    bool associateAllClustersToNeutron) const {
 
-  using CorrFunc = std::function<double(double, const std::vector<double>&)>;
+    (void)gammaLeaderFracMin;
+    
+    const double m_neutron = m_particleSvc.particle(2112).mass;
 
-  CorrFunc corr_power = [](double E, const std::vector<double>& coeffs) {
-    if (coeffs.size() < 2) {
-      return E;
-    }
-    return coeffs[0] * std::pow(E, coeffs[1]);
-  };
-
-  // helper for processing detectors
-  auto processNeutralCalo =
-    [&](auto clusters,
-        auto out_neutrals,
-        const std::vector<double>& gammaScaleCoeff,
-        const std::vector<double>& neutronScaleCoeff,
-        bool canDetectGammas,
-        bool canDetectNeutrons,
-        const CorrFunc& gammaCorr,
-        const CorrFunc& neutronCorr,
-        GammaMode gammaMode,
-        double gammaLeaderFracMin,
-        double clusterEmin,
-        NeutronMode neutronMode,
-        bool associateAllClustersToNeutron) -> int {
-
-      (void)gammaLeaderFracMin;
-
-      if (!clusters || clusters->empty()) {
+    if (!clusters || clusters->empty()) {
         return 0;
       }
       if (!canDetectGammas) {
@@ -261,9 +250,18 @@ void FarForwardNeutralsReconstruction::process(
       }
 
       return 1;
-    };
+}
 
-  // --- processing of detectors
+void FarForwardNeutralsReconstruction::process(
+    const FarForwardNeutralsReconstruction::Input& input,
+    const FarForwardNeutralsReconstruction::Output& output) const {
+
+  // Unpacking
+  const auto [clustersHcal, clustersB0, clustersEcalEndcapP, clustersLFHCAL] = input;
+  auto [out_neutralsHcal, out_neutralsB0, out_neutralsEcalEndcapP, out_neutralsLFHCAL] = output;
+
+  // Global
+  int n_neutrons = 0;
 
   // ZDC-Hcal
   n_neutrons += processNeutralCalo(
@@ -272,8 +270,8 @@ void FarForwardNeutralsReconstruction::process(
                                     /*neutronCorrCoefs=*/ m_cfg.neutronScaleCorrCoeffHcalZDC,
                                     /*canDetectGammas=*/  true,
                                     /*canDetectNeutrons=*/true,
-                                    /*gammaCorr=*/        corr_power,
-                                    /*neutronCorr=*/      corr_power,
+                                    /*gammaCorr=*/        corrPower,
+                                    /*neutronCorr=*/      corrPower,
                                     /*gammaMode=*/        GammaMode::AllPassing,
                                     /*gammaLeaderFracMin=*/0.0,
                                     /*clusterEmin=*/      m_cfg.clusterEminHcalZDC,
@@ -288,8 +286,8 @@ void FarForwardNeutralsReconstruction::process(
                                     /*neutronCorrCoefs=*/ m_cfg.neutronScaleCorrCoeffB0Ecal,
                                     /*canDetectGammas=*/  true,
                                     /*canDetectNeutrons=*/false,
-                                    /*gammaCorr=*/        corr_power,
-                                    /*neutronCorr=*/      corr_power,
+                                    /*gammaCorr=*/        corrPower,
+                                    /*neutronCorr=*/      corrPower,
                                     /*gammaMode=*/        GammaMode::LeaderOnly,
                                     /*gammaLeaderFracMin=*/0.0,
                                     /*clusterEmin=*/      m_cfg.clusterEminB0Ecal,
@@ -304,8 +302,8 @@ void FarForwardNeutralsReconstruction::process(
                                     /*neutronCorrCoefs=*/ m_cfg.neutronScaleCorrCoeffEcalEndcapP,
                                     /*canDetectGammas=*/  true,
                                     /*canDetectNeutrons=*/false,
-                                    /*gammaCorr=*/        corr_power,
-                                    /*neutronCorr=*/      corr_power,
+                                    /*gammaCorr=*/        corrPower,
+                                    /*neutronCorr=*/      corrPower,
                                     /*gammaMode=*/        GammaMode::LeaderOnly,
                                     /*gammaLeaderFracMin=*/0.0,
                                     /*clusterEmin=*/      m_cfg.clusterEminEcalEndcapP,
@@ -320,8 +318,8 @@ void FarForwardNeutralsReconstruction::process(
                                     /*neutronCorrCoefs=*/ m_cfg.neutronScaleCorrCoeffLFHCAL,
                                     /*canDetectGammas=*/  false,
                                     /*canDetectNeutrons=*/true,
-                                    /*gammaCorr=*/        corr_power,
-                                    /*neutronCorr=*/      corr_power,
+                                    /*gammaCorr=*/        corrPower,
+                                    /*neutronCorr=*/      corrPower,
                                     /*gammaMode=*/        GammaMode::None,
                                     /*gammaLeaderFracMin=*/0.0,
                                     /*clusterEmin=*/      m_cfg.clusterEminLFHCAL,

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
@@ -6,14 +6,12 @@
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <fmt/core.h>
-#include <cmath>
-#include <gsl/pointers>
-#include <stdexcept>
-#include <vector>
-#include <functional>
-#include <limits>
+#include <stddef.h>
 #include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <tuple>
+#include <vector>
 
 #include "FarForwardNeutralsReconstruction.h"
 

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.h
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.h
@@ -21,18 +21,34 @@
 namespace eicrecon {
 
 using FarForwardNeutralsReconstructionAlgorithm =
-    algorithms::Algorithm<algorithms::Input<const edm4eic::ClusterCollection>,
-                          algorithms::Output<edm4eic::ReconstructedParticleCollection>>;
+
+    algorithms::Algorithm<algorithms::Input<const edm4eic::ClusterCollection,            // clusters ZDC-Hcal
+                                            const edm4eic::ClusterCollection,            // clusters B0-Ecal
+                                            const edm4eic::ClusterCollection,            // clusters EndcapP-Ecal
+                                            const edm4eic::ClusterCollection>,           // clusters LFHCAL
+
+                          algorithms::Output<edm4eic::ReconstructedParticleCollection,   // neutrons/gamma in ZDC-Hcal
+                                             edm4eic::ReconstructedParticleCollection,   // neutrons/gamma in B0-Ecal
+                                             edm4eic::ReconstructedParticleCollection,   // neutrons/gamma in EndcapP-Ecal
+                                             edm4eic::ReconstructedParticleCollection>>; // neutrons/gamma in LFHCAL
 class FarForwardNeutralsReconstruction
     : public FarForwardNeutralsReconstructionAlgorithm,
       public WithPodConfig<FarForwardNeutralsReconstructionConfig> {
 public:
   FarForwardNeutralsReconstruction(std::string_view name)
       : FarForwardNeutralsReconstructionAlgorithm{name,
-                                                  {"inputClustersHcal"},
-                                                  {"outputNeutrals"},
-                                                  "Merges all HCAL clusters in a collection into a "
-                                                  "neutron candidate and photon candidates "} {}
+        
+                                                  {"clustersHcal", 
+                                                   "clustersB0", 
+                                                   "clustersEcalEndCapP",
+                                                   "clustersLFHCAL"},
+
+                                                  {"outputNeutralsHcal", 
+                                                   "outputNeutralsB0", 
+                                                   "outputNeutralsEcalEndCapP",
+                                                   "outputNeutralsLFHCAL"},
+
+                                                  "Merges all HCAL clusters in a collection into a neutron candidate and photon candidates "} {}
 
   void init() final;
   void process(const Input&, const Output&) const final;
@@ -46,4 +62,4 @@ private:
   const dd4hep::Detector* m_detector{algorithms::GeoSvc::instance().detector()};
   double m_gammaZMax{0};
 };
-} // namespace eicrecon
+}

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.h
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2025 Sebouh Paul
+// Copyright (C) 2025 Sebouh Paul, Baptiste Fraisse
 
 #pragma once
 #include <DD4hep/Detector.h>
@@ -31,6 +31,25 @@ using FarForwardNeutralsReconstructionAlgorithm =
                                              edm4eic::ReconstructedParticleCollection,   // neutrons/gamma in B0-Ecal
                                              edm4eic::ReconstructedParticleCollection,   // neutrons/gamma in EndcapP-Ecal
                                              edm4eic::ReconstructedParticleCollection>>; // neutrons/gamma in LFHCAL
+/**
+ * Reconstructs far-forward neutral candidates from multiple calorimeter cluster collections.
+ *
+ * This algorithm processes clusters from the configured far-forward calorimeters
+ * and builds reconstructed neutral candidates used downstream in the far-forward
+ * Lambda reconstruction chain.
+ *
+ * Photon-like candidates are identified from calorimeter-cluster properties and
+ * detector-dependent selections. The remaining neutral energy deposits can be used
+ * to form neutron-like candidates, depending on the detector response and clustering
+ * configuration.
+ *
+ * The reconstructed energies are corrected using detector-dependent linear
+ * calibration functions. Separate calibration parameters can be configured for
+ * the different calorimeters and neutral-candidate types.
+ *
+ * This implementation is intended to support a multi-calorimeter workflow beyond
+ * the ZDC-only reconstruction.
+ */
 class FarForwardNeutralsReconstruction
     : public FarForwardNeutralsReconstructionAlgorithm,
       public WithPodConfig<FarForwardNeutralsReconstructionConfig> {
@@ -48,7 +67,7 @@ public:
                                                    "outputNeutralsEcalEndCapP",
                                                    "outputNeutralsLFHCAL"},
 
-                                                  "Merges all HCAL clusters in a collection into a neutron candidate and photon candidates "} {}
+                                                  "Convert EMCal and HCal clusters into neutron or photon candidates"} {}
 
   void init() final;
   void process(const Input&, const Output&) const final;

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.h
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.h
@@ -22,15 +22,17 @@ namespace eicrecon {
 
 using FarForwardNeutralsReconstructionAlgorithm =
 
-    algorithms::Algorithm<algorithms::Input<const edm4eic::ClusterCollection,            // clusters ZDC-Hcal
-                                            const edm4eic::ClusterCollection,            // clusters B0-Ecal
-                                            const edm4eic::ClusterCollection,            // clusters EndcapP-Ecal
-                                            const edm4eic::ClusterCollection>,           // clusters LFHCAL
+    algorithms::Algorithm<
+        algorithms::Input<const edm4eic::ClusterCollection,  // clusters ZDC-Hcal
+                          const edm4eic::ClusterCollection,  // clusters B0-Ecal
+                          const edm4eic::ClusterCollection,  // clusters EndcapP-Ecal
+                          const edm4eic::ClusterCollection>, // clusters LFHCAL
 
-                          algorithms::Output<edm4eic::ReconstructedParticleCollection,   // neutrons/gamma in ZDC-Hcal
-                                             edm4eic::ReconstructedParticleCollection,   // neutrons/gamma in B0-Ecal
-                                             edm4eic::ReconstructedParticleCollection,   // neutrons/gamma in EndcapP-Ecal
-                                             edm4eic::ReconstructedParticleCollection>>; // neutrons/gamma in LFHCAL
+        algorithms::Output<
+            edm4eic::ReconstructedParticleCollection,   // neutrons/gamma in ZDC-Hcal
+            edm4eic::ReconstructedParticleCollection,   // neutrons/gamma in B0-Ecal
+            edm4eic::ReconstructedParticleCollection,   // neutrons/gamma in EndcapP-Ecal
+            edm4eic::ReconstructedParticleCollection>>; // neutrons/gamma in LFHCAL
 /**
  * Reconstructs far-forward neutral candidates from multiple calorimeter cluster collections.
  *
@@ -55,19 +57,15 @@ class FarForwardNeutralsReconstruction
       public WithPodConfig<FarForwardNeutralsReconstructionConfig> {
 public:
   FarForwardNeutralsReconstruction(std::string_view name)
-      : FarForwardNeutralsReconstructionAlgorithm{name,
-        
-                                                  {"clustersHcal", 
-                                                   "clustersB0", 
-                                                   "clustersEcalEndCapP",
-                                                   "clustersLFHCAL"},
+      : FarForwardNeutralsReconstructionAlgorithm{
+            name,
 
-                                                  {"outputNeutralsHcal", 
-                                                   "outputNeutralsB0", 
-                                                   "outputNeutralsEcalEndCapP",
-                                                   "outputNeutralsLFHCAL"},
+            {"clustersHcal", "clustersB0", "clustersEcalEndCapP", "clustersLFHCAL"},
 
-                                                  "Convert EMCal and HCal clusters into neutron or photon candidates"} {}
+            {"outputNeutralsHcal", "outputNeutralsB0", "outputNeutralsEcalEndCapP",
+             "outputNeutralsLFHCAL"},
+
+            "Convert EMCal and HCal clusters into neutron or photon candidates"} {}
 
   void init() final;
   void process(const Input&, const Output&) const final;
@@ -81,4 +79,4 @@ private:
   const dd4hep::Detector* m_detector{algorithms::GeoSvc::instance().detector()};
   double m_gammaZMax{0};
 };
-}
+} // namespace eicrecon

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.h
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2025 Sebouh Paul, Baptiste Fraisse
+// Copyright (C) 2026 Sebouh Paul, Baptiste Fraisse
 
 #pragma once
 #include <DD4hep/Detector.h>
@@ -73,9 +73,7 @@ public:
   void process(const Input&, const Output&) const final;
 
 private:
-  static double calc_corr(double Etot, const std::vector<double>&);
   bool isGamma(const edm4eic::Cluster& cluster) const;
-
   std::shared_ptr<spdlog::logger> m_log;
   const algorithms::ParticleSvc& m_particleSvc = algorithms::ParticleSvc::instance();
   const dd4hep::Detector* m_detector{algorithms::GeoSvc::instance().detector()};

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.h
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.h
@@ -22,15 +22,17 @@ namespace eicrecon {
 
 using FarForwardNeutralsReconstructionAlgorithm =
 
-    algorithms::Algorithm<algorithms::Input<const edm4eic::ClusterCollection,            // clusters ZDC-Hcal
-                                            const edm4eic::ClusterCollection,            // clusters B0-Ecal
-                                            const edm4eic::ClusterCollection,            // clusters EndcapP-Ecal
-                                            const edm4eic::ClusterCollection>,           // clusters LFHCAL
+    algorithms::Algorithm<
+        algorithms::Input<const edm4eic::ClusterCollection,  // clusters ZDC-Hcal
+                          const edm4eic::ClusterCollection,  // clusters B0-Ecal
+                          const edm4eic::ClusterCollection,  // clusters EndcapP-Ecal
+                          const edm4eic::ClusterCollection>, // clusters LFHCAL
 
-                          algorithms::Output<edm4eic::ReconstructedParticleCollection,   // neutrons/gamma in ZDC-Hcal
-                                             edm4eic::ReconstructedParticleCollection,   // neutrons/gamma in B0-Ecal
-                                             edm4eic::ReconstructedParticleCollection,   // neutrons/gamma in EndcapP-Ecal
-                                             edm4eic::ReconstructedParticleCollection>>; // neutrons/gamma in LFHCAL
+        algorithms::Output<
+            edm4eic::ReconstructedParticleCollection,   // neutrons/gamma in ZDC-Hcal
+            edm4eic::ReconstructedParticleCollection,   // neutrons/gamma in B0-Ecal
+            edm4eic::ReconstructedParticleCollection,   // neutrons/gamma in EndcapP-Ecal
+            edm4eic::ReconstructedParticleCollection>>; // neutrons/gamma in LFHCAL
 /**
  * Reconstructs far-forward neutral candidates from multiple calorimeter cluster collections.
  *
@@ -55,19 +57,15 @@ class FarForwardNeutralsReconstruction
       public WithPodConfig<FarForwardNeutralsReconstructionConfig> {
 public:
   FarForwardNeutralsReconstruction(std::string_view name)
-      : FarForwardNeutralsReconstructionAlgorithm{name,
-        
-                                                  {"clustersHcal", 
-                                                   "clustersB0", 
-                                                   "clustersEcalEndCapP",
-                                                   "clustersLFHCAL"},
+      : FarForwardNeutralsReconstructionAlgorithm{
+            name,
 
-                                                  {"outputNeutralsHcal", 
-                                                   "outputNeutralsB0", 
-                                                   "outputNeutralsEcalEndCapP",
-                                                   "outputNeutralsLFHCAL"},
+            {"clustersHcal", "clustersB0", "clustersEcalEndCapP", "clustersLFHCAL"},
 
-                                                  "Convert EMCal and HCal clusters into neutron or photon candidates"} {}
+            {"outputNeutralsHcal", "outputNeutralsB0", "outputNeutralsEcalEndCapP",
+             "outputNeutralsLFHCAL"},
+
+            "Convert EMCal and HCal clusters into neutron or photon candidates"} {}
 
   void init() final;
   void process(const Input&, const Output&) const final;
@@ -86,20 +84,14 @@ private:
 
   static double corrPower(double E, const std::vector<double>& coeffs);
 
-  int processNeutralCalo(
-      const edm4eic::ClusterCollection* clusters,
-      edm4eic::ReconstructedParticleCollection* out_neutrals,
-      const std::vector<double>& gammaScaleCoeff,
-      const std::vector<double>& neutronScaleCoeff,
-      bool canDetectGammas,
-      bool canDetectNeutrons,
-      const CorrFunc& gammaCorr,
-      const CorrFunc& neutronCorr,
-      GammaMode gammaMode,
-      double gammaLeaderFracMin,
-      double clusterEmin,
-      NeutronMode neutronMode,
-      bool associateAllClustersToNeutron) const;
+  int processNeutralCalo(const edm4eic::ClusterCollection* clusters,
+                         edm4eic::ReconstructedParticleCollection* out_neutrals,
+                         const std::vector<double>& gammaScaleCoeff,
+                         const std::vector<double>& neutronScaleCoeff, bool canDetectGammas,
+                         bool canDetectNeutrons, const CorrFunc& gammaCorr,
+                         const CorrFunc& neutronCorr, GammaMode gammaMode,
+                         double gammaLeaderFracMin, double clusterEmin, NeutronMode neutronMode,
+                         bool associateAllClustersToNeutron) const;
 };
 
 } // namespace eicrecon

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.h
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.h
@@ -13,7 +13,7 @@
 #include <string>      // for basic_string
 #include <string_view> // for string_view
 #include <vector>
-
+#include <functional>
 #include "algorithms/interfaces/WithPodConfig.h"
 #include "services/particle/ParticleSvc.h"
 #include "algorithms/reco/FarForwardNeutralsReconstructionConfig.h"
@@ -78,5 +78,28 @@ private:
   const algorithms::ParticleSvc& m_particleSvc = algorithms::ParticleSvc::instance();
   const dd4hep::Detector* m_detector{algorithms::GeoSvc::instance().detector()};
   double m_gammaZMax{0};
+
+  enum class GammaMode { None, LeaderOnly, AllPassing };
+  enum class NeutronMode { None, SumAll, LeaderOnly };
+
+  using CorrFunc = std::function<double(double, const std::vector<double>&)>;
+
+  static double corrPower(double E, const std::vector<double>& coeffs);
+
+  int processNeutralCalo(
+      const edm4eic::ClusterCollection* clusters,
+      edm4eic::ReconstructedParticleCollection* out_neutrals,
+      const std::vector<double>& gammaScaleCoeff,
+      const std::vector<double>& neutronScaleCoeff,
+      bool canDetectGammas,
+      bool canDetectNeutrons,
+      const CorrFunc& gammaCorr,
+      const CorrFunc& neutronCorr,
+      GammaMode gammaMode,
+      double gammaLeaderFracMin,
+      double clusterEmin,
+      NeutronMode neutronMode,
+      bool associateAllClustersToNeutron) const;
 };
-}
+
+} // namespace eicrecon

--- a/src/algorithms/reco/FarForwardNeutralsReconstructionConfig.h
+++ b/src/algorithms/reco/FarForwardNeutralsReconstructionConfig.h
@@ -29,8 +29,8 @@ struct FarForwardNeutralsReconstructionConfig {
   double globalToProtonRotation = -0.025;
   /** Neutron-photon separation in HcalFarForwardZDC */
   double gammaZMaxOffset = 400 * dd4hep::mm;
-  double gammaMaxLength = 100 * dd4hep::mm;
-  double gammaMaxWidth  = 12 * dd4hep::mm;
+  double gammaMaxLength  = 100 * dd4hep::mm;
+  double gammaMaxWidth   = 12 * dd4hep::mm;
 };
 
 } // namespace eicrecon

--- a/src/algorithms/reco/FarForwardNeutralsReconstructionConfig.h
+++ b/src/algorithms/reco/FarForwardNeutralsReconstructionConfig.h
@@ -9,15 +9,26 @@ namespace eicrecon {
 struct FarForwardNeutralsReconstructionConfig {
   /** detector constant describing distance to the ZDC */
   std::string offsetPositionName = "HcalFarForwardZDC_SiPMonTile_r_pos";
-  /** Correction factors for neutrons in the Hcal */
-  std::vector<double> neutronScaleCorrCoeffHcal = {-0.11, -1.5, 0};
-  /** Correction factors for gammas in the Hcal */
-  std::vector<double> gammaScaleCorrCoeffHcal = {0, -0.13, 0};
+  /** Correction factors for neutrons in the Hcal (ZDC) */
+  std::vector<double> neutronScaleCorrCoeffHcal = {2.4, 0.89};
+  /** Correction factors for gammas in the Hcal (ZDC) */
+  std::vector<double> gammaScaleCorrCoeffHcal = {1.1, 0.98};
+  /** Correction factors for neutrons in the LFHCAL */
+  std::vector<double> neutronScaleCorrCoeffLFHCAL = {2.55, 0.95};
+  /** Correction factors for gammas in the LFHCAL */
+  std::vector<double> gammaScaleCorrCoeffLFHCAL = {0., 0.};
+  /** Correction factors for neutrons in the B0-Ecal */
+  std::vector<double> neutronScaleCorrCoeffB0Ecal = {0., 0.};
+  /** Correction factors for gammas in the B0-Ecal */
+  std::vector<double> gammaScaleCorrCoeffB0Ecal = {0.99, 1.14};
+  /** Correction factors for neutrons in the Endcap-Ecal */
+  std::vector<double> neutronScaleCorrCoeffEcalEndcapP = {0., 0.};
+  /** Correction factors for gammas in the Endcap-Ecal */
+  std::vector<double> gammaScaleCorrCoeffEcalEndcapP = {1.05, 1.01};
   /** rotation from global to local coordinates */
   double globalToProtonRotation = -0.025;
-  /** position cuts for the clusters identified as photons */
-  double gammaZMaxOffset = 300 * dd4hep::mm;
-  /** cuts for the sqrts of the largest and second largest eigenvalues of the moment matrix */
+  /** Neutron-photon separation in HcalFarForwardZDC */
+  double gammaZMaxOffset = 400 * dd4hep::mm;
   double gammaMaxLength = 100 * dd4hep::mm;
   double gammaMaxWidth  = 12 * dd4hep::mm;
 };

--- a/src/algorithms/reco/FarForwardNeutralsReconstructionConfig.h
+++ b/src/algorithms/reco/FarForwardNeutralsReconstructionConfig.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2025 Sebouh Paul
+// Copyright (C) 2025 Sebouh Paul, Baptiste Fraisse
 #pragma once
 #include <float.h>
 #include <DD4hep/Detector.h>

--- a/src/algorithms/reco/FarForwardNeutralsReconstructionConfig.h
+++ b/src/algorithms/reco/FarForwardNeutralsReconstructionConfig.h
@@ -26,16 +26,16 @@ struct FarForwardNeutralsReconstructionConfig {
   /** Correction factors for gammas in the Endcap-Ecal */
   std::vector<double> gammaScaleCorrCoeffEcalEndcapP = {1.05, 1.01};
   /** Cluster thresholds */
-  double clusterEminHcalZDC = 0.0 ; // GeV
-  double clusterEminB0Ecal = 1.0 ; // GeV
-  double clusterEminEcalEndcapP = 1.0 ; // GeV
-  double clusterEminLFHCAL = 7.0 ; // GeV
+  double clusterEminHcalZDC     = 0.0; // GeV
+  double clusterEminB0Ecal      = 1.0; // GeV
+  double clusterEminEcalEndcapP = 1.0; // GeV
+  double clusterEminLFHCAL      = 7.0; // GeV
   /** rotation from global to local coordinates */
   double globalToProtonRotation = -0.025;
   /** Neutron-photon separation in HcalFarForwardZDC */
-  double gammaZMaxOffset = 400 ;
-  double gammaMaxLength = 100 ;
-  double gammaMaxWidth  = 12 ;
+  double gammaZMaxOffset = 400;
+  double gammaMaxLength  = 100;
+  double gammaMaxWidth   = 12;
 };
 
 } // namespace eicrecon

--- a/src/algorithms/reco/FarForwardNeutralsReconstructionConfig.h
+++ b/src/algorithms/reco/FarForwardNeutralsReconstructionConfig.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2025 Sebouh Paul, Baptiste Fraisse
+// Copyright (C) 2026 Sebouh Paul, Baptiste Fraisse
 #pragma once
 #include <float.h>
 #include <DD4hep/Detector.h>
@@ -10,9 +10,9 @@ struct FarForwardNeutralsReconstructionConfig {
   /** detector constant describing distance to the ZDC */
   std::string offsetPositionName = "HcalFarForwardZDC_SiPMonTile_r_pos";
   /** Correction factors for neutrons in the Hcal (ZDC) */
-  std::vector<double> neutronScaleCorrCoeffHcal = {2.4, 0.89};
+  std::vector<double> neutronScaleCorrCoeffHcalZDC = {2.4, 0.89};
   /** Correction factors for gammas in the Hcal (ZDC) */
-  std::vector<double> gammaScaleCorrCoeffHcal = {1.1, 0.98};
+  std::vector<double> gammaScaleCorrCoeffHcalZDC = {1.1, 0.98};
   /** Correction factors for neutrons in the LFHCAL */
   std::vector<double> neutronScaleCorrCoeffLFHCAL = {2.55, 0.95};
   /** Correction factors for gammas in the LFHCAL */
@@ -25,12 +25,17 @@ struct FarForwardNeutralsReconstructionConfig {
   std::vector<double> neutronScaleCorrCoeffEcalEndcapP = {0., 0.};
   /** Correction factors for gammas in the Endcap-Ecal */
   std::vector<double> gammaScaleCorrCoeffEcalEndcapP = {1.05, 1.01};
+  /** Cluster thresholds */
+  double clusterEminHcalZDC = 0.0 ; // GeV
+  double clusterEminB0Ecal = 1.0 ; // GeV
+  double clusterEminEcalEndcapP = 1.0 ; // GeV
+  double clusterEminLFHCAL = 7.0 ; // GeV
   /** rotation from global to local coordinates */
   double globalToProtonRotation = -0.025;
   /** Neutron-photon separation in HcalFarForwardZDC */
-  double gammaZMaxOffset = 400 * dd4hep::mm;
-  double gammaMaxLength = 100 * dd4hep::mm;
-  double gammaMaxWidth  = 12 * dd4hep::mm;
+  double gammaZMaxOffset = 400 ;
+  double gammaMaxLength = 100 ;
+  double gammaMaxWidth  = 12 ;
 };
 
 } // namespace eicrecon

--- a/src/factories/reco/FarForwardLambdaReconstruction_factory.h
+++ b/src/factories/reco/FarForwardLambdaReconstruction_factory.h
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2025 Sebouh Paul
+// Update/modification 2026 by Baptiste Fraisse
 
 #pragma once
 
@@ -19,14 +20,20 @@ public:
 
 private:
   std::unique_ptr<AlgoT> m_algo;
-  PodioInput<edm4eic::ReconstructedParticle> m_neutrals_input{this};
+
+  PodioInput<edm4eic::ReconstructedParticle> m_hcal_neutrals_input{this};
+  PodioInput<edm4eic::ReconstructedParticle> m_b0_neutrals_input{this};
+  PodioInput<edm4eic::ReconstructedParticle> m_ecalendcapp_neutrals_input{this};
+  PodioInput<edm4eic::ReconstructedParticle> m_lfhcal_neutrals_input{this};
+
   PodioOutput<edm4eic::ReconstructedParticle> m_lambda_output{this};
   PodioOutput<edm4eic::ReconstructedParticle> m_lambda_decay_products_cm_output{this};
 
   ParameterRef<std::string> m_offset_position_name{this, "offsetPositionName",
                                                    config().offsetPositionName};
   ParameterRef<double> m_rot_y{this, "globalToProtonRotation", config().globalToProtonRotation};
-  ParameterRef<double> m_lambda_max_mass_dev{this, "lambdaMaxMassDev", config().lambdaMaxMassDev};
+  ParameterRef<double> m_lambda_max_mass_dev{this, "lambdaMassWindow", config().lambdaMassWindow};
+  ParameterRef<double> m_pi0_max_mass_dev{this, "pi0Window", config().pi0Window};
   ParameterRef<int> m_iterations{this, "iterations", config().iterations};
   Service<AlgorithmsInit_service> m_algorithmsInit{this};
 
@@ -40,8 +47,19 @@ public:
   }
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
-    m_algo->process({m_neutrals_input()},
-                    {m_lambda_output().get(), m_lambda_decay_products_cm_output().get()});
+    m_algo->process(
+      
+      {
+        m_hcal_neutrals_input(),
+        m_b0_neutrals_input(), 
+        m_ecalendcapp_neutrals_input(),
+        m_lfhcal_neutrals_input()
+      },
+      
+      {
+        m_lambda_output().get(), 
+        m_lambda_decay_products_cm_output().get()
+      });
   }
 };
 

--- a/src/factories/reco/FarForwardLambdaReconstruction_factory.h
+++ b/src/factories/reco/FarForwardLambdaReconstruction_factory.h
@@ -46,17 +46,9 @@ public:
   }
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
-    m_algo->process( 
-      {
-        m_hcal_neutrals_input(),
-        m_b0_neutrals_input(), 
-        m_ecalendcapp_neutrals_input(),
-        m_lfhcal_neutrals_input()
-      },
-      {
-        m_lambda_output().get(), 
-        m_lambda_decay_products_cm_output().get()
-      });
+    m_algo->process({m_hcal_neutrals_input(), m_b0_neutrals_input(), m_ecalendcapp_neutrals_input(),
+                     m_lfhcal_neutrals_input()},
+                    {m_lambda_output().get(), m_lambda_decay_products_cm_output().get()});
   }
 };
 

--- a/src/factories/reco/FarForwardLambdaReconstruction_factory.h
+++ b/src/factories/reco/FarForwardLambdaReconstruction_factory.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2025 Sebouh Paul, Baptiste Fraisse
+// Copyright (C) 2026 Sebouh Paul, Baptiste Fraisse
 
 #pragma once
 

--- a/src/factories/reco/FarForwardLambdaReconstruction_factory.h
+++ b/src/factories/reco/FarForwardLambdaReconstruction_factory.h
@@ -32,8 +32,8 @@ private:
   ParameterRef<std::string> m_offset_position_name{this, "offsetPositionName",
                                                    config().offsetPositionName};
   ParameterRef<double> m_rot_y{this, "globalToProtonRotation", config().globalToProtonRotation};
-  ParameterRef<double> m_lambda_max_mass_dev{this, "lambdaMassWindow", config().lambdaMassWindow};
-  ParameterRef<double> m_pi0_max_mass_dev{this, "pi0Window", config().pi0Window};
+  ParameterRef<double> m_lambda_mass_window{this, "lambdaMassWindow", config().lambdaMassWindow};
+  ParameterRef<double> m_pi0_mass_window{this, "pi0Window", config().pi0Window};
   ParameterRef<int> m_iterations{this, "iterations", config().iterations};
   Service<AlgorithmsInit_service> m_algorithmsInit{this};
 
@@ -47,15 +47,13 @@ public:
   }
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
-    m_algo->process(
-      
+    m_algo->process( 
       {
         m_hcal_neutrals_input(),
         m_b0_neutrals_input(), 
         m_ecalendcapp_neutrals_input(),
         m_lfhcal_neutrals_input()
       },
-      
       {
         m_lambda_output().get(), 
         m_lambda_decay_products_cm_output().get()

--- a/src/factories/reco/FarForwardLambdaReconstruction_factory.h
+++ b/src/factories/reco/FarForwardLambdaReconstruction_factory.h
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2025 Sebouh Paul
-// Update/modification 2026 by Baptiste Fraisse
+// Copyright (C) 2025 Sebouh Paul, Baptiste Fraisse
 
 #pragma once
 

--- a/src/factories/reco/FarForwardNeutralsReconstruction_factory.h
+++ b/src/factories/reco/FarForwardNeutralsReconstruction_factory.h
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2025 Sebouh Paul
+// Update/modification 2026 by Baptiste Fraisse
 
 #pragma once
 
@@ -19,8 +20,16 @@ public:
 
 private:
   std::unique_ptr<AlgoT> m_algo;
+
   PodioInput<edm4eic::Cluster> m_clusters_hcal_input{this};
-  PodioOutput<edm4eic::ReconstructedParticle> m_neutrals_output{this};
+  PodioInput<edm4eic::Cluster> m_clusters_b0_input{this};
+  PodioInput<edm4eic::Cluster> m_clusters_ecalendcapp_input{this};
+  PodioInput<edm4eic::Cluster> m_clusters_lfhcal_input{this};
+
+  PodioOutput<edm4eic::ReconstructedParticle> m_hcal_neutrals_output{this};
+  PodioOutput<edm4eic::ReconstructedParticle> m_b0_neutrals_output{this};
+  PodioOutput<edm4eic::ReconstructedParticle> m_ecalendcapp_neutrals_output{this};
+  PodioOutput<edm4eic::ReconstructedParticle> m_lfhcal_neutrals_output{this};
 
   ParameterRef<std::string> m_offset_position_name{this, "offsetPositionName",
                                                    config().offsetPositionName};
@@ -28,6 +37,18 @@ private:
                                                               config().neutronScaleCorrCoeffHcal};
   ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_hcal{this, "gammaScaleCorrCoeffHcal",
                                                                   config().gammaScaleCorrCoeffHcal};
+  ParameterRef<std::vector<double>> m_n_scale_corr_coeff_b0ecal{this, "neutronScaleCorrCoeffB0Ecal",
+                                                                  config().neutronScaleCorrCoeffB0Ecal};
+  ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_b0ecal{this, "gammaScaleCorrCoeffB0Ecal",
+                                                                  config().gammaScaleCorrCoeffB0Ecal};
+  ParameterRef<std::vector<double>> m_n_scale_corr_coeff_ecalendcapp{this, "neutronScaleCorrCoeffEcalEndcapP",
+                                                                  config().neutronScaleCorrCoeffEcalEndcapP};
+  ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_ecalendcapp{this, "gammaScaleCorrCoeffEcalEndcapP",
+                                                                  config().gammaScaleCorrCoeffEcalEndcapP};
+  ParameterRef<std::vector<double>> m_n_scale_corr_coeff_lfhcal{this, "neutronScaleCorrCoeffLFHCAL",
+                                                                  config().neutronScaleCorrCoeffLFHCAL};
+  ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_lfhcal{this, "gammaScaleCorrCoeffLFHCAL",
+                                                                  config().gammaScaleCorrCoeffLFHCAL};
   ParameterRef<double> m_global_to_proton_rotation{this, "globalToProtonRotation",
                                                    config().globalToProtonRotation};
   ParameterRef<double> m_gamma_zmax_offset{this, "gammaZMaxOffset", config().gammaZMaxOffset};
@@ -50,9 +71,17 @@ public:
     m_algo->process(
         {
             m_clusters_hcal_input(),
+            m_clusters_b0_input(),
+            m_clusters_ecalendcapp_input(),
+            m_clusters_lfhcal_input(),
+
         },
         {
-            m_neutrals_output().get(),
+            m_hcal_neutrals_output().get(),
+            m_b0_neutrals_output().get(),
+            m_ecalendcapp_neutrals_output().get(),
+            m_lfhcal_neutrals_output().get(),
+
         });
   }
 };

--- a/src/factories/reco/FarForwardNeutralsReconstruction_factory.h
+++ b/src/factories/reco/FarForwardNeutralsReconstruction_factory.h
@@ -37,18 +37,18 @@ private:
                                                               config().neutronScaleCorrCoeffHcal};
   ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_hcal{this, "gammaScaleCorrCoeffHcal",
                                                                   config().gammaScaleCorrCoeffHcal};
-  ParameterRef<std::vector<double>> m_n_scale_corr_coeff_b0ecal{this, "neutronScaleCorrCoeffB0Ecal",
-                                                                  config().neutronScaleCorrCoeffB0Ecal};
-  ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_b0ecal{this, "gammaScaleCorrCoeffB0Ecal",
-                                                                  config().gammaScaleCorrCoeffB0Ecal};
-  ParameterRef<std::vector<double>> m_n_scale_corr_coeff_ecalendcapp{this, "neutronScaleCorrCoeffEcalEndcapP",
-                                                                  config().neutronScaleCorrCoeffEcalEndcapP};
-  ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_ecalendcapp{this, "gammaScaleCorrCoeffEcalEndcapP",
-                                                                  config().gammaScaleCorrCoeffEcalEndcapP};
-  ParameterRef<std::vector<double>> m_n_scale_corr_coeff_lfhcal{this, "neutronScaleCorrCoeffLFHCAL",
-                                                                  config().neutronScaleCorrCoeffLFHCAL};
-  ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_lfhcal{this, "gammaScaleCorrCoeffLFHCAL",
-                                                                  config().gammaScaleCorrCoeffLFHCAL};
+  ParameterRef<std::vector<double>> m_n_scale_corr_coeff_b0ecal{
+      this, "neutronScaleCorrCoeffB0Ecal", config().neutronScaleCorrCoeffB0Ecal};
+  ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_b0ecal{
+      this, "gammaScaleCorrCoeffB0Ecal", config().gammaScaleCorrCoeffB0Ecal};
+  ParameterRef<std::vector<double>> m_n_scale_corr_coeff_ecalendcapp{
+      this, "neutronScaleCorrCoeffEcalEndcapP", config().neutronScaleCorrCoeffEcalEndcapP};
+  ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_ecalendcapp{
+      this, "gammaScaleCorrCoeffEcalEndcapP", config().gammaScaleCorrCoeffEcalEndcapP};
+  ParameterRef<std::vector<double>> m_n_scale_corr_coeff_lfhcal{
+      this, "neutronScaleCorrCoeffLFHCAL", config().neutronScaleCorrCoeffLFHCAL};
+  ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_lfhcal{
+      this, "gammaScaleCorrCoeffLFHCAL", config().gammaScaleCorrCoeffLFHCAL};
   ParameterRef<double> m_global_to_proton_rotation{this, "globalToProtonRotation",
                                                    config().globalToProtonRotation};
   ParameterRef<double> m_gamma_zmax_offset{this, "gammaZMaxOffset", config().gammaZMaxOffset};

--- a/src/factories/reco/FarForwardNeutralsReconstruction_factory.h
+++ b/src/factories/reco/FarForwardNeutralsReconstruction_factory.h
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2025 Sebouh Paul
-// Update/modification 2026 by Baptiste Fraisse
+// Copyright (C) 2025 - 2026 Sebouh Paul, Baptiste Fraisse
 
 #pragma once
 

--- a/src/factories/reco/FarForwardNeutralsReconstruction_factory.h
+++ b/src/factories/reco/FarForwardNeutralsReconstruction_factory.h
@@ -30,11 +30,11 @@ private:
   PodioOutput<edm4eic::ReconstructedParticle> m_ecalendcapp_neutrals_output{this};
   PodioOutput<edm4eic::ReconstructedParticle> m_lfhcal_neutrals_output{this};
 
-  ParameterRef<std::string> m_offset_position_name{
-    this, "offsetPositionName",config().offsetPositionName};
+  ParameterRef<std::string> m_offset_position_name{this, "offsetPositionName",
+                                                   config().offsetPositionName};
 
   ParameterRef<std::vector<double>> m_n_scale_corr_coeff_hcal_zdc{
-    this, "neutronScaleCorrCoeffHcalZDC", config().neutronScaleCorrCoeffHcalZDC};
+      this, "neutronScaleCorrCoeffHcalZDC", config().neutronScaleCorrCoeffHcalZDC};
 
   ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_hcal_zdc{
       this, "gammaScaleCorrCoeffHcalZDC", config().gammaScaleCorrCoeffHcalZDC};
@@ -57,29 +57,24 @@ private:
   ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_lfhcal{
       this, "gammaScaleCorrCoeffLFHCAL", config().gammaScaleCorrCoeffLFHCAL};
 
-  ParameterRef<double> m_cluster_emin_hcal_zdc{
-      this, "clusterEminHcalZDC", config().clusterEminHcalZDC};
+  ParameterRef<double> m_cluster_emin_hcal_zdc{this, "clusterEminHcalZDC",
+                                               config().clusterEminHcalZDC};
 
-  ParameterRef<double> m_cluster_emin_b0ecal{
-      this, "clusterEminB0Ecal", config().clusterEminB0Ecal};
+  ParameterRef<double> m_cluster_emin_b0ecal{this, "clusterEminB0Ecal", config().clusterEminB0Ecal};
 
-  ParameterRef<double> m_cluster_emin_ecalendcapp{
-      this, "clusterEminEcalEndcapP", config().clusterEminEcalEndcapP};
+  ParameterRef<double> m_cluster_emin_ecalendcapp{this, "clusterEminEcalEndcapP",
+                                                  config().clusterEminEcalEndcapP};
 
-  ParameterRef<double> m_cluster_emin_lfhcal{
-      this, "clusterEminLFHCAL", config().clusterEminLFHCAL};
+  ParameterRef<double> m_cluster_emin_lfhcal{this, "clusterEminLFHCAL", config().clusterEminLFHCAL};
 
-  ParameterRef<double> m_global_to_proton_rotation{
-      this, "globalToProtonRotation", config().globalToProtonRotation};
+  ParameterRef<double> m_global_to_proton_rotation{this, "globalToProtonRotation",
+                                                   config().globalToProtonRotation};
 
-  ParameterRef<double> m_gamma_zmax_offset{
-      this, "gammaZMaxOffset", config().gammaZMaxOffset};
+  ParameterRef<double> m_gamma_zmax_offset{this, "gammaZMaxOffset", config().gammaZMaxOffset};
 
-  ParameterRef<double> m_gamma_max_length{
-      this, "gammaMaxLength", config().gammaMaxLength};
+  ParameterRef<double> m_gamma_max_length{this, "gammaMaxLength", config().gammaMaxLength};
 
-  ParameterRef<double> m_gamma_max_width{
-      this, "gammaMaxWidth", config().gammaMaxWidth};
+  ParameterRef<double> m_gamma_max_width{this, "gammaMaxWidth", config().gammaMaxWidth};
 
   Service<AlgorithmsInit_service> m_algorithmsInit{this};
 

--- a/src/factories/reco/FarForwardNeutralsReconstruction_factory.h
+++ b/src/factories/reco/FarForwardNeutralsReconstruction_factory.h
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2025 Sebouh Paul
-// Update/modification 2026 by Baptiste Fraisse
+// Copyright (C) 2026 Sebouh Paul, Baptiste Fraisse
 
 #pragma once
 
@@ -31,30 +30,56 @@ private:
   PodioOutput<edm4eic::ReconstructedParticle> m_ecalendcapp_neutrals_output{this};
   PodioOutput<edm4eic::ReconstructedParticle> m_lfhcal_neutrals_output{this};
 
-  ParameterRef<std::string> m_offset_position_name{this, "offsetPositionName",
-                                                   config().offsetPositionName};
-  ParameterRef<std::vector<double>> m_n_scale_corr_coeff_hcal{this, "neutronScaleCorrCoeffHcal",
-                                                              config().neutronScaleCorrCoeffHcal};
-  ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_hcal{this, "gammaScaleCorrCoeffHcal",
-                                                                  config().gammaScaleCorrCoeffHcal};
-  ParameterRef<std::vector<double>> m_n_scale_corr_coeff_b0ecal{this, "neutronScaleCorrCoeffB0Ecal",
-                                                                  config().neutronScaleCorrCoeffB0Ecal};
-  ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_b0ecal{this, "gammaScaleCorrCoeffB0Ecal",
-                                                                  config().gammaScaleCorrCoeffB0Ecal};
-  ParameterRef<std::vector<double>> m_n_scale_corr_coeff_ecalendcapp{this, "neutronScaleCorrCoeffEcalEndcapP",
-                                                                  config().neutronScaleCorrCoeffEcalEndcapP};
-  ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_ecalendcapp{this, "gammaScaleCorrCoeffEcalEndcapP",
-                                                                  config().gammaScaleCorrCoeffEcalEndcapP};
-  ParameterRef<std::vector<double>> m_n_scale_corr_coeff_lfhcal{this, "neutronScaleCorrCoeffLFHCAL",
-                                                                  config().neutronScaleCorrCoeffLFHCAL};
-  ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_lfhcal{this, "gammaScaleCorrCoeffLFHCAL",
-                                                                  config().gammaScaleCorrCoeffLFHCAL};
-  ParameterRef<double> m_global_to_proton_rotation{this, "globalToProtonRotation",
-                                                   config().globalToProtonRotation};
-  ParameterRef<double> m_gamma_zmax_offset{this, "gammaZMaxOffset", config().gammaZMaxOffset};
+  ParameterRef<std::string> m_offset_position_name{
+    this, "offsetPositionName",config().offsetPositionName};
 
-  ParameterRef<double> m_gamma_max_length{this, "gammaMaxLength", config().gammaMaxLength};
-  ParameterRef<double> m_gamma_max_width{this, "gammaMaxWidth", config().gammaMaxWidth};
+  ParameterRef<std::vector<double>> m_n_scale_corr_coeff_hcal_zdc{
+    this, "neutronScaleCorrCoeffHcalZDC", config().neutronScaleCorrCoeffHcalZDC};
+
+  ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_hcal_zdc{
+      this, "gammaScaleCorrCoeffHcalZDC", config().gammaScaleCorrCoeffHcalZDC};
+
+  ParameterRef<std::vector<double>> m_n_scale_corr_coeff_b0ecal{
+      this, "neutronScaleCorrCoeffB0Ecal", config().neutronScaleCorrCoeffB0Ecal};
+
+  ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_b0ecal{
+      this, "gammaScaleCorrCoeffB0Ecal", config().gammaScaleCorrCoeffB0Ecal};
+
+  ParameterRef<std::vector<double>> m_n_scale_corr_coeff_ecalendcapp{
+      this, "neutronScaleCorrCoeffEcalEndcapP", config().neutronScaleCorrCoeffEcalEndcapP};
+
+  ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_ecalendcapp{
+      this, "gammaScaleCorrCoeffEcalEndcapP", config().gammaScaleCorrCoeffEcalEndcapP};
+
+  ParameterRef<std::vector<double>> m_n_scale_corr_coeff_lfhcal{
+      this, "neutronScaleCorrCoeffLFHCAL", config().neutronScaleCorrCoeffLFHCAL};
+
+  ParameterRef<std::vector<double>> m_gamma_scale_corr_coeff_lfhcal{
+      this, "gammaScaleCorrCoeffLFHCAL", config().gammaScaleCorrCoeffLFHCAL};
+
+  ParameterRef<double> m_cluster_emin_hcal_zdc{
+      this, "clusterEminHcalZDC", config().clusterEminHcalZDC};
+
+  ParameterRef<double> m_cluster_emin_b0ecal{
+      this, "clusterEminB0Ecal", config().clusterEminB0Ecal};
+
+  ParameterRef<double> m_cluster_emin_ecalendcapp{
+      this, "clusterEminEcalEndcapP", config().clusterEminEcalEndcapP};
+
+  ParameterRef<double> m_cluster_emin_lfhcal{
+      this, "clusterEminLFHCAL", config().clusterEminLFHCAL};
+
+  ParameterRef<double> m_global_to_proton_rotation{
+      this, "globalToProtonRotation", config().globalToProtonRotation};
+
+  ParameterRef<double> m_gamma_zmax_offset{
+      this, "gammaZMaxOffset", config().gammaZMaxOffset};
+
+  ParameterRef<double> m_gamma_max_length{
+      this, "gammaMaxLength", config().gammaMaxLength};
+
+  ParameterRef<double> m_gamma_max_width{
+      this, "gammaMaxWidth", config().gammaMaxWidth};
 
   Service<AlgorithmsInit_service> m_algorithmsInit{this};
 

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -217,14 +217,9 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<FarForwardNeutralsReconstruction_factory>(
       "ReconstructedFarForwardZDCNeutrals",
-      {"HcalFarForwardZDCClusters", 
-        "B0ECalClusters", 
-        "EcalEndcapPClusters", 
-        "LFHCALClusters"},
-      {"ReconstructedHcalFarForwardZDCNeutrals", 
-        "ReconstructedB0EcalNeutrals", 
-        "ReconstructedEcalEndcapPNeutrals",
-        "ReconstructedLFHCALNeutrals"},
+      {"HcalFarForwardZDCClusters", "B0ECalClusters", "EcalEndcapPClusters", "LFHCALClusters"},
+      {"ReconstructedHcalFarForwardZDCNeutrals", "ReconstructedB0EcalNeutrals",
+       "ReconstructedEcalEndcapPNeutrals", "ReconstructedLFHCALNeutrals"},
       {.offsetPositionName               = "HcalFarForwardZDC_SiPMonTile_r_pos",
        .neutronScaleCorrCoeffHcal        = {2.4, 0.89},
        .gammaScaleCorrCoeffHcal          = {1.1, 0.98},
@@ -243,12 +238,9 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<FarForwardLambdaReconstruction_factory>(
       "ReconstructedFarForwardLambdas",
-      {"ReconstructedHcalFarForwardZDCNeutrals", 
-        "ReconstructedB0EcalNeutrals", 
-        "ReconstructedEcalEndcapPNeutrals", 
-        "ReconstructedLFHCALNeutrals"},
-      {"ReconstructedFarForwardLambdas", 
-        "ReconstructedFarForwardLambdaDecayProductsCM"},
+      {"ReconstructedHcalFarForwardZDCNeutrals", "ReconstructedB0EcalNeutrals",
+       "ReconstructedEcalEndcapPNeutrals", "ReconstructedLFHCALNeutrals"},
+      {"ReconstructedFarForwardLambdas", "ReconstructedFarForwardLambdaDecayProductsCM"},
       {.offsetPositionName     = "HcalFarForwardZDC_SiPMonTile_r_pos",
        .globalToProtonRotation = -0.025,
        .lambdaMassWindow       = 0.30,

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -216,27 +216,43 @@ void InitPlugin(JApplication* app) {
       {"ReconstructedBreitFrameParticles"}, {}, app));
 
   app->Add(new JOmniFactoryGeneratorT<FarForwardNeutralsReconstruction_factory>(
-      "ReconstructedFarForwardZDCNeutrons",
-      {"HcalFarForwardZDCClusters"},          // edm4eic::ClusterCollection
-      {"ReconstructedFarForwardZDCNeutrals"}, // edm4eic::ReconstrutedParticleCollection,
-      {.offsetPositionName        = "HcalFarForwardZDC_SiPMonTile_r_pos",
-       .neutronScaleCorrCoeffHcal = {-0.11, -1.5, 0},
-       .gammaScaleCorrCoeffHcal   = {0, -.13, 0},
-       .globalToProtonRotation    = -0.025,
-       .gammaZMaxOffset           = 300 * dd4hep::mm,
-       .gammaMaxLength            = 100 * dd4hep::mm,
-       .gammaMaxWidth             = 27 * dd4hep::mm},
+      "ReconstructedFarForwardZDCNeutrals",
+      {"HcalFarForwardZDCClusters", 
+        "B0ECalClusters", 
+        "EcalEndcapPClusters", 
+        "LFHCALClusters"},
+      {"ReconstructedHcalFarForwardZDCNeutrals", 
+        "ReconstructedB0EcalNeutrals", 
+        "ReconstructedEcalEndcapPNeutrals",
+        "ReconstructedLFHCALNeutrals"},
+      {.offsetPositionName               = "HcalFarForwardZDC_SiPMonTile_r_pos",
+       .neutronScaleCorrCoeffHcal        = {2.4, 0.89},
+       .gammaScaleCorrCoeffHcal          = {1.1, 0.98},
+       .neutronScaleCorrCoeffLFHCAL      = {2.55, 0.95},
+       .gammaScaleCorrCoeffLFHCAL        = {0., 0.},
+       .neutronScaleCorrCoeffB0Ecal      = {0., 0.},
+       .gammaScaleCorrCoeffB0Ecal        = {0.99, 1.14},
+       .neutronScaleCorrCoeffEcalEndcapP = {0., 0.},
+       .gammaScaleCorrCoeffEcalEndcapP   = {1.05, 1.01},
+       .globalToProtonRotation           = -0.025,
+       .gammaZMaxOffset                  = 400 * dd4hep::mm,
+       .gammaMaxLength                   = 100 * dd4hep::mm,
+       .gammaMaxWidth                    = 12 * dd4hep::mm},
       app // TODO: Remove me once fixed
       ));
 
   app->Add(new JOmniFactoryGeneratorT<FarForwardLambdaReconstruction_factory>(
-      "ReconstructedFarForwardZDCLambdas",
-      {"ReconstructedFarForwardZDCNeutrals"}, // edm4eic::ReconstrutedParticleCollection,
-      {"ReconstructedFarForwardZDCLambdas", "ReconstructedFarForwardZDCLambdaDecayProductsC"
-                                            "M"}, // edm4eic::ReconstrutedParticleCollection,
+      "ReconstructedFarForwardLambdas",
+      {"ReconstructedHcalFarForwardZDCNeutrals", 
+        "ReconstructedB0EcalNeutrals", 
+        "ReconstructedEcalEndcapPNeutrals", 
+        "ReconstructedLFHCALNeutrals"},
+      {"ReconstructedFarForwardLambdas", 
+        "ReconstructedFarForwardLambdaDecayProductsCM"},
       {.offsetPositionName     = "HcalFarForwardZDC_SiPMonTile_r_pos",
        .globalToProtonRotation = -0.025,
-       .lambdaMaxMassDev       = 0.030 * dd4hep::GeV,
+       .lambdaMassWindow       = 0.30,
+       .pi0Window              = 0.30,
        .iterations             = 10},
       app // TODO: Remove me once fixed
       ));

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -231,14 +231,9 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<FarForwardNeutralsReconstruction_factory>(
       "ReconstructedFarForwardNeutrals",
-      {"HcalFarForwardZDCClusters",
-        "B0ECalClusters",
-        "EcalEndcapPClusters",
-        "LFHCALClusters"},
-      {"ReconstructedHcalFarForwardZDCNeutrals",
-        "ReconstructedB0EcalNeutrals",
-        "ReconstructedEcalEndcapPNeutrals",
-        "ReconstructedLFHCALNeutrals"},
+      {"HcalFarForwardZDCClusters", "B0ECalClusters", "EcalEndcapPClusters", "LFHCALClusters"},
+      {"ReconstructedHcalFarForwardZDCNeutrals", "ReconstructedB0EcalNeutrals",
+       "ReconstructedEcalEndcapPNeutrals", "ReconstructedLFHCALNeutrals"},
       {.offsetPositionName               = "HcalFarForwardZDC_SiPMonTile_r_pos",
        .neutronScaleCorrCoeffHcalZDC     = {2.4, 0.89},
        .gammaScaleCorrCoeffHcalZDC       = {1.1, 0.98},
@@ -260,12 +255,9 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<FarForwardLambdaReconstruction_factory>(
       "ReconstructedLambdas",
-      {"ReconstructedHcalFarForwardZDCNeutrals",
-        "ReconstructedB0EcalNeutrals",
-        "ReconstructedEcalEndcapPNeutrals",
-        "ReconstructedLFHCALNeutrals"},
-      {"ReconstructedLambdas",
-        "ReconstructedLambdaDecayProductsCM"},
+      {"ReconstructedHcalFarForwardZDCNeutrals", "ReconstructedB0EcalNeutrals",
+       "ReconstructedEcalEndcapPNeutrals", "ReconstructedLFHCALNeutrals"},
+      {"ReconstructedLambdas", "ReconstructedLambdaDecayProductsCM"},
       {.offsetPositionName     = "HcalFarForwardZDC_SiPMonTile_r_pos",
        .globalToProtonRotation = -0.025,
        .lambdaMassWindow       = 0.1,

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -230,46 +230,48 @@ void InitPlugin(JApplication* app) {
       {"ReconstructedBreitFrameParticles"}, {}, app));
 
   app->Add(new JOmniFactoryGeneratorT<FarForwardNeutralsReconstruction_factory>(
-      "ReconstructedFarForwardZDCNeutrals",
-      {"HcalFarForwardZDCClusters", 
-        "B0ECalClusters", 
-        "EcalEndcapPClusters", 
+      "ReconstructedFarForwardNeutrals",
+      {"HcalFarForwardZDCClusters",
+        "B0ECalClusters",
+        "EcalEndcapPClusters",
         "LFHCALClusters"},
-      {"ReconstructedHcalFarForwardZDCNeutrals", 
-        "ReconstructedB0EcalNeutrals", 
+      {"ReconstructedHcalFarForwardZDCNeutrals",
+        "ReconstructedB0EcalNeutrals",
         "ReconstructedEcalEndcapPNeutrals",
         "ReconstructedLFHCALNeutrals"},
       {.offsetPositionName               = "HcalFarForwardZDC_SiPMonTile_r_pos",
-       .neutronScaleCorrCoeffHcal        = {2.4, 0.89},
-       .gammaScaleCorrCoeffHcal          = {1.1, 0.98},
+       .neutronScaleCorrCoeffHcalZDC     = {2.4, 0.89},
+       .gammaScaleCorrCoeffHcalZDC       = {1.1, 0.98},
        .neutronScaleCorrCoeffLFHCAL      = {2.55, 0.95},
        .gammaScaleCorrCoeffLFHCAL        = {0., 0.},
        .neutronScaleCorrCoeffB0Ecal      = {0., 0.},
        .gammaScaleCorrCoeffB0Ecal        = {0.99, 1.14},
        .neutronScaleCorrCoeffEcalEndcapP = {0., 0.},
        .gammaScaleCorrCoeffEcalEndcapP   = {1.05, 1.01},
+       .clusterEminHcalZDC               = 0.0,
+       .clusterEminB0Ecal                = 1.0,
+       .clusterEminEcalEndcapP           = 1.0,
+       .clusterEminLFHCAL                = 7.0,
        .globalToProtonRotation           = -0.025,
-       .gammaZMaxOffset                  = 400 * dd4hep::mm,
-       .gammaMaxLength                   = 100 * dd4hep::mm,
-       .gammaMaxWidth                    = 12 * dd4hep::mm},
-      app // TODO: Remove me once fixed
-      ));
+       .gammaZMaxOffset                  = 400,
+       .gammaMaxLength                   = 100,
+       .gammaMaxWidth                    = 12},
+      app));
 
   app->Add(new JOmniFactoryGeneratorT<FarForwardLambdaReconstruction_factory>(
-      "ReconstructedFarForwardLambdas",
-      {"ReconstructedHcalFarForwardZDCNeutrals", 
-        "ReconstructedB0EcalNeutrals", 
-        "ReconstructedEcalEndcapPNeutrals", 
+      "ReconstructedLambdas",
+      {"ReconstructedHcalFarForwardZDCNeutrals",
+        "ReconstructedB0EcalNeutrals",
+        "ReconstructedEcalEndcapPNeutrals",
         "ReconstructedLFHCALNeutrals"},
-      {"ReconstructedFarForwardLambdas", 
-        "ReconstructedFarForwardLambdaDecayProductsCM"},
+      {"ReconstructedLambdas",
+        "ReconstructedLambdaDecayProductsCM"},
       {.offsetPositionName     = "HcalFarForwardZDC_SiPMonTile_r_pos",
        .globalToProtonRotation = -0.025,
-       .lambdaMassWindow       = 0.30,
-       .pi0Window              = 0.30,
+       .lambdaMassWindow       = 0.1,
+       .pi0Window              = 0.1,
        .iterations             = 10},
-      app // TODO: Remove me once fixed
-      ));
+      app));
 
   app->Add(new JOmniFactoryGeneratorT<HadronicFinalState_factory<HadronicFinalState>>(
       "HadronicFinalState",

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -230,27 +230,43 @@ void InitPlugin(JApplication* app) {
       {"ReconstructedBreitFrameParticles"}, {}, app));
 
   app->Add(new JOmniFactoryGeneratorT<FarForwardNeutralsReconstruction_factory>(
-      "ReconstructedFarForwardZDCNeutrons",
-      {"HcalFarForwardZDCClusters"},          // edm4eic::ClusterCollection
-      {"ReconstructedFarForwardZDCNeutrals"}, // edm4eic::ReconstrutedParticleCollection,
-      {.offsetPositionName        = "HcalFarForwardZDC_SiPMonTile_r_pos",
-       .neutronScaleCorrCoeffHcal = {-0.11, -1.5, 0},
-       .gammaScaleCorrCoeffHcal   = {0, -.13, 0},
-       .globalToProtonRotation    = -0.025,
-       .gammaZMaxOffset           = 300 * dd4hep::mm,
-       .gammaMaxLength            = 100 * dd4hep::mm,
-       .gammaMaxWidth             = 27 * dd4hep::mm},
+      "ReconstructedFarForwardZDCNeutrals",
+      {"HcalFarForwardZDCClusters", 
+        "B0ECalClusters", 
+        "EcalEndcapPClusters", 
+        "LFHCALClusters"},
+      {"ReconstructedHcalFarForwardZDCNeutrals", 
+        "ReconstructedB0EcalNeutrals", 
+        "ReconstructedEcalEndcapPNeutrals",
+        "ReconstructedLFHCALNeutrals"},
+      {.offsetPositionName               = "HcalFarForwardZDC_SiPMonTile_r_pos",
+       .neutronScaleCorrCoeffHcal        = {2.4, 0.89},
+       .gammaScaleCorrCoeffHcal          = {1.1, 0.98},
+       .neutronScaleCorrCoeffLFHCAL      = {2.55, 0.95},
+       .gammaScaleCorrCoeffLFHCAL        = {0., 0.},
+       .neutronScaleCorrCoeffB0Ecal      = {0., 0.},
+       .gammaScaleCorrCoeffB0Ecal        = {0.99, 1.14},
+       .neutronScaleCorrCoeffEcalEndcapP = {0., 0.},
+       .gammaScaleCorrCoeffEcalEndcapP   = {1.05, 1.01},
+       .globalToProtonRotation           = -0.025,
+       .gammaZMaxOffset                  = 400 * dd4hep::mm,
+       .gammaMaxLength                   = 100 * dd4hep::mm,
+       .gammaMaxWidth                    = 12 * dd4hep::mm},
       app // TODO: Remove me once fixed
       ));
 
   app->Add(new JOmniFactoryGeneratorT<FarForwardLambdaReconstruction_factory>(
-      "ReconstructedFarForwardZDCLambdas",
-      {"ReconstructedFarForwardZDCNeutrals"}, // edm4eic::ReconstrutedParticleCollection,
-      {"ReconstructedFarForwardZDCLambdas", "ReconstructedFarForwardZDCLambdaDecayProductsC"
-                                            "M"}, // edm4eic::ReconstrutedParticleCollection,
+      "ReconstructedFarForwardLambdas",
+      {"ReconstructedHcalFarForwardZDCNeutrals", 
+        "ReconstructedB0EcalNeutrals", 
+        "ReconstructedEcalEndcapPNeutrals", 
+        "ReconstructedLFHCALNeutrals"},
+      {"ReconstructedFarForwardLambdas", 
+        "ReconstructedFarForwardLambdaDecayProductsCM"},
       {.offsetPositionName     = "HcalFarForwardZDC_SiPMonTile_r_pos",
        .globalToProtonRotation = -0.025,
-       .lambdaMaxMassDev       = 0.030 * dd4hep::GeV,
+       .lambdaMassWindow       = 0.30,
+       .pi0Window              = 0.30,
        .iterations             = 10},
       app // TODO: Remove me once fixed
       ));

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -566,9 +566,12 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       "HcalFarForwardZDCTruthClusterLinks",
 #endif
       "HcalFarForwardZDCTruthClusterAssociations",
-      "ReconstructedFarForwardZDCNeutrals",
-      "ReconstructedFarForwardZDCLambdas",
-      "ReconstructedFarForwardZDCLambdaDecayProductsCM",
+      "ReconstructedHcalFarForwardZDCNeutrals",
+      "ReconstructedB0EcalNeutrals",
+      "ReconstructedEcalEndcapPNeutrals",
+      "ReconstructedLFHCALNeutrals",
+      "ReconstructedFarForwardLambdas",
+      "ReconstructedFarForwardLambdaDecayProductsCM",
 
       // DIRC
       "DIRCRawHits",

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -570,8 +570,8 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       "ReconstructedB0EcalNeutrals",
       "ReconstructedEcalEndcapPNeutrals",
       "ReconstructedLFHCALNeutrals",
-      "ReconstructedFarForwardLambdas",
-      "ReconstructedFarForwardLambdaDecayProductsCM",
+      "ReconstructedLambdas",
+      "ReconstructedLambdaDecayProductsCM",
 
       // DIRC
       "DIRCRawHits",

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -558,9 +558,12 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       "HcalFarForwardZDCTruthClusterLinks",
 #endif
       "HcalFarForwardZDCTruthClusterAssociations",
-      "ReconstructedFarForwardZDCNeutrals",
-      "ReconstructedFarForwardZDCLambdas",
-      "ReconstructedFarForwardZDCLambdaDecayProductsCM",
+      "ReconstructedHcalFarForwardZDCNeutrals",
+      "ReconstructedB0EcalNeutrals",
+      "ReconstructedEcalEndcapPNeutrals",
+      "ReconstructedLFHCALNeutrals",
+      "ReconstructedFarForwardLambdas",
+      "ReconstructedFarForwardLambdaDecayProductsCM",
 
       // DIRC
       "DIRCRawHits",


### PR DESCRIPTION
## Summary

This PR extends the far-forward Λ reconstruction from the previous ZDC-only approach to a multi-calorimeter setup. 
This PR is a resubmission of PR #2609  from a branch in the shared repository so the workflows can run properly.

### Main changes
- Use additional calorimeters (B0 ECal, EndcapP ECal, LFHCAL) alongside the ZDC
- Add corresponding neutrals reconstruction
- Integrate everything into the reconstruction chain
- Cleanup following review comments of the closed PR #2609 have been addressed. 

### Motivation

The goal is to improve acceptance and make the far-forward Λ reconstruction usable in a more realistic multi-detector setup.

### Notes

- Rebased on the latest main