### PR TITLE
fardetectors_library: don't link to TMVA

### DIFF
--- a/src/algorithms/fardetectors/CMakeLists.txt
+++ b/src/algorithms/fardetectors/CMakeLists.txt
@@ -15,4 +15,4 @@ plugin_add_eigen3(${PLUGIN_NAME})
 plugin_add_event_model(${PLUGIN_NAME})
 plugin_add_cern_root(${PLUGIN_NAME})
 
-plugin_link_libraries(${PLUGIN_NAME} ROOT::TMVA particle_service_library)
+plugin_link_libraries(${PLUGIN_NAME} particle_service_library)


### PR DESCRIPTION
TMVA is out since b5c3eedaf4039ef925c928f96a138505437e917b, we don't need to link to it anymore.