### PR TITLE
fix(ci): broaden TSAN suppressions in ROOT

### DIFF
--- a/.github/tsan.supp
+++ b/.github/tsan.supp
@@ -4,6 +4,7 @@
 race:std::binomial_distribution<int>::param_type::_M_initialize
 race:std::binomial_distribution<int>::operator()
 
-# false positive in RNTuple reads, https://github.com/root-project/root/issues/22153
-race:ROOT::Internal::RCluster::Adopt
+# false positives in RNTuple reads, https://github.com/root-project/root/issues/22153
+race:ROOT::Internal::RCluster
+race:ROOT::Internal::RClusterPool
 race:ROOT::Internal::RRawFileUnix


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR suppresses the TSAN error in ROOT's RNTuple reading routines that causes CI failures in e.g. https://github.com/eic/EICrecon/actions/runs/26964129848/job/79563128662?pr=2551#step:7:670

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue: https://github.com/eic/EICrecon/actions/runs/26964129848/job/79563128662?pr=2551#step:7:670)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

This is a hotfix PR that aims to fix actively broken github actions pipelines.