### PR TITLE
Fix eigenvalue calculation in CalorimeterClusterShape

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterClusterShape.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterShape.cc
@@ -190,11 +190,11 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
       // set shape parameters
       out_clust.addToShapeParameters(radius);
       out_clust.addToShapeParameters(dispersion);
-      out_clust.addToShapeParameters(eigenValues_2D[0].real()); // 2D theta-phi out_cluster width 1
-      out_clust.addToShapeParameters(eigenValues_2D[1].real()); // 2D theta-phi out_cluster width 2
-      out_clust.addToShapeParameters(eigenValues_3D[0]);        // 3D x-y-z out_cluster width 1
-      out_clust.addToShapeParameters(eigenValues_3D[1]);        // 3D x-y-z out_cluster width 2
-      out_clust.addToShapeParameters(eigenValues_3D[2]);        // 3D x-y-z out_cluster width 3
+      out_clust.addToShapeParameters(std::sqrt(std::abs(eigenValues_2D[0].real()))); // 2D theta-phi out_cluster width 1 [rad]
+      out_clust.addToShapeParameters(std::sqrt(std::abs(eigenValues_2D[1].real()))); // 2D theta-phi out_cluster width 2 [rad]
+      out_clust.addToShapeParameters(std::sqrt(std::abs(eigenValues_3D[0])));        // 3D x-y-z out_cluster width 1 [mm]
+      out_clust.addToShapeParameters(std::sqrt(std::abs(eigenValues_3D[1])));        // 3D x-y-z out_cluster width 2 [mm]
+      out_clust.addToShapeParameters(std::sqrt(std::abs(eigenValues_3D[2])));        // 3D x-y-z out_cluster width 3 [mm]
 
       // check axis orientation
       double dot_product = out_clust.getPosition() * axis;
@@ -209,13 +209,16 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
       out_clust.setIntrinsicPhi(intrinsicPhi);
       // TODO intrinsicDirectionError
 
-      trace("ClusterShape: radius={:.3f} dispersion={:.3f} "
-            "2D_w1={:.4f} 2D_w2={:.4f} "
-            "3D_w1={:.3f} 3D_w2={:.3f} 3D_w3={:.3f} "
+      trace("ClusterShape: radius={:.3f} mm dispersion={:.3f} mm "
+            "2D_w1={:.4f} rad 2D_w2={:.4f} rad "
+            "3D_w1={:.3f} mm 3D_w2={:.3f} mm 3D_w3={:.3f} mm "
             "intrinsicTheta={:.4f} intrinsicPhi={:.4f}",
             radius, dispersion,
-            eigenValues_2D[0].real(), eigenValues_2D[1].real(),
-            eigenValues_3D[0], eigenValues_3D[1], eigenValues_3D[2],
+            std::sqrt(std::abs(eigenValues_2D[0].real())),
+            std::sqrt(std::abs(eigenValues_2D[1].real())),
+            std::sqrt(std::abs(eigenValues_3D[0])),
+            std::sqrt(std::abs(eigenValues_3D[1])),
+            std::sqrt(std::abs(eigenValues_3D[2])),
             intrinsicTheta, intrinsicPhi);
     } // end shape parameter calculation
 

--- a/src/algorithms/calorimetry/CalorimeterClusterShape.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterShape.cc
@@ -101,7 +101,7 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
       // create addresses for quantities we'll need later
       double radius     = 0;
       double dispersion = 0;
-      double w_sum     = 0;
+      double w_sum      = 0;
       // set up matrices/vectors — all double to avoid float32 cancellation
       Eigen::Matrix2d sum2_2D        = Eigen::Matrix2d::Zero();
       Eigen::Matrix3d sum2_3D        = Eigen::Matrix3d::Zero();
@@ -122,7 +122,7 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
           // theta, phi
           Eigen::Vector2d pos2D(edm4hep::utils::anglePolar(hit.getPosition()),
                                 edm4hep::utils::angleAzimuthal(hit.getPosition()));
-          // x, y, z 
+          // x, y, z
           Eigen::Vector3d pos3D(hit.getPosition().x, hit.getPosition().y, hit.getPosition().z);
           const auto delta = out_clust.getPosition() - hit.getPosition();
           radius += delta * delta;
@@ -161,9 +161,9 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
 
           // eigenvalues of symmetric real matrix are always real
           // Store descending: [0]=largest, [1/2]=smaller
