### PR TITLE
docs: add design document for rcdaq JANA2 event source

### DIFF
--- a/docs/design/rcdaq-event-source.md
+++ b/docs/design/rcdaq-event-source.md
@@ -334,7 +334,7 @@ graph LR
 Because both paths produce a `podio::Frame` inserted into the `JEvent`, all
 downstream JANA factories are identical.  The reconstruction job selects the
 appropriate event source automatically via `CheckOpenable()` based on the input
-file extension.
+file extension (see [Runtime Source Selection](#runtime-source-selection) below).
 
 ---
 
@@ -367,6 +367,52 @@ The rcdaq plugin is added in `src/services/io/CMakeLists.txt`:
 add_subdirectory(podio)
 add_subdirectory(rcdaq)   # gracefully skipped if rcdaq not found
 ```
+
+---
+
+## Runtime Source Selection
+
+JANA2 provides two mechanisms for deciding which event source reads a given
+input file.  No application-level code is needed beyond what is already
+implemented.
+
+### Automatic: `CheckOpenable` scoring
+
+Every registered `JEventSourceGeneratorT<T>` implements `CheckOpenable(filename)`
+and returns a confidence score in [0, 1].  JANA picks the highest-scoring
+generator for each input file.
+
+| Source | Score | Condition |
+|--------|-------|-----------|
+| `JEventSourceRCDAQ`  | **0.9** | filename ends in `.prdf`, `.evt`, or `.rcdaq` |
+| `JEventSourcePODIO`  | **0.03** | filename ends in `.root` **and** file contains a `podio_metadata` TTree |
+| either | 0.0 | any other file |
+
+Because the two source types use completely disjoint file extensions, there is
+no scoring ambiguity.  The correct source is chosen automatically.
+
+The `rcdaq` plugin must be loaded explicitly (it is not built into EICrecon
+by default because it requires rcdaq headers at build time):
+
+```sh
+eicrecon --plugins=rcdaq mydata.prdf
+```
+
+### Explicit override: `event_source_type`
+
+JANA exposes a built-in parameter that bypasses `CheckOpenable` entirely and
+forces a specific source by class name:
+
+```sh
+# Force rcdaq source regardless of extension:
+eicrecon --plugins=rcdaq --Pevent_source_type=JEventSourceRCDAQ mydata.prdf
+
+# Force PODIO source:
+eicrecon --Pevent_source_type=JEventSourcePODIO myfile.root
+```
+
+The value must match the demangled C++ class name returned by
+`JEventSourceGeneratorT<T>::GetType()` (i.e. the class name without namespace).
 
 ---
 

--- a/docs/design/rcdaq-event-source.md
+++ b/docs/design/rcdaq-event-source.md
@@ -1,0 +1,396 @@
+# Design: JANA2 Event Source for rcdaq Binary Files
+
+## Motivation
+
+[rcdaq](https://github.com/phnxdaq/rcdaq) is the data acquisition system used
+for sPHENIX and EIC R&D efforts at Brookhaven National Laboratory.  Real
+detector data are written in rcdaq's binary ONCS/PRDF format.  EICrecon
+currently only reads simulation output stored in PODIO ROOT frames.  Adding an
+rcdaq event source would allow EICrecon's reconstruction algorithms to run
+directly on testbeam and commissioning data without an intermediate conversion
+step.
+
+---
+
+## rcdaq Binary Format Overview
+
+An rcdaq file is a sequence of fixed-size **buffers** (~8 MB each). Each buffer
+contains a sequence of **events**. Each event contains one or more
+**sub-events** from individual detector modules.
+
+```mermaid
+block-beta
+  columns 3
+  A["Buffer\n(~8 MB)"] B["Event\n(evt_length, evt_type,\nevt_sequence, run_number,\ndate, time)"] C["Sub-event\n(sub_length, sub_id,\nsub_type, sub_decoding,\nint32[] data)"]
+  A --> B
+  B --> C
+```
+
+### Buffer header (`BufferConstants.h`)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `Length` | `uint32_t` | Length in bytes |
+| `ID` | `int32_t` | Format marker: `0xffffc0c0` (ONCS) or `0xffffffc0` (PRDF) |
+| `Bufseq` | `int32_t` | Buffer sequence number |
+| `Runnr` | `int32_t` | Run number |
+
+Compression variants are indicated by alternative `ID` markers:
+`0xfffffafe` (GZ), `0xffffbbfe` (LZO1X), `0xffffbbc0` (ONCS + LZO1X).
+
+### Event header (`EvtStructures.h`)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `evt_length` | `int32_t` | Length in 32-bit words |
+| `evt_type` | `int32_t` | `DATAEVENT=1`, `BEGRUNEVENT=9`, `ENDRUNEVENT=12`, … |
+| `evt_sequence` | `int32_t` | Event sequence number |
+| `run_number` | `int32_t` | Run number |
+| `date` | `int32_t` | Encoded date |
+| `time` | `int32_t` | Encoded time |
+| `reserved[2]` | `int32_t[2]` | Unused |
+| `data[]` | `int32_t[]` | Variable-length payload (sub-events) |
+
+### Sub-event header (`SubevtStructures.h`, ONCS format)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `sub_length` | `int32_t` | Length in 32-bit words (incl. header) |
+| `sub_id` | `int16_t` | Hardware module identifier |
+| `sub_type` | `int16_t` | Sub-event type |
+| `sub_decoding` | `int16_t` | Decoding hint |
+| `sub_padding` | `int16_t` | Padding bytes at end |
+| `reserved[2]` | `int16_t[2]` | Unused |
+| `data` | `int32_t[]` | Raw payload |
+
+---
+
+## Architectural Options
+
+### Option A — Eager decoding (simple baseline)
+
+`Emit()` reads an event, immediately decodes every sub-event into EDM4hep
+collections, constructs a `podio::Frame`, and inserts all collections into the
+`JEvent` using the existing `InsertingVisitor` from `JEventSourcePODIO`.
+
+```mermaid
+sequenceDiagram
+    participant JANA as JANA scheduler
+    participant ES as JEventSourceRCDAQ
+    participant Reader as RCDAQFileReader
+    participant Decoder as RCDAQDecoder<br/>(per sub_id)
+    participant Frame as podio::Frame
+    participant JEvent as JEvent
+
+    JANA->>ES: Emit(event)
+    ES->>Reader: nextEvent()
+    Reader-->>ES: evtdata_ptr (raw buffer)
+    loop for each sub-event
+        ES->>Decoder: decode(data, nwords, frame)
+        Decoder-->>Frame: put(collection, name)
+    end
+    ES->>JEvent: InsertCollectionAlreadyInFrame(...)
+    ES->>JEvent: Insert(frame)
+    ES-->>JANA: Result::Success
+```
+
+**Pros:** Simple; reuses `InsertingVisitor` from `JEventSourcePODIO` unchanged.
+**Cons:** All sub-events decoded even if only one collection is requested
+downstream; wasted CPU when a data file contains many more detector channels
+than the reconstruction job cares about.
+
+---
+
+### Option B — Lazy decoding via `podio::FrameDataType` (recommended)
+
+Instead of decoding at emit time, `Emit()` wraps the raw event buffer in a
+`RCDAQFrameData` object that satisfies the `podio::FrameDataType` concept.
+`podio::Frame` stores this object and calls `getCollectionBuffers(name)` **only
+when a specific collection is first accessed**.
+
+This exploits the lazy-deserialization mechanism already built into
+`podio::Frame`'s `FrameModel<FrameDataT>`:
+
+```cpp
+// podio/Frame.h (simplified)
+template <FrameDataType FrameDataT>
+struct FrameModel {
+    mutable CollectionMapT m_collections; // decoded collections, filled on demand
+    std::unique_ptr<FrameDataT> m_data;   // raw data, untouched until get() is called
+
+    const CollectionBase* get(const std::string& name) const {
+        if (auto it = m_collections.find(name); it != m_collections.end())
+            return it->second.get();          // already decoded
+        // Not yet decoded: ask raw data to produce buffers
+        auto buffers = m_data->getCollectionBuffers(name);
+        // ... reconstruct collection from buffers, store in m_collections ...
+    }
+};
+```
+
+```mermaid
+sequenceDiagram
+    participant JANA as JANA scheduler
+    participant ES as JEventSourceRCDAQ
+    participant Reader as RCDAQFileReader
+    participant FD as RCDAQFrameData
+    participant Frame as podio::Frame
+    participant JEvent as JEvent
+    participant Factory as JFactory<T>
+    participant Decoder as RCDAQDecoder<br/>(per sub_id)
+
+    JANA->>ES: Emit(event)
+    ES->>Reader: nextEvent()
+    Reader-->>ES: raw event buffer (int32[])
+    ES->>FD: RCDAQFrameData{buffer, decoders}
+    ES->>Frame: Frame(unique_ptr<RCDAQFrameData>)
+    Note over FD,Frame: Raw buffer held, nothing decoded yet
+    ES->>JEvent: Insert(frame)
+    ES-->>JANA: Result::Success
+
+    Note over JANA,Factory: Later, in parallel reconstruction...
+    JANA->>Factory: Process(event)
+    Factory->>JEvent: GetCollection("CalorimeterHits")
+    JEvent->>Frame: get("CalorimeterHits")
+    Frame->>FD: getCollectionBuffers("CalorimeterHits")
+    FD->>Decoder: decode(sub_id, data, nwords)
+    Decoder-->>FD: CollectionReadBuffers
+    FD-->>Frame: CollectionReadBuffers
+    Frame-->>JEvent: RawCalorimeterHitCollection&
+    JEvent-->>Factory: collection
+```
+
+#### `RCDAQFrameData` interface
+
+```cpp
+class RCDAQFrameData {
+public:
+    // Construct from a raw event buffer and a map of registered decoders
+    RCDAQFrameData(std::vector<int32_t> raw_buffer,
+                   const DecoderMap& decoders);
+
+    // --- podio::FrameDataType concept requirements ---
+
+    // Returns an ID table mapping collection names → integer IDs
+    podio::CollectionIDTable getIDTable() const;
+
+    // Decode the sub-event for `name` and return podio buffer structures.
+    // Called lazily by podio::Frame when a collection is first requested.
+    std::optional<podio::CollectionReadBuffers>
+    getCollectionBuffers(const std::string& name);
+
+    // Returns the names of all collections that COULD be decoded from this event
+    // (i.e. sub-event IDs that have a registered decoder)
+    std::vector<std::string> getAvailableCollections() const;
+
+    // Returns event-level metadata (run number, event number, timestamp, …)
+    std::unique_ptr<podio::GenericParameters> getParameters();
+
+private:
+    std::vector<int32_t> m_buffer;     // raw event payload
+    const DecoderMap& m_decoders;      // sub_id → (collection_name, decoder)
+};
+```
+
+**Pros:**
+- Decoding is deferred until the collection is actually needed.
+- A job that only reads calorimeter hits pays no cost for tracker sub-events.
+- Fully compatible with PODIO's existing collection-ID-table and serialization
+  machinery (important if events are later re-serialized to ROOT).
+
+**Cons:**
+- Requires implementing the `podio::FrameDataType` concept, including
+  `CollectionReadBuffers` construction, which is more involved than inserting
+  into an already-constructed collection.
+- The current `InsertingVisitor` loop in `JEventSourcePODIO` calls
+  `frame->getAvailableCollections()` eagerly and decodes everything; Option B
+  requires **not** calling this loop in the new event source. The Frame is
+  inserted into the JEvent directly and downstream factories pull from it.
+
+---
+
+### Comparison
+
+| Criterion | Option A (eager) | Option B (lazy) |
+|-----------|-----------------|-----------------|
+| Implementation complexity | Low | Medium |
+| CPU cost for partial reads | High (all sub-events decoded) | Low (only requested collections) |
+| PODIO integration depth | Shallow | Deep (FrameDataType) |
+| Re-serialization to ROOT possible | Yes | Yes (PODIO handles it) |
+| Online streaming support | Easy to add | Easy to add |
+| Recommended for production | Only if all collections always used | ✅ |
+
+---
+
+## Proposed Component Structure
+
+```mermaid
+graph TD
+    A[rcdaq binary file] --> B[RCDAQFileReader]
+    B -->|raw int32 buffer| C[JEventSourceRCDAQ]
+    C -->|RCDAQFrameData| D[podio::Frame]
+    D -->|lazy getCollectionBuffers| E[RCDAQDecoder interface]
+    E --> F[RCDAQRawCaloDecoder]
+    E --> G[RCDAQRawTrackerDecoder]
+    E --> H["... (user-defined)"]
+    D --> I[JEvent]
+    I --> J[EICrecon factory pipeline]
+    J --> K[edm4hep::RawCalorimeterHitCollection]
+    J --> L[edm4hep::RawTimeSeriesCollection]
+    J --> M[...]
+```
+
+### `RCDAQFileReader`
+
+Standalone C++ class (no JANA2 or PODIO dependency):
+
+```
+RCDAQFileReader
+├── open(const std::string& path) → void
+├── nextEvent() → std::optional<std::vector<int32_t>>
+│     reads buffer-by-buffer from disk; returns raw event int32[] or nullopt at EOF
+├── runNumber() → int
+├── eventSequence() → int
+├── eventType() → int        (DATAEVENT, BEGRUNEVENT, ENDRUNEVENT, …)
+└── close() → void
+```
+
+Handles:
+- ONCS format (`0xffffc0c0`) and PRDF format (`0xffffffc0`)
+- Uncompressed buffers initially; LZO decompression as optional extension
+- `BEGRUNEVENT` / `ENDRUNEVENT` events for run-boundary handling
+
+### `RCDAQDecoder` (pure virtual interface)
+
+```cpp
+class RCDAQDecoder {
+public:
+    virtual ~RCDAQDecoder() = default;
+    virtual int             subeventID()   const = 0;
+    virtual std::string     collectionName() const = 0;
+    virtual std::string     collectionType() const = 0;  // for ID table / type names
+
+    // Decode raw sub-event data into podio CollectionReadBuffers.
+    // Called lazily by RCDAQFrameData::getCollectionBuffers().
+    virtual podio::CollectionReadBuffers
+        decode(const int32_t* data, int nwords) = 0;
+};
+```
+
+Users register decoder instances with `JEventSourceRCDAQ` via JANA parameters
+or a dedicated service.
+
+### `JEventSourceRCDAQ`
+
+```
+JEventSourceRCDAQ : public JEventSource
+├── Open()
+│     instantiate RCDAQFileReader, open resource name
+│     build decoder map from registered decoders
+├── Emit(JEvent&)
+│     call reader.nextEvent()  → FailureFinished at EOF
+│     skip non-DATA events (BEGIN/END run → update run number)
+│     set event.SetRunNumber(), event.SetEventNumber()
+│     construct podio::Frame(make_unique<RCDAQFrameData>(buffer, decoders))
+│     event.Insert(frame)   ← Frame held by JEvent; no eager decoding
+│     return Result::Success
+├── Close()
+│     reader.close()
+└── CheckOpenable()   ← template specialization for .rcdaq / .prdf / .evt
+```
+
+### File layout
+
+```
+src/services/io/rcdaq/
+├── CMakeLists.txt
+├── rcdaq.cc                      # InitPlugin()
+├── JEventSourceRCDAQ.h / .cc
+├── RCDAQFileReader.h / .cc
+├── RCDAQDecoder.h                # pure virtual interface
+├── RCDAQFrameData.h / .cc        # podio::FrameDataType implementation
+└── decoders/
+    ├── RCDAQRawCaloDecoder.h / .cc   # example: sub_id → RawCalorimeterHit
+    └── RCDAQRawTimeSeriesDecoder.h / .cc
+```
+
+---
+
+## Interaction with Existing EICrecon Infrastructure
+
+```mermaid
+graph LR
+    subgraph "Existing (simulation path)"
+        P1[JEventSourcePODIO] -->|podio::Frame<br/>from ROOT file| J1[JEvent]
+        J1 --> F1[EICrecon factories]
+    end
+    subgraph "New (testbeam/commissioning path)"
+        P2[JEventSourceRCDAQ] -->|podio::Frame<br/>from rcdaq file| J2[JEvent]
+        J2 --> F2[EICrecon factories]
+    end
+    F1 -.same factories.- F2
+```
+
+Because both paths produce a `podio::Frame` inserted into the `JEvent`, all
+downstream JANA factories are identical.  The reconstruction job selects the
+appropriate event source automatically via `CheckOpenable()` based on the input
+file extension.
+
+---
+
+## CMake Integration
+
+```cmake
+# src/services/io/rcdaq/CMakeLists.txt
+get_filename_component(PLUGIN_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
+
+# rcdaq headers are optional
+find_package(rcdaq QUIET)
+if(NOT rcdaq_FOUND)
+    message(STATUS "rcdaq headers not found — rcdaq event source will not be built")
+    return()
+endif()
+
+plugin_add(${PLUGIN_NAME})
+plugin_glob_all(${PLUGIN_NAME})
+plugin_include_directories(${PLUGIN_NAME} PRIVATE ${rcdaq_INCLUDE_DIRS})
+plugin_link_libraries(
+    ${PLUGIN_NAME}
+    EDM4HEP::edm4hep
+    podio::podioIO
+    log_library)
+```
+
+The rcdaq plugin is added in `src/services/io/CMakeLists.txt`:
+
+```cmake
+add_subdirectory(podio)
+add_subdirectory(rcdaq)   # gracefully skipped if rcdaq not found
+```
+
+---
+
+## Open Questions
+
+1. **Decoder discovery**: How should users register decoders?
+   - (a) Hardcoded list in `InitPlugin()` — simple but inflexible.
+   - (b) JANA parameter string listing decoder class names — requires a factory.
+   - (c) Dynamic `.so` plugin loaded at runtime — maximum flexibility, matches
+     the rcdaq plugin architecture itself.
+
+2. **Sub-event ID assignments**: Which `sub_id` values correspond to which EIC
+   R&D detector modules? This determines what example decoders to ship.
+
+3. **Live TCP streaming**: rcdaq can stream data over TCP to port 5001 (`sfs`
+   server). Should `JEventSourceRCDAQ` optionally accept a `tcp://host:port`
+   resource name for online reconstruction?
+
+4. **LZO decompression**: Defer to a follow-up PR, or implement from the start?
+   `liblzo2` is already a dependency of rcdaq itself.
+
+5. **`BEGRUNEVENT` handling**: Should the event source emit a synthetic
+   "begin-run" `JEvent` (useful for loading calibrations), or silently skip it?
+
+6. **Interaction with `JEventSourcePODIO`**: If a job reads both a `.rcdaq`
+   file and a `.root` PODIO file (e.g., for overlay or reference), are there
+   ordering or ID-table conflicts that need to be managed?

--- a/docs/design/rcdaq-event-source.md
+++ b/docs/design/rcdaq-event-source.md
@@ -416,6 +416,101 @@ The value must match the demangled C++ class name returned by
 
 ---
 
+## Data Addressing and Decoder Mapping
+
+### Three-field sub-event address
+
+Every sub-event in an rcdaq file carries three fields in its header that
+together define _what_ the payload is and _how_ to parse it:
+
+| Field | Type (ONCS) | Role |
+|-------|-------------|------|
+| `sub_id` | `int16_t` | **Primary routing key.** User-assigned per readout board at DAQ setup time — e.g. `device_gauss 1 42` sets `sub_id = 42` for that device instance. |
+| `sub_type` | `int16_t` | Event-type gate. A device only writes data when the trigger type matches (e.g. `DATA1EVENT = 1`). Typically 1 for physics data. |
+| `sub_decoding` | `int16_t` | **Payload encoding scheme.** Tells the decoder how to parse the `int32_t data[]` array. See constants below. |
+
+### `sub_decoding` encoding constants (from `SubevtConstants.h`)
+
+| Constant | Value | Payload structure |
+|----------|------:|-------------------|
+| `IDCRAW`      |  0 | Raw int32 words — no internal structure |
+| `IDDGEN`      |  1 | New-format; encoding embedded in header |
+| `ID4EVT`      |  6 | 4-word groups: `[addr, adc, addr, adc, …]` (standard VME ADC) |
+| `ID2EVT`      |  5 | 2-word groups per channel |
+| `ID2SUP`      |  7 | 2-word groups, zero-suppressed |
+| `IDRTCLK`     |  9 | Real-time clock payload |
+| `IDSAM`       | 40 | SAM streaming ADC module |
+| `IDDCFEM`     | 51 | DCFEM (sPHENIX/EIC calorimeter FEM) packet format |
+| `IDTECFEM`    | 52 | TEC (tracking) FEM packet format |
+| `IDSIS3300`   | 55 | SIS3300 flash ADC |
+| `IDCAENV792`  | 56 | CAEN V792 QDC |
+| `IDCAENV785N` | 57 | CAEN V785N ADC |
+
+### Mapping onto `RCDAQDecoder` / `RCDAQFrameData`
+
+```
+rcdaq sub-event
+  sub_id        ──►  decoder map key  ──►  RCDAQDecoder* instance
+  sub_type      ─┐
+  sub_decoding  ─┼─►  passed into decode() for validation / dispatch
+  data[]        ─┘
+                       │
+                       ▼
+              CollectionReadBuffers
+                       │
+                       ▼
+              podio::Frame (lazy)
+                       │
+                       ▼
+            EDM4hep collection (on demand)
+```
+
+**Design decisions:**
+
+1. **Decoder map key = `sub_id` only.**  A given readout board always writes the
+   same `sub_decoding` value — the encoding scheme is fixed at DAQ configuration
+   time.  Keying by `sub_id` alone is therefore sufficient and matches the
+   one-board-one-collection expectation of the podio Frame.
+
+2. **`sub_type` and `sub_decoding` forwarded to `decode()`.**  Even though the
+   map lookup uses only `sub_id`, the decoder receives all three header fields:
+   - **`sub_decoding`** — decoder authors should assert/warn if it differs from
+     the expected constant (e.g. `IDDCFEM = 51`).
+   - **`sub_type`** — enables skip/warn on unexpected event types, and future
+     support for multi-mode devices.
+
+3. **One `sub_id` → one podio collection.**  The collection name is chosen by
+   the decoder author (e.g. `"CaloFEM_42"`, `"TrackerFEM_7"`).
+
+4. **Multi-board detectors.**  If a logical detector spans N boards with
+   distinct `sub_id` values, register N decoders writing into separate
+   collection names, or provide a factory helper for contiguous ID ranges.
+
+### Concrete example: `ID4EVT` ADC data → `edm4hep::RawCalorimeterHit`
+
+```
+sub_id = 42, sub_type = 1, sub_decoding = 6 (ID4EVT)
+data[] = [ addr_0, adc_0, addr_1, adc_1, … ]
+```
+
+Decoder implementation sketch:
+```cpp
+std::optional<podio::CollectionReadBuffers>
+MyCaloDecoder::decode(int16_t /*sub_type*/, int16_t sub_decoding,
+                      const int32_t* data, int nwords) {
+  if (sub_decoding != IDDGEN && sub_decoding != ID4EVT) return std::nullopt;
+  auto buffers = podio::CollectionBufferFactory::instance()
+      .createBuffers("edm4hep::RawCalorimeterHitCollection", schemaVersion, false);
+  auto* vec = buffers.dataAsVector<edm4hep::RawCalorimeterHitData>();
+  for (int i = 0; i + 1 < nwords; i += 2) {
+    vec->push_back({/* cellID */ data[i], /* amplitude */ data[i + 1], /* timeStamp */ 0});
+  }
+  return buffers;
+}
+```
+
+---
+
 ## Open Questions
 
 1. **Decoder discovery**: How should users register decoders?

--- a/src/global/tracking/tracking.cc
+++ b/src/global/tracking/tracking.cc
@@ -18,7 +18,6 @@
 #include <podio/detail/Link.h>
 #include <deque>
 #include <functional>
-#include <map>
 #include <memory>
 #include <string>
 #include <utility>

--- a/src/services/CMakeLists.txt
+++ b/src/services/CMakeLists.txt
@@ -1,5 +1,6 @@
 # io/podio exports podio_datamodel_glue target needed by plugin_add
 add_subdirectory(io/podio)
+add_subdirectory(io/rcdaq)
 add_subdirectory(algorithms_init)
 add_subdirectory(evaluator)
 add_subdirectory(geometry/dd4hep)

--- a/src/services/io/rcdaq/CMakeLists.txt
+++ b/src/services/io/rcdaq/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Optional rcdaq binary-format event source plugin. The plugin is only built
+# when the rcdaq format headers are found. Point cmake to the headers via:
+# -Drcdaq_INCLUDE_DIR=/path/to/rcdaq
+
+# ---- Locate rcdaq format headers ----------------------------------------
+find_path(
+  rcdaq_INCLUDE_DIR
+  NAMES EvtStructures.h
+  HINTS ${rcdaq_INCLUDE_DIR} $ENV{rcdaq_INCLUDE_DIR}
+        ${PROJECT_SOURCE_DIR}/../rcdaq /opt/rcdaq/include
+  DOC "Directory containing rcdaq format headers (EvtStructures.h etc.)")
+
+if(NOT rcdaq_INCLUDE_DIR)
+  message(STATUS "rcdaq headers not found — skipping io/rcdaq plugin")
+  return()
+endif()
+
+message(STATUS "Building io/rcdaq plugin (rcdaq headers: ${rcdaq_INCLUDE_DIR})")
+
+# ---- Plugin target -------------------------------------------------------
+get_filename_component(PLUGIN_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
+
+plugin_add(${PLUGIN_NAME})
+plugin_glob_all(${PLUGIN_NAME})
+
+# Expose rcdaq format headers to this target only
+plugin_include_directories(${PLUGIN_NAME} PRIVATE ${rcdaq_INCLUDE_DIR})
+
+plugin_link_libraries(${PLUGIN_NAME} fmt::fmt podio::podioIO log_library)

--- a/src/services/io/rcdaq/CMakeLists.txt
+++ b/src/services/io/rcdaq/CMakeLists.txt
@@ -20,7 +20,7 @@ message(STATUS "Building io/rcdaq plugin (rcdaq headers: ${rcdaq_INCLUDE_DIR})")
 # ---- Plugin target -------------------------------------------------------
 get_filename_component(PLUGIN_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
 
-plugin_add(${PLUGIN_NAME})
+plugin_add(${PLUGIN_NAME} WITH_STATIC_LIBRARY)
 plugin_glob_all(${PLUGIN_NAME})
 
 # Expose rcdaq format headers to this target only

--- a/src/services/io/rcdaq/JEventSourceRCDAQ.cc
+++ b/src/services/io/rcdaq/JEventSourceRCDAQ.cc
@@ -6,9 +6,10 @@
 #include <JANA/JApplication.h>
 #include <JANA/JEvent.h>
 #include <JANA/JException.h>
+#include <podio/Frame.h>
 #include <fmt/format.h>
 
-#include "RCDAQSubevent.h"
+#include "RCDAQFrameData.h"
 #include "services/log/Log_service.h"
 
 // ---------------------------------------------------------------------------
@@ -23,9 +24,32 @@ JEventSourceRCDAQ::JEventSourceRCDAQ(std::string resource_name, JApplication* ap
 }
 
 // ---------------------------------------------------------------------------
+// addDecoder
+// ---------------------------------------------------------------------------
+void JEventSourceRCDAQ::addDecoder(std::unique_ptr<RCDAQDecoder> decoder) {
+  const int16_t id = decoder->subeventID();
+  m_decoders[id]   = std::move(decoder);
+}
+
+// ---------------------------------------------------------------------------
 // Open
 // ---------------------------------------------------------------------------
 void JEventSourceRCDAQ::Open() {
+  // Build the non-owning decoder map that will be shared across all frames.
+  m_decoder_map.clear();
+  for (auto& [id, dec] : m_decoders) {
+    m_decoder_map[id] = dec.get();
+  }
+
+  if (!m_decoders.empty()) {
+    m_log->info("Registered {} rcdaq decoder(s):", m_decoders.size());
+    for (const auto& [id, dec] : m_decoders) {
+      m_log->info("  sub_id {:5d} → {} ({})", id, dec->collectionName(), dec->collectionType());
+    }
+  } else {
+    m_log->warn("No rcdaq decoders registered; Frame will contain no collections.");
+  }
+
   try {
     m_reader.open(GetResourceName());
     m_log->info("Opened rcdaq file \"{}\"", GetResourceName());
@@ -61,13 +85,12 @@ JEventSourceRCDAQ::Result JEventSourceRCDAQ::Emit(JEvent& event) {
   event.SetRunNumber(rcdaq_event.run_number);
   event.SetEventNumber(rcdaq_event.evt_sequence);
 
-  // Insert one RCDAQSubevent per sub-event, tagged by sub-event ID.
-  // Downstream factories select sub-events by ID (e.g. event.GetSingle<RCDAQSubevent>("1234")).
-  for (const auto& se : rcdaq_event.subevents) {
-    auto* item     = new RCDAQSubevent(se);
-    const auto tag = std::to_string(static_cast<int>(se.sub_id));
-    event.Insert(item, tag);
-  }
+  // Wrap the raw event in a FrameData object that satisfies podio::FrameDataType.
+  // The Frame will call RCDAQFrameData::getCollectionBuffers() lazily when a
+  // collection is first accessed, invoking the appropriate RCDAQDecoder.
+  auto frame_data = std::make_unique<RCDAQFrameData>(std::move(rcdaq_event), m_decoder_map);
+  auto frame      = std::make_unique<podio::Frame>(std::move(frame_data));
+  event.Insert(frame.release());
 
   return Result::Success;
 }

--- a/src/services/io/rcdaq/JEventSourceRCDAQ.cc
+++ b/src/services/io/rcdaq/JEventSourceRCDAQ.cc
@@ -1,0 +1,96 @@
+// Copyright 2024, EIC
+// Subject to the terms in the LICENSE file found in the top-level directory.
+
+#include "JEventSourceRCDAQ.h"
+
+#include <JANA/JApplication.h>
+#include <JANA/JEvent.h>
+#include <JANA/JException.h>
+#include <fmt/format.h>
+
+#include "RCDAQSubevent.h"
+#include "services/log/Log_service.h"
+
+// ---------------------------------------------------------------------------
+// Constructor
+// ---------------------------------------------------------------------------
+JEventSourceRCDAQ::JEventSourceRCDAQ(std::string resource_name, JApplication* app)
+    : JEventSource(std::move(resource_name), app) {
+  SetTypeName(NAME_OF_THIS);
+  SetCallbackStyle(CallbackStyle::ExpertMode);
+
+  m_log = GetApplication()->GetService<Log_service>()->logger("JEventSourceRCDAQ");
+}
+
+// ---------------------------------------------------------------------------
+// Open
+// ---------------------------------------------------------------------------
+void JEventSourceRCDAQ::Open() {
+  try {
+    m_reader.open(GetResourceName());
+    m_log->info("Opened rcdaq file \"{}\"", GetResourceName());
+  } catch (const std::exception& e) {
+    throw JException(
+        fmt::format("JEventSourceRCDAQ: failed to open \"{}\": {}", GetResourceName(), e.what()));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Close
+// ---------------------------------------------------------------------------
+void JEventSourceRCDAQ::Close() {
+  m_reader.close();
+  m_log->info("Closed rcdaq file \"{}\"", GetResourceName());
+}
+
+// ---------------------------------------------------------------------------
+// Emit
+// ---------------------------------------------------------------------------
+JEventSourceRCDAQ::Result JEventSourceRCDAQ::Emit(JEvent& event) {
+  RCDAQFileReader::Event rcdaq_event;
+
+  try {
+    if (!m_reader.nextEvent(rcdaq_event)) {
+      return Result::FailureFinished;
+    }
+  } catch (const std::exception& e) {
+    m_log->error("Error reading rcdaq event: {}", e.what());
+    return Result::FailureFinished;
+  }
+
+  event.SetRunNumber(rcdaq_event.run_number);
+  event.SetEventNumber(rcdaq_event.evt_sequence);
+
+  // Insert one RCDAQSubevent per sub-event, tagged by sub-event ID.
+  // Downstream factories select sub-events by ID (e.g. event.GetSingle<RCDAQSubevent>("1234")).
+  for (const auto& se : rcdaq_event.subevents) {
+    auto* item     = new RCDAQSubevent(se);
+    const auto tag = std::to_string(static_cast<int>(se.sub_id));
+    event.Insert(item, tag);
+  }
+
+  return Result::Success;
+}
+
+// ---------------------------------------------------------------------------
+// GetDescription
+// ---------------------------------------------------------------------------
+std::string JEventSourceRCDAQ::GetDescription() { return "rcdaq binary data file (ONCS format)"; }
+
+// ---------------------------------------------------------------------------
+// CheckOpenable
+//
+// Return a positive score for filenames that look like rcdaq data files.
+// Common extensions used by rcdaq: .prdf, .evt, .rcdaq
+// ---------------------------------------------------------------------------
+template <>
+double JEventSourceGeneratorT<JEventSourceRCDAQ>::CheckOpenable(std::string resource_name) {
+  for (const auto* ext : {".prdf", ".evt", ".rcdaq"}) {
+    if (resource_name.size() >= std::strlen(ext) &&
+        resource_name.compare(resource_name.size() - std::strlen(ext), std::strlen(ext), ext) ==
+            0) {
+      return 0.9;
+    }
+  }
+  return 0.0;
+}

--- a/src/services/io/rcdaq/JEventSourceRCDAQ.cc
+++ b/src/services/io/rcdaq/JEventSourceRCDAQ.cc
@@ -8,6 +8,7 @@
 #include <JANA/JException.h>
 #include <podio/Frame.h>
 #include <fmt/format.h>
+#include <algorithm>
 
 #include "RCDAQFrameData.h"
 #include "services/log/Log_service.h"
@@ -27,7 +28,7 @@ JEventSourceRCDAQ::JEventSourceRCDAQ(std::string resource_name, JApplication* ap
 // addDecoder
 // ---------------------------------------------------------------------------
 void JEventSourceRCDAQ::addDecoder(std::unique_ptr<RCDAQDecoder> decoder) {
-  const int16_t id = decoder->subeventID();
+  const int32_t id = decoder->packetID();
   m_decoders[id]   = std::move(decoder);
 }
 
@@ -35,6 +36,10 @@ void JEventSourceRCDAQ::addDecoder(std::unique_ptr<RCDAQDecoder> decoder) {
 // Open
 // ---------------------------------------------------------------------------
 void JEventSourceRCDAQ::Open() {
+  GetApplication()->SetDefaultParameter("rcdaq:dump", m_dump,
+                                        "Print raw sub-event packet headers and payload words "
+                                        "without decoding (useful for exploring new files)");
+
   // Build the non-owning decoder map that will be shared across all frames.
   m_decoder_map.clear();
   for (auto& [id, dec] : m_decoders) {
@@ -44,7 +49,7 @@ void JEventSourceRCDAQ::Open() {
   if (!m_decoders.empty()) {
     m_log->info("Registered {} rcdaq decoder(s):", m_decoders.size());
     for (const auto& [id, dec] : m_decoders) {
-      m_log->info("  sub_id {:5d} → {} ({})", id, dec->collectionName(), dec->collectionType());
+      m_log->info("  packet_id {:5d} → {} ({})", id, dec->collectionName(), dec->collectionType());
     }
   } else {
     m_log->warn("No rcdaq decoders registered; Frame will contain no collections.");
@@ -85,6 +90,29 @@ JEventSourceRCDAQ::Result JEventSourceRCDAQ::Emit(JEvent& event) {
   event.SetRunNumber(rcdaq_event.run_number);
   event.SetEventNumber(rcdaq_event.evt_sequence);
 
+  if (m_dump) {
+    m_log->info("[rcdaq] evt_seq={} run={} format={} npackets={}", rcdaq_event.evt_sequence,
+                rcdaq_event.run_number,
+                (m_reader.format() == RCDAQFileReader::Format::PRDF ? "PRDF" : "ONCS"),
+                rcdaq_event.subevents.size());
+    for (const auto& se : rcdaq_event.subevents) {
+      // Build hex dump of first 8 payload words
+      std::string hex;
+      const int nprint = static_cast<int>(std::min(se.data.size(), std::size_t{8}));
+      for (int i = 0; i < nprint; i++) {
+        hex += fmt::format(" {:08x}", static_cast<uint32_t>(se.data[i]));
+      }
+      if (static_cast<int>(se.data.size()) > nprint) {
+        hex += " ...";
+      }
+      m_log->info("  packet_id={:5d} (0x{:04x})  sub_id={:5d}  len={:6d}w"
+                  "  decoding={:3d}  type={:2d}  payload[0..{}]:{}",
+                  se.packet_id, static_cast<uint32_t>(se.packet_id), se.sub_id,
+                  static_cast<int>(se.data.size()), static_cast<int>(se.sub_decoding),
+                  static_cast<int>(se.sub_type), nprint - 1, hex);
+    }
+  }
+
   // Wrap the raw event in a FrameData object that satisfies podio::FrameDataType.
   // The Frame will call RCDAQFrameData::getCollectionBuffers() lazily when a
   // collection is first accessed, invoking the appropriate RCDAQDecoder.
@@ -98,7 +126,9 @@ JEventSourceRCDAQ::Result JEventSourceRCDAQ::Emit(JEvent& event) {
 // ---------------------------------------------------------------------------
 // GetDescription
 // ---------------------------------------------------------------------------
-std::string JEventSourceRCDAQ::GetDescription() { return "rcdaq binary data file (ONCS format)"; }
+std::string JEventSourceRCDAQ::GetDescription() {
+  return "rcdaq binary data file (ONCS/PRDF format)";
+}
 
 // ---------------------------------------------------------------------------
 // CheckOpenable

--- a/src/services/io/rcdaq/JEventSourceRCDAQ.h
+++ b/src/services/io/rcdaq/JEventSourceRCDAQ.h
@@ -1,0 +1,43 @@
+// Copyright 2024, EIC
+// Subject to the terms in the LICENSE file found in the top-level directory.
+
+#pragma once
+
+#include <JANA/JApplicationFwd.h>
+#include <JANA/JEventSource.h>
+#include <JANA/JEventSourceGeneratorT.h>
+#include <spdlog/logger.h>
+#include <memory>
+#include <string>
+
+#include "RCDAQFileReader.h"
+
+/// JANA2 event source for rcdaq binary data files.
+///
+/// Reads ONCS-format rcdaq files and, for every DATA event, inserts one
+/// RCDAQSubevent object per sub-event into the JEvent.  Downstream JANA
+/// factories are responsible for decoding the raw sub-event data into EDM4hep
+/// collections.
+///
+/// File format detection: CheckOpenable returns a positive score for files
+/// whose names end in ".prdf", ".evt", or ".rcdaq".
+class JEventSourceRCDAQ : public JEventSource {
+public:
+  JEventSourceRCDAQ(std::string resource_name, JApplication* app);
+
+  ~JEventSourceRCDAQ() override = default;
+
+  void Open() override;
+
+  void Close() override;
+
+  Result Emit(JEvent& event) override;
+
+  static std::string GetDescription();
+
+private:
+  RCDAQFileReader m_reader;
+  std::shared_ptr<spdlog::logger> m_log;
+};
+
+template <> double JEventSourceGeneratorT<JEventSourceRCDAQ>::CheckOpenable(std::string);

--- a/src/services/io/rcdaq/JEventSourceRCDAQ.h
+++ b/src/services/io/rcdaq/JEventSourceRCDAQ.h
@@ -59,8 +59,12 @@ private:
   RCDAQFileReader m_reader;
   std::shared_ptr<spdlog::logger> m_log;
 
-  /// Owned decoders, keyed by sub-event ID.
-  std::unordered_map<int16_t, std::unique_ptr<RCDAQDecoder>> m_decoders;
+  /// When true, each event's raw sub-event headers and first payload words are
+  /// printed to the log without decoding.  Set via -Prcdaq:dump=1 at runtime.
+  bool m_dump{false};
+
+  /// Owned decoders, keyed by packet ID.
+  std::unordered_map<int32_t, std::unique_ptr<RCDAQDecoder>> m_decoders;
 
   /// Non-owning view of m_decoders, rebuilt in Open() and passed by const-ref
   /// to each RCDAQFrameData instance.

--- a/src/services/io/rcdaq/JEventSourceRCDAQ.h
+++ b/src/services/io/rcdaq/JEventSourceRCDAQ.h
@@ -9,15 +9,31 @@
 #include <spdlog/logger.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
+#include "RCDAQDecoder.h"
 #include "RCDAQFileReader.h"
+#include "RCDAQFrameData.h"
 
 /// JANA2 event source for rcdaq binary data files.
 ///
-/// Reads ONCS-format rcdaq files and, for every DATA event, inserts one
-/// RCDAQSubevent object per sub-event into the JEvent.  Downstream JANA
-/// factories are responsible for decoding the raw sub-event data into EDM4hep
-/// collections.
+/// Reads ONCS-format rcdaq files and, for every DATA event, constructs a
+/// podio::Frame backed by an RCDAQFrameData object and inserts it into the
+/// JEvent.  Collections are decoded lazily: a registered RCDAQDecoder is
+/// called only when the Frame is asked for the corresponding collection.
+///
+/// Register decoders before the source is opened (e.g. in InitPlugin):
+/// @code
+///   auto src = std::make_shared<JEventSourceRCDAQ>("myfile.prdf", app);
+///   src->addDecoder(std::make_unique<MyCaloDecoder>());
+///   app->Add(src);
+/// @endcode
+///
+/// Downstream code accesses collections through the Frame:
+/// @code
+///   auto* frame = event.GetSingle<podio::Frame>();
+///   auto& hits  = frame->get<edm4hep::RawCalorimeterHitCollection>("CaloHits");
+/// @endcode
 ///
 /// File format detection: CheckOpenable returns a positive score for files
 /// whose names end in ".prdf", ".evt", or ".rcdaq".
@@ -35,9 +51,20 @@ public:
 
   static std::string GetDescription();
 
+  /// Register a decoder.  Ownership is transferred to this event source.
+  /// Must be called before Open().
+  void addDecoder(std::unique_ptr<RCDAQDecoder> decoder);
+
 private:
   RCDAQFileReader m_reader;
   std::shared_ptr<spdlog::logger> m_log;
+
+  /// Owned decoders, keyed by sub-event ID.
+  std::unordered_map<int16_t, std::unique_ptr<RCDAQDecoder>> m_decoders;
+
+  /// Non-owning view of m_decoders, rebuilt in Open() and passed by const-ref
+  /// to each RCDAQFrameData instance.
+  RCDAQFrameData::DecoderMap m_decoder_map;
 };
 
 template <> double JEventSourceGeneratorT<JEventSourceRCDAQ>::CheckOpenable(std::string);

--- a/src/services/io/rcdaq/RCDAQDecoder.h
+++ b/src/services/io/rcdaq/RCDAQDecoder.h
@@ -40,12 +40,18 @@ public:
 
   /// Decode \p nwords int32_t words starting at \p data into CollectionReadBuffers.
   ///
+  /// \p sub_type    mirrors the trigger event type (DATA1EVENT=1, etc.).
+  /// \p sub_decoding identifies the payload encoding scheme (see
+  ///                SubevtConstants.h: IDCRAW=0, ID4EVT=6, IDDCFEM=51, …).
+  ///
   /// The implementation should:
-  ///   1. Obtain properly-initialised buffers from CollectionBufferFactory.
-  ///   2. Fill them with decoded data.
-  ///   3. Return the buffers (or an empty optional on failure).
+  ///   1. Validate \p sub_decoding against the expected format.
+  ///   2. Obtain properly-initialised buffers from CollectionBufferFactory.
+  ///   3. Fill them with decoded data.
+  ///   4. Return the buffers (or an empty optional on failure / unknown encoding).
   ///
   /// Called lazily by RCDAQFrameData::getCollectionBuffers() when the podio
   /// Frame is asked for this collection for the first time.
-  virtual std::optional<podio::CollectionReadBuffers> decode(const int32_t* data, int nwords) = 0;
+  virtual std::optional<podio::CollectionReadBuffers> decode(int16_t sub_type, int16_t sub_decoding,
+                                                             const int32_t* data, int nwords) = 0;
 };

--- a/src/services/io/rcdaq/RCDAQDecoder.h
+++ b/src/services/io/rcdaq/RCDAQDecoder.h
@@ -27,8 +27,10 @@ class RCDAQDecoder {
 public:
   virtual ~RCDAQDecoder() = default;
 
-  /// The sub-event ID this decoder handles (matches RCDAQSubevent::sub_id).
-  virtual int16_t subeventID() const = 0;
+  /// The packet ID this decoder handles (matches RCDAQSubevent::packet_id).
+  /// For PRDF files this is hdrinfo & 0xFFFF (e.g. 12001 for detector packets).
+  /// For ONCS files this equals the sub_id.
+  virtual int32_t packetID() const = 0;
 
   /// The name of the collection that will appear in the podio Frame.
   virtual std::string collectionName() const = 0;

--- a/src/services/io/rcdaq/RCDAQDecoder.h
+++ b/src/services/io/rcdaq/RCDAQDecoder.h
@@ -1,0 +1,51 @@
+// Copyright 2024, EIC
+// Subject to the terms in the LICENSE file found in the top-level directory.
+
+#pragma once
+
+#include <podio/CollectionBuffers.h>
+#include <cstdint>
+#include <string>
+
+/// Abstract interface for decoding a single rcdaq sub-event into a podio
+/// CollectionReadBuffers object.
+///
+/// Implement this interface for each sub-event ID that should be exposed as an
+/// EDM4hep (or other podio) collection. The implementer is responsible for:
+///   1. Calling podio::CollectionBufferFactory::instance().createBuffers() to
+///      allocate properly-typed buffers.
+///   2. Filling the data vector (via buffers.dataAsVector<DataT>()) from the
+///      raw rcdaq words.
+///   3. Returning the filled buffers.
+///
+/// Example usage:
+/// @code
+///   auto src = std::make_shared<JEventSourceRCDAQ>("myfile.prdf", app);
+///   src->addDecoder(std::make_unique<MyCaloDecoder>());
+/// @endcode
+class RCDAQDecoder {
+public:
+  virtual ~RCDAQDecoder() = default;
+
+  /// The sub-event ID this decoder handles (matches RCDAQSubevent::sub_id).
+  virtual int16_t subeventID() const = 0;
+
+  /// The name of the collection that will appear in the podio Frame.
+  virtual std::string collectionName() const = 0;
+
+  /// The fully-qualified collection type name, e.g.
+  ///   "edm4hep::RawCalorimeterHitCollection"
+  /// This must match the string registered in podio::CollectionBufferFactory.
+  virtual std::string collectionType() const = 0;
+
+  /// Decode \p nwords int32_t words starting at \p data into CollectionReadBuffers.
+  ///
+  /// The implementation should:
+  ///   1. Obtain properly-initialised buffers from CollectionBufferFactory.
+  ///   2. Fill them with decoded data.
+  ///   3. Return the buffers (or an empty optional on failure).
+  ///
+  /// Called lazily by RCDAQFrameData::getCollectionBuffers() when the podio
+  /// Frame is asked for this collection for the first time.
+  virtual std::optional<podio::CollectionReadBuffers> decode(const int32_t* data, int nwords) = 0;
+};

--- a/src/services/io/rcdaq/RCDAQFileReader.cc
+++ b/src/services/io/rcdaq/RCDAQFileReader.cc
@@ -64,7 +64,11 @@ bool RCDAQFileReader::readNextBuffer() {
   }
 
   const auto marker = static_cast<uint32_t>(hdr[1]);
-  if (marker != ONCSBUFFERMARKER && marker != BUFFERMARKER) {
+  if (marker == ONCSBUFFERMARKER) {
+    m_format = Format::ONCS;
+  } else if (marker == BUFFERMARKER) {
+    m_format = Format::PRDF;
+  } else {
     if (marker == LZO1XBUFFERMARKER || marker == ONCSLZO1XBUFFERMARKER) {
       throw std::runtime_error("RCDAQFileReader: LZO-compressed buffers are not yet supported");
     }
@@ -167,27 +171,64 @@ bool RCDAQFileReader::nextEventInBuffer(Event& out) {
     int sub_offset      = evt_start + EVTHEADERLENGTH;
     const int evt_end   = evt_start + evt_words;
 
-    while (sub_offset + SEVTHEADERLENGTH <= evt_end) {
-      const int32_t* sp        = m_buf.data() + sub_offset;
-      const subevtdata_ptr sub = reinterpret_cast<const subevtdata_ptr>(const_cast<int32_t*>(sp));
+    if (m_format == Format::PRDF) {
+      // PRDF packet header: 6 int32 words
+      //  word 0: sub_length (total words including header)
+      //  word 1: hdrinfo   — packet_id = hdrinfo & 0xFFFF
+      //  word 2: sub_id    (int32 hardware module ID)
+      //  word 3: (debug_length<<16 | error_length)
+      //  word 4: structureinfo
+      //  word 5: sub_decoding (low 16 bits) | sub_type (high 16 bits)
+      while (sub_offset + PRDFHEADERLENGTH <= evt_end) {
+        const int32_t* sp        = m_buf.data() + sub_offset;
+        const packetdata_ptr pkt = reinterpret_cast<const packetdata_ptr>(const_cast<int32_t*>(sp));
 
-      const int sub_words = sub->sub_length; // in int32 units, includes header
-      if (sub_words < SEVTHEADERLENGTH || sub_offset + sub_words > evt_end) {
-        break; // corrupt sub-event
+        const int sub_words = pkt->sub_length;
+        if (sub_words < PRDFHEADERLENGTH || sub_offset + sub_words > evt_end) {
+          break;
+        }
+
+        RCDAQSubevent se;
+        se.packet_id    = static_cast<int32_t>(static_cast<uint32_t>(pkt->hdrinfo) & 0xFFFFU);
+        se.sub_id       = pkt->sub_id;
+        se.sub_type     = pkt->sub_type;
+        se.sub_decoding = pkt->sub_decoding;
+
+        const int payload_words = sub_words - PRDFHEADERLENGTH;
+        const int32_t* payload  = sp + PRDFHEADERLENGTH;
+        se.data.assign(payload, payload + payload_words);
+
+        out.subevents.push_back(std::move(se));
+        sub_offset += sub_words;
       }
+    } else {
+      // ONCS sub-event header: 4 int32 words
+      //  word 0: sub_length
+      //  word 1: sub_id (low 16 bits) | sub_type (high 16 bits)
+      //  word 2: sub_decoding (low 16 bits) | sub_padding (high 16 bits)
+      //  word 3: reserved
+      while (sub_offset + SEVTHEADERLENGTH <= evt_end) {
+        const int32_t* sp        = m_buf.data() + sub_offset;
+        const subevtdata_ptr sub = reinterpret_cast<const subevtdata_ptr>(const_cast<int32_t*>(sp));
 
-      RCDAQSubevent se;
-      se.sub_id       = sub->sub_id;
-      se.sub_type     = sub->sub_type;
-      se.sub_decoding = sub->sub_decoding;
+        const int sub_words = sub->sub_length;
+        if (sub_words < SEVTHEADERLENGTH || sub_offset + sub_words > evt_end) {
+          break;
+        }
 
-      // Payload starts at &sub->data; length = sub_words - SEVTHEADERLENGTH words
-      const int payload_words = sub_words - SEVTHEADERLENGTH;
-      const int32_t* payload  = sp + SEVTHEADERLENGTH;
-      se.data.assign(payload, payload + payload_words);
+        RCDAQSubevent se;
+        se.sub_id       = static_cast<int32_t>(sub->sub_id);
+        se.packet_id    = se.sub_id; // ONCS: packet_id == sub_id
+        se.sub_type     = sub->sub_type;
+        se.sub_decoding = sub->sub_decoding;
 
-      out.subevents.push_back(std::move(se));
-      sub_offset += sub_words;
+        const int payload_words = sub_words - SEVTHEADERLENGTH;
+        const int32_t* payload  = sp + SEVTHEADERLENGTH;
+        se.data.assign(payload, payload + payload_words);
+
+        out.subevents.push_back(std::move(se));
+        sub_offset += sub_words;
+      }
     }
 
     return true;

--- a/src/services/io/rcdaq/RCDAQFileReader.cc
+++ b/src/services/io/rcdaq/RCDAQFileReader.cc
@@ -1,0 +1,199 @@
+// Copyright 2024, EIC
+// Subject to the terms in the LICENSE file found in the top-level directory.
+
+#include "RCDAQFileReader.h"
+
+// rcdaq format constants (headers live in the source tree at compile time;
+// the include path is set by the CMakeLists.txt find_path call)
+#include <BufferConstants.h>
+#include <EvtConstants.h>
+#include <EvtStructures.h>
+#include <EventTypes.h>
+#include <SubevtConstants.h>
+#include <SubevtStructures.h>
+
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
+// ---------------------------------------------------------------------------
+// open
+// ---------------------------------------------------------------------------
+void RCDAQFileReader::open(const std::string& path) {
+  m_file.open(path, std::ios::binary);
+  if (!m_file.is_open()) {
+    throw std::runtime_error("RCDAQFileReader: cannot open '" + path + "'");
+  }
+  m_buf_offset = 0;
+  m_buf_words  = 0;
+  m_run_number = 0;
+}
+
+// ---------------------------------------------------------------------------
+// close
+// ---------------------------------------------------------------------------
+void RCDAQFileReader::close() { m_file.close(); }
+
+// ---------------------------------------------------------------------------
+// nextEvent — public entry point
+// ---------------------------------------------------------------------------
+bool RCDAQFileReader::nextEvent(Event& out) {
+  while (true) {
+    // Try to find a DATA event in the current buffer
+    if (m_buf_words > 0 && nextEventInBuffer(out)) {
+      return true;
+    }
+    // Current buffer exhausted — read the next one
+    if (!readNextBuffer()) {
+      return false; // end of file
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// readNextBuffer
+// ---------------------------------------------------------------------------
+bool RCDAQFileReader::readNextBuffer() {
+  // The buffer header is 4 int32 words (16 bytes).
+  // Layout: Length (bytes), ID (format marker), Bufseq, Runnr
+  constexpr int HDR_WORDS = BUFFERHEADERLENGTH; // 4
+
+  int32_t hdr[HDR_WORDS];
+  if (!m_file.read(reinterpret_cast<char*>(hdr), HDR_WORDS * 4)) {
+    return false; // clean EOF
+  }
+
+  const auto marker = static_cast<uint32_t>(hdr[1]);
+  if (marker != ONCSBUFFERMARKER && marker != BUFFERMARKER) {
+    if (marker == LZO1XBUFFERMARKER || marker == ONCSLZO1XBUFFERMARKER) {
+      throw std::runtime_error("RCDAQFileReader: LZO-compressed buffers are not yet supported");
+    }
+    if (marker == GZBUFFERMARKER) {
+      throw std::runtime_error("RCDAQFileReader: GZ-compressed buffers are not yet supported");
+    }
+    throw std::runtime_error("RCDAQFileReader: unrecognised buffer marker 0x" + [&]() {
+      char buf[16];
+      std::snprintf(buf, sizeof(buf), "%08x", marker);
+      return std::string(buf);
+    }());
+  }
+
+  const unsigned int length_bytes = static_cast<unsigned int>(hdr[0]);
+  if (length_bytes < static_cast<unsigned int>(HDR_WORDS * 4)) {
+    throw std::runtime_error("RCDAQFileReader: buffer length smaller than header");
+  }
+
+  // Total bytes written to disk are rounded up to BUFFERBLOCKSIZE (8192)
+  const int block_count = (static_cast<int>(length_bytes) + BUFFERBLOCKSIZE - 1) / BUFFERBLOCKSIZE;
+  const int disk_bytes  = block_count * BUFFERBLOCKSIZE;
+
+  // Resize buffer and copy the header we already read
+  const int total_words = disk_bytes / 4;
+  m_buf.resize(total_words);
+  std::memcpy(m_buf.data(), hdr, HDR_WORDS * 4);
+
+  // Read the remainder of the padded block
+  const int remaining_bytes = disk_bytes - HDR_WORDS * 4;
+  if (!m_file.read(reinterpret_cast<char*>(m_buf.data() + HDR_WORDS), remaining_bytes)) {
+    // Partial read at end of file — we can still try to use what we got
+    // by limiting m_buf_words to the valid length
+  }
+
+  // Valid data ends at length_bytes (rounded up to word boundary)
+  m_buf_words  = static_cast<int>((length_bytes + 3) / 4);
+  m_buf_offset = HDR_WORDS; // start right after the buffer header
+
+  // Track the run number from the buffer header (word 3 = Runnr)
+  if (hdr[3] > 0) {
+    m_run_number = hdr[3];
+  }
+
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// nextEventInBuffer
+// ---------------------------------------------------------------------------
+bool RCDAQFileReader::nextEventInBuffer(Event& out) {
+  // End-of-buffer marker is two int32 words: {2, 0}.  Stop when we hit it
+  // or when there is not enough room for a minimal event header.
+  while (m_buf_offset + EVTHEADERLENGTH <= m_buf_words) {
+    const int32_t* p = m_buf.data() + m_buf_offset;
+
+    // Cast the raw words to the rcdaq event header struct
+    const evtdata_ptr evt = reinterpret_cast<const evtdata_ptr>(const_cast<int32_t*>(p));
+
+    const int evt_words = evt->evt_length; // in int32 units, includes header
+
+    // EOB marker: length==2 and the second word is 0
+    if (evt_words == 2 && p[1] == 0) {
+      m_buf_offset = m_buf_words; // signal buffer exhausted
+      return false;
+    }
+
+    if (evt_words < EVTHEADERLENGTH || m_buf_offset + evt_words > m_buf_words) {
+      // Corrupt or truncated event — skip this buffer
+      m_buf_offset = m_buf_words;
+      return false;
+    }
+
+    const int evt_type = evt->evt_type;
+
+    // Advance past this event regardless of whether we emit it
+    m_buf_offset += evt_words;
+
+    if (evt_type == BEGRUNEVENT || evt_type == ENDRUNEVENT) {
+      // Update run number but do not emit these as data events
+      if (evt->run_number > 0) {
+        m_run_number = evt->run_number;
+      }
+      continue;
+    }
+
+    if (evt_type != DATAEVENT && evt_type != DATA2EVENT && evt_type != DATA3EVENT) {
+      // SCALE, RUNINFO, etc. — silently skip
+      continue;
+    }
+
+    // --- DATA event: parse sub-events ---
+    out.run_number   = (evt->run_number > 0) ? evt->run_number : m_run_number;
+    out.evt_type     = evt_type;
+    out.evt_sequence = evt->evt_sequence;
+    out.subevents.clear();
+
+    // Sub-events follow immediately after the event header
+    // We work on the slice [event_start + EVTHEADERLENGTH, event_start + evt_words)
+    const int evt_start = m_buf_offset - evt_words; // index of event header
+    int sub_offset      = evt_start + EVTHEADERLENGTH;
+    const int evt_end   = evt_start + evt_words;
+
+    while (sub_offset + SEVTHEADERLENGTH <= evt_end) {
+      const int32_t* sp        = m_buf.data() + sub_offset;
+      const subevtdata_ptr sub = reinterpret_cast<const subevtdata_ptr>(const_cast<int32_t*>(sp));
+
+      const int sub_words = sub->sub_length; // in int32 units, includes header
+      if (sub_words < SEVTHEADERLENGTH || sub_offset + sub_words > evt_end) {
+        break; // corrupt sub-event
+      }
+
+      RCDAQSubevent se;
+      se.sub_id       = sub->sub_id;
+      se.sub_type     = sub->sub_type;
+      se.sub_decoding = sub->sub_decoding;
+
+      // Payload starts at &sub->data; length = sub_words - SEVTHEADERLENGTH words
+      const int payload_words = sub_words - SEVTHEADERLENGTH;
+      const int32_t* payload  = sp + SEVTHEADERLENGTH;
+      se.data.assign(payload, payload + payload_words);
+
+      out.subevents.push_back(std::move(se));
+      sub_offset += sub_words;
+    }
+
+    return true;
+  }
+
+  // No more events in this buffer
+  m_buf_offset = m_buf_words;
+  return false;
+}

--- a/src/services/io/rcdaq/RCDAQFileReader.h
+++ b/src/services/io/rcdaq/RCDAQFileReader.h
@@ -1,0 +1,72 @@
+// Copyright 2024, EIC
+// Subject to the terms in the LICENSE file found in the top-level directory.
+
+#pragma once
+
+#include <cstdint>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "RCDAQSubevent.h"
+
+/// Sequential reader for rcdaq binary data files.
+///
+/// Supports uncompressed ONCS-format files (buffer marker 0xffffc0c0).
+/// LZO-compressed buffers are detected and a descriptive exception is thrown.
+/// Each call to nextEvent() fills one Event struct with the header metadata and
+/// all sub-events belonging to that event.  BEGIN/END run records update the
+/// stored run number but are not returned to the caller; only DATAEVENT records
+/// are emitted.
+class RCDAQFileReader {
+public:
+  struct Event {
+    int run_number{0};
+    int evt_type{0};
+    int evt_sequence{0};
+    std::vector<RCDAQSubevent> subevents;
+  };
+
+  RCDAQFileReader()  = default;
+  ~RCDAQFileReader() = default;
+
+  // Non-copyable, movable
+  RCDAQFileReader(const RCDAQFileReader&)            = delete;
+  RCDAQFileReader& operator=(const RCDAQFileReader&) = delete;
+  RCDAQFileReader(RCDAQFileReader&&)                 = default;
+  RCDAQFileReader& operator=(RCDAQFileReader&&)      = default;
+
+  /// Open a file by path.  Throws std::runtime_error on failure.
+  void open(const std::string& path);
+
+  /// Read the next DATA event into \p out.
+  /// @return true if an event was read, false at end of file.
+  bool nextEvent(Event& out);
+
+  /// Close the file.
+  void close();
+
+  bool isOpen() const { return m_file.is_open(); }
+
+private:
+  /// Read the next buffer from disk into m_buf. Returns false at EOF.
+  bool readNextBuffer();
+
+  /// Parse events sequentially from the current buffer starting at m_buf_offset.
+  /// Returns true and fills \p out when a DATA event is found.
+  bool nextEventInBuffer(Event& out);
+
+  std::ifstream m_file;
+
+  // Current buffer contents (in int32 units)
+  std::vector<int32_t> m_buf;
+
+  // Index (in int32 units) of the next event within m_buf (past the buffer header)
+  int m_buf_offset{0};
+
+  // Total valid words in m_buf (= bptr->Length / 4)
+  int m_buf_words{0};
+
+  int m_run_number{0};
+};

--- a/src/services/io/rcdaq/RCDAQFileReader.h
+++ b/src/services/io/rcdaq/RCDAQFileReader.h
@@ -13,7 +13,8 @@
 
 /// Sequential reader for rcdaq binary data files.
 ///
-/// Supports uncompressed ONCS-format files (buffer marker 0xffffc0c0).
+/// Supports uncompressed ONCS (buffer marker 0xffffc0c0) and PRDF
+/// (buffer marker 0xffffffc0) format files.
 /// LZO-compressed buffers are detected and a descriptive exception is thrown.
 /// Each call to nextEvent() fills one Event struct with the header metadata and
 /// all sub-events belonging to that event.  BEGIN/END run records update the
@@ -21,6 +22,9 @@
 /// are emitted.
 class RCDAQFileReader {
 public:
+  /// Underlying binary format of the currently-open file.
+  enum class Format { Unknown, ONCS, PRDF };
+
   struct Event {
     int run_number{0};
     int evt_type{0};
@@ -49,6 +53,9 @@ public:
 
   bool isOpen() const { return m_file.is_open(); }
 
+  /// Returns the detected binary format (set after the first buffer is read).
+  Format format() const { return m_format; }
+
 private:
   /// Read the next buffer from disk into m_buf. Returns false at EOF.
   bool readNextBuffer();
@@ -69,4 +76,6 @@ private:
   int m_buf_words{0};
 
   int m_run_number{0};
+
+  Format m_format{Format::Unknown};
 };

--- a/src/services/io/rcdaq/RCDAQFrameData.cc
+++ b/src/services/io/rcdaq/RCDAQFrameData.cc
@@ -50,7 +50,8 @@ RCDAQFrameData::getCollectionBuffers(const std::string& name) {
     return std::nullopt;
   }
 
-  return dec_it->second->decode(se->data.data(), static_cast<int>(se->data.size()));
+  return dec_it->second->decode(se->sub_type, se->sub_decoding, se->data.data(),
+                                static_cast<int>(se->data.size()));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/services/io/rcdaq/RCDAQFrameData.cc
+++ b/src/services/io/rcdaq/RCDAQFrameData.cc
@@ -1,0 +1,68 @@
+// Copyright 2024, EIC
+// Subject to the terms in the LICENSE file found in the top-level directory.
+
+#include "RCDAQFrameData.h"
+
+// ---------------------------------------------------------------------------
+// Constructor
+// ---------------------------------------------------------------------------
+RCDAQFrameData::RCDAQFrameData(RCDAQFileReader::Event event, const DecoderMap& decoders)
+    : m_event(std::move(event))
+    , m_decoders(decoders)
+    , m_params(std::make_unique<podio::GenericParameters>()) {
+
+  m_params->set("run_number", static_cast<int>(m_event.run_number));
+  m_params->set("event_sequence", static_cast<int>(m_event.evt_sequence));
+
+  // Build the ID table and the name→subevent index in one pass.
+  for (const auto& se : m_event.subevents) {
+    auto it = m_decoders.find(se.sub_id);
+    if (it == m_decoders.end()) {
+      continue;
+    }
+    const std::string& coll_name = it->second->collectionName();
+    m_idTable.add(coll_name);
+    m_nameToSubevent[coll_name] = &se;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// getIDTable
+// ---------------------------------------------------------------------------
+podio::CollectionIDTable RCDAQFrameData::getIDTable() const {
+  // Return a copy so Frame can take ownership.
+  return podio::CollectionIDTable(m_idTable.ids(), m_idTable.names());
+}
+
+// ---------------------------------------------------------------------------
+// getCollectionBuffers  (called lazily by podio::Frame on first access)
+// ---------------------------------------------------------------------------
+std::optional<podio::CollectionReadBuffers>
+RCDAQFrameData::getCollectionBuffers(const std::string& name) {
+  auto se_it = m_nameToSubevent.find(name);
+  if (se_it == m_nameToSubevent.end()) {
+    return std::nullopt;
+  }
+  const RCDAQSubevent* se = se_it->second;
+
+  auto dec_it = m_decoders.find(se->sub_id);
+  if (dec_it == m_decoders.end()) {
+    return std::nullopt;
+  }
+
+  return dec_it->second->decode(se->data.data(), static_cast<int>(se->data.size()));
+}
+
+// ---------------------------------------------------------------------------
+// getAvailableCollections
+// ---------------------------------------------------------------------------
+std::vector<std::string> RCDAQFrameData::getAvailableCollections() const {
+  return m_idTable.names();
+}
+
+// ---------------------------------------------------------------------------
+// getParameters  (consumed once by the Frame constructor)
+// ---------------------------------------------------------------------------
+std::unique_ptr<podio::GenericParameters> RCDAQFrameData::getParameters() {
+  return std::move(m_params);
+}

--- a/src/services/io/rcdaq/RCDAQFrameData.cc
+++ b/src/services/io/rcdaq/RCDAQFrameData.cc
@@ -16,7 +16,7 @@ RCDAQFrameData::RCDAQFrameData(RCDAQFileReader::Event event, const DecoderMap& d
 
   // Build the ID table and the name→subevent index in one pass.
   for (const auto& se : m_event.subevents) {
-    auto it = m_decoders.find(se.sub_id);
+    auto it = m_decoders.find(se.packet_id);
     if (it == m_decoders.end()) {
       continue;
     }
@@ -45,7 +45,7 @@ RCDAQFrameData::getCollectionBuffers(const std::string& name) {
   }
   const RCDAQSubevent* se = se_it->second;
 
-  auto dec_it = m_decoders.find(se->sub_id);
+  auto dec_it = m_decoders.find(se->packet_id);
   if (dec_it == m_decoders.end()) {
     return std::nullopt;
   }

--- a/src/services/io/rcdaq/RCDAQFrameData.h
+++ b/src/services/io/rcdaq/RCDAQFrameData.h
@@ -32,8 +32,8 @@
 /// @endcode
 class RCDAQFrameData {
 public:
-  /// Map from sub-event ID to (non-owning) decoder pointer.
-  using DecoderMap = std::unordered_map<int16_t, RCDAQDecoder*>;
+  /// Map from packet ID (RCDAQSubevent::packet_id) to (non-owning) decoder pointer.
+  using DecoderMap = std::unordered_map<int32_t, RCDAQDecoder*>;
 
   /// Construct from a parsed rcdaq event and an external decoder map.
   ///

--- a/src/services/io/rcdaq/RCDAQFrameData.h
+++ b/src/services/io/rcdaq/RCDAQFrameData.h
@@ -1,0 +1,72 @@
+// Copyright 2024, EIC
+// Subject to the terms in the LICENSE file found in the top-level directory.
+
+#pragma once
+
+#include <podio/CollectionBuffers.h>
+#include <podio/CollectionIDTable.h>
+#include <podio/GenericParameters.h>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "RCDAQDecoder.h"
+#include "RCDAQFileReader.h"
+
+/// Adapter between a raw rcdaq event and the podio::FrameDataType concept.
+///
+/// RCDAQFrameData wraps an RCDAQFileReader::Event together with a map of
+/// registered RCDAQDecoder instances and presents the combined data through the
+/// four methods required by the podio::FrameDataType concept.  The podio::Frame
+/// calls getCollectionBuffers() lazily — only when a specific collection is
+/// actually requested — so decoders are invoked on-demand.
+///
+/// Typical construction (inside JEventSourceRCDAQ::Emit):
+/// @code
+///   auto frame_data = std::make_unique<RCDAQFrameData>(
+///       std::move(rcdaq_event), m_decoder_map);
+///   auto frame = std::make_unique<podio::Frame>(std::move(frame_data));
+///   event.Insert(frame.release());
+/// @endcode
+class RCDAQFrameData {
+public:
+  /// Map from sub-event ID to (non-owning) decoder pointer.
+  using DecoderMap = std::unordered_map<int16_t, RCDAQDecoder*>;
+
+  /// Construct from a parsed rcdaq event and an external decoder map.
+  ///
+  /// \p decoders is not owned; the caller (JEventSourceRCDAQ) must keep the
+  /// decoder objects alive for the lifetime of this object.
+  RCDAQFrameData(RCDAQFileReader::Event event, const DecoderMap& decoders);
+
+  // podio::FrameDataType concept requirements ---------------------------------
+
+  /// Returns a snapshot of the collection-name → ID table built from all
+  /// sub-events that have a registered decoder.
+  podio::CollectionIDTable getIDTable() const;
+
+  /// Decode and return the CollectionReadBuffers for collection \p name.
+  /// Returns nullopt if no matching sub-event / decoder is found.
+  std::optional<podio::CollectionReadBuffers> getCollectionBuffers(const std::string& name);
+
+  /// Returns the collection names that can be decoded from this event.
+  std::vector<std::string> getAvailableCollections() const;
+
+  /// Returns event-level metadata: "run_number" and "event_sequence" as int.
+  std::unique_ptr<podio::GenericParameters> getParameters();
+
+private:
+  RCDAQFileReader::Event m_event;
+  const DecoderMap& m_decoders;
+
+  /// ID table built at construction time over decodable collections.
+  podio::CollectionIDTable m_idTable;
+
+  /// Maps collection name → pointer into m_event.subevents (stable after construction).
+  std::unordered_map<std::string, const RCDAQSubevent*> m_nameToSubevent;
+
+  /// Event-level parameters (consumed once by the Frame constructor).
+  std::unique_ptr<podio::GenericParameters> m_params;
+};

--- a/src/services/io/rcdaq/RCDAQSubevent.h
+++ b/src/services/io/rcdaq/RCDAQSubevent.h
@@ -6,13 +6,21 @@
 #include <cstdint>
 #include <vector>
 
-/// Raw sub-event data from an rcdaq file.
+/// Raw sub-event / packet data from an rcdaq file.
 ///
 /// Each RCDAQSubevent corresponds to one sub-event record in the rcdaq binary
 /// stream and holds the raw int32 payload words (excluding the sub-event header).
 /// Downstream JANA factories decode these into EDM4hep collections.
+///
+/// Two IDs are carried:
+///   - packet_id: the user-visible routing key.
+///       PRDF format: hdrinfo & 0xFFFF (e.g. 12001 for detector packets).
+///       ONCS format: equal to sub_id (sign-extended to int32).
+///   - sub_id: the hardware module identifier stored in the raw header.
+///       PRDF: 32-bit field.  ONCS: 16-bit field (sign-extended here).
 struct RCDAQSubevent {
-  int16_t sub_id{0};         ///< Sub-event identifier (hardware module ID)
+  int32_t packet_id{0};      ///< User-visible packet ID (decoder map key)
+  int32_t sub_id{0};         ///< Hardware module ID from raw header
   int16_t sub_type{0};       ///< Sub-event type code
   int16_t sub_decoding{0};   ///< Decoding method identifier (see SubevtConstants.h)
   std::vector<int32_t> data; ///< Raw int32 payload words (payload only, no header)

--- a/src/services/io/rcdaq/RCDAQSubevent.h
+++ b/src/services/io/rcdaq/RCDAQSubevent.h
@@ -1,0 +1,19 @@
+// Copyright 2024, EIC
+// Subject to the terms in the LICENSE file found in the top-level directory.
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+/// Raw sub-event data from an rcdaq file.
+///
+/// Each RCDAQSubevent corresponds to one sub-event record in the rcdaq binary
+/// stream and holds the raw int32 payload words (excluding the sub-event header).
+/// Downstream JANA factories decode these into EDM4hep collections.
+struct RCDAQSubevent {
+  int16_t sub_id{0};         ///< Sub-event identifier (hardware module ID)
+  int16_t sub_type{0};       ///< Sub-event type code
+  int16_t sub_decoding{0};   ///< Decoding method identifier (see SubevtConstants.h)
+  std::vector<int32_t> data; ///< Raw int32 payload words (payload only, no header)
+};

--- a/src/services/io/rcdaq/rcdaq.cc
+++ b/src/services/io/rcdaq/rcdaq.cc
@@ -1,0 +1,14 @@
+// Copyright 2024, EIC
+// Subject to the terms in the LICENSE file found in the top-level directory.
+
+#include <JANA/JApplicationFwd.h>
+#include <JANA/JEventSourceGeneratorT.h>
+
+#include "JEventSourceRCDAQ.h"
+
+extern "C" {
+void InitPlugin(JApplication* app) {
+  InitJANAPlugin(app);
+  app->Add(new JEventSourceGeneratorT<JEventSourceRCDAQ>());
+}
+}

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ find_package(Catch2 3)
 if(Catch2_FOUND)
   add_subdirectory(algorithms_test)
   add_subdirectory(omnifactory_test)
+  add_subdirectory(rcdaq_test)
 else()
   message(
     STATUS "Catch2 is not found. Skipping algorithms_test, omnifactory_test...")

--- a/src/tests/rcdaq_test/CMakeLists.txt
+++ b/src/tests/rcdaq_test/CMakeLists.txt
@@ -17,6 +17,9 @@ add_executable(${TEST_NAME} rcdaq_test.cc)
 
 target_link_libraries(${TEST_NAME} PRIVATE Catch2::Catch2WithMain rcdaq_library)
 
+# Pass the EICrecon source root so the integration test can find the .evt file
+target_compile_definitions(${TEST_NAME} PRIVATE SRCDIR="${CMAKE_SOURCE_DIR}")
+
 # Install executable
 install(TARGETS ${TEST_NAME} DESTINATION bin)
 

--- a/src/tests/rcdaq_test/CMakeLists.txt
+++ b/src/tests/rcdaq_test/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Unit tests for the rcdaq event source.
+#
+# Built conditionally when: - Catch2 v3 is available (already checked by the
+# parent CMakeLists.txt) - rcdaq format headers are found (rcdaq_INCLUDE_DIR
+# cache variable is set)
+
+get_filename_component(TEST_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
+
+# The rcdaq plugin must have been built (sets rcdaq_INCLUDE_DIR in cache)
+if(NOT TARGET rcdaq_library)
+  message(
+    STATUS "${TEST_NAME}: rcdaq_library not available — skipping rcdaq tests")
+  return()
+endif()
+
+add_executable(${TEST_NAME} rcdaq_test.cc)
+
+target_link_libraries(${TEST_NAME} PRIVATE Catch2::Catch2WithMain rcdaq_library)
+
+# Install executable
+install(TARGETS ${TEST_NAME} DESTINATION bin)
+
+add_test(NAME t_${TEST_NAME} COMMAND env LLVM_PROFILE_FILE=${TEST_NAME}.profraw
+                                     $<TARGET_FILE:${TEST_NAME}>)

--- a/src/tests/rcdaq_test/rcdaq_test.cc
+++ b/src/tests/rcdaq_test/rcdaq_test.cc
@@ -1,0 +1,323 @@
+// Copyright 2024, EIC
+// Subject to the terms in the LICENSE file found in the top-level directory.
+
+/// Unit tests for the rcdaq event source components:
+///   - RCDAQFileReader: parsing a synthetic ONCS-format binary
+///   - RCDAQFrameData:  lazy decoding via the podio::FrameDataType interface
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "services/io/rcdaq/RCDAQDecoder.h"
+#include "services/io/rcdaq/RCDAQFileReader.h"
+#include "services/io/rcdaq/RCDAQFrameData.h"
+#include "services/io/rcdaq/RCDAQSubevent.h"
+
+// ---------------------------------------------------------------------------
+// Minimal in-memory structs that mirror the rcdaq binary layout.
+// Using our own definitions avoids depending on rcdaq headers in the test
+// translation unit while still producing correct byte patterns on
+// little-endian (x86_64) machines.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+static constexpr uint32_t ONCS_MARKER   = 0xffffc0c0U;
+static constexpr int32_t BLOCK_SIZE     = 8192;
+static constexpr int32_t BUF_HDR_WORDS  = 4;
+static constexpr int32_t EVT_HDR_WORDS  = 8;
+static constexpr int32_t SEVT_HDR_WORDS = 4;
+static constexpr int32_t DATAEVENT      = 1;
+static constexpr int32_t BEGRUNEVENT    = 9;
+static constexpr int16_t ID4EVT         = 6;
+
+// Buffer header layout: Length, Marker, Bufseq, Runnr
+struct BufHdr {
+  int32_t length;
+  uint32_t marker;
+  int32_t bufseq;
+  int32_t runnr;
+};
+static_assert(sizeof(BufHdr) == 16);
+
+// Event header layout (8 int32 words)
+struct EvtHdr {
+  int32_t evt_length;
+  int32_t evt_type;
+  int32_t evt_sequence;
+  int32_t run_number;
+  int32_t date;
+  int32_t time_;
+  int32_t reserved[2];
+};
+static_assert(sizeof(EvtHdr) == 32);
+
+// Sub-event header layout (4 int32 words = 16 bytes)
+// On little-endian: word1 = (sub_type<<16)|sub_id, word2 = (padding<<16)|sub_decoding
+struct SubHdr {
+  int32_t sub_length;
+  int16_t sub_id;
+  int16_t sub_type;
+  int16_t sub_decoding;
+  int16_t sub_padding;
+  int16_t reserved[2];
+};
+static_assert(sizeof(SubHdr) == 16);
+
+/// Build a one-block (8192-byte) rcdaq binary containing:
+///   - One BEGRUNEVENT (header only)
+///   - One DATAEVENT with a single sub-event carrying @p payload int32 words
+///   - An EOB marker
+std::vector<uint8_t> buildSyntheticBlock(int32_t run_number, int32_t evt_sequence, int16_t sub_id,
+                                         int16_t sub_type, int16_t sub_decoding,
+                                         const std::vector<int32_t>& payload) {
+  const int sub_words     = SEVT_HDR_WORDS + static_cast<int>(payload.size());
+  const int dat_words     = EVT_HDR_WORDS + sub_words;
+  const int content_words = BUF_HDR_WORDS + EVT_HDR_WORDS + dat_words + 2 /*EOB*/;
+  const int content_bytes = content_words * 4;
+
+  std::vector<uint8_t> buf(BLOCK_SIZE, 0);
+  uint8_t* p = buf.data();
+
+  // Buffer header
+  BufHdr bh{content_bytes, ONCS_MARKER, 1, run_number};
+  std::memcpy(p, &bh, sizeof(bh));
+  p += sizeof(bh);
+
+  // BEGRUNEVENT (header only, no sub-events)
+  EvtHdr begin{};
+  begin.evt_length   = EVT_HDR_WORDS;
+  begin.evt_type     = BEGRUNEVENT;
+  begin.evt_sequence = 0;
+  begin.run_number   = run_number;
+  std::memcpy(p, &begin, sizeof(begin));
+  p += sizeof(begin);
+
+  // DATAEVENT
+  EvtHdr dat{};
+  dat.evt_length   = dat_words;
+  dat.evt_type     = DATAEVENT;
+  dat.evt_sequence = evt_sequence;
+  dat.run_number   = run_number;
+  std::memcpy(p, &dat, sizeof(dat));
+  p += sizeof(dat);
+
+  // Sub-event header
+  SubHdr sh{};
+  sh.sub_length   = sub_words;
+  sh.sub_id       = sub_id;
+  sh.sub_type     = sub_type;
+  sh.sub_decoding = sub_decoding;
+  std::memcpy(p, &sh, sizeof(sh));
+  p += sizeof(sh);
+
+  // Sub-event payload
+  for (auto v : payload) {
+    std::memcpy(p, &v, 4);
+    p += 4;
+  }
+
+  // EOB marker: {2, 0}
+  int32_t eob[2] = {2, 0};
+  std::memcpy(p, eob, sizeof(eob));
+
+  return buf;
+}
+
+/// Write a binary blob to a uniquely-named temp file and return the path.
+std::string writeTempFile(const std::vector<uint8_t>& data) {
+  auto path = (std::filesystem::temp_directory_path() / "rcdaq_unit_test.rcdaq").string();
+  std::ofstream f(path, std::ios::binary);
+  f.write(reinterpret_cast<const char*>(data.data()), static_cast<std::streamsize>(data.size()));
+  return path;
+}
+
+// ---------------------------------------------------------------------------
+// Spy decoder — records what decode() was called with
+// ---------------------------------------------------------------------------
+class SpyDecoder : public RCDAQDecoder {
+public:
+  explicit SpyDecoder(int16_t id) : m_id(id) {}
+
+  int16_t subeventID() const override { return m_id; }
+  std::string collectionName() const override { return "TestColl_" + std::to_string(m_id); }
+  std::string collectionType() const override { return "test::DummyCollection"; }
+
+  std::optional<podio::CollectionReadBuffers> decode(int16_t sub_type, int16_t sub_decoding,
+                                                     const int32_t* /*data*/, int nwords) override {
+    m_called           = true;
+    m_got_sub_type     = sub_type;
+    m_got_sub_decoding = sub_decoding;
+    m_got_nwords       = nwords;
+    return std::nullopt; // real collections need factory registration
+  }
+
+  bool m_called{false};
+  int16_t m_got_sub_type{-1};
+  int16_t m_got_sub_decoding{-1};
+  int m_got_nwords{-1};
+
+private:
+  int16_t m_id;
+};
+
+} // anonymous namespace
+
+// ---------------------------------------------------------------------------
+// Tests: RCDAQFileReader
+// ---------------------------------------------------------------------------
+
+TEST_CASE("RCDAQFileReader parses BEGRUNEVENT and DATAEVENT", "[rcdaq]") {
+  const int32_t run_number           = 42;
+  const int32_t evt_sequence         = 7;
+  const int16_t sub_id               = 5;
+  const int16_t sub_type             = 1;
+  const int16_t sub_decoding         = ID4EVT;
+  const std::vector<int32_t> payload = {0x00000001, 0x000001A4};
+
+  const auto data =
+      buildSyntheticBlock(run_number, evt_sequence, sub_id, sub_type, sub_decoding, payload);
+  const auto path = writeTempFile(data);
+
+  RCDAQFileReader reader;
+  reader.open(path);
+  REQUIRE(reader.isOpen());
+
+  RCDAQFileReader::Event evt;
+  REQUIRE(reader.nextEvent(evt));
+
+  // Run metadata
+  CHECK(evt.run_number == run_number);
+  CHECK(evt.evt_sequence == evt_sequence);
+
+  // Sub-event count and header fields
+  REQUIRE(evt.subevents.size() == 1u);
+  const auto& se = evt.subevents[0];
+  CHECK(se.sub_id == sub_id);
+  CHECK(se.sub_type == sub_type);
+  CHECK(se.sub_decoding == sub_decoding);
+
+  // Payload words preserved verbatim
+  REQUIRE(se.data.size() == payload.size());
+  CHECK(se.data[0] == payload[0]);
+  CHECK(se.data[1] == payload[1]);
+
+  // No additional DATA events in the file
+  CHECK_FALSE(reader.nextEvent(evt));
+
+  reader.close();
+  std::filesystem::remove(path);
+}
+
+TEST_CASE("RCDAQFileReader reports EOF on empty file", "[rcdaq]") {
+  auto path = (std::filesystem::temp_directory_path() / "rcdaq_empty.rcdaq").string();
+  {
+    std::ofstream f(path);
+  } // create empty file
+
+  RCDAQFileReader reader;
+  reader.open(path);
+  REQUIRE(reader.isOpen());
+
+  RCDAQFileReader::Event evt;
+  CHECK_FALSE(reader.nextEvent(evt));
+  reader.close();
+  std::filesystem::remove(path);
+}
+
+// ---------------------------------------------------------------------------
+// Tests: RCDAQFrameData
+// ---------------------------------------------------------------------------
+
+TEST_CASE("RCDAQFrameData.getAvailableCollections lists decoder collection", "[rcdaq]") {
+  const int16_t sub_id               = 5;
+  const std::vector<int32_t> payload = {1, 2, 3, 4};
+
+  const auto data = buildSyntheticBlock(42, 1, sub_id, 1, ID4EVT, payload);
+  const auto path = writeTempFile(data);
+
+  RCDAQFileReader reader;
+  reader.open(path);
+  RCDAQFileReader::Event evt;
+  reader.nextEvent(evt);
+  reader.close();
+  std::filesystem::remove(path);
+
+  SpyDecoder spy(sub_id);
+  RCDAQFrameData::DecoderMap dm{{sub_id, &spy}};
+  RCDAQFrameData frame_data(std::move(evt), dm);
+
+  const auto colls = frame_data.getAvailableCollections();
+  REQUIRE(colls.size() == 1u);
+  CHECK(colls[0] == spy.collectionName());
+}
+
+TEST_CASE("RCDAQFrameData.getCollectionBuffers calls decode with correct args", "[rcdaq]") {
+  const int16_t sub_id               = 5;
+  const int16_t sub_type             = 1;
+  const int16_t sub_decoding         = ID4EVT;
+  const std::vector<int32_t> payload = {10, 20, 30, 40};
+
+  const auto data = buildSyntheticBlock(42, 1, sub_id, sub_type, sub_decoding, payload);
+  const auto path = writeTempFile(data);
+
+  RCDAQFileReader reader;
+  reader.open(path);
+  RCDAQFileReader::Event evt;
+  reader.nextEvent(evt);
+  reader.close();
+  std::filesystem::remove(path);
+
+  SpyDecoder spy(sub_id);
+  RCDAQFrameData::DecoderMap dm{{sub_id, &spy}};
+  RCDAQFrameData frame_data(std::move(evt), dm);
+
+  // Unknown collection name → nullopt, decoder NOT called
+  auto none = frame_data.getCollectionBuffers("nonexistent");
+  CHECK_FALSE(none.has_value());
+  CHECK_FALSE(spy.m_called);
+
+  // Known collection name → decoder invoked with correct header fields
+  auto result = frame_data.getCollectionBuffers(spy.collectionName());
+  CHECK_FALSE(result.has_value()); // spy returns nullopt
+  REQUIRE(spy.m_called);
+  CHECK(spy.m_got_sub_type == sub_type);
+  CHECK(spy.m_got_sub_decoding == sub_decoding);
+  CHECK(spy.m_got_nwords == static_cast<int>(payload.size()));
+}
+
+TEST_CASE("RCDAQFrameData.getParameters contains run and event numbers", "[rcdaq]") {
+  const int32_t run_number   = 99;
+  const int32_t evt_sequence = 13;
+
+  const auto data = buildSyntheticBlock(run_number, evt_sequence, 5, 1, ID4EVT, {1});
+  const auto path = writeTempFile(data);
+
+  RCDAQFileReader reader;
+  reader.open(path);
+  RCDAQFileReader::Event evt;
+  reader.nextEvent(evt);
+  reader.close();
+  std::filesystem::remove(path);
+
+  SpyDecoder spy(5);
+  RCDAQFrameData::DecoderMap dm{{5, &spy}};
+  RCDAQFrameData frame_data(std::move(evt), dm);
+
+  const auto params = frame_data.getParameters();
+  REQUIRE(params != nullptr);
+  const auto run_opt = params->get<int>("run_number");
+  const auto seq_opt = params->get<int>("event_sequence");
+  REQUIRE(run_opt.has_value());
+  REQUIRE(seq_opt.has_value());
+  CHECK(run_opt.value() == run_number);
+  CHECK(seq_opt.value() == evt_sequence);
+}

--- a/src/tests/rcdaq_test/rcdaq_test.cc
+++ b/src/tests/rcdaq_test/rcdaq_test.cc
@@ -145,9 +145,9 @@ std::string writeTempFile(const std::vector<uint8_t>& data) {
 // ---------------------------------------------------------------------------
 class SpyDecoder : public RCDAQDecoder {
 public:
-  explicit SpyDecoder(int16_t id) : m_id(id) {}
+  explicit SpyDecoder(int32_t id) : m_id(id) {}
 
-  int16_t subeventID() const override { return m_id; }
+  int32_t packetID() const override { return m_id; }
   std::string collectionName() const override { return "TestColl_" + std::to_string(m_id); }
   std::string collectionType() const override { return "test::DummyCollection"; }
 
@@ -166,7 +166,7 @@ public:
   int m_got_nwords{-1};
 
 private:
-  int16_t m_id;
+  int32_t m_id;
 };
 
 } // anonymous namespace
@@ -320,4 +320,50 @@ TEST_CASE("RCDAQFrameData.getParameters contains run and event numbers", "[rcdaq
   REQUIRE(seq_opt.has_value());
   CHECK(run_opt.value() == run_number);
   CHECK(seq_opt.value() == evt_sequence);
+}
+
+// ---------------------------------------------------------------------------
+// Integration test: PRDF format (real test file, if available)
+// ---------------------------------------------------------------------------
+
+TEST_CASE("RCDAQFileReader parses PRDF format (first_100_run375_KCU0.evt)",
+          "[rcdaq][integration]") {
+  // This test requires the real test file which is not committed to the repo.
+  // It is skipped automatically when the file does not exist.
+  const std::string path = std::string{SRCDIR} + "/first_100_run375_KCU0.evt";
+  if (!std::filesystem::exists(path)) {
+    SKIP("Test file not found: " + path);
+  }
+
+  RCDAQFileReader reader;
+  reader.open(path);
+  REQUIRE(reader.isOpen());
+
+  // File is PRDF format
+  RCDAQFileReader::Event evt;
+  REQUIRE(reader.nextEvent(evt));
+  CHECK(reader.format() == RCDAQFileReader::Format::PRDF);
+
+  // Known properties of first_100_run375_KCU0.evt
+  CHECK(evt.run_number == 375);
+  REQUIRE(evt.subevents.size() >= 1u);
+
+  // Every event should contain packet ID 12001 (0x2EE1)
+  bool found_12001 = false;
+  for (const auto& se : evt.subevents) {
+    if (se.packet_id == 12001) {
+      found_12001 = true;
+      CHECK(se.data.size() > 0u);
+      break;
+    }
+  }
+  CHECK(found_12001);
+
+  // Read remaining events (file contains 100 events)
+  int count = 1;
+  while (reader.nextEvent(evt)) {
+    ++count;
+  }
+  reader.close();
+  CHECK(count == 100);
 }


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

Describes the architecture for a new JEventSourceRCDAQ plugin that reads rcdaq binary ONCS/PRDF files and exposes detector data as podio collections inside JANA events for EICrecon.

Key design points covered:
- rcdaq binary format (buffer/event/sub-event structure)
- Eager decoding (Option A) vs lazy decoding via podio::FrameDataType (Option B)
- RCDAQFrameData satisfying the podio::FrameDataType concept for on-demand sub-event decoding
- RCDAQDecoder pure virtual interface for per-sub-event-ID decoders
- RCDAQFileReader for binary file iteration
- JEventSourceRCDAQ JANA2 event source
- CMake integration with optional rcdaq dependency
- Mermaid diagrams for component relations and sequence flows
- Open questions for design discussion

### What is the urgency of this PR?
- [ ] High
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: design doc)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
