### PR TITLE
fix: remove duplicate plugin_glob_all in onnx

### DIFF
--- a/src/algorithms/onnx/CMakeLists.txt
+++ b/src/algorithms/onnx/CMakeLists.txt
@@ -13,8 +13,3 @@ plugin_glob_all(${PLUGIN_NAME})
 plugin_add_algorithms(${PLUGIN_NAME})
 plugin_add_event_model(${PLUGIN_NAME})
 plugin_add_onnxruntime(${PLUGIN_NAME})
-
-# The macro grabs sources as *.cc *.cpp *.c and headers as *.h *.hh *.hpp Then
-# correctly sets sources for ${_name}_plugin and ${_name}_library targets Adds
-# headers to the correct installation directory
-plugin_glob_all(${PLUGIN_NAME})


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This removes a duplicate plugin_glob_all call in onnx.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ ] Medium
- [x] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: redundant duplication)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

First issue found with a copilot CLI running against a local Qwen3-Coder-Next LLM inside a slurm job :-P