### PR TITLE
[Backport v1.39] BUGFIX: JEventProcessorPODIO: write CentralWithoutTOFTrackerMeasurements

### DIFF
--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -73,6 +73,7 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       "CentralTrackSeeds",
       "CentralTrackSeedParameters",
       "CentralTrackerMeasurements",
+      "CentralWithoutTOFTrackerMeasurements",
 
       // Si tracker hits
       "SiBarrelTrackerRecHits",


### PR DESCRIPTION
# Description
Backport of #2745 to `v1.39`.