### PR TITLE
JComponentManager_compat.h: correct GetSources condition

### DIFF
--- a/src/extensions/jana/JComponentManager_compat.h
+++ b/src/extensions/jana/JComponentManager_compat.h
@@ -9,8 +9,10 @@
 // JANA2 recently deprecated get_evt_srces() in favor of GetSources().
 // Keep compatibility with older JANA2 while avoiding deprecation warnings
 // on newer versions.
-#if defined(JANA_VERSION_MAJOR) && defined(JANA_VERSION_MINOR) && defined(JANA_VERSION_PATCH) &&   \
-    ((JANA_VERSION_MAJOR > 2) || (JANA_VERSION_MAJOR == 2 && JANA_VERSION_MINOR >= 5))
+#if defined(JANA_VERSION_MAJOR) && defined(JANA_VERSION_MINOR) && defined(JANA_VERSION_PATCH) && \
+    ((JANA_VERSION_MAJOR > 2026) ||                                                               \
+     (JANA_VERSION_MAJOR == 2026 && JANA_VERSION_MINOR > 2) ||                                   \
+     (JANA_VERSION_MAJOR == 2026 && JANA_VERSION_MINOR == 2 && JANA_VERSION_PATCH > 0))
 #define EICRECON_JANA_COMPONENT_MANAGER_HAS_GETSOURCES 1
 #endif
 

--- a/src/extensions/jana/JComponentManager_compat.h
+++ b/src/extensions/jana/JComponentManager_compat.h
@@ -9,9 +9,8 @@
 // JANA2 recently deprecated get_evt_srces() in favor of GetSources().
 // Keep compatibility with older JANA2 while avoiding deprecation warnings
 // on newer versions.
-#if defined(JANA_VERSION_MAJOR) && defined(JANA_VERSION_MINOR) && defined(JANA_VERSION_PATCH) && \
-    ((JANA_VERSION_MAJOR > 2026) ||                                                               \
-     (JANA_VERSION_MAJOR == 2026 && JANA_VERSION_MINOR > 2) ||                                   \
+#if defined(JANA_VERSION_MAJOR) && defined(JANA_VERSION_MINOR) && defined(JANA_VERSION_PATCH) &&   \
+    ((JANA_VERSION_MAJOR > 2026) || (JANA_VERSION_MAJOR == 2026 && JANA_VERSION_MINOR > 2) ||      \
      (JANA_VERSION_MAJOR == 2026 && JANA_VERSION_MINOR == 2 && JANA_VERSION_PATCH > 0))
 #define EICRECON_JANA_COMPONENT_MANAGER_HAS_GETSOURCES 1
 #endif


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

Hotfix for a hotfix https://github.com/eic/EICrecon/pull/2751
The issue is that https://github.com/JeffersonLab/JANA2/commit/c6755ef4eaa6b2d6b9bf890663bf8987dc9314ce came out after 2026.02.00 and not 2.5

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.
  claude