### PR TITLE
fix: update ACTS EventData headers for compatibility with PR #5496

### DIFF
--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -8,7 +8,11 @@
 #include <Acts/Definitions/Direction.hpp>
 #include <Acts/Definitions/TrackParametrization.hpp>
 #include <Acts/Definitions/Units.hpp>
+#if Acts_VERSION_MAJOR >= 46
+#include <Acts/EventData/BoundTrackParameters.hpp>
+#else
 #include <Acts/EventData/GenericBoundTrackParameters.hpp>
+#endif
 #include <Acts/EventData/MeasurementHelpers.hpp>
 #include <Acts/EventData/TrackStatePropMask.hpp>
 #include <Acts/Geometry/GeometryContext.hpp>

--- a/src/algorithms/tracking/CKFTracking.cc
+++ b/src/algorithms/tracking/CKFTracking.cc
@@ -4,8 +4,6 @@
 #include "CKFTracking.h"
 
 #include <Acts/Definitions/Algebra.hpp>
-#include <Acts/Definitions/Common.hpp>
-#include <Acts/Definitions/Direction.hpp>
 #include <Acts/Definitions/TrackParametrization.hpp>
 #include <Acts/Definitions/Units.hpp>
 #if Acts_VERSION_MAJOR >= 46

--- a/src/algorithms/tracking/CKFTracking.h
+++ b/src/algorithms/tracking/CKFTracking.h
@@ -15,6 +15,7 @@
 #include <algorithms/algorithm.h>
 #include <edm4eic/Measurement2DCollection.h>
 #include <edm4eic/TrackSeedCollection.h>
+#include <Eigen/Core>
 #include <memory>
 #include <string>
 #include <string_view>

--- a/src/algorithms/tracking/IterativeVertexFinder.cc
+++ b/src/algorithms/tracking/IterativeVertexFinder.cc
@@ -6,7 +6,11 @@
 
 #include <Acts/Definitions/TrackParametrization.hpp>
 #include <Acts/Definitions/Units.hpp>
+#if Acts_VERSION_MAJOR >= 46
+#include <Acts/EventData/BoundTrackParameters.hpp>
+#else
 #include <Acts/EventData/TrackParameters.hpp>
+#endif
 #include <Acts/EventData/TrackProxy.hpp>
 #include <Acts/Propagator/EigenStepper.hpp>
 #include <Acts/Propagator/Propagator.hpp>

--- a/src/algorithms/tracking/SecondaryVertexFinder.cc
+++ b/src/algorithms/tracking/SecondaryVertexFinder.cc
@@ -5,7 +5,11 @@
 
 #include <Acts/Definitions/TrackParametrization.hpp>
 #include <Acts/Definitions/Units.hpp>
+#if Acts_VERSION_MAJOR >= 46
+#include <Acts/EventData/BoundTrackParameters.hpp>
+#else
 #include <Acts/EventData/TrackParameters.hpp>
+#endif
 #include <Acts/EventData/TrackProxy.hpp>
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
 #include <Acts/EventData/VectorTrackContainer.hpp>

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -2,7 +2,6 @@
 // Copyright (C) 2022, 2023 Wenqing Fan, Barak Schmookler, Whitney Armstrong, Sylvester Joosten, Dmitry Romanov, Christopher Dilks, Wouter Deconinck
 
 #include <Acts/Definitions/Algebra.hpp>
-#include <Acts/Definitions/Common.hpp>
 #include <Acts/Definitions/Direction.hpp>
 #include <Acts/Definitions/TrackParametrization.hpp>
 #include <Acts/Definitions/Units.hpp>
@@ -38,6 +37,7 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <algorithm>
+#include <any>
 #include <cmath>
 #include <cstdint>
 #include <functional>

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -6,7 +6,11 @@
 #include <Acts/Definitions/Direction.hpp>
 #include <Acts/Definitions/TrackParametrization.hpp>
 #include <Acts/Definitions/Units.hpp>
+#if Acts_VERSION_MAJOR >= 46
+#include <Acts/EventData/BoundTrackParameters.hpp>
+#else
 #include <Acts/EventData/GenericBoundTrackParameters.hpp>
+#endif
 #include <Acts/EventData/MultiTrajectoryHelpers.hpp>
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
 #include <Acts/Geometry/GeometryIdentifier.hpp>

--- a/src/algorithms/tracking/TrackPropagation.h
+++ b/src/algorithms/tracking/TrackPropagation.h
@@ -3,7 +3,11 @@
 
 #pragma once
 
+#if Acts_VERSION_MAJOR >= 46
+#include <Acts/EventData/BoundTrackParameters.hpp>
+#else
 #include <Acts/EventData/TrackParameters.hpp>
+#endif
 #include <Acts/EventData/TrackProxy.hpp>
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
 #include <Acts/EventData/VectorTrackContainer.hpp>


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

This PR replaces deprecated ACTS headers with their modern equivalents:
- Acts/EventData/GenericBoundTrackParameters.hpp → Acts/EventData/BoundTrackParameters.hpp
- Acts/EventData/TrackParameters.hpp → Acts/EventData/BoundTrackParameters.hpp

This fixes compilation errors caused by ACTS PR #5496 which removed deprecated interfaces. Preprocessor guards ensure compatibility with both ACTS v45 and earlier (using old headers) and v46+ (using new headers).

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/acts-project/acts/actions/runs/27369443117/job/80877508432?pr=5496#step:8:170)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

This fixes currently broken ACTS pipelines in their main branch.