### PR TITLE
hotfix: avoid deprecated JComponentManager::get_evt_srces

### DIFF
--- a/src/extensions/jana/JComponentManager_compat.h
+++ b/src/extensions/jana/JComponentManager_compat.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <JANA/Services/JComponentManager.h>
+#include <memory>
 
 // JANA2 recently deprecated get_evt_srces() in favor of GetSources().
 // Keep compatibility with older JANA2 while avoiding deprecation warnings
@@ -21,6 +22,11 @@ inline std::vector<JEventSource*>& GetEventSources(JComponentManager* component_
 #else
   return component_manager->get_evt_srces();
 #endif
+}
+
+inline std::vector<JEventSource*>&
+GetEventSources(const std::shared_ptr<JComponentManager>& component_manager) {
+  return GetEventSources(component_manager.get());
 }
 
 } // namespace eicrecon::jana_compat

--- a/src/extensions/jana/JComponentManager_compat.h
+++ b/src/extensions/jana/JComponentManager_compat.h
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Wouter Deconinck
+
+#pragma once
+
+#include <JANA/Services/JComponentManager.h>
+
+// JANA2 recently deprecated get_evt_srces() in favor of GetSources().
+// Keep compatibility with older JANA2 while avoiding deprecation warnings
+// on newer versions.
+#if defined(JANA_VERSION_MAJOR) && defined(JANA_VERSION_MINOR) && defined(JANA_VERSION_PATCH) &&   \
+    ((JANA_VERSION_MAJOR > 2) || (JANA_VERSION_MAJOR == 2 && JANA_VERSION_MINOR >= 5))
+#define EICRECON_JANA_COMPONENT_MANAGER_HAS_GETSOURCES 1
+#endif
+
+namespace eicrecon::jana_compat {
+
+inline std::vector<JEventSource*>& GetEventSources(JComponentManager* component_manager) {
+#if defined(EICRECON_JANA_COMPONENT_MANAGER_HAS_GETSOURCES)
+  return component_manager->GetSources();
+#else
+  return component_manager->get_evt_srces();
+#endif
+}
+
+} // namespace eicrecon::jana_compat

--- a/src/services/io/podio/JEventProcessorManagedPODIO.cc
+++ b/src/services/io/podio/JEventProcessorManagedPODIO.cc
@@ -3,6 +3,7 @@
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/JEventSource.h>
+#include <JANA/Services/JComponentManager.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <cerrno>
 #include <fmt/format.h>

