### PR TITLE
BUGFIX: JEventProcessorPODIO: write CentralWithoutTOFTrackerMeasurements

### DIFF
--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -73,6 +73,7 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       "CentralTrackSeeds",
       "CentralTrackSeedParameters",
       "CentralTrackerMeasurements",
+      "CentralWithoutTOFTrackerMeasurements",
 
       // Si tracker hits
       "SiBarrelTrackerRecHits",


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

Issue discovered by @jaenam1991 

Fixes a regression from 1f87dad8ea715bfc8f92abe72e562236ba899aa0
The existing `CentralTrackerMeasurements` became a subset collection, so we are not anymore storing the output of the `TrackerMeasurementFromHits` algorithm because we don't write `CentralWithoutTOFTrackerMeasurements`

Closes: #2744

### What is the urgency of this PR?
- [x] High (please describe reason below)
  may impede tracking studies
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
