### PR TITLE
fix(ci): use pythia6_*_run000.* input since other one disappeared

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -576,7 +576,7 @@ jobs:
         platform-release: "${{ env.platform }}:${{ env.release }}"
         setup: "/opt/detector/epic-${{ env.detector-version }}/bin/thisepic.sh"
         run: |
-          url=root://dtn-eic.jlab.org//volatile/eic/EPIC/EVGEN/DIS/pythia6.428-1.0/NC/noRad/ep/${{matrix.beam}}/q2_${{matrix.minq2}}to${{matrix.minq2}}0/pythia6.428-1.0_NC_noRad_ep_${{matrix.beam}}_q2_${{matrix.minq2}}to${{matrix.minq2}}0_ab.hepmc3.tree.root
+          url=root://dtn-eic.jlab.org//volatile/eic/EPIC/EVGEN/DIS/pythia6.428-1.0/NC/noRad/ep/${{matrix.beam}}/q2_${{matrix.minq2}}to${{matrix.minq2}}0/pythia6.428-1.0_NC_noRad_ep_${{matrix.beam}}_q2_${{matrix.minq2}}to${{matrix.minq2}}0_ab_run000.hepmc3.tree.root
           npsim --compactFile ${DETECTOR_PATH}/${DETECTOR}_${{ matrix.detector_config }}.xml -N 100 --inputFiles ${url} --random.seed 1 --outputFile sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root -v WARNING
     - uses: actions/upload-artifact@v7
       with:


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR fixes the failing CI checks in e.g. https://github.com/eic/EICrecon/actions/runs/24592926657/job/71917359867?pr=2623. The file has disappeared from xrootd and now we use one of the run* files.
```
$ xrdfs dtn-eic.jlab.org ls /volatile/eic/EPIC/EVGEN/DIS/pythia6.428-1.0/NC/noRad/ep/10x130/q2_1to10/
/volatile/eic/EPIC/EVGEN/DIS/pythia6.428-1.0/NC/noRad/ep/10x130/q2_1to10/pythia6.428-1.0_NC_noRad_ep_10x130_q2_1to10_ab_run000.hepmc3.tree.root
/volatile/eic/EPIC/EVGEN/DIS/pythia6.428-1.0/NC/noRad/ep/10x130/q2_1to10/pythia6.428-1.0_NC_noRad_ep_10x130_q2_1to10_ab_run001.hepmc3.tree.root
/volatile/eic/EPIC/EVGEN/DIS/pythia6.428-1.0/NC/noRad/ep/10x130/q2_1to10/pythia6.428-1.0_NC_noRad_ep_10x130_q2_1to10_ab_run002.hepmc3.tree.root
/volatile/eic/EPIC/EVGEN/DIS/pythia6.428-1.0/NC/noRad/ep/10x130/q2_1to10/pythia6.428-1.0_NC_noRad_ep_10x130_q2_1to10_ab_run003.hepmc3.tree.root
/volatile/eic/EPIC/EVGEN/DIS/pythia6.428-1.0/NC/noRad/ep/10x130/q2_1to10/pythia6.428-1.0_NC_noRad_ep_10x130_q2_1to10_ab_run004.hepmc3.tree.root
/volatile/eic/EPIC/EVGEN/DIS/pythia6.428-1.0/NC/noRad/ep/10x130/q2_1to10/pythia6.428-1.0_NC_noRad_ep_10x130_q2_1to10_ab_run005.hepmc3.tree.root
/volatile/eic/EPIC/EVGEN/DIS/pythia6.428-1.0/NC/noRad/ep/10x130/q2_1to10/pythia6.428-1.0_NC_noRad_ep_10x130_q2_1to10_ab_run006.hepmc3.tree.root
/volatile/eic/EPIC/EVGEN/DIS/pythia6.428-1.0/NC/noRad/ep/10x130/q2_1to10/pythia6.428-1.0_NC_noRad_ep_10x130_q2_1to10_ab_run007.hepmc3.tree.root
/volatile/eic/EPIC/EVGEN/DIS/pythia6.428-1.0/NC/noRad/ep/10x130/q2_1to10/pythia6.428-1.0_NC_noRad_ep_10x130_q2_1to10_ab_run008.hepmc3.tree.root
/volatile/eic/EPIC/EVGEN/DIS/pythia6.428-1.0/NC/noRad/ep/10x130/q2_1to10/pythia6.428-1.0_NC_noRad_ep_10x130_q2_1to10_ab_run009.hepmc3.tree.root
```

### What is the urgency of this PR?
- [x] High
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: CI on main is failing)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