-          auto ev2 = es_2D.eigenvalues(); // ascending real double
-          eigenValues_2D[0] = ev2[1];     // largest
-          eigenValues_2D[1] = ev2[0];     // smallest
+          auto ev2          = es_2D.eigenvalues(); // ascending real double
+          eigenValues_2D[0] = ev2[1];              // largest
+          eigenValues_2D[1] = ev2[0];              // smallest
 
           auto ev3          = es_3D.eigenvalues(); // ascending real double
           eigenValues_3D[0] = ev3[2];              // largest
@@ -183,11 +183,16 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
       // set shape parameters
       out_clust.addToShapeParameters(radius);
       out_clust.addToShapeParameters(dispersion);
-      out_clust.addToShapeParameters(std::sqrt(std::abs(eigenValues_2D[0]))); // 2D theta-phi out_cluster width 1 [rad]
-      out_clust.addToShapeParameters(std::sqrt(std::abs(eigenValues_2D[1]))); // 2D theta-phi out_cluster width 2 [rad]
-      out_clust.addToShapeParameters(std::sqrt(std::abs(eigenValues_3D[0]))); // 3D x-y-z out_cluster width 1 [mm]
-      out_clust.addToShapeParameters(std::sqrt(std::abs(eigenValues_3D[1]))); // 3D x-y-z out_cluster width 2 [mm]
-      out_clust.addToShapeParameters(std::sqrt(std::abs(eigenValues_3D[2]))); // 3D x-y-z out_cluster width 3 [mm]
+      out_clust.addToShapeParameters(
+          std::sqrt(std::abs(eigenValues_2D[0]))); // 2D theta-phi out_cluster width 1 [rad]
+      out_clust.addToShapeParameters(
+          std::sqrt(std::abs(eigenValues_2D[1]))); // 2D theta-phi out_cluster width 2 [rad]
+      out_clust.addToShapeParameters(
+          std::sqrt(std::abs(eigenValues_3D[0]))); // 3D x-y-z out_cluster width 1 [mm]
+      out_clust.addToShapeParameters(
+          std::sqrt(std::abs(eigenValues_3D[1]))); // 3D x-y-z out_cluster width 2 [mm]
+      out_clust.addToShapeParameters(
+          std::sqrt(std::abs(eigenValues_3D[2]))); // 3D x-y-z out_cluster width 3 [mm]
 
       // check axis orientation
       double dot_product = out_clust.getPosition() * axis;
@@ -206,12 +211,9 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
             "2D w1={:.4f} w2={:.4f} [rad] "
             "3D w1={:.3f} w2={:.3f} w3={:.3f} [mm] "
             "intrinsicTheta={:.4f} Phi={:.4f} [rad]",
-            radius, dispersion,
-            std::sqrt(std::abs(eigenValues_2D[0])),
-            std::sqrt(std::abs(eigenValues_2D[1])),
-            std::sqrt(std::abs(eigenValues_3D[0])),
-            std::sqrt(std::abs(eigenValues_3D[1])),
-            std::sqrt(std::abs(eigenValues_3D[2])),
+            radius, dispersion, std::sqrt(std::abs(eigenValues_2D[0])),
+            std::sqrt(std::abs(eigenValues_2D[1])), std::sqrt(std::abs(eigenValues_3D[0])),
+            std::sqrt(std::abs(eigenValues_3D[1])), std::sqrt(std::abs(eigenValues_3D[2])),
             intrinsicTheta, intrinsicPhi);
     } // end shape parameter calculation
 

