### PR TITLE
cmake: fix git_version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,10 +34,10 @@ cmake_policy(SET CMP0144 NEW)
 include(cmake/git_version.cmake)
 set_git_version(EICRECON_VERSION)
 
-project(EICrecon
+project(
+  EICrecon
   VERSION ${EICRECON_VERSION}
-  LANGUAGES CXX
-)
+  LANGUAGES CXX)
 
 # CMake includes
 include(CheckCXXCompilerFlag)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,14 +31,16 @@ cmake_minimum_required(VERSION 3.24)
 # 3.27: find_package() uses upper-case <PACKAGENAME>_ROOT variables
 cmake_policy(SET CMP0144 NEW)
 
-project(EICrecon LANGUAGES CXX)
+include(cmake/git_version.cmake)
+set_git_version(EICRECON_VERSION)
+
+project(EICrecon
+  VERSION ${EICRECON_VERSION}
+  LANGUAGES CXX
+)
 
 # CMake includes
 include(CheckCXXCompilerFlag)
-
-# Set version based on git
-include(cmake/git_version.cmake)
-set_git_version(CMAKE_PROJECT_VERSION)
 
 # Set a default build type if none was specified
 set(default_build_type "Release")

--- a/cmake/git_version.cmake
+++ b/cmake/git_version.cmake
@@ -1,10 +1,9 @@
 # Determine version from git describe cmake-lint: disable=C0103
 #
-# Sets two variables in the calling scope:
-#   ${VERSION}       - CMake-compatible version (X.Y.Z or X.Y.Z.N), suitable
-#                      for passing to the project() command.
-#   ${VERSION}_FULL  - Full git-describe string (e.g. 26.06.0-10-ge600dc77d),
-#                      suitable for display / install scripts.
+# Sets two variables in the calling scope: ${VERSION}       - CMake-compatible
+# version (X.Y.Z or X.Y.Z.N), suitable for passing to the project() command.
+# ${VERSION}_FULL  - Full git-describe string (e.g. 26.06.0-10-ge600dc77d),
+# suitable for display / install scripts.
 macro(set_git_version VERSION)
   if(NOT Git_Found)
     find_package(Git)
@@ -38,7 +37,8 @@ macro(set_git_version VERSION)
 
   # Extract only the leading X.Y.Z or X.Y.Z.N numeric part so the result is a
   # valid CMake version string that can be passed to project().
-  string(REGEX MATCH "^([0-9]+\\.[0-9]+(\\.[0-9]+(\\.[0-9]+)?)?)" _git_version_clean "${_git_version_stripped}")
+  string(REGEX MATCH "^([0-9]+\\.[0-9]+(\\.[0-9]+(\\.[0-9]+)?)?)"
+               _git_version_clean "${_git_version_stripped}")
 
   if(_git_version_clean)
     set(${VERSION} "${_git_version_clean}")

--- a/cmake/git_version.cmake
+++ b/cmake/git_version.cmake
@@ -1,4 +1,10 @@
 # Determine version from git describe cmake-lint: disable=C0103
+#
+# Sets two variables in the calling scope:
+#   ${VERSION}       - CMake-compatible version (X.Y.Z or X.Y.Z.N), suitable
+#                      for passing to the project() command.
+#   ${VERSION}_FULL  - Full git-describe string (e.g. 26.06.0-10-ge600dc77d),
+#                      suitable for display / install scripts.
 macro(set_git_version VERSION)
   if(NOT Git_Found)
     find_package(Git)
@@ -7,23 +13,42 @@ macro(set_git_version VERSION)
   if(GIT_EXECUTABLE)
     # Generate a git-describe version string from Git repository tags
     execute_process(
-      COMMAND ${GIT_EXECUTABLE} describe --tags --dirty --match "v*"
+      COMMAND ${GIT_EXECUTABLE} describe --tags --dirty --match "*.*.*"
       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
       OUTPUT_VARIABLE GIT_DESCRIBE_VERSION
       RESULT_VARIABLE GIT_DESCRIBE_ERROR_CODE
       OUTPUT_STRIP_TRAILING_WHITESPACE)
     if(NOT GIT_DESCRIBE_ERROR_CODE)
-      set(${VERSION} ${GIT_DESCRIBE_VERSION})
+      set(${VERSION}_FULL ${GIT_DESCRIBE_VERSION})
     endif()
   endif()
 
   # Final fallback: Just use a bogus version string that is semantically older
   # than anything else and spit out a warning to the developer.
-  if(NOT DEFINED ${VERSION})
-    set(${VERSION} v0.0.0-unknown)
+  if(NOT DEFINED ${VERSION}_FULL)
+    set(${VERSION}_FULL "0.0.0-unknown")
     message(
       WARNING
-        "Failed to determine VERSION from Git tags. Using default version \"${${VERSION}}\"."
+        "Failed to determine VERSION from Git tags. Using default version \"${${VERSION}_FULL}\"."
     )
   endif()
+
+  # Strip a leading "v" (e.g. v1.2.3 -> 1.2.3)
+  string(REGEX REPLACE "^v" "" _git_version_stripped "${${VERSION}_FULL}")
+
+  # Extract only the leading X.Y.Z or X.Y.Z.N numeric part so the result is a
+  # valid CMake version string that can be passed to project().
+  string(REGEX MATCH "^([0-9]+\\.[0-9]+(\\.[0-9]+(\\.[0-9]+)?)?)" _git_version_clean "${_git_version_stripped}")
+
+  if(_git_version_clean)
+    set(${VERSION} "${_git_version_clean}")
+  else()
+    set(${VERSION} "0.0.0")
+    message(
+      WARNING
+        "Could not parse a numeric version from \"${${VERSION}_FULL}\". Falling back to \"${${VERSION}}\"."
+    )
+  endif()
+  unset(_git_version_stripped)
+  unset(_git_version_clean)
 endmacro()

--- a/src/utilities/eicrecon/CMakeLists.txt
+++ b/src/utilities/eicrecon/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries(eicrecon PRIVATE ${JANA_LIB} ROOT::Core)
 
 # Set compile definitions
 target_compile_definitions(
-  eicrecon PRIVATE EICRECON_APP_VERSION=${CMAKE_PROJECT_VERSION})
+  eicrecon PRIVATE EICRECON_APP_VERSION=${EICRECON_VERSION_FULL})
 
 # Install executable
 install(TARGETS eicrecon DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
We currently always get v0.0.0-unknown.

Two issues here

 * CMAKE_PROJECT_VERSION is not settable externally
 * project() only accepts specific format of the version (no -dirty and such)

This follows the same route taken https://github.com/eic/epic/commit/c56bfbb0f2a1d024b11d170bf3787a300a3f1356

### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ ] Medium
- [x] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
