### PR TITLE
refactor: JEventProcessorPODIO: Factor out PropagateNonEventCategories

### DIFF
--- a/src/services/io/podio/JEventProcessorManagedPODIO.cc
+++ b/src/services/io/podio/JEventProcessorManagedPODIO.cc
@@ -21,7 +21,6 @@
 #include <filesystem>
 #include <map>
 #include <stdexcept>
-#include <string_view>
 #include <thread>
 #include <utility>
 #include <vector>

--- a/src/services/io/podio/JEventProcessorManagedPODIO.cc
+++ b/src/services/io/podio/JEventProcessorManagedPODIO.cc
@@ -252,30 +252,18 @@ nlohmann::json JEventProcessorManagedPODIO::CloseOutputFile() {
   }
 
   try {
-    // Propagate non-"events" frames (e.g. "runs", "metadata") to the output
-    // and then release the reader.  Emit() no longer resets m_reader on EOF
-    // precisely so that this code can still read from it safely.
+    // Propagate non-"events" frames (e.g. "runs", "metadata") to the output.
+    PropagateNonEventCategories();
+
+    // Release the reader so it doesn't hold the input file open until the
+    // next SetCurrentFile() call.
     auto* app          = GetApplication();
     auto event_sources = app->GetService<JComponentManager>()->get_evt_srces();
     for (auto* source : event_sources) {
       auto* managed_source = dynamic_cast<JEventSourceManagedPODIO*>(source);
-      if (managed_source == nullptr) {
-        continue;
+      if (managed_source != nullptr) {
+        managed_source->ResetReader();
       }
-      for (const auto& _category : managed_source->getAvailableCategories()) {
-        std::string category{_category};
-        if (category == "events") {
-          continue;
-        }
-        std::size_t n = managed_source->getEntries(category);
-        for (std::size_t i = 0; i < n; ++i) {
-          m_writer->writeFrame(managed_source->getFrame(category, i), category);
-        }
-        m_log->info("Propagated {} '{}' frame(s) to output file", n, category);
-      }
-      // Now that all frames are written, release the reader so it doesn't
-      // hold the input file open until the next SetCurrentFile() call.
-      managed_source->ResetReader();
     }
 
     m_writer->finish();

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -811,7 +811,7 @@ void JEventProcessorPODIO::Process(const std::shared_ptr<const JEvent>& event) {
   }
 }
 
-void JEventProcessorPODIO::Finish() {
+void JEventProcessorPODIO::PropagateNonEventCategories() {
   // Propagate all non-event frames from input to output
   auto* app          = GetApplication();
   auto event_sources = app->GetService<JComponentManager>()->get_evt_srces();
@@ -830,5 +830,9 @@ void JEventProcessorPODIO::Finish() {
       m_log->info("Propagated {} '{}' frame(s) to output file", n, category);
     }
   }
+}
+
+void JEventProcessorPODIO::Finish() {
+  PropagateNonEventCategories();
   m_writer->finish();
 }

--- a/src/services/io/podio/JEventProcessorPODIO.h
+++ b/src/services/io/podio/JEventProcessorPODIO.h
@@ -23,6 +23,12 @@ public:
 
   void FindCollectionsToWrite(const std::shared_ptr<const JEvent>& event);
 
+protected:
+  /// Propagate all non-"events" frames from any JEventSourcePODIO input source(s)
+  /// to the output file.
+  void PropagateNonEventCategories();
+
+public:
   std::unique_ptr<podio::Writer> m_writer;
   std::mutex m_mutex;
   std::once_flag m_is_first_event;


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

This is a minor refactor reducing some code duplication. Next will move PropagateNonEventCategories out of CloseOutputFile.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ ] Medium
- [x] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.