--- a/src/algorithms/calorimetry/CalorimeterClusterShape.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterShape.cc
@@ -99,10 +99,11 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
     {
 
       // create addresses for quantities we'll need later
-      float radius     = 0;
-      float dispersion = 0;
+      double radius     = 0;
+      double dispersion = 0;
       double w_sum     = 0;
       // set up matrices/vectors — all double to avoid float32 cancellation
+      Eigen::Matrix2d sum2_2D        = Eigen::Matrix2d::Zero();
       Eigen::Matrix3d sum2_3D        = Eigen::Matrix3d::Zero();
       Eigen::Vector2d sum1_2D        = Eigen::Vector2d::Zero();
       Eigen::Vector3d sum1_3D        = Eigen::Vector3d::Zero();
@@ -116,7 +117,7 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
 
           // get weight of hit
           const double eTotal = out_clust.getEnergy() * m_cfg.sampFrac;
-          const float w       = m_weightFunc(hit.getEnergy(), eTotal, logWeightBase, 0);
+          const double w      = m_weightFunc(hit.getEnergy(), eTotal, logWeightBase, 0);
 
           // theta, phi
           Eigen::Vector2d pos2D(edm4hep::utils::anglePolar(hit.getPosition()),

--- a/src/algorithms/calorimetry/CalorimeterClusterShape.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterShape.cc
@@ -114,7 +114,7 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
       Eigen::Vector2f sum1_2D         = Eigen::Vector2f::Zero();
       Eigen::Vector3d sum1_3D         = Eigen::Vector3d::Zero();
       Eigen::Vector2cf eigenValues_2D = Eigen::Vector2cf::Zero();
-      Eigen::Vector3d  eigenValues_3D = Eigen::Vector3d::Zero();
+      Eigen::Vector3d eigenValues_3D  = Eigen::Vector3d::Zero();
 
       // the axis is the direction of the eigenvalue corresponding to the largest eigenvalue.
       edm4hep::Vector3f axis;
@@ -168,18 +168,18 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
 
           // eigenvalues of symmetric real matrix are always real
           // Store descending: [0]=largest, [2]=smallest
-          auto ev2 = es_2D.eigenvalues(); // ascending real float
-          eigenValues_2D[0] = ev2[1];     // largest
-          eigenValues_2D[1] = ev2[0];     // smallest
+          auto ev2          = es_2D.eigenvalues(); // ascending real float
+          eigenValues_2D[0] = ev2[1];              // largest
+          eigenValues_2D[1] = ev2[0];              // smallest
 
-          auto ev3 = es_3D.eigenvalues(); // ascending real double
-          eigenValues_3D[0] = ev3[2];     // largest
+          auto ev3          = es_3D.eigenvalues(); // ascending real double
+          eigenValues_3D[0] = ev3[2];              // largest
           eigenValues_3D[1] = ev3[1];
-          eigenValues_3D[2] = ev3[0];     // smallest (0 for flat-z detectors)
+          eigenValues_3D[2] = ev3[0]; // smallest (0 for flat-z detectors)
 
           // eigenvector for largest eigenvalue (index 2 in ascending order)
           auto axis_eigen = es_3D.eigenvectors().col(2);
-          axis = {
+          axis            = {
               static_cast<float>(axis_eigen(0)),
               static_cast<float>(axis_eigen(1)),
               static_cast<float>(axis_eigen(2)),
@@ -190,11 +190,16 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
       // set shape parameters
       out_clust.addToShapeParameters(radius);
       out_clust.addToShapeParameters(dispersion);
-      out_clust.addToShapeParameters(std::sqrt(std::abs(eigenValues_2D[0].real()))); // 2D theta-phi out_cluster width 1 [rad]
-      out_clust.addToShapeParameters(std::sqrt(std::abs(eigenValues_2D[1].real()))); // 2D theta-phi out_cluster width 2 [rad]
-      out_clust.addToShapeParameters(std::sqrt(std::abs(eigenValues_3D[0])));        // 3D x-y-z out_cluster width 1 [mm]
-      out_clust.addToShapeParameters(std::sqrt(std::abs(eigenValues_3D[1])));        // 3D x-y-z out_cluster width 2 [mm]
-      out_clust.addToShapeParameters(std::sqrt(std::abs(eigenValues_3D[2])));        // 3D x-y-z out_cluster width 3 [mm]
+      out_clust.addToShapeParameters(
+          std::sqrt(std::abs(eigenValues_2D[0].real()))); // 2D theta-phi out_cluster width 1 [rad]
+      out_clust.addToShapeParameters(
+          std::sqrt(std::abs(eigenValues_2D[1].real()))); // 2D theta-phi out_cluster width 2 [rad]
+      out_clust.addToShapeParameters(
+          std::sqrt(std::abs(eigenValues_3D[0]))); // 3D x-y-z out_cluster width 1 [mm]
+      out_clust.addToShapeParameters(
+          std::sqrt(std::abs(eigenValues_3D[1]))); // 3D x-y-z out_cluster width 2 [mm]
+      out_clust.addToShapeParameters(
+          std::sqrt(std::abs(eigenValues_3D[2]))); // 3D x-y-z out_cluster width 3 [mm]
 
       // check axis orientation
       double dot_product = out_clust.getPosition() * axis;
@@ -213,12 +218,9 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
             "2D_w1={:.4f} rad 2D_w2={:.4f} rad "
             "3D_w1={:.3f} mm 3D_w2={:.3f} mm 3D_w3={:.3f} mm "
             "intrinsicTheta={:.4f} intrinsicPhi={:.4f}",
-            radius, dispersion,
-            std::sqrt(std::abs(eigenValues_2D[0].real())),
-            std::sqrt(std::abs(eigenValues_2D[1].real())),
-            std::sqrt(std::abs(eigenValues_3D[0])),
-            std::sqrt(std::abs(eigenValues_3D[1])),
-            std::sqrt(std::abs(eigenValues_3D[2])),
+            radius, dispersion, std::sqrt(std::abs(eigenValues_2D[0].real())),
+            std::sqrt(std::abs(eigenValues_2D[1].real())), std::sqrt(std::abs(eigenValues_3D[0])),
+            std::sqrt(std::abs(eigenValues_3D[1])), std::sqrt(std::abs(eigenValues_3D[2])),
             intrinsicTheta, intrinsicPhi);
     } // end shape parameter calculation
 

--- a/src/algorithms/calorimetry/CalorimeterClusterShape.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterShape.cc
@@ -10,7 +10,6 @@
 #include <edm4hep/MCParticle.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
 #include <podio/detail/Link.h>
 #include <podio/detail/LinkCollectionImpl.h>

--- a/src/algorithms/calorimetry/CalorimeterClusterShape.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterShape.cc
@@ -181,16 +181,11 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
       // set shape parameters
       out_clust.addToShapeParameters(radius);
       out_clust.addToShapeParameters(dispersion);
-      out_clust.addToShapeParameters(
-          std::sqrt(std::abs(eigenValues_2D[0]))); // 2D theta-phi out_cluster width 1 [rad]
-      out_clust.addToShapeParameters(
-          std::sqrt(std::abs(eigenValues_2D[1]))); // 2D theta-phi out_cluster width 2 [rad]
-      out_clust.addToShapeParameters(
-          std::sqrt(std::abs(eigenValues_3D[0]))); // 3D x-y-z out_cluster width 1 [mm]
-      out_clust.addToShapeParameters(
-          std::sqrt(std::abs(eigenValues_3D[1]))); // 3D x-y-z out_cluster width 2 [mm]
-      out_clust.addToShapeParameters(
-          std::sqrt(std::abs(eigenValues_3D[2]))); // 3D x-y-z out_cluster width 3 [mm]
+      out_clust.addToShapeParameters(eigenValues_2D[0]); // 2D theta-phi out_cluster width 1 [rad^2]
+      out_clust.addToShapeParameters(eigenValues_2D[1]); // 2D theta-phi out_cluster width 2 [rad^2]
+      out_clust.addToShapeParameters(eigenValues_3D[0]); // 3D x-y-z out_cluster width 1 [mm^2]
+      out_clust.addToShapeParameters(eigenValues_3D[1]); // 3D x-y-z out_cluster width 2 [mm^2]
+      out_clust.addToShapeParameters(eigenValues_3D[2]); // 3D x-y-z out_cluster width 3 [mm^2]
 
       // check axis orientation
       double dot_product = out_clust.getPosition() * axis;

--- a/src/algorithms/calorimetry/CalorimeterClusterShape.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterShape.cc
@@ -100,7 +100,7 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
       double radius     = 0;
       double dispersion = 0;
       double w_sum      = 0;
-      // set up matrices/vectors — all double to avoid float32 cancellation
+      // set up matrices/vectors
       Eigen::Matrix2d sum2_2D        = Eigen::Matrix2d::Zero();
       Eigen::Matrix3d sum2_3D        = Eigen::Matrix3d::Zero();
       Eigen::Vector2d sum1_2D        = Eigen::Vector2d::Zero();

--- a/src/algorithms/calorimetry/CalorimeterClusterShape.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterShape.cc
@@ -21,7 +21,6 @@
 #include <algorithm>
 #include <cctype>
 #include <cmath>
-#include <complex>
 #include <cstddef>
 #include <gsl/pointers>
 #include <iterator>
@@ -103,18 +102,12 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
       float radius     = 0;
       float dispersion = 0;
       double w_sum     = 0;
-
-      // set up matrices/vectors
-      // 2D (theta-phi) uses float — angles are O(1), no precision issue.
-      // 3D (x-y-z) uses double — hit positions are O(1000) mm; float32 causes
-      //   catastrophic cancellation in cov[2,2] = <z²> - <z>² for detectors
-      //   with fixed large z (e.g. FEMC at z~3500 mm), giving spurious sigma3.
-      Eigen::Matrix2f sum2_2D         = Eigen::Matrix2f::Zero();
-      Eigen::Matrix3d sum2_3D         = Eigen::Matrix3d::Zero();
-      Eigen::Vector2f sum1_2D         = Eigen::Vector2f::Zero();
-      Eigen::Vector3d sum1_3D         = Eigen::Vector3d::Zero();
-      Eigen::Vector2cf eigenValues_2D = Eigen::Vector2cf::Zero();
-      Eigen::Vector3d eigenValues_3D  = Eigen::Vector3d::Zero();
+      // set up matrices/vectors — all double to avoid float32 cancellation
+      Eigen::Matrix3d sum2_3D        = Eigen::Matrix3d::Zero();
+      Eigen::Vector2d sum1_2D        = Eigen::Vector2d::Zero();
+      Eigen::Vector3d sum1_3D        = Eigen::Vector3d::Zero();
+      Eigen::Vector2d eigenValues_2D = Eigen::Vector2d::Zero();
+      Eigen::Vector3d eigenValues_3D = Eigen::Vector3d::Zero();
 
       // the axis is the direction of the eigenvalue corresponding to the largest eigenvalue.
       edm4hep::Vector3f axis;
@@ -126,11 +119,10 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
           const float w       = m_weightFunc(hit.getEnergy(), eTotal, logWeightBase, 0);
 
           // theta, phi
-          Eigen::Vector2f pos2D(edm4hep::utils::anglePolar(hit.getPosition()),
+          Eigen::Vector2d pos2D(edm4hep::utils::anglePolar(hit.getPosition()),
                                 edm4hep::utils::angleAzimuthal(hit.getPosition()));
-          // x, y, z — double to avoid float32 cancellation for large z
+          // x, y, z 
           Eigen::Vector3d pos3D(hit.getPosition().x, hit.getPosition().y, hit.getPosition().z);
-
           const auto delta = out_clust.getPosition() - hit.getPosition();
           radius += delta * delta;
           dispersion += delta * delta * w;
@@ -151,26 +143,26 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
           dispersion = sqrt(dispersion / w_sum);
 
           // normalize matrices
-          sum2_2D /= static_cast<float>(w_sum);
+          sum2_2D /= w_sum;
           sum2_3D /= w_sum;
-          sum1_2D /= static_cast<float>(w_sum);
+          sum1_2D /= w_sum;
           sum1_3D /= w_sum;
 
           // 2D and 3D covariance matrices
-          Eigen::Matrix2f cov2 = sum2_2D - sum1_2D * sum1_2D.transpose();
+          Eigen::Matrix2d cov2 = sum2_2D - sum1_2D * sum1_2D.transpose();
           Eigen::Matrix3d cov3 = sum2_3D - sum1_3D * sum1_3D.transpose();
 
           // Use SelfAdjointEigenSolver for symmetric covariance matrices.
           // More accurate than EigenSolver for symmetric matrices, guarantees
           // real eigenvalues, and returns them sorted ascending: [0]=smallest.
-          Eigen::SelfAdjointEigenSolver<Eigen::Matrix2f> es_2D(cov2);
+          Eigen::SelfAdjointEigenSolver<Eigen::Matrix2d> es_2D(cov2);
           Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> es_3D(cov3);
 
           // eigenvalues of symmetric real matrix are always real
-          // Store descending: [0]=largest, [2]=smallest
-          auto ev2          = es_2D.eigenvalues(); // ascending real float
-          eigenValues_2D[0] = ev2[1];              // largest
-          eigenValues_2D[1] = ev2[0];              // smallest
+          // Store descending: [0]=largest, [1/2]=smaller
+          auto ev2 = es_2D.eigenvalues(); // ascending real double
+          eigenValues_2D[0] = ev2[1];     // largest
+          eigenValues_2D[1] = ev2[0];     // smallest
 
           auto ev3          = es_3D.eigenvalues(); // ascending real double
           eigenValues_3D[0] = ev3[2];              // largest
@@ -190,16 +182,11 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
       // set shape parameters
       out_clust.addToShapeParameters(radius);
       out_clust.addToShapeParameters(dispersion);
-      out_clust.addToShapeParameters(
-          std::sqrt(std::abs(eigenValues_2D[0].real()))); // 2D theta-phi out_cluster width 1 [rad]
-      out_clust.addToShapeParameters(
-          std::sqrt(std::abs(eigenValues_2D[1].real()))); // 2D theta-phi out_cluster width 2 [rad]
-      out_clust.addToShapeParameters(
-          std::sqrt(std::abs(eigenValues_3D[0]))); // 3D x-y-z out_cluster width 1 [mm]
-      out_clust.addToShapeParameters(
-          std::sqrt(std::abs(eigenValues_3D[1]))); // 3D x-y-z out_cluster width 2 [mm]
-      out_clust.addToShapeParameters(
-          std::sqrt(std::abs(eigenValues_3D[2]))); // 3D x-y-z out_cluster width 3 [mm]
+      out_clust.addToShapeParameters(std::sqrt(std::abs(eigenValues_2D[0]))); // 2D theta-phi out_cluster width 1 [rad]
+      out_clust.addToShapeParameters(std::sqrt(std::abs(eigenValues_2D[1]))); // 2D theta-phi out_cluster width 2 [rad]
+      out_clust.addToShapeParameters(std::sqrt(std::abs(eigenValues_3D[0]))); // 3D x-y-z out_cluster width 1 [mm]
+      out_clust.addToShapeParameters(std::sqrt(std::abs(eigenValues_3D[1]))); // 3D x-y-z out_cluster width 2 [mm]
+      out_clust.addToShapeParameters(std::sqrt(std::abs(eigenValues_3D[2]))); // 3D x-y-z out_cluster width 3 [mm]
 
       // check axis orientation
       double dot_product = out_clust.getPosition() * axis;
@@ -214,18 +201,20 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
       out_clust.setIntrinsicPhi(intrinsicPhi);
       // TODO intrinsicDirectionError
 
-      trace("ClusterShape: radius={:.3f} mm dispersion={:.3f} mm "
-            "2D_w1={:.4f} rad 2D_w2={:.4f} rad "
-            "3D_w1={:.3f} mm 3D_w2={:.3f} mm 3D_w3={:.3f} mm "
-            "intrinsicTheta={:.4f} intrinsicPhi={:.4f}",
-            radius, dispersion, std::sqrt(std::abs(eigenValues_2D[0].real())),
-            std::sqrt(std::abs(eigenValues_2D[1].real())), std::sqrt(std::abs(eigenValues_3D[0])),
-            std::sqrt(std::abs(eigenValues_3D[1])), std::sqrt(std::abs(eigenValues_3D[2])),
+      trace("ClusterShape: radius={:.3f} [mm] dispersion={:.3f} [mm] "
+            "2D w1={:.4f} w2={:.4f} [rad] "
+            "3D w1={:.3f} w2={:.3f} w3={:.3f} [mm] "
+            "intrinsicTheta={:.4f} Phi={:.4f} [rad]",
+            radius, dispersion,
+            std::sqrt(std::abs(eigenValues_2D[0])),
+            std::sqrt(std::abs(eigenValues_2D[1])),
+            std::sqrt(std::abs(eigenValues_3D[0])),
+            std::sqrt(std::abs(eigenValues_3D[1])),
+            std::sqrt(std::abs(eigenValues_3D[2])),
             intrinsicTheta, intrinsicPhi);
     } // end shape parameter calculation
 
     out_clusters->push_back(out_clust);
-    trace("Completed shape calculation for cluster {}", in_clust.getObjectID().index);
 
     // ----------------------------------------------------------------------
     // if provided, copy associations

--- a/src/algorithms/calorimetry/CalorimeterClusterShape.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterShape.cc
@@ -102,15 +102,19 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
       // create addresses for quantities we'll need later
       float radius     = 0;
       float dispersion = 0;
-      float w_sum      = 0;
+      double w_sum     = 0;
 
       // set up matrices/vectors
+      // 2D (theta-phi) uses float — angles are O(1), no precision issue.
+      // 3D (x-y-z) uses double — hit positions are O(1000) mm; float32 causes
+      //   catastrophic cancellation in cov[2,2] = <z²> - <z>² for detectors
+      //   with fixed large z (e.g. FEMC at z~3500 mm), giving spurious sigma3.
       Eigen::Matrix2f sum2_2D         = Eigen::Matrix2f::Zero();
-      Eigen::Matrix3f sum2_3D         = Eigen::Matrix3f::Zero();
+      Eigen::Matrix3d sum2_3D         = Eigen::Matrix3d::Zero();
       Eigen::Vector2f sum1_2D         = Eigen::Vector2f::Zero();
-      Eigen::Vector3f sum1_3D         = Eigen::Vector3f::Zero();
+      Eigen::Vector3d sum1_3D         = Eigen::Vector3d::Zero();
       Eigen::Vector2cf eigenValues_2D = Eigen::Vector2cf::Zero();
-      Eigen::Vector3cf eigenValues_3D = Eigen::Vector3cf::Zero();
+      Eigen::Vector3d  eigenValues_3D = Eigen::Vector3d::Zero();
 
       // the axis is the direction of the eigenvalue corresponding to the largest eigenvalue.
       edm4hep::Vector3f axis;
@@ -124,8 +128,8 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
           // theta, phi
           Eigen::Vector2f pos2D(edm4hep::utils::anglePolar(hit.getPosition()),
                                 edm4hep::utils::angleAzimuthal(hit.getPosition()));
-          // x, y, z
-          Eigen::Vector3f pos3D(hit.getPosition().x, hit.getPosition().y, hit.getPosition().z);
+          // x, y, z — double to avoid float32 cancellation for large z
+          Eigen::Vector3d pos3D(hit.getPosition().x, hit.getPosition().y, hit.getPosition().z);
 
           const auto delta = out_clust.getPosition() - hit.getPosition();
           radius += delta * delta;
@@ -147,34 +151,38 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
           dispersion = sqrt(dispersion / w_sum);
 
           // normalize matrices
-          sum2_2D /= w_sum;
+          sum2_2D /= static_cast<float>(w_sum);
           sum2_3D /= w_sum;
-          sum1_2D /= w_sum;
+          sum1_2D /= static_cast<float>(w_sum);
           sum1_3D /= w_sum;
 
           // 2D and 3D covariance matrices
           Eigen::Matrix2f cov2 = sum2_2D - sum1_2D * sum1_2D.transpose();
-          Eigen::Matrix3f cov3 = sum2_3D - sum1_3D * sum1_3D.transpose();
+          Eigen::Matrix3d cov3 = sum2_3D - sum1_3D * sum1_3D.transpose();
 
-          // Solve for eigenvalues.  Corresponds to out_cluster's 2nd moments (widths)
-          Eigen::EigenSolver<Eigen::Matrix2f> es_2D(
-              cov2, false); // set to true for eigenvector calculation
-          Eigen::EigenSolver<Eigen::Matrix3f> es_3D(
-              cov3, true); // set to true for eigenvector calculation
+          // Use SelfAdjointEigenSolver for symmetric covariance matrices.
+          // More accurate than EigenSolver for symmetric matrices, guarantees
+          // real eigenvalues, and returns them sorted ascending: [0]=smallest.
+          Eigen::SelfAdjointEigenSolver<Eigen::Matrix2f> es_2D(cov2);
+          Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> es_3D(cov3);
 
           // eigenvalues of symmetric real matrix are always real
-          eigenValues_2D = es_2D.eigenvalues();
-          eigenValues_3D = es_3D.eigenvalues();
-          //find the eigenvector corresponding to the largest eigenvalue
-          auto eigenvectors      = es_3D.eigenvectors();
-          auto max_eigenvalue_it = std::ranges::max_element(
-              eigenValues_3D, [](auto a, auto b) { return std::real(a) < std::real(b); });
-          auto axis_eigen =
-              eigenvectors.col(std::distance(eigenValues_3D.begin(), max_eigenvalue_it));
+          // Store descending: [0]=largest, [2]=smallest
+          auto ev2 = es_2D.eigenvalues(); // ascending real float
+          eigenValues_2D[0] = ev2[1];     // largest
+          eigenValues_2D[1] = ev2[0];     // smallest
+
+          auto ev3 = es_3D.eigenvalues(); // ascending real double
+          eigenValues_3D[0] = ev3[2];     // largest
+          eigenValues_3D[1] = ev3[1];
+          eigenValues_3D[2] = ev3[0];     // smallest (0 for flat-z detectors)
+
+          // eigenvector for largest eigenvalue (index 2 in ascending order)
+          auto axis_eigen = es_3D.eigenvectors().col(2);
           axis = {
-              axis_eigen(0, 0).real(),
-              axis_eigen(1, 0).real(),
-              axis_eigen(2, 0).real(),
+              static_cast<float>(axis_eigen(0)),
+              static_cast<float>(axis_eigen(1)),
+              static_cast<float>(axis_eigen(2)),
           };
         } // end if weight sum is nonzero
       } // end if n hits > 1
@@ -184,9 +192,9 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
       out_clust.addToShapeParameters(dispersion);
       out_clust.addToShapeParameters(eigenValues_2D[0].real()); // 2D theta-phi out_cluster width 1
       out_clust.addToShapeParameters(eigenValues_2D[1].real()); // 2D theta-phi out_cluster width 2
-      out_clust.addToShapeParameters(eigenValues_3D[0].real()); // 3D x-y-z out_cluster width 1
-      out_clust.addToShapeParameters(eigenValues_3D[1].real()); // 3D x-y-z out_cluster width 2
-      out_clust.addToShapeParameters(eigenValues_3D[2].real()); // 3D x-y-z out_cluster width 3
+      out_clust.addToShapeParameters(eigenValues_3D[0]);        // 3D x-y-z out_cluster width 1
+      out_clust.addToShapeParameters(eigenValues_3D[1]);        // 3D x-y-z out_cluster width 2
+      out_clust.addToShapeParameters(eigenValues_3D[2]);        // 3D x-y-z out_cluster width 3
 
       // check axis orientation
       double dot_product = out_clust.getPosition() * axis;
@@ -194,15 +202,21 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
         axis = -1 * axis;
       }
 
