### PR TITLE
Beam.h: add 9 GeV electron beams

### DIFF
--- a/src/algorithms/reco/Beam.h
+++ b/src/algorithms/reco/Beam.h
@@ -60,7 +60,7 @@ inline auto find_first_scattered_electron(const edm4eic::ReconstructedParticleCo
 
 // Canonical beam momentum allowlists used by all kinematics algorithms.
 // Electron beam: negative pz (beam goes in -z direction).
-inline const std::vector<float> electron_beam_pz_set{-5.0, -10.0, -18.0};
+inline const std::vector<float> electron_beam_pz_set{-5.0, -9.0, -10.0, -18.0};
 // Hadron beam: positive pz (beam goes in +z direction).
 inline const std::vector<float> hadron_beam_pz_set{41.0, 100.0, 130.0, 250.0, 275.0};
 
@@ -82,7 +82,7 @@ PxPyPzEVector round_beam_four_momentum(const Vector3& p_in, const float mass,
   }
   if (!found_match) {
     throw std::runtime_error(
-        fmt::format("round_beam_four_momentum: no match for beam momentum {:.3f} GeV within 10%% "
+        fmt::format("round_beam_four_momentum: no match for beam momentum {:.3f} GeV within 10% "
                     "of any of the allowed values",
                     p_in.z));
   }


### PR DESCRIPTION
Just like for protons there is a potential for overlap with 10% tolerance (for electrons it's between 9 and 10 GeV). The same workaround that applies closest match should work, I assume.

### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
