### PR TITLE
CalorimeterClusterRecoCoG_factory.h update for 2 pass running

### DIFF
--- a/src/factories/calorimetry/CalorimeterClusterRecoCoG_factory.h
+++ b/src/factories/calorimetry/CalorimeterClusterRecoCoG_factory.h
@@ -21,9 +21,9 @@ private:
 
   PodioInput<edm4eic::ProtoCluster> m_proto_input{this};
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-  PodioInput<edm4eic::MCRecoCalorimeterHitLink> m_mchitlinks_input{this};
+  PodioInput<edm4eic::MCRecoCalorimeterHitLink, true> m_mchitlinks_input{this};  // Optional: for truth associations
 #endif
-  PodioInput<edm4eic::MCRecoCalorimeterHitAssociation> m_mchitassocs_input{this};
+  PodioInput<edm4eic::MCRecoCalorimeterHitAssociation, true> m_mchitassocs_input{this};  // Optional: for truth associations
 
   PodioOutput<edm4eic::Cluster> m_cluster_output{this};
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)

--- a/src/factories/calorimetry/CalorimeterClusterRecoCoG_factory.h
+++ b/src/factories/calorimetry/CalorimeterClusterRecoCoG_factory.h
@@ -21,9 +21,11 @@ private:
 
   PodioInput<edm4eic::ProtoCluster> m_proto_input{this};
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)
-  PodioInput<edm4eic::MCRecoCalorimeterHitLink, true> m_mchitlinks_input{this};  // Optional: for truth associations
+  PodioInput<edm4eic::MCRecoCalorimeterHitLink, true> m_mchitlinks_input{
+      this}; // Optional: for truth associations
 #endif
-  PodioInput<edm4eic::MCRecoCalorimeterHitAssociation, true> m_mchitassocs_input{this};  // Optional: for truth associations
+  PodioInput<edm4eic::MCRecoCalorimeterHitAssociation, true> m_mchitassocs_input{
+      this}; // Optional: for truth associations
 
   PodioOutput<edm4eic::Cluster> m_cluster_output{this};
 #if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8, 7, 0)


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

This is for https://github.com/eic/EICrecon/issues/2593.

When running EICrecon for reading RECO file, re-run modified cluster finder and shape analysis and use & save new results, we need to ignore MCRecoCalorimeterHitLink and association when RECO file does not have them. Those are optional inputs for CalorimeterClusterRecoCoG and it works without them. But it can't run since they do not exist and will not pass the Podio checks. Those 2 line changes make them optional and enable to run the factory without those inputs on 2nd pass.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ ] Medium
- [x] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
