### PR TITLE
feat: use edm4eic::Jet when available

### DIFF
--- a/src/algorithms/reco/JetReconstruction.cc
+++ b/src/algorithms/reco/JetReconstruction.cc
@@ -135,7 +135,6 @@ void JetReconstruction<InputT>::process(
   }
   this->trace("  Number of particles: {}", particles.size());
 
-  std::vector<PseudoJet> jets;
   // Create per-event AreaDefinition with reproducible seed
   // This avoids contention on fastjet's static random generator
   auto seed                    = m_uid.getUniqueID(*headers, this->name());
@@ -144,7 +143,7 @@ void JetReconstruction<InputT>::process(
   auto local_area_def          = m_area_def->with_fixed_seed(seed_vector);
 
   fastjet::ClusterSequenceArea clus_seq(particles, *m_jet_def, local_area_def);
-  jets = sorted_by_pt(clus_seq.inclusive_jets(m_cfg.minJetPt));
+  std::vector<PseudoJet> jets = sorted_by_pt(clus_seq.inclusive_jets(m_cfg.minJetPt));
   // delete_self_when_unused keeps the cluster sequence alive (via PseudoJet
   // back-references) so jets[i].area() remains valid in the loop below.
   clus_seq.delete_self_when_unused();

--- a/src/algorithms/reco/JetReconstruction.cc
+++ b/src/algorithms/reco/JetReconstruction.cc
@@ -5,7 +5,12 @@
 #include "JetReconstruction.h"
 
 // for error handling
-#include <edm4hep/MCParticleCollection.h> // IWYU pragma: keep
+#include <edm4eic/EDM4eicVersion.h>
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 9, 0)
+#include <edm4eic/JetCollection.h>
+#include <edm4eic/MutableJet.h>
+#endif
+#include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <fastjet/ClusterSequenceArea.hh>
@@ -130,6 +135,7 @@ void JetReconstruction<InputT>::process(
   }
   this->trace("  Number of particles: {}", particles.size());
 
+  std::vector<PseudoJet> jets;
   // Create per-event AreaDefinition with reproducible seed
   // This avoids contention on fastjet's static random generator
   auto seed                    = m_uid.getUniqueID(*headers, this->name());
@@ -137,9 +143,11 @@ void JetReconstruction<InputT>::process(
                                   static_cast<int>((seed >> 32) & 0xFFFFFFFF)};
   auto local_area_def          = m_area_def->with_fixed_seed(seed_vector);
 
-  // Run the clustering, extract the jets
   fastjet::ClusterSequenceArea clus_seq(particles, *m_jet_def, local_area_def);
-  std::vector<PseudoJet> jets = sorted_by_pt(clus_seq.inclusive_jets(m_cfg.minJetPt));
+  jets = sorted_by_pt(clus_seq.inclusive_jets(m_cfg.minJetPt));
+  // delete_self_when_unused keeps the cluster sequence alive (via PseudoJet
+  // back-references) so jets[i].area() remains valid in the loop below.
+  clus_seq.delete_self_when_unused();
 
   // Print out some infos
   this->trace("  Clustering with : {}", m_jet_def->description());
@@ -151,15 +159,26 @@ void JetReconstruction<InputT>::process(
                 jets[i].phi());
 
     // create jet to store in output collection
-    edm4eic::MutableReconstructedParticle jet_output = jet_collection->create();
-    jet_output.setMomentum(edm4hep::Vector3f(jets[i].px(), jets[i].py(), jets[i].pz()));
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 9, 0)
+    edm4eic::MutableJet jet_output = jet_collection->create();
+    jet_output.setType(static_cast<std::uint32_t>(m_jet_def->jet_algorithm()));
+    jet_output.setArea(static_cast<float>(jets[i].area()));
     jet_output.setEnergy(jets[i].e());
-    jet_output.setMass(jets[i].m());
+    jet_output.setMomentum(edm4hep::Vector3f(jets[i].px(), jets[i].py(), jets[i].pz()));
+#else
+    auto jet_output = jet_collection->create();
+    jet_output.setEnergy(jets[i].e());
+    jet_output.setMomentum(edm4hep::Vector3f(jets[i].px(), jets[i].py(), jets[i].pz()));
+#endif
 