-      // set intrinsic theta/phi
-      if (m_cfg.longitudinalShowerInfoAvailable) {
-        out_clust.setIntrinsicTheta(edm4hep::utils::anglePolar(axis));
-        out_clust.setIntrinsicPhi(edm4hep::utils::angleAzimuthal(axis));
-        // TODO intrinsicDirectionError
-      } else {
-        out_clust.setIntrinsicTheta(NAN);
-        out_clust.setIntrinsicPhi(NAN);
-      }
+      // set intrinsic theta/phi from 3D principal axis
+      float intrinsicTheta = edm4hep::utils::anglePolar(axis);
+      float intrinsicPhi   = edm4hep::utils::angleAzimuthal(axis);
+      out_clust.setIntrinsicTheta(intrinsicTheta);
+      out_clust.setIntrinsicPhi(intrinsicPhi);
+      // TODO intrinsicDirectionError
+
+      trace("ClusterShape: radius={:.3f} dispersion={:.3f} "
+            "2D_w1={:.4f} 2D_w2={:.4f} "
+            "3D_w1={:.3f} 3D_w2={:.3f} 3D_w3={:.3f} "
+            "intrinsicTheta={:.4f} intrinsicPhi={:.4f}",
+            radius, dispersion,
+            eigenValues_2D[0].real(), eigenValues_2D[1].real(),
+            eigenValues_3D[0], eigenValues_3D[1], eigenValues_3D[2],
+            intrinsicTheta, intrinsicPhi);
     } // end shape parameter calculation
 
     out_clusters->push_back(out_clust);

