### PR TITLE
fix(cmake): use REALPATH in FindFastJet, and vendor FindVdt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,7 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 # Add custom Find<Package>.cmake modules early so they take priority over
 # bundled finders shipped by third-party packages (e.g. ROOT ships FindVdt.cmake
 # and appends its cmake/modules to CMAKE_MODULE_PATH during find_package(ROOT)).
-list(PREPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+list(PREPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 # Check and print what JANA2 is used
 find_package(JANA ${JANA_VERSION_MIN} REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,11 @@ set(CMAKE_INSTALL_RPATH
 # outside the build tree to the install RPATH
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
+# Add custom Find<Package>.cmake modules early so they take priority over
+# bundled finders shipped by third-party packages (e.g. ROOT ships FindVdt.cmake
+# and appends its cmake/modules to CMAKE_MODULE_PATH during find_package(ROOT)).
+list(PREPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+
 # Check and print what JANA2 is used
 find_package(JANA ${JANA_VERSION_MIN} REQUIRED)
 message(STATUS "${CMAKE_PROJECT_NAME}: JANA2 CMake   : ${JANA_DIR}")
@@ -303,8 +308,6 @@ find_package(onnxruntime ${onnxruntime_MIN_VERSION} CONFIG)
 
 # Add CMake additional functionality:
 include(cmake/jana_plugin.cmake) # Add common settings for plugins
-list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake) # Find
-                                                           # Find<Modules>.cmake
 
 enable_testing()
 

--- a/cmake/FindFastJet.cmake
+++ b/cmake/FindFastJet.cmake
@@ -4,13 +4,27 @@
 # FASTJET_LIBRARY FASTJET_LIBRARIES (not cached) FASTJET_LIBRARY_DIRS (not
 # cached)
 
-find_path(FASTJET_INCLUDE_DIR fastjet/version.hh
-          HINTS $ENV{FASTJET_ROOT}/include ${FASTJET_ROOT_DIR}/include)
-
 find_library(
   FASTJET_LIBRARY
   NAMES fastjet
   HINTS $ENV{FASTJET_ROOT}/lib ${FASTJET_ROOT_DIR}/lib)
+
+# Resolve symlinks on the library to derive the real package prefix.
+if(FASTJET_LIBRARY)
+        file(REAL_PATH "${FASTJET_LIBRARY}" _fastjet_real_lib)
+  get_filename_component(_fastjet_lib_dir "${_fastjet_real_lib}" DIRECTORY)
+  get_filename_component(_fastjet_prefix "${_fastjet_lib_dir}" DIRECTORY)
+else()
+  set(_fastjet_prefix "")
+endif()
+
+find_path(FASTJET_INCLUDE_DIR fastjet/version.hh
+  HINTS ${_fastjet_prefix}/include $ENV{FASTJET_ROOT}/include ${FASTJET_ROOT_DIR}/include
+  NO_CMAKE_ENVIRONMENT_PATH)
+
+unset(_fastjet_prefix)
+unset(_fastjet_real_lib)
+unset(_fastjet_lib_dir)
 
 # handle the QUIETLY and REQUIRED arguments and set FASTJET_FOUND to TRUE if all
 # listed variables are TRUE

--- a/cmake/FindFastJet.cmake
+++ b/cmake/FindFastJet.cmake
@@ -27,6 +27,8 @@ find_path(
         ${FASTJET_ROOT_DIR}/include
   NO_CMAKE_ENVIRONMENT_PATH)
 
+unset(_fastjet_include_hints)
+
 # handle the QUIETLY and REQUIRED arguments and set FASTJET_FOUND to TRUE if all
 # listed variables are TRUE
 include(FindPackageHandleStandardArgs)

--- a/cmake/FindFastJet.cmake
+++ b/cmake/FindFastJet.cmake
@@ -22,10 +22,9 @@ if(FASTJET_LIBRARY)
   unset(_fastjet_prefix)
 endif()
 
-find_path(
-  FASTJET_INCLUDE_DIR fastjet/version.hh
-  HINTS ${_fastjet_include_hints} $ENV{FASTJET_ROOT}/include
-        ${FASTJET_ROOT_DIR}/include)
+find_path(FASTJET_INCLUDE_DIR fastjet/version.hh
+          HINTS ${_fastjet_include_hints} $ENV{FASTJET_ROOT}/include
+                ${FASTJET_ROOT_DIR}/include)
 
 unset(_fastjet_include_hints)
 

--- a/cmake/FindFastJet.cmake
+++ b/cmake/FindFastJet.cmake
@@ -11,15 +11,17 @@ find_library(
 
 # Resolve symlinks on the library to derive the real package prefix.
 if(FASTJET_LIBRARY)
-        file(REAL_PATH "${FASTJET_LIBRARY}" _fastjet_real_lib)
+  file(REAL_PATH "${FASTJET_LIBRARY}" _fastjet_real_lib)
   get_filename_component(_fastjet_lib_dir "${_fastjet_real_lib}" DIRECTORY)
   get_filename_component(_fastjet_prefix "${_fastjet_lib_dir}" DIRECTORY)
 else()
   set(_fastjet_prefix "")
 endif()
 
-find_path(FASTJET_INCLUDE_DIR fastjet/version.hh
-  HINTS ${_fastjet_prefix}/include $ENV{FASTJET_ROOT}/include ${FASTJET_ROOT_DIR}/include
+find_path(
+  FASTJET_INCLUDE_DIR fastjet/version.hh
+  HINTS ${_fastjet_prefix}/include $ENV{FASTJET_ROOT}/include
+        ${FASTJET_ROOT_DIR}/include
   NO_CMAKE_ENVIRONMENT_PATH)
 
 unset(_fastjet_prefix)

--- a/cmake/FindFastJet.cmake
+++ b/cmake/FindFastJet.cmake
@@ -27,7 +27,6 @@ find_path(
         ${FASTJET_ROOT_DIR}/include
   NO_CMAKE_ENVIRONMENT_PATH)
 
-
 # handle the QUIETLY and REQUIRED arguments and set FASTJET_FOUND to TRUE if all
 # listed variables are TRUE
 include(FindPackageHandleStandardArgs)

--- a/cmake/FindFastJet.cmake
+++ b/cmake/FindFastJet.cmake
@@ -25,8 +25,7 @@ endif()
 find_path(
   FASTJET_INCLUDE_DIR fastjet/version.hh
   HINTS ${_fastjet_include_hints} $ENV{FASTJET_ROOT}/include
-        ${FASTJET_ROOT_DIR}/include
-  NO_CMAKE_ENVIRONMENT_PATH)
+        ${FASTJET_ROOT_DIR}/include)
 
 unset(_fastjet_include_hints)
 

--- a/cmake/FindFastJet.cmake
+++ b/cmake/FindFastJet.cmake
@@ -10,23 +10,23 @@ find_library(
   HINTS $ENV{FASTJET_ROOT}/lib ${FASTJET_ROOT_DIR}/lib)
 
 # Resolve symlinks on the library to derive the real package prefix.
+set(_fastjet_include_hints)
 if(FASTJET_LIBRARY)
   file(REAL_PATH "${FASTJET_LIBRARY}" _fastjet_real_lib)
   get_filename_component(_fastjet_lib_dir "${_fastjet_real_lib}" DIRECTORY)
   get_filename_component(_fastjet_prefix "${_fastjet_lib_dir}" DIRECTORY)
-else()
-  set(_fastjet_prefix "")
+  list(APPEND _fastjet_include_hints "${_fastjet_prefix}/include")
+  unset(_fastjet_real_lib)
+  unset(_fastjet_lib_dir)
+  unset(_fastjet_prefix)
 endif()
 
 find_path(
   FASTJET_INCLUDE_DIR fastjet/version.hh
-  HINTS ${_fastjet_prefix}/include $ENV{FASTJET_ROOT}/include
+  HINTS ${_fastjet_include_hints} $ENV{FASTJET_ROOT}/include
         ${FASTJET_ROOT_DIR}/include
   NO_CMAKE_ENVIRONMENT_PATH)
 
-unset(_fastjet_prefix)
-unset(_fastjet_real_lib)
-unset(_fastjet_lib_dir)
 
 # handle the QUIETLY and REQUIRED arguments and set FASTJET_FOUND to TRUE if all
 # listed variables are TRUE

--- a/cmake/FindFastJet.cmake
+++ b/cmake/FindFastJet.cmake
@@ -12,6 +12,7 @@ find_library(
 # Resolve symlinks on the library to derive the real package prefix.
 set(_fastjet_include_hints)
 if(FASTJET_LIBRARY)
+  # cmake-lint: disable=E1126
   file(REAL_PATH "${FASTJET_LIBRARY}" _fastjet_real_lib)
   get_filename_component(_fastjet_lib_dir "${_fastjet_real_lib}" DIRECTORY)
   get_filename_component(_fastjet_prefix "${_fastjet_lib_dir}" DIRECTORY)

--- a/cmake/FindFastJetContrib.cmake
+++ b/cmake/FindFastJetContrib.cmake
@@ -22,10 +22,9 @@ if(FJCONTRIB_LIBRARY)
   unset(_fjcontrib_prefix)
 endif()
 
-find_path(
-  FJCONTRIB_INCLUDE_DIR fastjet/contrib/Centauro.hh
-  HINTS ${_fjcontrib_include_hints} $ENV{FASTJET_ROOT}/include
-        ${FASTJET_ROOT_DIR}/include)
+find_path(FJCONTRIB_INCLUDE_DIR fastjet/contrib/Centauro.hh
+          HINTS ${_fjcontrib_include_hints} $ENV{FASTJET_ROOT}/include
+                ${FASTJET_ROOT_DIR}/include)
 
 unset(_fjcontrib_include_hints)
 

--- a/cmake/FindFastJetContrib.cmake
+++ b/cmake/FindFastJetContrib.cmake
@@ -4,13 +4,27 @@
 # FJCONTRIB_LIBRARY FJCONTRIB_LIBRARIES (not cached) FJCONTRIB_LIBRARY_DIRS (not
 # cached)
 
-find_path(FJCONTRIB_INCLUDE_DIR fastjet/contrib/Centauro.hh
-          HINTS $ENV{FASTJET_ROOT}/include ${FASTJET_ROOT_DIR}/include)
-
 find_library(
   FJCONTRIB_LIBRARY
   NAMES fastjetcontribfragile
   HINTS $ENV{FASTJET_ROOT}/lib ${FASTJET_ROOT_DIR}/lib)
+
+# Resolve symlinks on the library to derive the real package prefix.
+if(FJCONTRIB_LIBRARY)
+  file(REAL_PATH "${FJCONTRIB_LIBRARY}" _fjcontrib_real_lib)
+  get_filename_component(_fjcontrib_lib_dir "${_fjcontrib_real_lib}" DIRECTORY)
+  get_filename_component(_fjcontrib_prefix "${_fjcontrib_lib_dir}" DIRECTORY)
+else()
+  set(_fjcontrib_prefix "")
+endif()
+
+find_path(FJCONTRIB_INCLUDE_DIR fastjet/contrib/Centauro.hh
+  HINTS ${_fjcontrib_prefix}/include $ENV{FASTJET_ROOT}/include ${FASTJET_ROOT_DIR}/include
+  NO_CMAKE_ENVIRONMENT_PATH)
+
+unset(_fjcontrib_real_lib)
+unset(_fjcontrib_lib_dir)
+unset(_fjcontrib_prefix)
 
 # handle the QUIETLY and REQUIRED arguments and set FJCONTRIB_FOUND to TRUE if
 # all listed variables are TRUE

--- a/cmake/FindFastJetContrib.cmake
+++ b/cmake/FindFastJetContrib.cmake
@@ -12,6 +12,7 @@ find_library(
 # Resolve symlinks on the library to derive the real package prefix.
 set(_fjcontrib_include_hints)
 if(FJCONTRIB_LIBRARY)
+  # cmake-lint: disable=E1126
   file(REAL_PATH "${FJCONTRIB_LIBRARY}" _fjcontrib_real_lib)
   get_filename_component(_fjcontrib_lib_dir "${_fjcontrib_real_lib}" DIRECTORY)
   get_filename_component(_fjcontrib_prefix "${_fjcontrib_lib_dir}" DIRECTORY)

--- a/cmake/FindFastJetContrib.cmake
+++ b/cmake/FindFastJetContrib.cmake
@@ -25,8 +25,7 @@ endif()
 find_path(
   FJCONTRIB_INCLUDE_DIR fastjet/contrib/Centauro.hh
   HINTS ${_fjcontrib_include_hints} $ENV{FASTJET_ROOT}/include
-        ${FASTJET_ROOT_DIR}/include
-  NO_CMAKE_ENVIRONMENT_PATH)
+        ${FASTJET_ROOT_DIR}/include)
 
 unset(_fjcontrib_include_hints)
 

--- a/cmake/FindFastJetContrib.cmake
+++ b/cmake/FindFastJetContrib.cmake
@@ -10,23 +10,24 @@ find_library(
   HINTS $ENV{FASTJET_ROOT}/lib ${FASTJET_ROOT_DIR}/lib)
 
 # Resolve symlinks on the library to derive the real package prefix.
+set(_fjcontrib_include_hints)
 if(FJCONTRIB_LIBRARY)
   file(REAL_PATH "${FJCONTRIB_LIBRARY}" _fjcontrib_real_lib)
   get_filename_component(_fjcontrib_lib_dir "${_fjcontrib_real_lib}" DIRECTORY)
   get_filename_component(_fjcontrib_prefix "${_fjcontrib_lib_dir}" DIRECTORY)
-else()
-  set(_fjcontrib_prefix "")
+  list(APPEND _fjcontrib_include_hints "${_fjcontrib_prefix}/include")
+  unset(_fjcontrib_real_lib)
+  unset(_fjcontrib_lib_dir)
+  unset(_fjcontrib_prefix)
 endif()
 
 find_path(
   FJCONTRIB_INCLUDE_DIR fastjet/contrib/Centauro.hh
-  HINTS ${_fjcontrib_prefix}/include $ENV{FASTJET_ROOT}/include
+  HINTS ${_fjcontrib_include_hints} $ENV{FASTJET_ROOT}/include
         ${FASTJET_ROOT_DIR}/include
   NO_CMAKE_ENVIRONMENT_PATH)
 
-unset(_fjcontrib_real_lib)
-unset(_fjcontrib_lib_dir)
-unset(_fjcontrib_prefix)
+unset(_fjcontrib_include_hints)
 
 # handle the QUIETLY and REQUIRED arguments and set FJCONTRIB_FOUND to TRUE if
 # all listed variables are TRUE

--- a/cmake/FindFastJetContrib.cmake
+++ b/cmake/FindFastJetContrib.cmake
@@ -18,8 +18,10 @@ else()
   set(_fjcontrib_prefix "")
 endif()
 
-find_path(FJCONTRIB_INCLUDE_DIR fastjet/contrib/Centauro.hh
-  HINTS ${_fjcontrib_prefix}/include $ENV{FASTJET_ROOT}/include ${FASTJET_ROOT_DIR}/include
+find_path(
+  FJCONTRIB_INCLUDE_DIR fastjet/contrib/Centauro.hh
+  HINTS ${_fjcontrib_prefix}/include $ENV{FASTJET_ROOT}/include
+        ${FASTJET_ROOT_DIR}/include
   NO_CMAKE_ENVIRONMENT_PATH)
 
 unset(_fjcontrib_real_lib)

--- a/cmake/FindFastJetTools.cmake
+++ b/cmake/FindFastJetTools.cmake
@@ -10,23 +10,24 @@ find_library(
   HINTS $ENV{FASTJET_ROOT}/lib ${FASTJET_ROOT_DIR}/lib)
 
 # Resolve symlinks on the library to derive the real package prefix.
+set(_fjtools_include_hints)
 if(FJTOOLS_LIBRARY)
   file(REAL_PATH "${FJTOOLS_LIBRARY}" _fjtools_real_lib)
   get_filename_component(_fjtools_lib_dir "${_fjtools_real_lib}" DIRECTORY)
   get_filename_component(_fjtools_prefix "${_fjtools_lib_dir}" DIRECTORY)
-else()
-  set(_fjtools_prefix "")
+  list(APPEND _fjtools_include_hints "${_fjtools_prefix}/include")
+  unset(_fjtools_real_lib)
+  unset(_fjtools_lib_dir)
+  unset(_fjtools_prefix)
 endif()
 
 find_path(
   FJTOOLS_INCLUDE_DIR fastjet/tools/BackgroundEstimatorBase.hh
-  HINTS ${_fjtools_prefix}/include $ENV{FASTJET_ROOT}/include
+  HINTS ${_fjtools_include_hints} $ENV{FASTJET_ROOT}/include
         ${FASTJET_ROOT_DIR}/include
   NO_CMAKE_ENVIRONMENT_PATH)
 
-unset(_fjtools_real_lib)
-unset(_fjtools_lib_dir)
-unset(_fjtools_prefix)
+unset(_fjtools_include_hints)
 
 # handle the QUIETLY and REQUIRED arguments and set FJTOOLS_FOUND to TRUE if all
 # listed variables are TRUE

--- a/cmake/FindFastJetTools.cmake
+++ b/cmake/FindFastJetTools.cmake
@@ -22,10 +22,9 @@ if(FJTOOLS_LIBRARY)
   unset(_fjtools_prefix)
 endif()
 
-find_path(
-  FJTOOLS_INCLUDE_DIR fastjet/tools/BackgroundEstimatorBase.hh
-  HINTS ${_fjtools_include_hints} $ENV{FASTJET_ROOT}/include
-        ${FASTJET_ROOT_DIR}/include)
+find_path(FJTOOLS_INCLUDE_DIR fastjet/tools/BackgroundEstimatorBase.hh
+          HINTS ${_fjtools_include_hints} $ENV{FASTJET_ROOT}/include
+                ${FASTJET_ROOT_DIR}/include)
 
 unset(_fjtools_include_hints)
 

--- a/cmake/FindFastJetTools.cmake
+++ b/cmake/FindFastJetTools.cmake
@@ -4,13 +4,27 @@
 # FJTOOLS_LIBRARY FJTOOLS_LIBRARIES (not cached) FJTOOLS_LIBRARY_DIRS (not
 # cached)
 
-find_path(FJTOOLS_INCLUDE_DIR fastjet/tools/BackgroundEstimatorBase.hh
-          HINTS $ENV{FASTJET_ROOT}/include ${FASTJET_ROOT_DIR}/include)
-
 find_library(
   FJTOOLS_LIBRARY
   NAMES fastjettools
   HINTS $ENV{FASTJET_ROOT}/lib ${FASTJET_ROOT_DIR}/lib)
+
+# Resolve symlinks on the library to derive the real package prefix.
+if(FJTOOLS_LIBRARY)
+  file(REAL_PATH "${FJTOOLS_LIBRARY}" _fjtools_real_lib)
+  get_filename_component(_fjtools_lib_dir "${_fjtools_real_lib}" DIRECTORY)
+  get_filename_component(_fjtools_prefix "${_fjtools_lib_dir}" DIRECTORY)
+else()
+  set(_fjtools_prefix "")
+endif()
+
+find_path(FJTOOLS_INCLUDE_DIR fastjet/tools/BackgroundEstimatorBase.hh
+  HINTS ${_fjtools_prefix}/include $ENV{FASTJET_ROOT}/include ${FASTJET_ROOT_DIR}/include
+  NO_CMAKE_ENVIRONMENT_PATH)
+
+unset(_fjtools_real_lib)
+unset(_fjtools_lib_dir)
+unset(_fjtools_prefix)
 
 # handle the QUIETLY and REQUIRED arguments and set FJTOOLS_FOUND to TRUE if all
 # listed variables are TRUE

--- a/cmake/FindFastJetTools.cmake
+++ b/cmake/FindFastJetTools.cmake
@@ -12,6 +12,7 @@ find_library(
 # Resolve symlinks on the library to derive the real package prefix.
 set(_fjtools_include_hints)
 if(FJTOOLS_LIBRARY)
+  # cmake-lint: disable=E1126
   file(REAL_PATH "${FJTOOLS_LIBRARY}" _fjtools_real_lib)
   get_filename_component(_fjtools_lib_dir "${_fjtools_real_lib}" DIRECTORY)
   get_filename_component(_fjtools_prefix "${_fjtools_lib_dir}" DIRECTORY)

--- a/cmake/FindFastJetTools.cmake
+++ b/cmake/FindFastJetTools.cmake
@@ -25,8 +25,7 @@ endif()
 find_path(
   FJTOOLS_INCLUDE_DIR fastjet/tools/BackgroundEstimatorBase.hh
   HINTS ${_fjtools_include_hints} $ENV{FASTJET_ROOT}/include
-        ${FASTJET_ROOT_DIR}/include
-  NO_CMAKE_ENVIRONMENT_PATH)
+        ${FASTJET_ROOT_DIR}/include)
 
 unset(_fjtools_include_hints)
 

--- a/cmake/FindFastJetTools.cmake
+++ b/cmake/FindFastJetTools.cmake
@@ -18,8 +18,10 @@ else()
   set(_fjtools_prefix "")
 endif()
 
-find_path(FJTOOLS_INCLUDE_DIR fastjet/tools/BackgroundEstimatorBase.hh
-  HINTS ${_fjtools_prefix}/include $ENV{FASTJET_ROOT}/include ${FASTJET_ROOT_DIR}/include
+find_path(
+  FJTOOLS_INCLUDE_DIR fastjet/tools/BackgroundEstimatorBase.hh
+  HINTS ${_fjtools_prefix}/include $ENV{FASTJET_ROOT}/include
+        ${FASTJET_ROOT_DIR}/include
   NO_CMAKE_ENVIRONMENT_PATH)
 
 unset(_fjtools_real_lib)

--- a/cmake/FindVdt.cmake
+++ b/cmake/FindVdt.cmake
@@ -36,7 +36,7 @@ else()
   find_package_handle_standard_args(Vdt REQUIRED_VARS VDT_INCLUDE_DIR
                                                       VDT_LIBRARY)
   if(VDT_FOUND AND NOT TARGET VDT::VDT)
-    add_library(VDT::VDT SHARED IMPORTED)
+    add_library(VDT::VDT UNKNOWN IMPORTED)
     target_include_directories(VDT::VDT SYSTEM INTERFACE "${VDT_INCLUDE_DIR}")
     set_target_properties(VDT::VDT PROPERTIES IMPORTED_LOCATION
                                               "${VDT_LIBRARY}")

--- a/cmake/FindVdt.cmake
+++ b/cmake/FindVdt.cmake
@@ -1,0 +1,40 @@
+# Wrapper around ROOT's FindVdt.cmake that resolves Spack view symlinks so
+# that the package-specific include path (under /opt/software/…/<hash>/) is
+# used instead of the merged view path (/opt/local/include).
+#
+# ROOT's FindVdt.cmake guards both find_library() and find_path() with
+# "if(NOT VDT_LIBRARY)" / "if(NOT VDT_INCLUDE_DIR)", so pre-setting these
+# cache variables here causes it to skip its own search and use our values.
+
+# Step 1: find the library (may resolve to a spack-view symlink).
+if(NOT VDT_LIBRARY)
+  find_library(VDT_LIBRARY NAMES vdt)
+endif()
+
+# Step 2: resolve the library symlink to derive the real package prefix and
+# pre-set VDT_INCLUDE_DIR before ROOT's finder runs its find_path().
+if(VDT_LIBRARY AND NOT VDT_INCLUDE_DIR)
+  file(REAL_PATH "${VDT_LIBRARY}" _vdt_real_lib)
+  get_filename_component(_vdt_lib_dir "${_vdt_real_lib}" DIRECTORY)
+  get_filename_component(_vdt_prefix "${_vdt_lib_dir}" DIRECTORY)
+  set(VDT_INCLUDE_DIR "${_vdt_prefix}/include"
+      CACHE PATH "Path to VDT include directory")
+  unset(_vdt_prefix)
+  unset(_vdt_lib_dir)
+  unset(_vdt_real_lib)
+endif()
+
+# Step 3: delegate version detection and target creation to ROOT's upstream
+# finder.  It skips find_path/find_library because the variables are already
+# set.  Fall back to a minimal implementation when ROOT is not yet available.
+if(DEFINED ROOT_CMAKE_DIR AND EXISTS "${ROOT_CMAKE_DIR}/modules/FindVdt.cmake")
+  include("${ROOT_CMAKE_DIR}/modules/FindVdt.cmake")
+else()
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Vdt REQUIRED_VARS VDT_INCLUDE_DIR VDT_LIBRARY)
+  if(VDT_FOUND AND NOT TARGET VDT::VDT)
+    add_library(VDT::VDT SHARED IMPORTED)
+    target_include_directories(VDT::VDT SYSTEM INTERFACE "${VDT_INCLUDE_DIR}")
+    set_target_properties(VDT::VDT PROPERTIES IMPORTED_LOCATION "${VDT_LIBRARY}")
+  endif()
+endif()

--- a/cmake/FindVdt.cmake
+++ b/cmake/FindVdt.cmake
@@ -1,10 +1,10 @@
-# Wrapper around ROOT's FindVdt.cmake that resolves Spack view symlinks so
-# that the package-specific include path (under /opt/software/…/<hash>/) is
-# used instead of the merged view path (/opt/local/include).
+# Wrapper around ROOT's FindVdt.cmake that resolves Spack view symlinks so that
+# the package-specific include path (under /opt/software/…/<hash>/) is used
+# instead of the merged view path (/opt/local/include).
 #
-# ROOT's FindVdt.cmake guards both find_library() and find_path() with
-# "if(NOT VDT_LIBRARY)" / "if(NOT VDT_INCLUDE_DIR)", so pre-setting these
-# cache variables here causes it to skip its own search and use our values.
+# ROOT's FindVdt.cmake guards both find_library() and find_path() with "if(NOT
+# VDT_LIBRARY)" / "if(NOT VDT_INCLUDE_DIR)", so pre-setting these cache
+# variables here causes it to skip its own search and use our values.
 
 # Step 1: find the library (may resolve to a spack-view symlink).
 if(NOT VDT_LIBRARY)
@@ -17,7 +17,8 @@ if(VDT_LIBRARY AND NOT VDT_INCLUDE_DIR)
   file(REAL_PATH "${VDT_LIBRARY}" _vdt_real_lib)
   get_filename_component(_vdt_lib_dir "${_vdt_real_lib}" DIRECTORY)
   get_filename_component(_vdt_prefix "${_vdt_lib_dir}" DIRECTORY)
-  set(VDT_INCLUDE_DIR "${_vdt_prefix}/include"
+  set(VDT_INCLUDE_DIR
+      "${_vdt_prefix}/include"
       CACHE PATH "Path to VDT include directory")
   unset(_vdt_prefix)
   unset(_vdt_lib_dir)
@@ -31,10 +32,12 @@ if(DEFINED ROOT_CMAKE_DIR AND EXISTS "${ROOT_CMAKE_DIR}/modules/FindVdt.cmake")
   include("${ROOT_CMAKE_DIR}/modules/FindVdt.cmake")
 else()
   include(FindPackageHandleStandardArgs)
-  find_package_handle_standard_args(Vdt REQUIRED_VARS VDT_INCLUDE_DIR VDT_LIBRARY)
+  find_package_handle_standard_args(Vdt REQUIRED_VARS VDT_INCLUDE_DIR
+                                                      VDT_LIBRARY)
   if(VDT_FOUND AND NOT TARGET VDT::VDT)
     add_library(VDT::VDT SHARED IMPORTED)
     target_include_directories(VDT::VDT SYSTEM INTERFACE "${VDT_INCLUDE_DIR}")
-    set_target_properties(VDT::VDT PROPERTIES IMPORTED_LOCATION "${VDT_LIBRARY}")
+    set_target_properties(VDT::VDT PROPERTIES IMPORTED_LOCATION
+                                              "${VDT_LIBRARY}")
   endif()
 endif()

--- a/cmake/FindVdt.cmake
+++ b/cmake/FindVdt.cmake
@@ -35,7 +35,7 @@ else()
   include(FindPackageHandleStandardArgs)
   find_package_handle_standard_args(Vdt REQUIRED_VARS VDT_INCLUDE_DIR
                                                       VDT_LIBRARY)
-  if(VDT_FOUND AND NOT TARGET VDT::VDT)
+  if(Vdt_FOUND AND NOT TARGET VDT::VDT)
     add_library(VDT::VDT UNKNOWN IMPORTED)
     target_include_directories(VDT::VDT SYSTEM INTERFACE "${VDT_INCLUDE_DIR}")
     set_target_properties(VDT::VDT PROPERTIES IMPORTED_LOCATION

--- a/cmake/FindVdt.cmake
+++ b/cmake/FindVdt.cmake
@@ -14,6 +14,7 @@ endif()
 # Step 2: resolve the library symlink to derive the real package prefix and
 # pre-set VDT_INCLUDE_DIR before ROOT's finder runs its find_path().
 if(VDT_LIBRARY AND NOT VDT_INCLUDE_DIR)
+  # cmake-lint: disable=E1126
   file(REAL_PATH "${VDT_LIBRARY}" _vdt_real_lib)
   get_filename_component(_vdt_lib_dir "${_vdt_real_lib}" DIRECTORY)
   get_filename_component(_vdt_prefix "${_vdt_lib_dir}" DIRECTORY)


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
When attempting to use custom dependencies in the eic-shell container, there is always some remaining `-I/opt/local/include` somewhere that causes system-default dependencies to be picked up. This PR allows this to be avoided completely with `CMAKE_FIND_PACKAGE_RESOLVE_SYMLINKS=ON` by calling REALPATH on the two Find*.cmake modules that do not follow this variable already.

### What is the urgency of this PR?
- [ ] High
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: allows us to simplify/streamline local development workflows)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

AI churned on the problem scope to determine what was going on exactly (i.e. which package was to blame for the remaining `/opt/local/include` directories).