-    // link constituents to jet kinematic info
+    // link constituents to jet
     std::vector<PseudoJet> csts = jets[i].constituents();
     for (const auto& cst : csts) {
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 9, 0)
+      jet_output.addToConstituents(input_collection->at(cst.user_index()));
+#else
       jet_output.addToParticles(input_collection->at(cst.user_index()));
+#endif
     } // for constituent j
   } // for jet i
 

--- a/src/algorithms/reco/JetReconstruction.cc
+++ b/src/algorithms/reco/JetReconstruction.cc
@@ -145,9 +145,7 @@ void JetReconstruction<InputT>::process(
 
   fastjet::ClusterSequenceArea clus_seq(particles, *m_jet_def, local_area_def);
   std::vector<PseudoJet> jets = sorted_by_pt(clus_seq.inclusive_jets(m_cfg.minJetPt));
-  // delete_self_when_unused keeps the cluster sequence alive (via PseudoJet
-  // back-references) so jets[i].area() remains valid in the loop below.
-  clus_seq.delete_self_when_unused();
+  // clus_seq remains in-scope for the loop below, so jets[i].area() stays valid.
 
   // Print out some infos
   this->trace("  Clustering with : {}", m_jet_def->description());

--- a/src/algorithms/reco/JetReconstruction.cc
+++ b/src/algorithms/reco/JetReconstruction.cc
@@ -8,7 +8,6 @@
 #include <edm4eic/EDM4eicVersion.h>
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 9, 0)
 #include <edm4eic/JetCollection.h>
-#include <edm4eic/MutableJet.h>
 #endif
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/Vector3f.h>
@@ -19,7 +18,9 @@
 #include <fastjet/PseudoJet.hh>
 #include <fastjet/contrib/Centauro.hh>
 #include <fmt/format.h>
+#include <cstdint>
 #include <stdexcept>
+#include <tuple>
 #include <vector>
 
 #include "algorithms/reco/JetReconstructionConfig.h"

--- a/src/algorithms/reco/JetReconstruction.h
+++ b/src/algorithms/reco/JetReconstruction.h
@@ -4,7 +4,12 @@
 #pragma once
 
 #include <algorithms/algorithm.h>
+#include <edm4eic/EDM4eicVersion.h>
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 9, 0)
+#include <edm4eic/JetCollection.h>
+#else
 #include <edm4eic/ReconstructedParticleCollection.h>
+#endif
 #include <edm4hep/EventHeaderCollection.h>
 #include <fastjet/AreaDefinition.hh>
 #include <fastjet/JetDefinition.hh>
@@ -21,10 +26,16 @@
 
 namespace eicrecon {
 
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 9, 0)
+using JetOutputCollection = edm4eic::JetCollection;
+#else
+using JetOutputCollection = edm4eic::ReconstructedParticleCollection;
+#endif
+
 template <typename InputT>
 using JetReconstructionAlgorithm = algorithms::Algorithm<
     algorithms::Input<edm4hep::EventHeaderCollection, typename InputT::collection_type>,
-    algorithms::Output<edm4eic::ReconstructedParticleCollection>>;
+    algorithms::Output<JetOutputCollection>>;
 
 template <typename InputT>
 class JetReconstruction : public JetReconstructionAlgorithm<InputT>,

--- a/src/factories/reco/JetReconstruction_factory.h
+++ b/src/factories/reco/JetReconstruction_factory.h
@@ -27,7 +27,11 @@ private:
   typename FactoryT::template PodioInput<InputT> m_input{this};
 
   // output collection
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 9, 0)
+  typename FactoryT::template PodioOutput<edm4eic::Jet> m_output{this};
+#else
   typename FactoryT::template PodioOutput<edm4eic::ReconstructedParticle> m_output{this};
+#endif
 
   // parameter bindings
   typename FactoryT::template ParameterRef<float> m_rJet{this, "rJet", FactoryT::config().rJet};


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR modifies JetReconstruction to use the new edm4eic::Jet type, which can store the area we spend so many CPU cycles on calculating.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: store calculated jet area)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