--- a/src/algorithms/calorimetry/CalorimeterClusterShape.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterShape.cc
@@ -22,9 +22,8 @@
 #include <cctype>
 #include <cmath>
 #include <cstddef>
-#include <gsl/pointers>
-#include <iterator>
 #include <memory>
+#include <tuple>
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

- Change float to double for 3d cluster shape covariance matrix calculation because floating point rounding error was giving ⟨z²⟩ − ⟨z⟩² = none-zero thus sigma_Z often to be around ~2 mm for Forward Ecal where z of hits are always exactly the same and sigma-z should be always 0.
- Replace Eigen::EigenSolver (general) with Eigen::SelfAdjointEigenSolver (for symmetric matrix). This also fixes that 2d and 3d sigmas were not sorted by its size. We'll need to fix https://github.com/eic/EDM4eic/blob/main/edm4eic.yaml on cluster shapeParams  : "3 entries for x-y-z widths [mm]." to something like "3 entries for 3D max, middle and min widths [mm]".
- Also they needed to be sqrt of egen values to make them [rad] and [mm] unit for shape parameters as specified in edm4eic.yaml.
- Always do intrinsic theta & phi calculations, since phi is indeed 2d "theta" (cluster long axis angle in xy) for detectors like Forward Ecal and useful even if there is no depth information.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ ] Medium
- [ x] Low

### What kind of change does this PR introduce?
- [ x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