--- a/src/services/io/podio/JEventProcessorManagedPODIO.cc
+++ b/src/services/io/podio/JEventProcessorManagedPODIO.cc
@@ -262,7 +262,7 @@ nlohmann::json JEventProcessorManagedPODIO::CloseOutputFile() {
     // Release the reader so it doesn't hold the input file open until the
     // next SetCurrentFile() call.
     auto* app = GetApplication();
-    auto event_sources =
+    const auto& event_sources =
         eicrecon::jana_compat::GetEventSources(app->GetService<JComponentManager>());
     for (auto* source : event_sources) {
       auto* managed_source = dynamic_cast<JEventSourceManagedPODIO*>(source);
@@ -360,8 +360,9 @@ void JEventProcessorManagedPODIO::Finish() {
 void JEventProcessorManagedPODIO::NotifySourceNewFile(const std::string& input_file, uint64_t nskip,
                                                       uint64_t nevents) {
   // Find the managed event source and notify it of the new file
-  auto* app          = GetApplication();
-  auto event_sources = eicrecon::jana_compat::GetEventSources(app->GetService<JComponentManager>());
+  auto* app = GetApplication();
+  const auto& event_sources =
+      eicrecon::jana_compat::GetEventSources(app->GetService<JComponentManager>());
 
   for (auto* source : event_sources) {
     auto* managed_source = dynamic_cast<JEventSourceManagedPODIO*>(source);
@@ -374,8 +375,9 @@ void JEventProcessorManagedPODIO::NotifySourceNewFile(const std::string& input_f
 }
 
 bool JEventProcessorManagedPODIO::IsCurrentFileComplete() {
-  auto* app          = GetApplication();
-  auto event_sources = eicrecon::jana_compat::GetEventSources(app->GetService<JComponentManager>());
+  auto* app = GetApplication();
+  const auto& event_sources =
+      eicrecon::jana_compat::GetEventSources(app->GetService<JComponentManager>());
 
   for (auto* source : event_sources) {
     auto* managed_source = dynamic_cast<JEventSourceManagedPODIO*>(source);
@@ -387,8 +389,9 @@ bool JEventProcessorManagedPODIO::IsCurrentFileComplete() {
 }
 
 std::size_t JEventProcessorManagedPODIO::GetNeventsInCurrentFile() {
-  auto* app          = GetApplication();
-  auto event_sources = eicrecon::jana_compat::GetEventSources(app->GetService<JComponentManager>());
+  auto* app = GetApplication();
+  const auto& event_sources =
+      eicrecon::jana_compat::GetEventSources(app->GetService<JComponentManager>());
 
   for (auto* source : event_sources) {
     auto* managed_source = dynamic_cast<JEventSourceManagedPODIO*>(source);

--- a/src/services/io/podio/JEventProcessorManagedPODIO.cc
+++ b/src/services/io/podio/JEventProcessorManagedPODIO.cc
@@ -4,7 +4,7 @@
 #include <JANA/JApplicationFwd.h>
 #include <JANA/JEventSource.h>
 #include <JANA/Utils/JTypeInfo.h>
-#include <errno.h>
+#include <cerrno>
 #include <fmt/format.h>
 #include <nlohmann/detail/json_ref.hpp>
 #include <nlohmann/json.hpp>

--- a/src/services/io/podio/JEventProcessorManagedPODIO.cc
+++ b/src/services/io/podio/JEventProcessorManagedPODIO.cc
@@ -261,9 +261,9 @@ nlohmann::json JEventProcessorManagedPODIO::CloseOutputFile() {
   try {
     // Release the reader so it doesn't hold the input file open until the
     // next SetCurrentFile() call.
-    auto* app = GetApplication();
-    const auto& event_sources =
-        eicrecon::jana_compat::GetEventSources(app->GetService<JComponentManager>());
+    auto* app                 = GetApplication();
+    auto component_manager    = app->GetService<JComponentManager>();
+    const auto& event_sources = eicrecon::jana_compat::GetEventSources(component_manager);
     for (auto* source : event_sources) {
       auto* managed_source = dynamic_cast<JEventSourceManagedPODIO*>(source);
       if (managed_source != nullptr) {
@@ -360,9 +360,9 @@ void JEventProcessorManagedPODIO::Finish() {
 void JEventProcessorManagedPODIO::NotifySourceNewFile(const std::string& input_file, uint64_t nskip,
                                                       uint64_t nevents) {
   // Find the managed event source and notify it of the new file
-  auto* app = GetApplication();
-  const auto& event_sources =
-      eicrecon::jana_compat::GetEventSources(app->GetService<JComponentManager>());
+  auto* app                 = GetApplication();
+  auto component_manager    = app->GetService<JComponentManager>();
+  const auto& event_sources = eicrecon::jana_compat::GetEventSources(component_manager);
 
   for (auto* source : event_sources) {
     auto* managed_source = dynamic_cast<JEventSourceManagedPODIO*>(source);
@@ -375,9 +375,9 @@ void JEventProcessorManagedPODIO::NotifySourceNewFile(const std::string& input_f
 }
 
 bool JEventProcessorManagedPODIO::IsCurrentFileComplete() {
-  auto* app = GetApplication();
-  const auto& event_sources =
-      eicrecon::jana_compat::GetEventSources(app->GetService<JComponentManager>());
+  auto* app                 = GetApplication();
+  auto component_manager    = app->GetService<JComponentManager>();
+  const auto& event_sources = eicrecon::jana_compat::GetEventSources(component_manager);
 
   for (auto* source : event_sources) {
     auto* managed_source = dynamic_cast<JEventSourceManagedPODIO*>(source);
@@ -389,9 +389,9 @@ bool JEventProcessorManagedPODIO::IsCurrentFileComplete() {
 }
 
 std::size_t JEventProcessorManagedPODIO::GetNeventsInCurrentFile() {
-  auto* app = GetApplication();
-  const auto& event_sources =
-      eicrecon::jana_compat::GetEventSources(app->GetService<JComponentManager>());
+  auto* app                 = GetApplication();
+  auto component_manager    = app->GetService<JComponentManager>();
+  const auto& event_sources = eicrecon::jana_compat::GetEventSources(component_manager);
 
   for (auto* source : event_sources) {
     auto* managed_source = dynamic_cast<JEventSourceManagedPODIO*>(source);

--- a/src/services/io/podio/JEventProcessorManagedPODIO.cc
+++ b/src/services/io/podio/JEventProcessorManagedPODIO.cc
@@ -3,7 +3,6 @@
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/JEventSource.h>
-#include <JANA/Services/JComponentManager.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <errno.h>
 #include <fmt/format.h>
@@ -25,6 +24,7 @@
 #include <utility>
 #include <vector>
 
+#include "extensions/jana/JComponentManager_compat.h"
 #include "services/io/podio/JEventProcessorPODIO.h"
 #include "services/io/podio/JEventSourceManagedPODIO.h"
 #include "services/log/Log_service.h"
@@ -261,8 +261,9 @@ nlohmann::json JEventProcessorManagedPODIO::CloseOutputFile() {
   try {
     // Release the reader so it doesn't hold the input file open until the
     // next SetCurrentFile() call.
-    auto* app          = GetApplication();
-    auto event_sources = app->GetService<JComponentManager>()->get_evt_srces();
+    auto* app = GetApplication();
+    auto event_sources =
+        eicrecon::jana_compat::GetEventSources(app->GetService<JComponentManager>());
     for (auto* source : event_sources) {
       auto* managed_source = dynamic_cast<JEventSourceManagedPODIO*>(source);
       if (managed_source != nullptr) {
@@ -360,7 +361,7 @@ void JEventProcessorManagedPODIO::NotifySourceNewFile(const std::string& input_f
                                                       uint64_t nevents) {
   // Find the managed event source and notify it of the new file
   auto* app          = GetApplication();
-  auto event_sources = app->GetService<JComponentManager>()->get_evt_srces();
+  auto event_sources = eicrecon::jana_compat::GetEventSources(app->GetService<JComponentManager>());
 
   for (auto* source : event_sources) {
     auto* managed_source = dynamic_cast<JEventSourceManagedPODIO*>(source);
@@ -374,7 +375,7 @@ void JEventProcessorManagedPODIO::NotifySourceNewFile(const std::string& input_f
 
 bool JEventProcessorManagedPODIO::IsCurrentFileComplete() {
   auto* app          = GetApplication();
-  auto event_sources = app->GetService<JComponentManager>()->get_evt_srces();
+  auto event_sources = eicrecon::jana_compat::GetEventSources(app->GetService<JComponentManager>());
 
   for (auto* source : event_sources) {
     auto* managed_source = dynamic_cast<JEventSourceManagedPODIO*>(source);
@@ -387,7 +388,7 @@ bool JEventProcessorManagedPODIO::IsCurrentFileComplete() {
 
 std::size_t JEventProcessorManagedPODIO::GetNeventsInCurrentFile() {
   auto* app          = GetApplication();
-  auto event_sources = app->GetService<JComponentManager>()->get_evt_srces();
+  auto event_sources = eicrecon::jana_compat::GetEventSources(app->GetService<JComponentManager>());
 
   for (auto* source : event_sources) {
     auto* managed_source = dynamic_cast<JEventSourceManagedPODIO*>(source);

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -818,8 +818,9 @@ void JEventProcessorPODIO::Process(const std::shared_ptr<const JEvent>& event) {
 
 void JEventProcessorPODIO::PropagateNonEventCategories() {
   // Propagate all non-event frames from input to output
-  auto* app          = GetApplication();
-  auto event_sources = eicrecon::jana_compat::GetEventSources(app->GetService<JComponentManager>());
+  auto* app = GetApplication();
+  const auto& event_sources =
+      eicrecon::jana_compat::GetEventSources(app->GetService<JComponentManager>());
   for (auto* source : event_sources) {
     auto* podio_source = dynamic_cast<JEventSourcePODIO*>(source);
     if (podio_source == nullptr)

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -818,9 +818,9 @@ void JEventProcessorPODIO::Process(const std::shared_ptr<const JEvent>& event) {
 
 void JEventProcessorPODIO::PropagateNonEventCategories() {
   // Propagate all non-event frames from input to output
-  auto* app = GetApplication();
-  const auto& event_sources =
-      eicrecon::jana_compat::GetEventSources(app->GetService<JComponentManager>());
+  auto* app                 = GetApplication();
+  auto component_manager    = app->GetService<JComponentManager>();
+  const auto& event_sources = eicrecon::jana_compat::GetEventSources(component_manager);
   for (auto* source : event_sources) {
     auto* podio_source = dynamic_cast<JEventSourcePODIO*>(source);
     if (podio_source == nullptr)

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -3,7 +3,6 @@
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/JEventSource.h>
-#include <JANA/Services/JComponentManager.h>
 #include <JANA/Services/JParameterManager.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <edm4eic/EDM4eicVersion.h>
@@ -22,6 +21,7 @@
 #include <stdexcept>
 #include <string_view>
 
+#include "extensions/jana/JComponentManager_compat.h"
 #include "services/io/podio/JEventSourcePODIO.h"
 #include "services/log/Log_service.h"
 
@@ -819,7 +819,7 @@ void JEventProcessorPODIO::Process(const std::shared_ptr<const JEvent>& event) {
 void JEventProcessorPODIO::PropagateNonEventCategories() {
   // Propagate all non-event frames from input to output
   auto* app          = GetApplication();
-  auto event_sources = app->GetService<JComponentManager>()->get_evt_srces();
+  auto event_sources = eicrecon::jana_compat::GetEventSources(app->GetService<JComponentManager>());
   for (auto* source : event_sources) {
     auto* podio_source = dynamic_cast<JEventSourcePODIO*>(source);
     if (podio_source == nullptr)

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -3,6 +3,7 @@
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/JEventSource.h>
+#include <JANA/Services/JComponentManager.h>
 #include <JANA/Services/JParameterManager.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <edm4eic/EDM4eicVersion.h>

--- a/src/utilities/eicrecon/CMakeLists.txt
+++ b/src/utilities/eicrecon/CMakeLists.txt
@@ -14,7 +14,11 @@ target_link_libraries(eicrecon PRIVATE ${JANA_LIB} ROOT::Core)
 
 # Set compile definitions
 target_compile_definitions(
-  eicrecon PRIVATE EICRECON_APP_VERSION=${EICRECON_VERSION_FULL})
+  eicrecon
+  PRIVATE EICRECON_APP_VERSION=${EICRECON_VERSION_FULL}
+          JANA_VERSION_MAJOR=${JANA_VERSION_MAJOR}
+          JANA_VERSION_MINOR=${JANA_VERSION_MINOR}
+          JANA_VERSION_PATCH=${JANA_VERSION_PATCH})
 
 # Install executable
 install(TARGETS eicrecon DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/utilities/eicrecon/eicrecon_cli.cc
+++ b/src/utilities/eicrecon/eicrecon_cli.cc
@@ -8,7 +8,6 @@
 #include <JANA/CLI/JSignalHandler.h>
 #include <JANA/JApplication.h>
 #include <JANA/JVersion.h>
-#include <JANA/Services/JComponentManager.h>
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
@@ -24,6 +23,7 @@
 #include "JANA/JEventSource.h"
 #include "JANA/JException.h"
 #include "JANA/Services/JParameterManager.h"
+#include "extensions/jana/JComponentManager_compat.h"
 #include "print_info.h"
 
 #define QUOTE(name) #name
@@ -327,7 +327,8 @@ void PrintPodioCollections(JApplication* app) {
 
     // cli criteria: Ppodio:print_type_table=1
     if (print_type_table) {
-      auto event_sources = app->GetService<JComponentManager>()->get_evt_srces();
+      auto event_sources =
+          eicrecon::jana_compat::GetEventSources(app->GetService<JComponentManager>());
       for (auto* event_source : event_sources) {
         //                    std::cout << event_source->GetPluginName() << std::endl;  // podio.so
         //                    std::cout << event_source->GetResourceName() << std::endl;

--- a/src/utilities/eicrecon/eicrecon_cli.cc
+++ b/src/utilities/eicrecon/eicrecon_cli.cc
@@ -8,12 +8,12 @@
 #include <JANA/CLI/JSignalHandler.h>
 #include <JANA/JApplication.h>
 #include <JANA/JVersion.h>
+#include <JANA/Services/JComponentManager.h>
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <iostream>
-#include <memory>
 #include <set>
 #include <sstream>
 #include <stdexcept>

--- a/src/utilities/eicrecon/eicrecon_cli.cc
+++ b/src/utilities/eicrecon/eicrecon_cli.cc
@@ -327,7 +327,7 @@ void PrintPodioCollections(JApplication* app) {
 
     // cli criteria: Ppodio:print_type_table=1
     if (print_type_table) {
-      auto event_sources =
+      const auto& event_sources =
           eicrecon::jana_compat::GetEventSources(app->GetService<JComponentManager>());
       for (auto* event_source : event_sources) {
         //                    std::cout << event_source->GetPluginName() << std::endl;  // podio.so

--- a/src/utilities/eicrecon/eicrecon_cli.cc
+++ b/src/utilities/eicrecon/eicrecon_cli.cc
@@ -327,8 +327,8 @@ void PrintPodioCollections(JApplication* app) {
 
     // cli criteria: Ppodio:print_type_table=1
     if (print_type_table) {
-      const auto& event_sources =
-          eicrecon::jana_compat::GetEventSources(app->GetService<JComponentManager>());
+      auto component_manager    = app->GetService<JComponentManager>();
+      const auto& event_sources = eicrecon::jana_compat::GetEventSources(component_manager);
       for (auto* event_source : event_sources) {
         //                    std::cout << event_source->GetPluginName() << std::endl;  // podio.so
         //                    std::cout << event_source->GetResourceName() << std::endl;


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR fixes the pipeline errors here due to the upgrade of JANA2 to 2026.03.00, and the deprecation of `JComponentManager::get_evt_srces`, e.g. in https://github.com/eic/EICrecon/actions/runs/29492880773/job/87602978094?pr=2714.

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/EICrecon/actions/runs/29492880773/job/87602978094?pr=2714)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

High priority since broken CI; AI was used in the interest of expediency (I don't know if a compat header is best, but ok it's a choice and avoids many preprocessor directives all over).