### PR TITLE
Fix associations in FarDetectorLinearTracking

### DIFF
--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -103,6 +103,8 @@ void FarDetectorLinearTracking::process(const FarDetectorLinearTracking::Input& 
 
   std::vector<std::vector<Eigen::Vector3d>> convertedHits;
   std::vector<std::vector<edm4hep::MCParticle>> assocParts;
+  convertedHits.reserve(m_cfg.n_layer);
+  assocParts.reserve(m_cfg.n_layer);
 
   // Check there aren't too many hits in any layer to handle
   // Temporary limit of number of hits per layer before Kalman filtering/GNN implemented
@@ -229,11 +231,11 @@ void FarDetectorLinearTracking::checkHitCombination(
                            charge, chi2, ndf, pdg);
 
   // Add Measurement2D relations and count occurrence of particles contributing to the track
-  std::unordered_map<const edm4hep::MCParticle*, int> particleCount;
+  std::unordered_map<edm4hep::MCParticle, int> particleCount;
   for (std::size_t layer = 0; layer < layerHitIndex.size(); layer++) {
     track.addToMeasurements((*inputHits[layer])[layerHitIndex[layer]]);
     const auto& assocParticle = assocParts[layer][layerHitIndex[layer]];
-    particleCount[&assocParticle]++;
+    particleCount[assocParticle]++;
   }
 
   // Create track associations for each particle
@@ -241,12 +243,12 @@ void FarDetectorLinearTracking::checkHitCombination(
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
     auto trackLink = trackLinks->create();
     trackLink.setFrom(track);
-    trackLink.setTo(*particle);
+    trackLink.setTo(particle);
     trackLink.setWeight(count / static_cast<double>(m_cfg.n_layer));
 #endif
     auto trackAssoc = assocTracks->create();
     trackAssoc.setRec(track);
-    trackAssoc.setSim(*particle);
+    trackAssoc.setSim(particle);
     trackAssoc.setWeight(count / static_cast<double>(m_cfg.n_layer));
   }
 }

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -36,6 +36,7 @@
 #include <cstdint>
 #include <memory>
 #include <new>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
 


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
Bug highlighted in https://github.com/eic/EICrecon/issues/2643 this PR fixes the associations of the tracks to MCParticles. Where previously associations were being made for every layer hit, now they are correctly combined into weighted associations based on the MCParticle responsible for the Measurement2D used from each layer.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #2643 )
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [x] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

TaggerTrackerM[12]LocalTrackAssociations are expected to (mostly) contain a single association for each track with weight 1 rather than 4 with weight 0.25