### PR TITLE
refactor: unify LinkNavigator truth-link handling

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -86,7 +86,7 @@ void CalorimeterClusterRecoCoG::process(const CalorimeterClusterRecoCoG::Input& 
 
     // If sim hits are available, associate cluster with MCParticle
     if (do_assoc) {
-      associate(cl, mchitassociations, link_nav.navigator(), links, associations);
+      associate(cl, mchitassociations, link_nav, links, associations);
     }
   }
 }
@@ -176,7 +176,7 @@ CalorimeterClusterRecoCoG::reconstruct(const edm4eic::ProtoCluster& pcl) const {
 void CalorimeterClusterRecoCoG::associate(
     const edm4eic::Cluster& cl,
     [[maybe_unused]] const edm4eic::MCRecoCalorimeterHitAssociationCollection* mchitassociations,
-    const podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& link_nav,
+    const truth::EventLinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& link_nav,
     edm4eic::MCRecoClusterParticleLinkCollection* links,
     edm4eic::MCRecoClusterParticleAssociationCollection* assocs) const {
   // --------------------------------------------------------------------------
@@ -202,7 +202,7 @@ void CalorimeterClusterRecoCoG::associate(
   for (auto clhit : cl.getHits()) {
 
     // Get linked sim hits using LinkNavigator
-    const auto vecAssocSimHits = link_nav.getLinked(clhit.getRawHit());
+    const auto vecAssocSimHits = link_nav.linked(clhit.getRawHit());
 
     for (const auto& [simHit, weight] : vecAssocSimHits) {
       eSimHitSum += simHit.getEnergy();

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -13,6 +13,8 @@
 #include <boost/range/adaptor/map.hpp>
 #include <edm4eic/CalorimeterHitCollection.h>
 #include <edm4eic/Cov3f.h>
+#include <edm4hep/CaloHitContribution.h>
+#include <edm4hep/MCParticle.h>
 #include <edm4hep/RawCalorimeterHit.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
 #include <edm4hep/Vector3f.h>
@@ -20,7 +22,6 @@
 #include <podio/LinkNavigator.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
-#include <podio/detail/Link.h>
 #include <algorithm>
 #include <cctype>
 #include <cstddef>

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -19,6 +19,7 @@
 #include <edm4hep/SimCalorimeterHitCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
+#include <gsl/pointers>
 #include <podio/LinkNavigator.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
@@ -237,7 +238,10 @@ void CalorimeterClusterRecoCoG::associate(
     // calculate weight
     const double weight = contribution / eSimHitSum;
 
-    truth::addWeightedRelation(cl, part, static_cast<float>(weight), links, assocs);
+    truth::addWeightedRelation(
+        cl, part, static_cast<float>(weight),
+        gsl::not_null<edm4eic::MCRecoClusterParticleLinkCollection*>{links},
+        gsl::not_null<edm4eic::MCRecoClusterParticleAssociationCollection*>{assocs});
 
     debug("Associated cluster #{} to MC Particle #{} (pid = {}, status = {}, energy = {}) with "
           "weight ({})",

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.cc
@@ -32,6 +32,8 @@
 
 #include "CalorimeterClusterRecoCoG.h"
 #include "algorithms/calorimetry/CalorimeterClusterRecoCoGConfig.h"
+#include "algorithms/interfaces/CompareObjectID.h"
+#include "algorithms/interfaces/LinkTruthUtils.h"
 
 namespace eicrecon {
 
@@ -57,15 +59,11 @@ void CalorimeterClusterRecoCoG::process(const CalorimeterClusterRecoCoG::Input& 
   auto [clusters, links, associations]              = output;
 
   // Check if truth associations are possible
-  const bool do_assoc = mchitlinks != nullptr && !mchitlinks->empty();
+  const truth::EventLinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection> link_nav(mchitlinks);
+  const bool do_assoc = link_nav.enabled();
   if (!do_assoc) {
     debug("Provided MCRecoCalorimeterHitLink collection is empty. No truth associations "
           "will be performed.");
-  }
-  // Build fast lookup once per event using podio::LinkNavigator
-  std::optional<podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>> link_nav;
-  if (do_assoc) {
-    link_nav.emplace(*mchitlinks);
   }
 
   for (const auto& pcl : *proto) {
@@ -87,7 +85,7 @@ void CalorimeterClusterRecoCoG::process(const CalorimeterClusterRecoCoG::Input& 
 
     // If sim hits are available, associate cluster with MCParticle
     if (do_assoc) {
-      associate(cl, mchitassociations, *link_nav, links, associations);
+      associate(cl, mchitassociations, link_nav.navigator(), links, associations);
     }
   }
 }
@@ -193,16 +191,8 @@ void CalorimeterClusterRecoCoG::associate(
    *     of contributed energy over total sim hit energy.
    */
 
-  // lambda to compare MCParticles
-  auto compare = [](const edm4hep::MCParticle& lhs, const edm4hep::MCParticle& rhs) {
-    if (lhs.getObjectID().collectionID == rhs.getObjectID().collectionID) {
-      return (lhs.getObjectID().index < rhs.getObjectID().index);
-    }
-    return (lhs.getObjectID().collectionID < rhs.getObjectID().collectionID);
-  };
-
   // bookkeeping maps for associated primaries
-  std::map<edm4hep::MCParticle, double, decltype(compare)> mapMCParToContrib(compare);
+  std::map<edm4hep::MCParticle, double, CompareObjectID<edm4hep::MCParticle>> mapMCParToContrib;
 
   // --------------------------------------------------------------------------
   // 1. get associated sim hits and sum energy
@@ -228,7 +218,7 @@ void CalorimeterClusterRecoCoG::associate(
         // --------------------------------------------------------------------
         // grab primary responsible for contribution & increment relevant sum
         // --------------------------------------------------------------------
-        edm4hep::MCParticle primary = get_primary(contrib);
+        edm4hep::MCParticle primary = truth::primaryFrom(contrib);
         mapMCParToContrib[primary] += contrib.getEnergy();
 
         trace("Identified primary: id = {}, pid = {}, total energy = {}, contributed = {}",
@@ -246,41 +236,13 @@ void CalorimeterClusterRecoCoG::associate(
     // calculate weight
     const double weight = contribution / eSimHitSum;
 
-    // create link
-    auto link = links->create();
-    link.setWeight(weight);
-    link.setFrom(cl);
-    link.setTo(part);
-
-    // set association
-    auto assoc = assocs->create();
-    assoc.setWeight(weight);
-    assoc.setRec(cl);
-    assoc.setSim(part);
+    truth::addWeightedRelation(cl, part, static_cast<float>(weight), links, assocs);
 
     debug("Associated cluster #{} to MC Particle #{} (pid = {}, status = {}, energy = {}) with "
           "weight ({})",
           cl.getObjectID().index, part.getObjectID().index, part.getPDG(),
           part.getGeneratorStatus(), part.getEnergy(), weight);
   }
-}
-
-edm4hep::MCParticle
-CalorimeterClusterRecoCoG::get_primary(const edm4hep::CaloHitContribution& contrib) {
-  // get contributing particle
-  const auto contributor = contrib.getParticle();
-
-  // walk back through parents to find primary
-  //   - TODO finalize primary selection. This
-  //     can be improved!!
-  edm4hep::MCParticle primary = contributor;
-  while (primary.parents_size() > 0) {
-    if (primary.getGeneratorStatus() != 0) {
-      break;
-    }
-    primary = primary.getParents(0);
-  }
-  return primary;
 }
 
 } // namespace eicrecon

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
@@ -88,7 +88,6 @@ private:
                  const podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& link_nav,
                  edm4eic::MCRecoClusterParticleLinkCollection* links,
                  edm4eic::MCRecoClusterParticleAssociationCollection* assocs) const;
-  static edm4hep::MCParticle get_primary(const edm4hep::CaloHitContribution& contrib);
 };
 
 } // namespace eicrecon

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
@@ -17,8 +17,6 @@
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <edm4eic/MCRecoClusterParticleLinkCollection.h>
 #include <edm4eic/ProtoClusterCollection.h>
-#include <edm4hep/CaloHitContribution.h>
-#include <edm4hep/MCParticle.h>
 #include <podio/LinkNavigator.h>
 #include <algorithm>
 #include <cmath>

--- a/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
+++ b/src/algorithms/calorimetry/CalorimeterClusterRecoCoG.h
@@ -17,7 +17,6 @@
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <edm4eic/MCRecoClusterParticleLinkCollection.h>
 #include <edm4eic/ProtoClusterCollection.h>
-#include <podio/LinkNavigator.h>
 #include <algorithm>
 #include <cmath>
 #include <functional>
@@ -29,6 +28,7 @@
 #include <utility>
 
 #include "CalorimeterClusterRecoCoGConfig.h"
+#include "algorithms/interfaces/LinkTruthUtils.h"
 #include "algorithms/interfaces/WithPodConfig.h"
 
 static double constWeight(double /*E*/, double /*tE*/, double /*p*/, int /*type*/) { return 1.0; }
@@ -81,11 +81,12 @@ private:
 
 private:
   std::optional<edm4eic::MutableCluster> reconstruct(const edm4eic::ProtoCluster& pcl) const;
-  void associate(const edm4eic::Cluster& cl,
-                 const edm4eic::MCRecoCalorimeterHitAssociationCollection* mchitassociations,
-                 const podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& link_nav,
-                 edm4eic::MCRecoClusterParticleLinkCollection* links,
-                 edm4eic::MCRecoClusterParticleAssociationCollection* assocs) const;
+  void
+  associate(const edm4eic::Cluster& cl,
+            const edm4eic::MCRecoCalorimeterHitAssociationCollection* mchitassociations,
+            const truth::EventLinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& link_nav,
+            edm4eic::MCRecoClusterParticleLinkCollection* links,
+            edm4eic::MCRecoClusterParticleAssociationCollection* assocs) const;
 };
 
 } // namespace eicrecon

--- a/src/algorithms/calorimetry/CalorimeterClusterShape.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterShape.cc
@@ -10,8 +10,9 @@
 #include <edm4hep/MCParticle.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <gsl/pointers>
 #include <podio/LinkNavigator.h>
+#include <podio/RelationRange.h>
+#include <podio/detail/LinkCollectionImpl.h>
 #include <Eigen/Core>
 #include <Eigen/Eigenvalues>
 #include <Eigen/Householder> // IWYU pragma: keep
@@ -20,7 +21,7 @@
 #include <cctype>
 #include <cmath>
 #include <cstddef>
-#include <memory>
+#include <gsl/pointers>
 #include <tuple>
 #include <utility>
 #include <vector>

--- a/src/algorithms/calorimetry/CalorimeterClusterShape.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterShape.cc
@@ -10,6 +10,7 @@
 #include <edm4hep/MCParticle.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
+#include <gsl/pointers>
 #include <podio/LinkNavigator.h>
 #include <Eigen/Core>
 #include <Eigen/Eigenvalues>
@@ -231,7 +232,10 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
     // ----------------------------------------------------------------------
     if (link_nav.enabled()) {
       for (const auto& [mc_par, weight] : link_nav.linked(in_clust)) {
-        truth::addWeightedRelation(out_clust, mc_par, weight, out_links, out_associations);
+        truth::addWeightedRelation(
+            out_clust, mc_par, weight,
+            gsl::not_null<edm4eic::MCRecoClusterParticleLinkCollection*>{out_links},
+            gsl::not_null<edm4eic::MCRecoClusterParticleAssociationCollection*>{out_associations});
       }
     } // end input link loop
   } // end input cluster loop

--- a/src/algorithms/calorimetry/CalorimeterClusterShape.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterShape.cc
@@ -22,6 +22,7 @@
 #include <cctype>
 #include <cmath>
 #include <cstddef>
+#include <deque>
 #include <memory>
 #include <tuple>
 #include <utility>

--- a/src/algorithms/calorimetry/CalorimeterClusterShape.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterShape.cc
@@ -10,6 +10,7 @@
 #include <edm4hep/MCParticle.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
+#include <podio/LinkNavigator.h>
 #include <podio/RelationRange.h>
 #include <podio/detail/Link.h>
 #include <podio/detail/LinkCollectionImpl.h>
@@ -64,6 +65,20 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
   // grab inputs/outputs
   const auto [in_clusters, in_associations]        = input;
   auto [out_clusters, out_links, out_associations] = output;
+
+  edm4eic::MCRecoClusterParticleLinkCollection in_links;
+  std::optional<podio::LinkNavigator<edm4eic::MCRecoClusterParticleLinkCollection>> link_nav;
+  if (in_associations != nullptr) {
+    for (const auto& in_assoc : *in_associations) {
+      auto in_link = in_links.create();
+      in_link.setFrom(in_assoc.getRec());
+      in_link.setTo(in_assoc.getSim());
+      in_link.setWeight(in_assoc.getWeight());
+    }
+    if (!in_links.empty()) {
+      link_nav.emplace(in_links);
+    }
+  }
 
   // exit if no clusters in collection
   if (in_clusters->empty()) {
@@ -228,17 +243,16 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
     // ----------------------------------------------------------------------
     // if provided, copy associations
     // ----------------------------------------------------------------------
-    for (auto in_assoc : *in_associations) {
-      if (in_assoc.getRec() == in_clust) {
-        auto mc_par   = in_assoc.getSim();
+    if (link_nav) {
+      for (const auto& [mc_par, weight] : link_nav->getLinked(in_clust)) {
         auto out_link = out_links->create();
         out_link.setFrom(out_clust);
         out_link.setTo(mc_par);
-        out_link.setWeight(in_assoc.getWeight());
+        out_link.setWeight(weight);
         auto out_assoc = out_associations->create();
         out_assoc.setRec(out_clust);
         out_assoc.setSim(mc_par);
-        out_assoc.setWeight(in_assoc.getWeight());
+        out_assoc.setWeight(weight);
       }
     } // end input association loop
   } // end input cluster loop

--- a/src/algorithms/calorimetry/CalorimeterClusterShape.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterShape.cc
@@ -11,9 +11,6 @@
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <podio/LinkNavigator.h>
-#include <podio/RelationRange.h>
-#include <podio/detail/Link.h>
-#include <podio/detail/LinkCollectionImpl.h>
 #include <Eigen/Core>
 #include <Eigen/Eigenvalues>
 #include <Eigen/Householder> // IWYU pragma: keep
@@ -22,13 +19,13 @@
 #include <cctype>
 #include <cmath>
 #include <cstddef>
-#include <deque>
 #include <memory>
 #include <tuple>
 #include <utility>
 #include <vector>
 
 #include "algorithms/calorimetry/CalorimeterClusterShapeConfig.h"
+#include "algorithms/interfaces/LinkTruthUtils.h"
 
 namespace eicrecon {
 
@@ -64,22 +61,10 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
                                       const CalorimeterClusterShape::Output& output) const {
 
   // grab inputs/outputs
-  const auto [in_clusters, in_associations]        = input;
+  const auto [in_clusters, in_links]               = input;
   auto [out_clusters, out_links, out_associations] = output;
 
-  edm4eic::MCRecoClusterParticleLinkCollection in_links;
-  std::optional<podio::LinkNavigator<edm4eic::MCRecoClusterParticleLinkCollection>> link_nav;
-  if (in_associations != nullptr) {
-    for (const auto& in_assoc : *in_associations) {
-      auto in_link = in_links.create();
-      in_link.setFrom(in_assoc.getRec());
-      in_link.setTo(in_assoc.getSim());
-      in_link.setWeight(in_assoc.getWeight());
-    }
-    if (!in_links.empty()) {
-      link_nav.emplace(in_links);
-    }
-  }
+  const truth::EventLinkNavigator<edm4eic::MCRecoClusterParticleLinkCollection> link_nav(in_links);
 
   // exit if no clusters in collection
   if (in_clusters->empty()) {
@@ -242,20 +227,13 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
     out_clusters->push_back(out_clust);
 
     // ----------------------------------------------------------------------
-    // if provided, copy associations
+    // if provided, copy links and associations
     // ----------------------------------------------------------------------
-    if (link_nav) {
-      for (const auto& [mc_par, weight] : link_nav->getLinked(in_clust)) {
-        auto out_link = out_links->create();
-        out_link.setFrom(out_clust);
-        out_link.setTo(mc_par);
-        out_link.setWeight(weight);
-        auto out_assoc = out_associations->create();
-        out_assoc.setRec(out_clust);
-        out_assoc.setSim(mc_par);
-        out_assoc.setWeight(weight);
+    if (link_nav.enabled()) {
+      for (const auto& [mc_par, weight] : link_nav.navigator().getLinked(in_clust)) {
+        truth::addWeightedRelation(out_clust, mc_par, weight, out_links, out_associations);
       }
-    } // end input association loop
+    } // end input link loop
   } // end input cluster loop
   debug("Completed processing input clusters");
 

--- a/src/algorithms/calorimetry/CalorimeterClusterShape.cc
+++ b/src/algorithms/calorimetry/CalorimeterClusterShape.cc
@@ -230,7 +230,7 @@ void CalorimeterClusterShape::process(const CalorimeterClusterShape::Input& inpu
     // if provided, copy links and associations
     // ----------------------------------------------------------------------
     if (link_nav.enabled()) {
-      for (const auto& [mc_par, weight] : link_nav.navigator().getLinked(in_clust)) {
+      for (const auto& [mc_par, weight] : link_nav.linked(in_clust)) {
         truth::addWeightedRelation(out_clust, mc_par, weight, out_links, out_associations);
       }
     } // end input link loop

--- a/src/algorithms/calorimetry/CalorimeterClusterShape.h
+++ b/src/algorithms/calorimetry/CalorimeterClusterShape.h
@@ -5,6 +5,7 @@
 
 #include <algorithms/algorithm.h>
 #include <edm4eic/ClusterCollection.h>
+#include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <edm4eic/MCRecoClusterParticleLinkCollection.h>
 #include <algorithm>
 #include <cmath>

--- a/src/algorithms/calorimetry/CalorimeterClusterShape.h
+++ b/src/algorithms/calorimetry/CalorimeterClusterShape.h
@@ -5,7 +5,6 @@
 
 #include <algorithms/algorithm.h>
 #include <edm4eic/ClusterCollection.h>
-#include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <edm4eic/MCRecoClusterParticleLinkCollection.h>
 #include <algorithm>
 #include <cmath>
@@ -26,7 +25,7 @@ namespace eicrecon {
 // --------------------------------------------------------------------------
 using CalorimeterClusterShapeAlgorithm = algorithms::Algorithm<
     algorithms::Input<edm4eic::ClusterCollection,
-                      std::optional<edm4eic::MCRecoClusterParticleAssociationCollection>>,
+                      std::optional<edm4eic::MCRecoClusterParticleLinkCollection>>,
     algorithms::Output<edm4eic::ClusterCollection,
                        std::optional<edm4eic::MCRecoClusterParticleLinkCollection>,
                        std::optional<edm4eic::MCRecoClusterParticleAssociationCollection>>>;
@@ -46,7 +45,7 @@ public:
   CalorimeterClusterShape(std::string_view name)
       : CalorimeterClusterShapeAlgorithm{
             name,
-            {"inputClusters", "inputMCClusterAssociations"},
+            {"inputClusters", "inputMCClusterLinks"},
             {"outputClusters", "outputMCClusterLinks", "outputMCClusterAssociations"},
             "Computes cluster shape parameters"} {}
 

--- a/src/algorithms/calorimetry/ImagingClusterReco.cc
+++ b/src/algorithms/calorimetry/ImagingClusterReco.cc
@@ -73,7 +73,7 @@ void ImagingClusterReco::process(const Input& input, const Output& output) const
 
     // If sim hits are available, associate cluster with MCParticle
     if (do_assoc) {
-      associate_mc_particles(cl, mchitassociations, link_nav.navigator(), links, associations);
+      associate_mc_particles(cl, mchitassociations, link_nav, links, associations);
     }
   }
 
@@ -232,7 +232,7 @@ ImagingClusterReco::fit_track(const std::vector<edm4eic::MutableCluster>& layers
 void ImagingClusterReco::associate_mc_particles(
     const edm4eic::Cluster& cl,
     [[maybe_unused]] const edm4eic::MCRecoCalorimeterHitAssociationCollection* mchitassociations,
-    const podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& link_nav,
+    const truth::EventLinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& link_nav,
     edm4eic::MCRecoClusterParticleLinkCollection* links,
     edm4eic::MCRecoClusterParticleAssociationCollection* assocs) const {
   // --------------------------------------------------------------------------
@@ -257,7 +257,7 @@ void ImagingClusterReco::associate_mc_particles(
   double eSimHitSum = 0.;
   for (auto clhit : cl.getHits()) {
     // Get linked sim hits using LinkNavigator
-    const auto vecAssocSimHits = link_nav.getLinked(clhit.getRawHit());
+    const auto vecAssocSimHits = link_nav.linked(clhit.getRawHit());
 
     for (const auto& [simHit, weight] : vecAssocSimHits) {
       eSimHitSum += simHit.getEnergy();

--- a/src/algorithms/calorimetry/ImagingClusterReco.cc
+++ b/src/algorithms/calorimetry/ImagingClusterReco.cc
@@ -15,6 +15,7 @@
 #include <edm4hep/SimCalorimeterHit.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
+#include <gsl/pointers>
 #include <podio/LinkNavigator.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
@@ -295,7 +296,10 @@ void ImagingClusterReco::associate_mc_particles(
     // calculate weight
     const double weight = contribution / eSimHitSum;
 
-    truth::addWeightedRelation(cl, part, static_cast<float>(weight), links, assocs);
+    truth::addWeightedRelation(
+        cl, part, static_cast<float>(weight),
+        gsl::not_null<edm4eic::MCRecoClusterParticleLinkCollection*>{links},
+        gsl::not_null<edm4eic::MCRecoClusterParticleAssociationCollection*>{assocs});
 
     debug("Associated cluster #{} to MC Particle #{} (pid = {}, status = {}, energy = {}) with "
           "weight ({})",

--- a/src/algorithms/calorimetry/ImagingClusterReco.cc
+++ b/src/algorithms/calorimetry/ImagingClusterReco.cc
@@ -9,6 +9,8 @@
  */
 
 #include <Evaluator/DD4hepUnits.h>
+#include <edm4hep/CaloHitContribution.h>
+#include <edm4hep/MCParticle.h>
 #include <edm4hep/RawCalorimeterHit.h>
 #include <edm4hep/SimCalorimeterHit.h>
 #include <edm4hep/Vector3f.h>
@@ -16,8 +18,6 @@
 #include <podio/LinkNavigator.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
-#include <podio/detail/Link.h>
-#include <podio/detail/LinkCollectionImpl.h>
 #include <Eigen/Core>
 #include <Eigen/Householder> // IWYU pragma: keep
 #include <Eigen/Jacobi>
@@ -25,9 +25,7 @@
 #include <algorithm>
 #include <cmath>
 #include <map>
-#include <memory>
 #include <new>
-#include <optional>
 #include <tuple>
 
 #include "algorithms/calorimetry/ClusterTypes.h"

--- a/src/algorithms/calorimetry/ImagingClusterReco.cc
+++ b/src/algorithms/calorimetry/ImagingClusterReco.cc
@@ -33,6 +33,8 @@
 #include "algorithms/calorimetry/ClusterTypes.h"
 #include "algorithms/calorimetry/ImagingClusterReco.h"
 #include "algorithms/calorimetry/ImagingClusterRecoConfig.h"
+#include "algorithms/interfaces/CompareObjectID.h"
+#include "algorithms/interfaces/LinkTruthUtils.h"
 
 namespace eicrecon {
 
@@ -42,15 +44,11 @@ void ImagingClusterReco::process(const Input& input, const Output& output) const
   auto [clusters, links, associations, layers]      = output;
 
   // Check if truth associations are possible
-  const bool do_assoc = mchitlinks != nullptr && !mchitlinks->empty();
+  const truth::EventLinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection> link_nav(mchitlinks);
+  const bool do_assoc = link_nav.enabled();
   if (!do_assoc) {
     debug("Provided MCRecoCalorimeterHitLink collection is empty. No truth associations "
           "will be performed.");
-  }
-  // Build fast lookup once per event using podio::LinkNavigator
-  std::optional<podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>> link_nav;
-  if (do_assoc) {
-    link_nav.emplace(*mchitlinks);
   }
 
   for (const auto& pcl : *proto) {
@@ -77,7 +75,7 @@ void ImagingClusterReco::process(const Input& input, const Output& output) const
 
     // If sim hits are available, associate cluster with MCParticle
     if (do_assoc) {
-      associate_mc_particles(cl, mchitassociations, *link_nav, links, associations);
+      associate_mc_particles(cl, mchitassociations, link_nav.navigator(), links, associations);
     }
   }
 
@@ -255,17 +253,8 @@ void ImagingClusterReco::associate_mc_particles(
          *     of contributed energy over total sim hit energy.
          */
 
-  // lambda to compare MCParticles
-  auto compare = [](const edm4hep::MCParticle& lhs, const edm4hep::MCParticle& rhs) {
-    if (lhs.getObjectID().collectionID == rhs.getObjectID().collectionID) {
-      return (lhs.getObjectID().index < rhs.getObjectID().index);
-    } else {
-      return (lhs.getObjectID().collectionID < rhs.getObjectID().collectionID);
-    }
-  };
-
   // bookkeeping maps for associated primaries
-  std::map<edm4hep::MCParticle, double, decltype(compare)> mapMCParToContrib(compare);
+  std::map<edm4hep::MCParticle, double, CompareObjectID<edm4hep::MCParticle>> mapMCParToContrib;
 
   // --------------------------------------------------------------------------
   // 1. get associated sim hits and sum energy
@@ -290,7 +279,7 @@ void ImagingClusterReco::associate_mc_particles(
         // --------------------------------------------------------------------
         // grab primary responsible for contribution & increment relevant sum
         // --------------------------------------------------------------------
-        edm4hep::MCParticle primary = get_primary(contrib);
+        edm4hep::MCParticle primary = truth::primaryFrom(contrib);
         mapMCParToContrib[primary] += contrib.getEnergy();
 
         trace("Identified primary: id = {}, pid = {}, total energy = {}, contributed = {}",
@@ -308,41 +297,13 @@ void ImagingClusterReco::associate_mc_particles(
     // calculate weight
     const double weight = contribution / eSimHitSum;
 
-    // create link
-    auto link = links->create();
-    link.setWeight(weight);
-    link.setFrom(cl);
-    link.setTo(part);
-
-    // set association
-    auto assoc = assocs->create();
-    assoc.setWeight(weight);
-    assoc.setRec(cl);
-    assoc.setSim(part);
+    truth::addWeightedRelation(cl, part, static_cast<float>(weight), links, assocs);
 
     debug("Associated cluster #{} to MC Particle #{} (pid = {}, status = {}, energy = {}) with "
           "weight ({})",
           cl.getObjectID().index, part.getObjectID().index, part.getPDG(),
           part.getGeneratorStatus(), part.getEnergy(), weight);
   }
-}
-
-edm4hep::MCParticle
-ImagingClusterReco::get_primary(const edm4hep::CaloHitContribution& contrib) const {
-  // get contributing particle
-  const auto contributor = contrib.getParticle();
-
-  // walk back through parents to find primary
-  //   - TODO finalize primary selection. This
-  //     can be improved!!
-  edm4hep::MCParticle primary = contributor;
-  while (primary.parents_size() > 0) {
-    if (primary.getGeneratorStatus() != 0) {
-      break;
-    }
-    primary = primary.getParents(0);
-  }
-  return primary;
 }
 
 } // namespace eicrecon

--- a/src/algorithms/calorimetry/ImagingClusterReco.cc
+++ b/src/algorithms/calorimetry/ImagingClusterReco.cc
@@ -73,7 +73,7 @@ void ImagingClusterReco::process(const Input& input, const Output& output) const
 
     // If sim hits are available, associate cluster with MCParticle
     if (do_assoc) {
-      associate_mc_particles(cl, mchitassociations, link_nav.navigator(), links, associations);
+      associate_mc_particles(cl, mchitassociations, link_nav, links, associations);
     }
   }
 
@@ -235,7 +235,7 @@ ImagingClusterReco::fit_track(const std::vector<edm4eic::MutableCluster>& layers
 void ImagingClusterReco::associate_mc_particles(
     const edm4eic::Cluster& cl,
     [[maybe_unused]] const edm4eic::MCRecoCalorimeterHitAssociationCollection* mchitassociations,
-    const podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& link_nav,
+    const truth::EventLinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& link_nav,
     edm4eic::MCRecoClusterParticleLinkCollection* links,
     edm4eic::MCRecoClusterParticleAssociationCollection* assocs) const {
   // --------------------------------------------------------------------------
@@ -260,7 +260,7 @@ void ImagingClusterReco::associate_mc_particles(
   double eSimHitSum = 0.;
   for (auto clhit : cl.getHits()) {
     // Get linked sim hits using LinkNavigator
-    const auto vecAssocSimHits = link_nav.getLinked(clhit.getRawHit());
+    const auto vecAssocSimHits = link_nav.linked(clhit.getRawHit());
 
     for (const auto& [simHit, weight] : vecAssocSimHits) {
       eSimHitSum += simHit.getEnergy();

--- a/src/algorithms/calorimetry/ImagingClusterReco.cc
+++ b/src/algorithms/calorimetry/ImagingClusterReco.cc
@@ -33,6 +33,8 @@
 #include "algorithms/calorimetry/ClusterTypes.h"
 #include "algorithms/calorimetry/ImagingClusterReco.h"
 #include "algorithms/calorimetry/ImagingClusterRecoConfig.h"
+#include "algorithms/interfaces/CompareObjectID.h"
+#include "algorithms/interfaces/LinkTruthUtils.h"
 
 namespace eicrecon {
 
@@ -42,15 +44,11 @@ void ImagingClusterReco::process(const Input& input, const Output& output) const
   auto [clusters, links, associations, layers]      = output;
 
   // Check if truth associations are possible
-  const bool do_assoc = mchitlinks != nullptr && !mchitlinks->empty();
+  const truth::EventLinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection> link_nav(mchitlinks);
+  const bool do_assoc = link_nav.enabled();
   if (!do_assoc) {
     debug("Provided MCRecoCalorimeterHitLink collection is empty. No truth associations "
           "will be performed.");
-  }
-  // Build fast lookup once per event using podio::LinkNavigator
-  std::optional<podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>> link_nav;
-  if (do_assoc) {
-    link_nav.emplace(*mchitlinks);
   }
 
   for (const auto& pcl : *proto) {
@@ -77,7 +75,7 @@ void ImagingClusterReco::process(const Input& input, const Output& output) const
 
     // If sim hits are available, associate cluster with MCParticle
     if (do_assoc) {
-      associate_mc_particles(cl, mchitassociations, *link_nav, links, associations);
+      associate_mc_particles(cl, mchitassociations, link_nav.navigator(), links, associations);
     }
   }
 
@@ -252,17 +250,8 @@ void ImagingClusterReco::associate_mc_particles(
          *     of contributed energy over total sim hit energy.
          */
 
-  // lambda to compare MCParticles
-  auto compare = [](const edm4hep::MCParticle& lhs, const edm4hep::MCParticle& rhs) {
-    if (lhs.getObjectID().collectionID == rhs.getObjectID().collectionID) {
-      return (lhs.getObjectID().index < rhs.getObjectID().index);
-    } else {
-      return (lhs.getObjectID().collectionID < rhs.getObjectID().collectionID);
-    }
-  };
-
   // bookkeeping maps for associated primaries
-  std::map<edm4hep::MCParticle, double, decltype(compare)> mapMCParToContrib(compare);
+  std::map<edm4hep::MCParticle, double, CompareObjectID<edm4hep::MCParticle>> mapMCParToContrib;
 
   // --------------------------------------------------------------------------
   // 1. get associated sim hits and sum energy
@@ -287,7 +276,7 @@ void ImagingClusterReco::associate_mc_particles(
         // --------------------------------------------------------------------
         // grab primary responsible for contribution & increment relevant sum
         // --------------------------------------------------------------------
-        edm4hep::MCParticle primary = get_primary(contrib);
+        edm4hep::MCParticle primary = truth::primaryFrom(contrib);
         mapMCParToContrib[primary] += contrib.getEnergy();
 
         trace("Identified primary: id = {}, pid = {}, total energy = {}, contributed = {}",
@@ -305,41 +294,13 @@ void ImagingClusterReco::associate_mc_particles(
     // calculate weight
     const double weight = contribution / eSimHitSum;
 
-    // create link
-    auto link = links->create();
-    link.setWeight(weight);
-    link.setFrom(cl);
-    link.setTo(part);
-
-    // set association
-    auto assoc = assocs->create();
-    assoc.setWeight(weight);
-    assoc.setRec(cl);
-    assoc.setSim(part);
+    truth::addWeightedRelation(cl, part, static_cast<float>(weight), links, assocs);
 
     debug("Associated cluster #{} to MC Particle #{} (pid = {}, status = {}, energy = {}) with "
           "weight ({})",
           cl.getObjectID().index, part.getObjectID().index, part.getPDG(),
           part.getGeneratorStatus(), part.getEnergy(), weight);
   }
-}
-
-edm4hep::MCParticle
-ImagingClusterReco::get_primary(const edm4hep::CaloHitContribution& contrib) const {
-  // get contributing particle
-  const auto contributor = contrib.getParticle();
-
-  // walk back through parents to find primary
-  //   - TODO finalize primary selection. This
-  //     can be improved!!
-  edm4hep::MCParticle primary = contributor;
-  while (primary.parents_size() > 0) {
-    if (primary.getGeneratorStatus() != 0) {
-      break;
-    }
-    primary = primary.getParents(0);
-  }
-  return primary;
 }
 
 } // namespace eicrecon

--- a/src/algorithms/calorimetry/ImagingClusterReco.cc
+++ b/src/algorithms/calorimetry/ImagingClusterReco.cc
@@ -15,6 +15,7 @@
 #include <edm4hep/SimCalorimeterHit.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
+#include <gsl/pointers>
 #include <podio/LinkNavigator.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
@@ -292,7 +293,10 @@ void ImagingClusterReco::associate_mc_particles(
     // calculate weight
     const double weight = contribution / eSimHitSum;
 
-    truth::addWeightedRelation(cl, part, static_cast<float>(weight), links, assocs);
+    truth::addWeightedRelation(
+        cl, part, static_cast<float>(weight),
+        gsl::not_null<edm4eic::MCRecoClusterParticleLinkCollection*>{links},
+        gsl::not_null<edm4eic::MCRecoClusterParticleAssociationCollection*>{assocs});
 
     debug("Associated cluster #{} to MC Particle #{} (pid = {}, status = {}, energy = {}) with "
           "weight ({})",

--- a/src/algorithms/calorimetry/ImagingClusterReco.h
+++ b/src/algorithms/calorimetry/ImagingClusterReco.h
@@ -18,11 +18,7 @@
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <edm4eic/MCRecoClusterParticleLinkCollection.h>
 #include <edm4eic/ProtoClusterCollection.h>
-#include <edm4hep/CaloHitContribution.h>
-// Event Model related classes
-#include <edm4hep/MCParticleCollection.h>
 #include <podio/LinkNavigator.h>
-#include <iterator>
 #include <string>
 #include <string_view>
 #include <utility>

--- a/src/algorithms/calorimetry/ImagingClusterReco.h
+++ b/src/algorithms/calorimetry/ImagingClusterReco.h
@@ -82,8 +82,6 @@ private:
       const podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& link_nav,
       edm4eic::MCRecoClusterParticleLinkCollection* links,
       edm4eic::MCRecoClusterParticleAssociationCollection* assocs) const;
-
-  edm4hep::MCParticle get_primary(const edm4hep::CaloHitContribution& contrib) const;
 };
 
 } // namespace eicrecon

--- a/src/algorithms/calorimetry/ImagingClusterReco.h
+++ b/src/algorithms/calorimetry/ImagingClusterReco.h
@@ -18,13 +18,13 @@
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <edm4eic/MCRecoClusterParticleLinkCollection.h>
 #include <edm4eic/ProtoClusterCollection.h>
-#include <podio/LinkNavigator.h>
 #include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
 
 #include "ImagingClusterRecoConfig.h"
+#include "algorithms/interfaces/LinkTruthUtils.h"
 #include "algorithms/interfaces/WithPodConfig.h"
 
 namespace eicrecon {
@@ -75,7 +75,7 @@ private:
   void associate_mc_particles(
       const edm4eic::Cluster& cl,
       const edm4eic::MCRecoCalorimeterHitAssociationCollection* mchitassociations,
-      const podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& link_nav,
+      const truth::EventLinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& link_nav,
       edm4eic::MCRecoClusterParticleLinkCollection* links,
       edm4eic::MCRecoClusterParticleAssociationCollection* assocs) const;
 };

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -19,7 +19,6 @@
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <podio/LinkNavigator.h>
 #include <podio/RelationRange.h>
 #include <podio/detail/Link.h>
 #include <Eigen/Geometry>

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -20,7 +20,6 @@
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <podio/LinkNavigator.h>
 #include <podio/RelationRange.h>
 #include <podio/detail/Link.h>
 #include <Eigen/Geometry>
@@ -39,6 +38,7 @@
 
 #include "FarDetectorLinearTracking.h"
 #include "algorithms/fardetectors/FarDetectorLinearTrackingConfig.h"
+#include "algorithms/interfaces/LinkTruthUtils.h"
 
 namespace eicrecon {
 
@@ -66,6 +66,7 @@ void FarDetectorLinearTracking::process(const FarDetectorLinearTracking::Input& 
 
   const auto [inputhits, hitLinks, assocHits]  = input;
   auto [outputTracks, trackLinks, assocTracks] = output;
+  (void)assocHits;
 
   // Check the number of input collections is correct
   std::size_t nCollections = inputhits.size();
@@ -75,15 +76,11 @@ void FarDetectorLinearTracking::process(const FarDetectorLinearTracking::Input& 
   }
 
   // Check if truth associations are possible
-  const bool do_assoc = hitLinks != nullptr && !hitLinks->empty();
+  const truth::EventLinkNavigator<edm4eic::MCRecoTrackerHitLinkCollection> link_nav(hitLinks);
+  const bool do_assoc = link_nav.enabled();
   if (!do_assoc) {
     debug("Provided MCRecoTrackerHitLink collection is empty. No truth associations "
           "will be performed.");
-  }
-  // Build fast lookup once per event using podio::LinkNavigator
-  std::optional<podio::LinkNavigator<edm4eic::MCRecoTrackerHitLinkCollection>> link_nav;
-  if (do_assoc) {
-    link_nav.emplace(*hitLinks);
   }
 
   std::vector<std::vector<Eigen::Vector3d>> convertedHits;
@@ -103,7 +100,7 @@ void FarDetectorLinearTracking::process(const FarDetectorLinearTracking::Input& 
       trace("No hits in layer");
       return;
     }
-    ConvertClusters(*layerHits, *link_nav, *assocHits, convertedHits, assocParts);
+    ConvertClusters(*layerHits, link_nav, convertedHits, assocParts);
   }
 
   // Create a matrix to store the hit positions
@@ -129,7 +126,7 @@ void FarDetectorLinearTracking::process(const FarDetectorLinearTracking::Input& 
       if (layer == static_cast<long>(m_cfg.n_layer) - 1) {
         // Check the combination, if chi2 limit is passed, add the track to the output
         checkHitCombination(&hitMatrix, outputTracks, trackLinks, assocTracks, inputhits,
-                            assocParts, layerHitIndex);
+                            assocParts, layerHitIndex, do_assoc);
       } else {
         layer++;
         continue;
@@ -163,7 +160,7 @@ void FarDetectorLinearTracking::checkHitCombination(
     edm4eic::MCRecoTrackParticleAssociationCollection* assocTracks,
     const std::vector<gsl::not_null<const edm4eic::Measurement2DCollection*>>& inputHits,
     const std::vector<std::vector<edm4hep::MCParticle>>& assocParts,
-    const std::vector<std::size_t>& layerHitIndex) const {
+    const std::vector<std::size_t>& layerHitIndex, const bool do_assoc) const {
 
   Eigen::Vector3d weightedAnchor = (*hitMatrix) * m_layerWeights / (m_layerWeights.sum());
 
@@ -210,8 +207,12 @@ void FarDetectorLinearTracking::checkHitCombination(
   std::unordered_map<edm4hep::MCParticle, int> particleCount;
   for (std::size_t layer = 0; layer < layerHitIndex.size(); layer++) {
     track.addToMeasurements((*inputHits[layer])[layerHitIndex[layer]]);
-    const auto& assocParticle = assocParts[layer][layerHitIndex[layer]];
-    particleCount[assocParticle]++;
+    if (do_assoc) {
+      const auto& assocParticle = assocParts[layer][layerHitIndex[layer]];
+      if (assocParticle.isAvailable()) {
+        particleCount[assocParticle]++;
+      }
+    }
   }
 
   // Create track associations for each particle
@@ -247,8 +248,7 @@ bool FarDetectorLinearTracking::checkHitPair(const Eigen::Vector3d& hit1,
 // Convert measurements into global coordinates
 void FarDetectorLinearTracking::ConvertClusters(
     const edm4eic::Measurement2DCollection& clusters,
-    const podio::LinkNavigator<edm4eic::MCRecoTrackerHitLinkCollection>& link_nav,
-    [[maybe_unused]] const edm4eic::MCRecoTrackerHitAssociationCollection& assoc_hits,
+    const truth::EventLinkNavigator<edm4eic::MCRecoTrackerHitLinkCollection>& link_nav,
     std::vector<std::vector<Eigen::Vector3d>>& pointPositions,
     std::vector<std::vector<edm4hep::MCParticle>>& assoc_parts) const {
 
@@ -277,16 +277,19 @@ void FarDetectorLinearTracking::ConvertClusters(
     }
     if (maxIndex == cluster.getWeights().size()) {
       // no maximum found (e.g. all weights zero, cluster size zero)
+      assocParticles.emplace_back();
       continue;
     }
     auto maxHit = cluster.getHits()[maxIndex];
     // Get associated raw hit
     auto rawHit = maxHit.getRawHit();
 
-    const auto sim_hits = link_nav.getLinked(rawHit);
+    const auto sim_hits = link_nav.linked(rawHit);
     if (!sim_hits.empty()) {
       auto particle = sim_hits[0].o.getParticle();
       assocParticles.push_back(particle);
+    } else {
+      assocParticles.emplace_back();
     }
   }
 

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -19,6 +19,7 @@
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
+#include <podio/LinkNavigator.h>
 #include <podio/RelationRange.h>
 #include <podio/detail/Link.h>
 #include <Eigen/Geometry>
@@ -35,12 +36,11 @@
 #include <tuple>
 #include <utility>
 
-#include <map>
-
 #include "FarDetectorLinearTracking.h"
 #include "algorithms/fardetectors/FarDetectorLinearTrackingConfig.h"
 #include "algorithms/interfaces/CompareObjectID.h"
 #include "algorithms/interfaces/LinkTruthUtils.h"
+
 namespace eicrecon {
 
 void FarDetectorLinearTracking::init() {

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -217,15 +217,17 @@ void FarDetectorLinearTracking::checkHitCombination(
   }
 
   // Create track associations for each particle
-  for (const auto& [particle, count] : particleCount) {
-    auto trackLink = trackLinks->create();
-    trackLink.setFrom(track);
-    trackLink.setTo(particle);
-    trackLink.setWeight(count / static_cast<double>(m_cfg.n_layer));
-    auto trackAssoc = assocTracks->create();
-    trackAssoc.setRec(track);
-    trackAssoc.setSim(particle);
-    trackAssoc.setWeight(count / static_cast<double>(m_cfg.n_layer));
+  if (do_assoc && trackLinks != nullptr && assocTracks != nullptr) {
+    for (const auto& [particle, count] : particleCount) {
+      auto trackLink = trackLinks->create();
+      trackLink.setFrom(track);
+      trackLink.setTo(particle);
+      trackLink.setWeight(count / static_cast<double>(m_cfg.n_layer));
+      auto trackAssoc = assocTracks->create();
+      trackAssoc.setRec(track);
+      trackAssoc.setSim(particle);
+      trackAssoc.setWeight(count / static_cast<double>(m_cfg.n_layer));
+    }
   }
 }
 

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -36,10 +36,12 @@
 #include <unordered_map>
 #include <utility>
 
+#include <map>
+
 #include "FarDetectorLinearTracking.h"
 #include "algorithms/fardetectors/FarDetectorLinearTrackingConfig.h"
+#include "algorithms/interfaces/CompareObjectID.h"
 #include "algorithms/interfaces/LinkTruthUtils.h"
-
 namespace eicrecon {
 
 void FarDetectorLinearTracking::init() {
@@ -204,7 +206,7 @@ void FarDetectorLinearTracking::checkHitCombination(
                            charge, chi2, ndf, pdg);
 
   // Add Measurement2D relations and count occurrence of particles contributing to the track
-  std::unordered_map<edm4hep::MCParticle, int> particleCount;
+  std::map<edm4hep::MCParticle, int, CompareObjectID<edm4hep::MCParticle>> particleCount;
   for (std::size_t layer = 0; layer < layerHitIndex.size(); layer++) {
     track.addToMeasurements((*inputHits[layer])[layerHitIndex[layer]]);
     if (do_assoc) {

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -8,7 +8,6 @@
 #include <algorithms/geo.h>
 #include <edm4eic/Cov6f.h>
 #include <edm4eic/MCRecoTrackParticleAssociationCollection.h>
-#include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
 #include <edm4eic/MCRecoTrackerHitLinkCollection.h>
 #include <edm4eic/Measurement2DCollection.h>
 #include <edm4eic/RawTrackerHit.h>
@@ -20,6 +19,7 @@
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
+#include <podio/LinkNavigator.h>
 #include <podio/RelationRange.h>
 #include <podio/detail/Link.h>
 #include <Eigen/Geometry>
@@ -30,18 +30,17 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <new>
 #include <tuple>
-#include <unordered_map>
 #include <utility>
-
-#include <map>
 
 #include "FarDetectorLinearTracking.h"
 #include "algorithms/fardetectors/FarDetectorLinearTrackingConfig.h"
 #include "algorithms/interfaces/CompareObjectID.h"
 #include "algorithms/interfaces/LinkTruthUtils.h"
+
 namespace eicrecon {
 
 void FarDetectorLinearTracking::init() {

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.cc
@@ -35,11 +35,12 @@
 #include <tuple>
 #include <utility>
 
+#include <map>
+
 #include "FarDetectorLinearTracking.h"
 #include "algorithms/fardetectors/FarDetectorLinearTrackingConfig.h"
 #include "algorithms/interfaces/CompareObjectID.h"
 #include "algorithms/interfaces/LinkTruthUtils.h"
-
 namespace eicrecon {
 
 void FarDetectorLinearTracking::init() {

--- a/src/algorithms/fardetectors/FarDetectorLinearTracking.h
+++ b/src/algorithms/fardetectors/FarDetectorLinearTracking.h
@@ -13,7 +13,6 @@
 #include <edm4eic/Measurement2DCollection.h>
 #include <edm4eic/TrackCollection.h>
 #include <edm4hep/MCParticle.h>
-#include <podio/LinkNavigator.h>
 #include <Eigen/Core>
 #include <cstddef>
 #include <gsl/pointers>
@@ -23,6 +22,7 @@
 #include <vector>
 
 #include "FarDetectorLinearTrackingConfig.h"
+#include "algorithms/interfaces/LinkTruthUtils.h"
 
 namespace eicrecon {
 
@@ -64,18 +64,17 @@ private:
       edm4eic::MCRecoTrackParticleAssociationCollection* assocTracks,
       const std::vector<gsl::not_null<const edm4eic::Measurement2DCollection*>>& inputHits,
       const std::vector<std::vector<edm4hep::MCParticle>>& assocParts,
-      const std::vector<std::size_t>& layerHitIndex) const;
+      const std::vector<std::size_t>& layerHitIndex, bool do_assoc) const;
 
   /** Check if the last two hits are within a certain angle of the optimum direction **/
   bool checkHitPair(const Eigen::Vector3d& hit1, const Eigen::Vector3d& hit2) const;
 
   /** Convert 2D clusters to 3D coordinates and match associated particle **/
-  void
-  ConvertClusters(const edm4eic::Measurement2DCollection& clusters,
-                  const podio::LinkNavigator<edm4eic::MCRecoTrackerHitLinkCollection>& link_nav,
-                  const edm4eic::MCRecoTrackerHitAssociationCollection& assoc_hits,
-                  std::vector<std::vector<Eigen::Vector3d>>& pointPositions,
-                  std::vector<std::vector<edm4hep::MCParticle>>& assoc_parts) const;
+  void ConvertClusters(
+      const edm4eic::Measurement2DCollection& clusters,
+      const truth::EventLinkNavigator<edm4eic::MCRecoTrackerHitLinkCollection>& link_nav,
+      std::vector<std::vector<Eigen::Vector3d>>& pointPositions,
+      std::vector<std::vector<edm4hep::MCParticle>>& assoc_parts) const;
 };
 
 } // namespace eicrecon

--- a/src/algorithms/fardetectors/FarDetectorTransportationPreML.cc
+++ b/src/algorithms/fardetectors/FarDetectorTransportationPreML.cc
@@ -79,6 +79,9 @@ void FarDetectorTransportationPreML::process(
         target_tensor.addToFloatData(MCElectronMomentum.x);
         target_tensor.addToFloatData(MCElectronMomentum.y);
         target_tensor.addToFloatData(MCElectronMomentum.z);
+      } else {
+        error("Track has no linked MC particle. Targets cannot be constructed.");
+        throw std::runtime_error("Missing track-particle link required for target tensor");
       }
     }
   }

--- a/src/algorithms/fardetectors/FarDetectorTransportationPreML.cc
+++ b/src/algorithms/fardetectors/FarDetectorTransportationPreML.cc
@@ -6,8 +6,9 @@
 #include <edm4hep/utils/vector_utils.h>
 #include <podio/LinkNavigator.h>
 #include <cmath>
-#include <gsl/pointers>
 #include <stdexcept>
+#include <tuple>
+#include <vector>
 
 #include "FarDetectorTransportationPreML.h"
 #include "algorithms/fardetectors/FarDetectorTransportationPreML.h"

--- a/src/algorithms/fardetectors/FarDetectorTransportationPreML.cc
+++ b/src/algorithms/fardetectors/FarDetectorTransportationPreML.cc
@@ -4,6 +4,7 @@
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
+#include <podio/LinkNavigator.h>
 #include <cmath>
 #include <stdexcept>
 #include <tuple>

--- a/src/algorithms/fardetectors/FarDetectorTransportationPreML.cc
+++ b/src/algorithms/fardetectors/FarDetectorTransportationPreML.cc
@@ -4,6 +4,7 @@
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
+#include <podio/LinkNavigator.h>
 #include <cmath>
 #include <gsl/pointers>
 #include <stdexcept>
@@ -19,8 +20,8 @@ void FarDetectorTransportationPreML::process(
     const FarDetectorTransportationPreML::Input& input,
     const FarDetectorTransportationPreML::Output& output) const {
 
-  const auto [inputTracks, mcAssociation, beamElectrons] = input;
-  auto [feature_tensors, target_tensors]                 = output;
+  const auto [inputTracks, trackLinks, beamElectrons] = input;
+  auto [feature_tensors, target_tensors]              = output;
 
   //Set beam energy from first MCBeamElectron, using std::call_once
   if (beamElectrons != nullptr) {
@@ -45,11 +46,16 @@ void FarDetectorTransportationPreML::process(
   feature_tensor.setElementType(1); // 1 - float
 
   edm4eic::MutableTensor target_tensor;
-  if (mcAssociation != nullptr) {
+  if (trackLinks != nullptr) {
     target_tensor = target_tensors->create();
     target_tensor.addToShape(inputTracks->size());
     target_tensor.addToShape(3);     // px,py,pz
     target_tensor.setElementType(1); // 1 - float
+  }
+
+  std::optional<podio::LinkNavigator<edm4eic::MCRecoTrackParticleLinkCollection>> link_nav;
+  if (trackLinks != nullptr && !trackLinks->empty()) {
+    link_nav.emplace(*trackLinks);
   }
 
   // Loop through inputTracks and simultaneously optionally associations if available
@@ -66,18 +72,14 @@ void FarDetectorTransportationPreML::process(
     feature_tensor.addToFloatData(momentum.y); // diry
     feature_tensor.addToFloatData(momentum.z); // dirz
 
-    if ((mcAssociation != nullptr) && (!mcAssociation->empty())) {
-      //Loop through the MCRecoTrackParticleAssociationCollection finding the first one associated with the current track
-      for (const auto& assoc : *mcAssociation) {
-        if (assoc.getRec() == track) {
-          // Process the association if it exists and is non-empty
-          const auto& association = assoc.getSim(); // Assuming 1-to-1 mapping
-          auto MCElectronMomentum = association.getMomentum() / m_beamE;
-          target_tensor.addToFloatData(MCElectronMomentum.x);
-          target_tensor.addToFloatData(MCElectronMomentum.y);
-          target_tensor.addToFloatData(MCElectronMomentum.z);
-          break; // Exit loop after finding the first association
-        }
+    if (link_nav) {
+      // Use the first linked MC particle, matching previous first-association behavior.
+      const auto linked_particles = link_nav->getLinked(track);
+      if (!linked_particles.empty()) {
+        auto MCElectronMomentum = linked_particles.front().o.getMomentum() / m_beamE;
+        target_tensor.addToFloatData(MCElectronMomentum.x);
+        target_tensor.addToFloatData(MCElectronMomentum.y);
+        target_tensor.addToFloatData(MCElectronMomentum.z);
       }
     }
   }

--- a/src/algorithms/fardetectors/FarDetectorTransportationPreML.cc
+++ b/src/algorithms/fardetectors/FarDetectorTransportationPreML.cc
@@ -4,7 +4,6 @@
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <podio/LinkNavigator.h>
 #include <cmath>
 #include <stdexcept>
 #include <tuple>
@@ -12,6 +11,7 @@
 
 #include "FarDetectorTransportationPreML.h"
 #include "algorithms/fardetectors/FarDetectorTransportationPreML.h"
+#include "algorithms/interfaces/LinkTruthUtils.h"
 
 namespace eicrecon {
 
@@ -54,10 +54,7 @@ void FarDetectorTransportationPreML::process(
     target_tensor.setElementType(1); // 1 - float
   }
 
-  std::optional<podio::LinkNavigator<edm4eic::MCRecoTrackParticleLinkCollection>> link_nav;
-  if (trackLinks != nullptr && !trackLinks->empty()) {
-    link_nav.emplace(*trackLinks);
-  }
+  const truth::EventLinkNavigator<edm4eic::MCRecoTrackParticleLinkCollection> link_nav(trackLinks);
 
   // Loop through inputTracks and simultaneously optionally associations if available
   // and fill the feature and target tensors
@@ -73,9 +70,9 @@ void FarDetectorTransportationPreML::process(
     feature_tensor.addToFloatData(momentum.y); // diry
     feature_tensor.addToFloatData(momentum.z); // dirz
 
-    if (link_nav) {
+    if (link_nav.enabled()) {
       // Use the first linked MC particle, matching previous first-association behavior.
-      const auto linked_particles = link_nav->getLinked(track);
+      const auto linked_particles = link_nav.linked(track);
       if (!linked_particles.empty()) {
         auto MCElectronMomentum = linked_particles.front().o.getMomentum() / m_beamE;
         target_tensor.addToFloatData(MCElectronMomentum.x);

--- a/src/algorithms/fardetectors/FarDetectorTransportationPreML.cc
+++ b/src/algorithms/fardetectors/FarDetectorTransportationPreML.cc
@@ -50,7 +50,7 @@ void FarDetectorTransportationPreML::process(
   const truth::EventLinkNavigator<edm4eic::MCRecoTrackParticleLinkCollection> link_nav(trackLinks);
 
   edm4eic::MutableTensor target_tensor;
-  if (link_nav.enabled()) {
+  if (link_nav.enabled() && target_tensors != nullptr) {
     target_tensor = target_tensors->create();
     target_tensor.addToShape(inputTracks->size());
     target_tensor.addToShape(3);     // px,py,pz
@@ -71,7 +71,7 @@ void FarDetectorTransportationPreML::process(
     feature_tensor.addToFloatData(momentum.y); // diry
     feature_tensor.addToFloatData(momentum.z); // dirz
 
-    if (link_nav.enabled()) {
+    if (link_nav.enabled() && target_tensors != nullptr) {
       // Use the first linked MC particle, matching previous first-association behavior.
       const auto linked_particles = link_nav.linked(track);
       if (!linked_particles.empty()) {

--- a/src/algorithms/fardetectors/FarDetectorTransportationPreML.cc
+++ b/src/algorithms/fardetectors/FarDetectorTransportationPreML.cc
@@ -46,15 +46,15 @@ void FarDetectorTransportationPreML::process(
   feature_tensor.addToShape(6);     // x,y,z,dirx,diry,dirz
   feature_tensor.setElementType(1); // 1 - float
 
+  const truth::EventLinkNavigator<edm4eic::MCRecoTrackParticleLinkCollection> link_nav(trackLinks);
+
   edm4eic::MutableTensor target_tensor;
-  if (trackLinks != nullptr) {
+  if (link_nav.enabled()) {
     target_tensor = target_tensors->create();
     target_tensor.addToShape(inputTracks->size());
     target_tensor.addToShape(3);     // px,py,pz
     target_tensor.setElementType(1); // 1 - float
   }
-
-  const truth::EventLinkNavigator<edm4eic::MCRecoTrackParticleLinkCollection> link_nav(trackLinks);
 
   // Loop through inputTracks and simultaneously optionally associations if available
   // and fill the feature and target tensors

--- a/src/algorithms/fardetectors/FarDetectorTransportationPreML.h
+++ b/src/algorithms/fardetectors/FarDetectorTransportationPreML.h
@@ -4,9 +4,9 @@
 #pragma once
 
 #include <algorithms/algorithm.h>
+#include <edm4eic/MCRecoTrackParticleLinkCollection.h>
 #include <edm4eic/TensorCollection.h>
 #include <edm4eic/TrackCollection.h>
-#include <edm4eic/MCRecoTrackParticleAssociationCollection.h>
 #include <edm4hep/MCParticleCollection.h>
 #include <mutex>
 #include <optional>
@@ -20,7 +20,7 @@ namespace eicrecon {
 
 using FarDetectorTransportationPreMLAlgorithm = algorithms::Algorithm<
     algorithms::Input<edm4eic::TrackCollection,
-                      std::optional<edm4eic::MCRecoTrackParticleAssociationCollection>,
+                      std::optional<edm4eic::MCRecoTrackParticleLinkCollection>,
                       std::optional<edm4hep::MCParticleCollection>>,
     algorithms::Output<edm4eic::TensorCollection, std::optional<edm4eic::TensorCollection>>>;
 
@@ -31,7 +31,7 @@ public:
   FarDetectorTransportationPreML(std::string_view name)
       : FarDetectorTransportationPreMLAlgorithm{
             name,
-            {"tracks", "trackAssociations", "beamElectrons"},
+            {"tracks", "trackLinks", "beamElectrons"},
             {"outputFeatureTensor", "outputTargetTensor"},
             "Create tensor for input to far-detector magnetic transportation ML."} {}
 

--- a/src/algorithms/interfaces/LinkTruthUtils.h
+++ b/src/algorithms/interfaces/LinkTruthUtils.h
@@ -21,8 +21,6 @@ public:
   }
 
   bool enabled() const { return m_enabled; }
-
-  const podio::LinkNavigator<LinkCollectionT>& navigator() const { return *m_nav; }
   template <typename SrcT> auto linked(const SrcT& src) const {
     using ReturnT = decltype(std::declval<podio::LinkNavigator<LinkCollectionT>>().getLinked(src));
     return m_enabled ? m_nav->getLinked(src) : ReturnT{};

--- a/src/algorithms/interfaces/LinkTruthUtils.h
+++ b/src/algorithms/interfaces/LinkTruthUtils.h
@@ -22,7 +22,7 @@ public:
 
   bool enabled() const { return m_enabled; }
 
-  const podio::LinkNavigator<LinkCollectionT>& navigator() const { return m_nav.value(); }
+  const podio::LinkNavigator<LinkCollectionT>& navigator() const { return *m_nav; }
   template <typename SrcT> auto linked(const SrcT& src) const {
     using ReturnT = decltype(std::declval<podio::LinkNavigator<LinkCollectionT>>().getLinked(src));
     return m_enabled ? m_nav->getLinked(src) : ReturnT{};

--- a/src/algorithms/interfaces/LinkTruthUtils.h
+++ b/src/algorithms/interfaces/LinkTruthUtils.h
@@ -22,8 +22,7 @@ public:
 
   bool enabled() const { return m_enabled; }
 
-  const podio::LinkNavigator<LinkCollectionT>& navigator() const { return *m_nav; }
-
+  const podio::LinkNavigator<LinkCollectionT>& navigator() const { return m_nav.value(); }
   template <typename SrcT> auto linked(const SrcT& src) const {
     using ReturnT = decltype(std::declval<podio::LinkNavigator<LinkCollectionT>>().getLinked(src));
     return m_enabled ? m_nav->getLinked(src) : ReturnT{};

--- a/src/algorithms/interfaces/LinkTruthUtils.h
+++ b/src/algorithms/interfaces/LinkTruthUtils.h
@@ -21,8 +21,6 @@ public:
   }
 
   bool enabled() const { return m_enabled; }
-
-  const podio::LinkNavigator<LinkCollectionT>& navigator() const { return m_nav.value(); }
   template <typename SrcT> auto linked(const SrcT& src) const {
     using ReturnT = decltype(std::declval<podio::LinkNavigator<LinkCollectionT>>().getLinked(src));
     return m_enabled ? m_nav->getLinked(src) : ReturnT{};

--- a/src/algorithms/interfaces/LinkTruthUtils.h
+++ b/src/algorithms/interfaces/LinkTruthUtils.h
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 ePIC Collaboration
+
+#pragma once
+
+#include <edm4hep/CaloHitContribution.h>
+#include <edm4hep/MCParticle.h>
+#include <podio/LinkNavigator.h>
+#include <optional>
+#include <utility>
+
+namespace eicrecon::truth {
+
+template <typename LinkCollectionT> class EventLinkNavigator {
+public:
+  explicit EventLinkNavigator(const LinkCollectionT* links)
+      : m_enabled(links != nullptr && !links->empty()) {
+    if (m_enabled) {
+      m_nav.emplace(*links);
+    }
+  }
+
+  bool enabled() const { return m_enabled; }
+
+  const podio::LinkNavigator<LinkCollectionT>& navigator() const { return *m_nav; }
+
+  template <typename SrcT> auto linked(const SrcT& src) const {
+    using ReturnT = decltype(std::declval<podio::LinkNavigator<LinkCollectionT>>().getLinked(src));
+    return m_enabled ? m_nav->getLinked(src) : ReturnT{};
+  }
+
+private:
+  bool m_enabled = false;
+  std::optional<podio::LinkNavigator<LinkCollectionT>> m_nav;
+};
+
+template <typename RecT, typename SimT, typename LinkCollT, typename AssocCollT>
+inline void addWeightedRelation(const RecT& rec, const SimT& sim, float weight, LinkCollT* links,
+                                AssocCollT* assocs) {
+  auto link = links->create();
+  link.setFrom(rec);
+  link.setTo(sim);
+  link.setWeight(weight);
+
+  auto assoc = assocs->create();
+  assoc.setRec(rec);
+  assoc.setSim(sim);
+  assoc.setWeight(weight);
+}
+
+inline edm4hep::MCParticle primaryFrom(const edm4hep::CaloHitContribution& contrib) {
+  edm4hep::MCParticle primary = contrib.getParticle();
+  while (primary.parents_size() > 0) {
+    if (primary.getGeneratorStatus() != 0) {
+      break;
+    }
+    primary = primary.getParents(0);
+  }
+  return primary;
+}
+
+} // namespace eicrecon::truth

--- a/src/algorithms/interfaces/LinkTruthUtils.h
+++ b/src/algorithms/interfaces/LinkTruthUtils.h
@@ -5,6 +5,7 @@
 
 #include <edm4hep/CaloHitContribution.h>
 #include <edm4hep/MCParticle.h>
+#include <gsl/pointers>
 #include <podio/LinkNavigator.h>
 #include <optional>
 #include <utility>
@@ -32,8 +33,9 @@ private:
 };
 
 template <typename RecT, typename SimT, typename LinkCollT, typename AssocCollT>
-inline void addWeightedRelation(const RecT& rec, const SimT& sim, float weight, LinkCollT* links,
-                                AssocCollT* assocs) {
+inline void addWeightedRelation(const RecT& rec, const SimT& sim, float weight,
+                                gsl::not_null<LinkCollT*> links,
+                                gsl::not_null<AssocCollT*> assocs) {
   auto link = links->create();
   link.setFrom(rec);
   link.setTo(sim);

--- a/src/algorithms/onnx/CalorimeterParticleIDPostML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPostML.cc
@@ -85,7 +85,7 @@ void CalorimeterParticleIDPostML::process(const CalorimeterParticleIDPostML::Inp
                                                           ));
 
     // propagate associations
-    if (link_nav.enabled()) {
+    if (link_nav.enabled() && out_links != nullptr && out_assocs != nullptr) {
       for (const auto& [sim_particle, weight] : link_nav.linked(in_cluster)) {
         truth::addWeightedRelation(
             out_cluster, sim_particle, weight,

--- a/src/algorithms/onnx/CalorimeterParticleIDPostML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPostML.cc
@@ -3,6 +3,7 @@
 
 #include <edm4hep/MCParticle.h>
 #include <fmt/format.h>
+#include <podio/LinkNavigator.h>
 #include <podio/detail/Link.h>
 #include <podio/detail/LinkCollectionImpl.h>
 #include <cstddef>
@@ -21,8 +22,13 @@ void CalorimeterParticleIDPostML::init() {
 void CalorimeterParticleIDPostML::process(const CalorimeterParticleIDPostML::Input& input,
                                           const CalorimeterParticleIDPostML::Output& output) const {
 
-  const auto [in_clusters, in_assocs, prediction_tensors]      = input;
+  const auto [in_clusters, in_links, prediction_tensors]       = input;
   auto [out_clusters, out_links, out_assocs, out_particle_ids] = output;
+
+  std::optional<podio::LinkNavigator<edm4eic::MCRecoClusterParticleLinkCollection>> link_nav;
+  if (in_links != nullptr && !in_links->empty()) {
+    link_nav.emplace(*in_links);
+  }
 
   if (prediction_tensors->size() != 1) {
     error("Expected to find a single tensor, found {}", prediction_tensors->size());
@@ -81,15 +87,16 @@ void CalorimeterParticleIDPostML::process(const CalorimeterParticleIDPostML::Inp
                                                           ));
 
     // propagate associations
-    for (auto in_assoc : *in_assocs) {
-      if (in_assoc.getRec() == in_cluster) {
+    if (link_nav) {
+      for (const auto& [sim_particle, weight] : link_nav->getLinked(in_cluster)) {
         auto out_link = out_links->create();
         out_link.setFrom(out_cluster);
-        out_link.setTo(in_assoc.getSim());
-        out_link.setWeight(in_assoc.getWeight());
-        auto out_assoc = in_assoc.clone();
+        out_link.setTo(sim_particle);
+        out_link.setWeight(weight);
+        auto out_assoc = out_assocs->create();
         out_assoc.setRec(out_cluster);
-        out_assocs->push_back(out_assoc);
+        out_assoc.setSim(sim_particle);
+        out_assoc.setWeight(weight);
       }
     }
   }

--- a/src/algorithms/onnx/CalorimeterParticleIDPostML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPostML.cc
@@ -2,7 +2,6 @@
 // Copyright (C) 2024 Dmitry Kalinkin
 
 #include <edm4hep/MCParticle.h>
-#include <fmt/format.h>
 #include <podio/LinkNavigator.h>
 #include <podio/detail/LinkCollectionImpl.h>
 #include <cstddef>

--- a/src/algorithms/onnx/CalorimeterParticleIDPostML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPostML.cc
@@ -2,7 +2,8 @@
 // Copyright (C) 2024 Dmitry Kalinkin
 
 #include <edm4hep/MCParticle.h>
-#include <format>
+#include <fmt/format.h>
+#include <podio/LinkNavigator.h>
 #include <podio/detail/Link.h>
 #include <podio/detail/LinkCollectionImpl.h>
 #include <cstddef>
@@ -21,8 +22,13 @@ void CalorimeterParticleIDPostML::init() {
 void CalorimeterParticleIDPostML::process(const CalorimeterParticleIDPostML::Input& input,
                                           const CalorimeterParticleIDPostML::Output& output) const {
 
-  const auto [in_clusters, in_assocs, prediction_tensors]      = input;
+  const auto [in_clusters, in_links, prediction_tensors]       = input;
   auto [out_clusters, out_links, out_assocs, out_particle_ids] = output;
+
+  std::optional<podio::LinkNavigator<edm4eic::MCRecoClusterParticleLinkCollection>> link_nav;
+  if (in_links != nullptr && !in_links->empty()) {
+    link_nav.emplace(*in_links);
+  }
 
   if (prediction_tensors->size() != 1) {
     error("Expected to find a single tensor, found {}", prediction_tensors->size());
@@ -81,15 +87,16 @@ void CalorimeterParticleIDPostML::process(const CalorimeterParticleIDPostML::Inp
                                                           ));
 
     // propagate associations
-    for (auto in_assoc : *in_assocs) {
-      if (in_assoc.getRec() == in_cluster) {
+    if (link_nav) {
+      for (const auto& [sim_particle, weight] : link_nav->getLinked(in_cluster)) {
         auto out_link = out_links->create();
         out_link.setFrom(out_cluster);
-        out_link.setTo(in_assoc.getSim());
-        out_link.setWeight(in_assoc.getWeight());
-        auto out_assoc = in_assoc.clone();
+        out_link.setTo(sim_particle);
+        out_link.setWeight(weight);
+        auto out_assoc = out_assocs->create();
         out_assoc.setRec(out_cluster);
-        out_assocs->push_back(out_assoc);
+        out_assoc.setSim(sim_particle);
+        out_assoc.setWeight(weight);
       }
     }
   }

--- a/src/algorithms/onnx/CalorimeterParticleIDPostML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPostML.cc
@@ -10,6 +10,7 @@
 #include <memory>
 #include <stdexcept>
 #include <tuple>
+#include <vector>
 
 #include "CalorimeterParticleIDPostML.h"
 

--- a/src/algorithms/onnx/CalorimeterParticleIDPostML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPostML.cc
@@ -6,6 +6,7 @@
 #include <podio/LinkNavigator.h>
 #include <podio/detail/LinkCollectionImpl.h>
 #include <cstddef>
+#include <format>
 #include <gsl/pointers>
 #include <stdexcept>
 #include <tuple>

--- a/src/algorithms/onnx/CalorimeterParticleIDPostML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPostML.cc
@@ -3,9 +3,10 @@
 
 #include <edm4hep/MCParticle.h>
 #include <fmt/format.h>
-#include <gsl/pointers>
+#include <podio/LinkNavigator.h>
+#include <podio/detail/LinkCollectionImpl.h>
 #include <cstddef>
-#include <memory>
+#include <gsl/pointers>
 #include <stdexcept>
 #include <tuple>
 #include <vector>

--- a/src/algorithms/onnx/CalorimeterParticleIDPostML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPostML.cc
@@ -3,9 +3,7 @@
 
 #include <edm4hep/MCParticle.h>
 #include <fmt/format.h>
-#include <podio/LinkNavigator.h>
-#include <podio/detail/Link.h>
-#include <podio/detail/LinkCollectionImpl.h>
+#include <gsl/pointers>
 #include <cstddef>
 #include <memory>
 #include <stdexcept>
@@ -13,6 +11,7 @@
 #include <vector>
 
 #include "CalorimeterParticleIDPostML.h"
+#include "algorithms/interfaces/LinkTruthUtils.h"
 
 namespace eicrecon {
 
@@ -26,10 +25,7 @@ void CalorimeterParticleIDPostML::process(const CalorimeterParticleIDPostML::Inp
   const auto [in_clusters, in_links, prediction_tensors]       = input;
   auto [out_clusters, out_links, out_assocs, out_particle_ids] = output;
 
-  std::optional<podio::LinkNavigator<edm4eic::MCRecoClusterParticleLinkCollection>> link_nav;
-  if (in_links != nullptr && !in_links->empty()) {
-    link_nav.emplace(*in_links);
-  }
+  const truth::EventLinkNavigator<edm4eic::MCRecoClusterParticleLinkCollection> link_nav(in_links);
 
   if (prediction_tensors->size() != 1) {
     error("Expected to find a single tensor, found {}", prediction_tensors->size());
@@ -88,16 +84,12 @@ void CalorimeterParticleIDPostML::process(const CalorimeterParticleIDPostML::Inp
                                                           ));
 
     // propagate associations
-    if (link_nav) {
-      for (const auto& [sim_particle, weight] : link_nav->getLinked(in_cluster)) {
-        auto out_link = out_links->create();
-        out_link.setFrom(out_cluster);
-        out_link.setTo(sim_particle);
-        out_link.setWeight(weight);
-        auto out_assoc = out_assocs->create();
-        out_assoc.setRec(out_cluster);
-        out_assoc.setSim(sim_particle);
-        out_assoc.setWeight(weight);
+    if (link_nav.enabled()) {
+      for (const auto& [sim_particle, weight] : link_nav.linked(in_cluster)) {
+        truth::addWeightedRelation(
+            out_cluster, sim_particle, weight,
+            gsl::not_null<edm4eic::MCRecoClusterParticleLinkCollection*>{out_links},
+            gsl::not_null<edm4eic::MCRecoClusterParticleAssociationCollection*>{out_assocs});
       }
     }
   }

--- a/src/algorithms/onnx/CalorimeterParticleIDPostML.h
+++ b/src/algorithms/onnx/CalorimeterParticleIDPostML.h
@@ -19,7 +19,7 @@ namespace eicrecon {
 
 using CalorimeterParticleIDPostMLAlgorithm = algorithms::Algorithm<
     algorithms::Input<edm4eic::ClusterCollection,
-                      std::optional<edm4eic::MCRecoClusterParticleAssociationCollection>,
+                      std::optional<edm4eic::MCRecoClusterParticleLinkCollection>,
                       edm4eic::TensorCollection>,
     algorithms::Output<edm4eic::ClusterCollection,
                        std::optional<edm4eic::MCRecoClusterParticleLinkCollection>,
@@ -33,7 +33,7 @@ public:
   CalorimeterParticleIDPostML(std::string_view name)
       : CalorimeterParticleIDPostMLAlgorithm{
             name,
-            {"inputClusters", "inputClusterAssociations", "inputPredictionsTensor"},
+            {"inputClusters", "inputClusterLinks", "inputPredictionsTensor"},
             {"outputClusters", "outputClusterLinks", "outputClusterAssociations",
              "outputParticleIDs"},
             ""} {}

--- a/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
@@ -1,18 +1,17 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2024 Dmitry Kalinkin
 
-#include <cstddef>
-#include <cstdint>
 #include <edm4hep/MCParticle.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <podio/LinkNavigator.h>
-#include <cmath>
+#include <cstddef>
+#include <cstdint>
 #include <limits>
 #include <stdexcept>
-
-#include <gsl/pointers>
+#include <tuple>
+#include <vector>
 
 #include "CalorimeterParticleIDPreML.h"
 

--- a/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
@@ -60,8 +60,8 @@ void CalorimeterParticleIDPreML::process(const CalorimeterParticleIDPreML::Input
         }
       }
       if (!found_assoc) {
-        warning("Can't find association for cluster. Skipping...");
-        continue;
+        error("Can't find association for cluster. Targets cannot be constructed.");
+        throw std::runtime_error("Missing cluster-particle association required for target tensor");
       }
       momentum = edm4hep::utils::magnitude(best_sim.getMomentum());
     }

--- a/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
@@ -4,10 +4,12 @@
 #include <edm4hep/MCParticle.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
+#include <fmt/core.h>
+#include <podio/LinkNavigator.h>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
-#include <format>
+#include <limits>
 #include <stdexcept>
 #include <tuple>
 
@@ -22,8 +24,13 @@ void CalorimeterParticleIDPreML::init() {
 void CalorimeterParticleIDPreML::process(const CalorimeterParticleIDPreML::Input& input,
                                          const CalorimeterParticleIDPreML::Output& output) const {
 
-  const auto [clusters, cluster_assocs]  = input;
+  const auto [clusters, cluster_links]   = input;
   auto [feature_tensors, target_tensors] = output;
+
+  if (cluster_links == nullptr || cluster_links->empty()) {
+    error("Cluster links are required for CalorimeterParticleIDPreML");
+    throw std::runtime_error("Missing inputClusterLinks");
+  }
 
   edm4eic::MutableTensor feature_tensor = feature_tensors->create();
   feature_tensor.addToShape(clusters->size());
@@ -31,32 +38,30 @@ void CalorimeterParticleIDPreML::process(const CalorimeterParticleIDPreML::Input
   feature_tensor.setElementType(1); // 1 - float
 
   edm4eic::MutableTensor target_tensor;
-  if (cluster_assocs != nullptr) {
-    target_tensor = target_tensors->create();
-    target_tensor.addToShape(clusters->size());
-    target_tensor.addToShape(2);     // is electron, is hadron
-    target_tensor.setElementType(7); // 7 - int64
-  }
+  target_tensor = target_tensors->create();
+  target_tensor.addToShape(clusters->size());
+  target_tensor.addToShape(2);     // is electron, is hadron
+  target_tensor.setElementType(7); // 7 - int64
+
+  podio::LinkNavigator<edm4eic::MCRecoClusterParticleLinkCollection> link_nav(*cluster_links);
 
   for (edm4eic::Cluster cluster : *clusters) {
-    double momentum = NAN;
-    {
-      // FIXME: use track momentum once matching to tracks becomes available
-      edm4eic::MCRecoClusterParticleAssociation best_assoc;
-      for (auto assoc : *cluster_assocs) {
-        if (assoc.getRec() == cluster) {
-          if ((not best_assoc.isAvailable()) || (assoc.getWeight() > best_assoc.getWeight())) {
-            best_assoc = assoc;
-          }
-        }
-      }
-      if (best_assoc.isAvailable()) {
-        momentum = edm4hep::utils::magnitude(best_assoc.getSim().getMomentum());
-      } else {
-        warning("Can't find association for cluster. Skipping...");
-        continue;
+    // FIXME: use track momentum once matching to tracks becomes available
+    edm4hep::MCParticle best_sim;
+    float best_weight = std::numeric_limits<float>::lowest();
+    bool found_assoc  = false;
+    for (const auto& [sim_particle, weight] : link_nav.getLinked(cluster)) {
+      if (!found_assoc || weight > best_weight) {
+        best_sim    = sim_particle;
+        best_weight = weight;
+        found_assoc = true;
       }
     }
+    if (!found_assoc) {
+      warning("Can't find association for cluster. Skipping...");
+      continue;
+    }
+    const double momentum = edm4hep::utils::magnitude(best_sim.getMomentum());
 
     feature_tensor.addToFloatData(momentum);
     feature_tensor.addToFloatData(cluster.getEnergy() / momentum);
@@ -67,24 +72,10 @@ void CalorimeterParticleIDPreML::process(const CalorimeterParticleIDPreML::Input
       feature_tensor.addToFloatData(cluster.getShapeParameters(par_ix));
     }
 
-    if (cluster_assocs != nullptr) {
-      edm4eic::MCRecoClusterParticleAssociation best_assoc;
-      for (auto assoc : *cluster_assocs) {
-        if (assoc.getRec() == cluster) {
-          if ((not best_assoc.isAvailable()) || (assoc.getWeight() > best_assoc.getWeight())) {
-            best_assoc = assoc;
-          }
-        }
-      }
-      int64_t is_electron = 0;
-      int64_t is_pion     = 0;
-      if (best_assoc.isAvailable()) {
-        is_electron = static_cast<int64_t>(best_assoc.getSim().getPDG() == 11);
-        is_pion     = static_cast<int64_t>(best_assoc.getSim().getPDG() != 11);
-      }
-      target_tensor.addToInt64Data(is_pion);
-      target_tensor.addToInt64Data(is_electron);
-    }
+    int64_t is_electron = static_cast<int64_t>(best_sim.getPDG() == 11);
+    int64_t is_pion     = static_cast<int64_t>(best_sim.getPDG() != 11);
+    target_tensor.addToInt64Data(is_pion);
+    target_tensor.addToInt64Data(is_electron);
   }
 
   std::size_t expected_num_entries = feature_tensor.getShape(0) * feature_tensor.getShape(1);

--- a/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
@@ -7,7 +7,9 @@
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
+#include <podio/LinkNavigator.h>
 #include <cmath>
+#include <limits>
 #include <stdexcept>
 
 #include <gsl/pointers>
@@ -23,8 +25,13 @@ void CalorimeterParticleIDPreML::init() {
 void CalorimeterParticleIDPreML::process(const CalorimeterParticleIDPreML::Input& input,
                                          const CalorimeterParticleIDPreML::Output& output) const {
 
-  const auto [clusters, cluster_assocs]  = input;
+  const auto [clusters, cluster_links]   = input;
   auto [feature_tensors, target_tensors] = output;
+
+  if (cluster_links == nullptr || cluster_links->empty()) {
+    error("Cluster links are required for CalorimeterParticleIDPreML");
+    throw std::runtime_error("Missing inputClusterLinks");
+  }
 
   edm4eic::MutableTensor feature_tensor = feature_tensors->create();
   feature_tensor.addToShape(clusters->size());
@@ -32,32 +39,30 @@ void CalorimeterParticleIDPreML::process(const CalorimeterParticleIDPreML::Input
   feature_tensor.setElementType(1); // 1 - float
 
   edm4eic::MutableTensor target_tensor;
-  if (cluster_assocs != nullptr) {
-    target_tensor = target_tensors->create();
-    target_tensor.addToShape(clusters->size());
-    target_tensor.addToShape(2);     // is electron, is hadron
-    target_tensor.setElementType(7); // 7 - int64
-  }
+  target_tensor = target_tensors->create();
+  target_tensor.addToShape(clusters->size());
+  target_tensor.addToShape(2);     // is electron, is hadron
+  target_tensor.setElementType(7); // 7 - int64
+
+  podio::LinkNavigator<edm4eic::MCRecoClusterParticleLinkCollection> link_nav(*cluster_links);
 
   for (edm4eic::Cluster cluster : *clusters) {
-    double momentum = NAN;
-    {
-      // FIXME: use track momentum once matching to tracks becomes available
-      edm4eic::MCRecoClusterParticleAssociation best_assoc;
-      for (auto assoc : *cluster_assocs) {
-        if (assoc.getRec() == cluster) {
-          if ((not best_assoc.isAvailable()) || (assoc.getWeight() > best_assoc.getWeight())) {
-            best_assoc = assoc;
-          }
-        }
-      }
-      if (best_assoc.isAvailable()) {
-        momentum = edm4hep::utils::magnitude(best_assoc.getSim().getMomentum());
-      } else {
-        warning("Can't find association for cluster. Skipping...");
-        continue;
+    // FIXME: use track momentum once matching to tracks becomes available
+    edm4hep::MCParticle best_sim;
+    float best_weight = std::numeric_limits<float>::lowest();
+    bool found_assoc  = false;
+    for (const auto& [sim_particle, weight] : link_nav.getLinked(cluster)) {
+      if (!found_assoc || weight > best_weight) {
+        best_sim    = sim_particle;
+        best_weight = weight;
+        found_assoc = true;
       }
     }
+    if (!found_assoc) {
+      warning("Can't find association for cluster. Skipping...");
+      continue;
+    }
+    const double momentum = edm4hep::utils::magnitude(best_sim.getMomentum());
 
     feature_tensor.addToFloatData(momentum);
     feature_tensor.addToFloatData(cluster.getEnergy() / momentum);
@@ -68,24 +73,10 @@ void CalorimeterParticleIDPreML::process(const CalorimeterParticleIDPreML::Input
       feature_tensor.addToFloatData(cluster.getShapeParameters(par_ix));
     }
 
-    if (cluster_assocs != nullptr) {
-      edm4eic::MCRecoClusterParticleAssociation best_assoc;
-      for (auto assoc : *cluster_assocs) {
-        if (assoc.getRec() == cluster) {
-          if ((not best_assoc.isAvailable()) || (assoc.getWeight() > best_assoc.getWeight())) {
-            best_assoc = assoc;
-          }
-        }
-      }
-      int64_t is_electron = 0;
-      int64_t is_pion     = 0;
-      if (best_assoc.isAvailable()) {
-        is_electron = static_cast<int64_t>(best_assoc.getSim().getPDG() == 11);
-        is_pion     = static_cast<int64_t>(best_assoc.getSim().getPDG() != 11);
-      }
-      target_tensor.addToInt64Data(is_pion);
-      target_tensor.addToInt64Data(is_electron);
-    }
+    int64_t is_electron = static_cast<int64_t>(best_sim.getPDG() == 11);
+    int64_t is_pion     = static_cast<int64_t>(best_sim.getPDG() != 11);
+    target_tensor.addToInt64Data(is_pion);
+    target_tensor.addToInt64Data(is_electron);
   }
 
   std::size_t expected_num_entries = feature_tensor.getShape(0) * feature_tensor.getShape(1);

--- a/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
@@ -5,7 +5,6 @@
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <fmt/format.h>
-#include <podio/LinkNavigator.h>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -15,6 +14,7 @@
 #include <vector>
 
 #include "CalorimeterParticleIDPreML.h"
+#include "algorithms/interfaces/LinkTruthUtils.h"
 
 namespace eicrecon {
 
@@ -27,11 +27,9 @@ void CalorimeterParticleIDPreML::process(const CalorimeterParticleIDPreML::Input
 
   const auto [clusters, cluster_links]   = input;
   auto [feature_tensors, target_tensors] = output;
-
-  if (cluster_links == nullptr || cluster_links->empty()) {
-    error("Cluster links are required for CalorimeterParticleIDPreML");
-    throw std::runtime_error("Missing inputClusterLinks");
-  }
+  const truth::EventLinkNavigator<edm4eic::MCRecoClusterParticleLinkCollection> link_nav(
+      cluster_links);
+  const bool fill_targets = link_nav.enabled();
 
   edm4eic::MutableTensor feature_tensor = feature_tensors->create();
   feature_tensor.addToShape(clusters->size());
@@ -39,19 +37,19 @@ void CalorimeterParticleIDPreML::process(const CalorimeterParticleIDPreML::Input
   feature_tensor.setElementType(1); // 1 - float
 
   edm4eic::MutableTensor target_tensor;
-  target_tensor = target_tensors->create();
-  target_tensor.addToShape(clusters->size());
-  target_tensor.addToShape(2);     // is electron, is hadron
-  target_tensor.setElementType(7); // 7 - int64
-
-  podio::LinkNavigator<edm4eic::MCRecoClusterParticleLinkCollection> link_nav(*cluster_links);
+  if (fill_targets) {
+    target_tensor = target_tensors->create();
+    target_tensor.addToShape(clusters->size());
+    target_tensor.addToShape(2);     // is electron, is hadron
+    target_tensor.setElementType(7); // 7 - int64
+  }
 
   for (edm4eic::Cluster cluster : *clusters) {
     // FIXME: use track momentum once matching to tracks becomes available
     edm4hep::MCParticle best_sim;
     float best_weight = std::numeric_limits<float>::lowest();
     bool found_assoc  = false;
-    for (const auto& [sim_particle, weight] : link_nav.getLinked(cluster)) {
+    for (const auto& [sim_particle, weight] : link_nav.linked(cluster)) {
       if (!found_assoc || weight > best_weight) {
         best_sim    = sim_particle;
         best_weight = weight;
@@ -73,10 +71,12 @@ void CalorimeterParticleIDPreML::process(const CalorimeterParticleIDPreML::Input
       feature_tensor.addToFloatData(cluster.getShapeParameters(par_ix));
     }
 
-    auto is_electron = static_cast<int64_t>(best_sim.getPDG() == 11);
-    auto is_pion     = static_cast<int64_t>(best_sim.getPDG() != 11);
-    target_tensor.addToInt64Data(is_pion);
-    target_tensor.addToInt64Data(is_electron);
+    if (fill_targets) {
+      int64_t is_electron = static_cast<int64_t>(best_sim.getPDG() == 11);
+      int64_t is_pion     = static_cast<int64_t>(best_sim.getPDG() != 11);
+      target_tensor.addToInt64Data(is_pion);
+      target_tensor.addToInt64Data(is_electron);
+    }
   }
 
   std::size_t expected_num_entries = feature_tensor.getShape(0) * feature_tensor.getShape(1);

--- a/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
@@ -4,7 +4,6 @@
 #include <edm4hep/MCParticle.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <fmt/format.h>
 #include <podio/LinkNavigator.h>
 #include <cmath>
 #include <cstddef>

--- a/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
@@ -72,8 +72,8 @@ void CalorimeterParticleIDPreML::process(const CalorimeterParticleIDPreML::Input
       feature_tensor.addToFloatData(cluster.getShapeParameters(par_ix));
     }
 
-    int64_t is_electron = static_cast<int64_t>(best_sim.getPDG() == 11);
-    int64_t is_pion     = static_cast<int64_t>(best_sim.getPDG() != 11);
+    auto is_electron = static_cast<int64_t>(best_sim.getPDG() == 11);
+    auto is_pion     = static_cast<int64_t>(best_sim.getPDG() != 11);
     target_tensor.addToInt64Data(is_pion);
     target_tensor.addToInt64Data(is_electron);
   }

--- a/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
@@ -72,8 +72,8 @@ void CalorimeterParticleIDPreML::process(const CalorimeterParticleIDPreML::Input
     }
 
     if (fill_targets) {
-      int64_t is_electron = static_cast<int64_t>(best_sim.getPDG() == 11);
-      int64_t is_pion     = static_cast<int64_t>(best_sim.getPDG() != 11);
+      auto is_electron = static_cast<int64_t>(best_sim.getPDG() == 11);
+      auto is_pion     = static_cast<int64_t>(best_sim.getPDG() != 11);
       target_tensor.addToInt64Data(is_pion);
       target_tensor.addToInt64Data(is_electron);
     }

--- a/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
@@ -4,7 +4,7 @@
 #include <edm4hep/MCParticle.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <podio/LinkNavigator.h>
 #include <cmath>
 #include <cstddef>
@@ -12,6 +12,7 @@
 #include <limits>
 #include <stdexcept>
 #include <tuple>
+#include <vector>
 
 #include "CalorimeterParticleIDPreML.h"
 

--- a/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
@@ -9,6 +9,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <format>
 #include <limits>
 #include <stdexcept>
 #include <tuple>

--- a/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
@@ -26,11 +26,8 @@ void CalorimeterParticleIDPreML::process(const CalorimeterParticleIDPreML::Input
 
   const auto [clusters, cluster_links]   = input;
   auto [feature_tensors, target_tensors] = output;
-
-  if (cluster_links == nullptr || cluster_links->empty()) {
-    error("Cluster links are required for CalorimeterParticleIDPreML");
-    throw std::runtime_error("Missing inputClusterLinks");
-  }
+  const truth::EventLinkNavigator<edm4eic::MCRecoClusterParticleLinkCollection> link_nav(
+      cluster_links);
 
   edm4eic::MutableTensor feature_tensor = feature_tensors->create();
   feature_tensor.addToShape(clusters->size());
@@ -38,31 +35,33 @@ void CalorimeterParticleIDPreML::process(const CalorimeterParticleIDPreML::Input
   feature_tensor.setElementType(1); // 1 - float
 
   edm4eic::MutableTensor target_tensor;
-  target_tensor = target_tensors->create();
-  target_tensor.addToShape(clusters->size());
-  target_tensor.addToShape(2);     // is electron, is hadron
-  target_tensor.setElementType(7); // 7 - int64
-
-  const truth::EventLinkNavigator<edm4eic::MCRecoClusterParticleLinkCollection> link_nav(
-      cluster_links);
+  if (link_nav.enabled()) {
+    target_tensor = target_tensors->create();
+    target_tensor.addToShape(clusters->size());
+    target_tensor.addToShape(2);     // is electron, is hadron
+    target_tensor.setElementType(7); // 7 - int64
+  }
 
   for (edm4eic::Cluster cluster : *clusters) {
-    // FIXME: use track momentum once matching to tracks becomes available
-    edm4hep::MCParticle best_sim;
-    float best_weight = std::numeric_limits<float>::lowest();
-    bool found_assoc  = false;
-    for (const auto& [sim_particle, weight] : link_nav.linked(cluster)) {
-      if (!found_assoc || weight > best_weight) {
-        best_sim    = sim_particle;
-        best_weight = weight;
-        found_assoc = true;
+    double momentum = NAN;
+    if (link_nav.enabled()) {
+      // FIXME: use track momentum once matching to tracks becomes available
+      edm4hep::MCParticle best_sim;
+      float best_weight = std::numeric_limits<float>::lowest();
+      bool found_assoc  = false;
+      for (const auto& [sim_particle, weight] : link_nav.linked(cluster)) {
+        if (!found_assoc || weight > best_weight) {
+          best_sim    = sim_particle;
+          best_weight = weight;
+          found_assoc = true;
+        }
       }
+      if (!found_assoc) {
+        warning("Can't find association for cluster. Skipping...");
+        continue;
+      }
+      double momentum = edm4hep::utils::magnitude(best_sim.getMomentum());
     }
-    if (!found_assoc) {
-      warning("Can't find association for cluster. Skipping...");
-      continue;
-    }
-    const double momentum = edm4hep::utils::magnitude(best_sim.getMomentum());
 
     feature_tensor.addToFloatData(momentum);
     feature_tensor.addToFloatData(cluster.getEnergy() / momentum);
@@ -73,10 +72,12 @@ void CalorimeterParticleIDPreML::process(const CalorimeterParticleIDPreML::Input
       feature_tensor.addToFloatData(cluster.getShapeParameters(par_ix));
     }
 
-    auto is_electron = static_cast<int64_t>(best_sim.getPDG() == 11);
-    auto is_pion     = static_cast<int64_t>(best_sim.getPDG() != 11);
-    target_tensor.addToInt64Data(is_pion);
-    target_tensor.addToInt64Data(is_electron);
+    if (link_nav.enabled()) {
+      auto is_electron = static_cast<int64_t>(best_sim.getPDG() == 11);
+      auto is_pion     = static_cast<int64_t>(best_sim.getPDG() != 11);
+      target_tensor.addToInt64Data(is_pion);
+      target_tensor.addToInt64Data(is_electron);
+    }
   }
 
   std::size_t expected_num_entries = feature_tensor.getShape(0) * feature_tensor.getShape(1);

--- a/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
@@ -45,22 +45,25 @@ void CalorimeterParticleIDPreML::process(const CalorimeterParticleIDPreML::Input
   }
 
   for (edm4eic::Cluster cluster : *clusters) {
-    // FIXME: use track momentum once matching to tracks becomes available
+    double momentum = NAN;
     edm4hep::MCParticle best_sim;
-    float best_weight = std::numeric_limits<float>::lowest();
-    bool found_assoc  = false;
-    for (const auto& [sim_particle, weight] : link_nav.linked(cluster)) {
-      if (!found_assoc || weight > best_weight) {
-        best_sim    = sim_particle;
-        best_weight = weight;
-        found_assoc = true;
+    if (fill_targets) {
+      // FIXME: use track momentum once matching to tracks becomes available
+      float best_weight = std::numeric_limits<float>::lowest();
+      bool found_assoc  = false;
+      for (const auto& [sim_particle, weight] : link_nav.linked(cluster)) {
+        if (!found_assoc || weight > best_weight) {
+          best_sim    = sim_particle;
+          best_weight = weight;
+          found_assoc = true;
+        }
       }
+      if (!found_assoc) {
+        warning("Can't find association for cluster. Skipping...");
+        continue;
+      }
+      momentum = edm4hep::utils::magnitude(best_sim.getMomentum());
     }
-    if (!found_assoc) {
-      warning("Can't find association for cluster. Skipping...");
-      continue;
-    }
-    const double momentum = edm4hep::utils::magnitude(best_sim.getMomentum());
 
     feature_tensor.addToFloatData(momentum);
     feature_tensor.addToFloatData(cluster.getEnergy() / momentum);

--- a/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
@@ -5,7 +5,6 @@
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <fmt/format.h>
-#include <podio/LinkNavigator.h>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -14,6 +13,7 @@
 #include <vector>
 
 #include "CalorimeterParticleIDPreML.h"
+#include "algorithms/interfaces/LinkTruthUtils.h"
 
 namespace eicrecon {
 
@@ -43,14 +43,15 @@ void CalorimeterParticleIDPreML::process(const CalorimeterParticleIDPreML::Input
   target_tensor.addToShape(2);     // is electron, is hadron
   target_tensor.setElementType(7); // 7 - int64
 
-  podio::LinkNavigator<edm4eic::MCRecoClusterParticleLinkCollection> link_nav(*cluster_links);
+  const truth::EventLinkNavigator<edm4eic::MCRecoClusterParticleLinkCollection> link_nav(
+      cluster_links);
 
   for (edm4eic::Cluster cluster : *clusters) {
     // FIXME: use track momentum once matching to tracks becomes available
     edm4hep::MCParticle best_sim;
     float best_weight = std::numeric_limits<float>::lowest();
     bool found_assoc  = false;
-    for (const auto& [sim_particle, weight] : link_nav.getLinked(cluster)) {
+    for (const auto& [sim_particle, weight] : link_nav.linked(cluster)) {
       if (!found_assoc || weight > best_weight) {
         best_sim    = sim_particle;
         best_weight = weight;

--- a/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
@@ -60,8 +60,8 @@ void CalorimeterParticleIDPreML::process(const CalorimeterParticleIDPreML::Input
         }
       }
       if (!found_assoc) {
-        error("Can't find association for cluster. Targets cannot be constructed.");
-        throw std::runtime_error("Missing cluster-particle association required for target tensor");
+        error("Can't find link for cluster. Targets cannot be constructed.");
+        throw std::runtime_error("Missing cluster-particle link required for target tensor");
       }
       momentum = edm4hep::utils::magnitude(best_sim.getMomentum());
     }

--- a/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
@@ -73,8 +73,8 @@ void CalorimeterParticleIDPreML::process(const CalorimeterParticleIDPreML::Input
       feature_tensor.addToFloatData(cluster.getShapeParameters(par_ix));
     }
 
-    int64_t is_electron = static_cast<int64_t>(best_sim.getPDG() == 11);
-    int64_t is_pion     = static_cast<int64_t>(best_sim.getPDG() != 11);
+    auto is_electron = static_cast<int64_t>(best_sim.getPDG() == 11);
+    auto is_pion     = static_cast<int64_t>(best_sim.getPDG() != 11);
     target_tensor.addToInt64Data(is_pion);
     target_tensor.addToInt64Data(is_electron);
   }

--- a/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
@@ -5,6 +5,7 @@
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <fmt/format.h>
+#include <podio/LinkNavigator.h>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>

--- a/src/algorithms/onnx/CalorimeterParticleIDPreML.h
+++ b/src/algorithms/onnx/CalorimeterParticleIDPreML.h
@@ -5,7 +5,7 @@
 
 #include <algorithms/algorithm.h>
 #include <edm4eic/ClusterCollection.h>
-#include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
+#include <edm4eic/MCRecoClusterParticleLinkCollection.h>
 #include <edm4eic/TensorCollection.h>
 #include <optional>
 #include <string>
@@ -17,7 +17,7 @@ namespace eicrecon {
 
 using CalorimeterParticleIDPreMLAlgorithm = algorithms::Algorithm<
     algorithms::Input<edm4eic::ClusterCollection,
-                      std::optional<edm4eic::MCRecoClusterParticleAssociationCollection>>,
+                      std::optional<edm4eic::MCRecoClusterParticleLinkCollection>>,
     algorithms::Output<edm4eic::TensorCollection, std::optional<edm4eic::TensorCollection>>>;
 
 class CalorimeterParticleIDPreML : public CalorimeterParticleIDPreMLAlgorithm,
@@ -25,8 +25,10 @@ class CalorimeterParticleIDPreML : public CalorimeterParticleIDPreMLAlgorithm,
 
 public:
   CalorimeterParticleIDPreML(std::string_view name)
-      : CalorimeterParticleIDPreMLAlgorithm{
-            name, {"inputClusters"}, {"outputFeatureTensor", "outputTargetTensor"}, ""} {}
+      : CalorimeterParticleIDPreMLAlgorithm{name,
+                                            {"inputClusters", "inputClusterLinks"},
+                                            {"outputFeatureTensor", "outputTargetTensor"},
+                                            ""} {}
 
   void init() final;
   void process(const Input&, const Output&) const final;

--- a/src/algorithms/pid/MatchToRICHPID.cc
+++ b/src/algorithms/pid/MatchToRICHPID.cc
@@ -8,11 +8,8 @@
 #include <edm4hep/MCParticle.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <podio/LinkNavigator.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
-#include <podio/detail/Link.h>
-#include <podio/detail/LinkCollectionImpl.h>
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
@@ -22,6 +19,7 @@
 #include <vector>
 
 #include "algorithms/pid/ConvertParticleID.h"
+#include "algorithms/interfaces/LinkTruthUtils.h"
 #include "algorithms/pid/MatchToRICHPIDConfig.h"
 
 namespace eicrecon {
@@ -32,7 +30,7 @@ void MatchToRICHPID::process(const MatchToRICHPID::Input& input,
                              const MatchToRICHPID::Output& output) const {
   const auto [parts_in, links_in, drich_cherenkov_pid] = input;
   auto [parts_out, links_out, assocs_out, pids]        = output;
-  podio::LinkNavigator<edm4eic::MCRecoParticleLinkCollection> link_nav(*links_in);
+  const truth::EventLinkNavigator<edm4eic::MCRecoParticleLinkCollection> link_nav(links_in);
 
   for (auto part_in : *parts_in) {
     auto part_out = part_in.clone();
@@ -44,7 +42,7 @@ void MatchToRICHPID::process(const MatchToRICHPID::Input& input,
             part_out.getParticleIDUsed().isAvailable() ? part_out.getParticleIDUsed().getPDG() : 0);
     }
 
-    for (const auto& [sim_particle, weight] : link_nav.getLinked(part_in)) {
+    for (const auto& [sim_particle, weight] : link_nav.linked(part_in)) {
       auto link_out = links_out->create();
       link_out.setFrom(part_out);
       link_out.setTo(sim_particle);

--- a/src/algorithms/pid/MatchToRICHPID.cc
+++ b/src/algorithms/pid/MatchToRICHPID.cc
@@ -8,6 +8,7 @@
 #include <edm4hep/MCParticle.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
+#include <podio/LinkNavigator.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
 #include <podio/detail/Link.h>
@@ -29,8 +30,9 @@ void MatchToRICHPID::init() {}
 
 void MatchToRICHPID::process(const MatchToRICHPID::Input& input,
                              const MatchToRICHPID::Output& output) const {
-  const auto [parts_in, assocs_in, drich_cherenkov_pid] = input;
-  auto [parts_out, links_out, assocs_out, pids]         = output;
+  const auto [parts_in, links_in, drich_cherenkov_pid] = input;
+  auto [parts_out, links_out, assocs_out, pids]        = output;
+  podio::LinkNavigator<edm4eic::MCRecoParticleLinkCollection> link_nav(*links_in);
 
   for (auto part_in : *parts_in) {
     auto part_out = part_in.clone();
@@ -42,16 +44,15 @@ void MatchToRICHPID::process(const MatchToRICHPID::Input& input,
             part_out.getParticleIDUsed().isAvailable() ? part_out.getParticleIDUsed().getPDG() : 0);
     }
 
-    for (auto assoc_in : *assocs_in) {
-      if (assoc_in.getRec() == part_in) {
-        auto link_out = links_out->create();
-        link_out.setFrom(part_out);
-        link_out.setTo(assoc_in.getSim());
-        link_out.setWeight(assoc_in.getWeight());
-        auto assoc_out = assoc_in.clone();
-        assoc_out.setRec(part_out);
-        assocs_out->push_back(assoc_out);
-      }
+    for (const auto& [sim_particle, weight] : link_nav.getLinked(part_in)) {
+      auto link_out = links_out->create();
+      link_out.setFrom(part_out);
+      link_out.setTo(sim_particle);
+      link_out.setWeight(weight);
+      auto assoc_out = assocs_out->create();
+      assoc_out.setRec(part_out);
+      assoc_out.setSim(sim_particle);
+      assoc_out.setWeight(weight);
     }
 
     parts_out->push_back(part_out);

--- a/src/algorithms/pid/MatchToRICHPID.cc
+++ b/src/algorithms/pid/MatchToRICHPID.cc
@@ -8,8 +8,11 @@
 #include <edm4hep/MCParticle.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
+#include <podio/LinkNavigator.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
+#include <podio/detail/Link.h>
+#include <podio/detail/LinkCollectionImpl.h>
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
@@ -18,8 +21,8 @@
 #include <utility>
 #include <vector>
 
-#include "algorithms/pid/ConvertParticleID.h"
 #include "algorithms/interfaces/LinkTruthUtils.h"
+#include "algorithms/pid/ConvertParticleID.h"
 #include "algorithms/pid/MatchToRICHPIDConfig.h"
 
 namespace eicrecon {

--- a/src/algorithms/pid/MatchToRICHPID.h
+++ b/src/algorithms/pid/MatchToRICHPID.h
@@ -19,7 +19,7 @@ namespace eicrecon {
 
 using MatchToRICHPIDAlgorithm = algorithms::Algorithm<
     algorithms::Input<edm4eic::ReconstructedParticleCollection,
-                      edm4eic::MCRecoParticleAssociationCollection,
+                      edm4eic::MCRecoParticleLinkCollection,
                       edm4eic::CherenkovParticleIDCollection>,
     algorithms::Output<
         edm4eic::ReconstructedParticleCollection, edm4eic::MCRecoParticleLinkCollection,
@@ -29,8 +29,7 @@ class MatchToRICHPID : public MatchToRICHPIDAlgorithm, public WithPodConfig<Matc
 public:
   MatchToRICHPID(std::string_view name)
       : MatchToRICHPIDAlgorithm{name,
-                                {"inputReconstructedParticlesCollection",
-                                 "inputAssociationsCollection",
+                                {"inputReconstructedParticlesCollection", "inputLinksCollection",
                                  "inputCherenkovParticleIDCollection"},
                                 {"outputReconstructedParticlesCollection", "outputLinks",
                                  "outputAssociationsCollection"},

--- a/src/algorithms/pid_lut/PIDLookup.cc
+++ b/src/algorithms/pid_lut/PIDLookup.cc
@@ -7,6 +7,9 @@
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
+#include <podio/LinkNavigator.h>
+#include <podio/detail/Link.h>
+#include <podio/detail/LinkCollectionImpl.h>
 #include <cmath>
 #include <exception>
 #include <limits>
@@ -16,9 +19,9 @@
 #include <tuple>
 #include <vector>
 
+#include "algorithms/interfaces/LinkTruthUtils.h"
 #include "algorithms/pid_lut/PIDLookup.h"
 #include "algorithms/pid_lut/PIDLookupConfig.h"
-#include "algorithms/interfaces/LinkTruthUtils.h"
 #include "services/pid_lut/PIDLookupTableSvc.h"
 
 namespace eicrecon {

--- a/src/algorithms/pid_lut/PIDLookup.cc
+++ b/src/algorithms/pid_lut/PIDLookup.cc
@@ -7,9 +7,6 @@
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <podio/LinkNavigator.h>
-#include <podio/detail/Link.h>
-#include <podio/detail/LinkCollectionImpl.h>
 #include <cmath>
 #include <exception>
 #include <limits>
@@ -21,6 +18,7 @@
 
 #include "algorithms/pid_lut/PIDLookup.h"
 #include "algorithms/pid_lut/PIDLookupConfig.h"
+#include "algorithms/interfaces/LinkTruthUtils.h"
 #include "services/pid_lut/PIDLookupTableSvc.h"
 
 namespace eicrecon {
@@ -58,7 +56,7 @@ void PIDLookup::init() {
 void PIDLookup::process(const Input& input, const Output& output) const {
   const auto [headers, recoparts_in, partlinks_in]                 = input;
   auto [recoparts_out, partlinks_out, partassocs_out, partids_out] = output;
-  podio::LinkNavigator<edm4eic::MCRecoParticleLinkCollection> link_nav(*partlinks_in);
+  const truth::EventLinkNavigator<edm4eic::MCRecoParticleLinkCollection> link_nav(partlinks_in);
 
   // local random generator
   auto seed = m_uid.getUniqueID(*headers, name());
@@ -72,7 +70,7 @@ void PIDLookup::process(const Input& input, const Output& output) const {
     edm4hep::MCParticle best_sim;
     float best_weight = std::numeric_limits<float>::lowest();
     bool has_best     = false;
-    for (const auto& [sim_particle, weight] : link_nav.getLinked(recopart_without_pid)) {
+    for (const auto& [sim_particle, weight] : link_nav.linked(recopart_without_pid)) {
       if (!has_best || best_weight < weight) {
         best_sim    = sim_particle;
         best_weight = weight;

--- a/src/algorithms/pid_lut/PIDLookup.cc
+++ b/src/algorithms/pid_lut/PIDLookup.cc
@@ -7,10 +7,12 @@
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
+#include <podio/LinkNavigator.h>
 #include <podio/detail/Link.h>
 #include <podio/detail/LinkCollectionImpl.h>
 #include <cmath>
 #include <exception>
+#include <limits>
 #include <memory>
 #include <random>
 #include <stdexcept>
@@ -54,8 +56,9 @@ void PIDLookup::init() {
 }
 
 void PIDLookup::process(const Input& input, const Output& output) const {
-  const auto [headers, recoparts_in, partassocs_in]                = input;
+  const auto [headers, recoparts_in, partlinks_in]                 = input;
   auto [recoparts_out, partlinks_out, partassocs_out, partids_out] = output;
+  podio::LinkNavigator<edm4eic::MCRecoParticleLinkCollection> link_nav(*partlinks_in);
 
   // local random generator
   auto seed = m_uid.getUniqueID(*headers, name());
@@ -65,28 +68,31 @@ void PIDLookup::process(const Input& input, const Output& output) const {
   for (const auto& recopart_without_pid : *recoparts_in) {
     auto recopart = recopart_without_pid.clone();
 
-    // Find MCParticle from associations and propagate the relevant ones further
-    auto best_assoc = edm4eic::MCRecoParticleAssociation::makeEmpty();
-    for (auto assoc_in : *partassocs_in) {
-      if (assoc_in.getRec() == recopart_without_pid) {
-        if ((not best_assoc.isAvailable()) || (best_assoc.getWeight() < assoc_in.getWeight())) {
-          best_assoc = assoc_in;
-        }
-        auto link_out = partlinks_out->create();
-        link_out.setFrom(recopart);
-        link_out.setTo(assoc_in.getSim());
-        link_out.setWeight(assoc_in.getWeight());
-        auto assoc_out = assoc_in.clone();
-        assoc_out.setRec(recopart);
-        partassocs_out->push_back(assoc_out);
+    // Find MCParticle from links and propagate the relevant ones further
+    edm4hep::MCParticle best_sim;
+    float best_weight = std::numeric_limits<float>::lowest();
+    bool has_best     = false;
+    for (const auto& [sim_particle, weight] : link_nav.getLinked(recopart_without_pid)) {
+      if (!has_best || best_weight < weight) {
+        best_sim    = sim_particle;
+        best_weight = weight;
+        has_best    = true;
       }
+      auto link_out = partlinks_out->create();
+      link_out.setFrom(recopart);
+      link_out.setTo(sim_particle);
+      link_out.setWeight(weight);
+      auto assoc_out = partassocs_out->create();
+      assoc_out.setRec(recopart);
+      assoc_out.setSim(sim_particle);
+      assoc_out.setWeight(weight);
     }
-    if (not best_assoc.isAvailable()) {
+    if (!has_best) {
       recoparts_out->push_back(recopart);
       continue;
     }
 
-    edm4hep::MCParticle mcpart = best_assoc.getSim();
+    edm4hep::MCParticle mcpart = best_sim;
 
     int true_pdg    = mcpart.getPDG();
     int true_charge = mcpart.getCharge();

--- a/src/algorithms/pid_lut/PIDLookup.h
+++ b/src/algorithms/pid_lut/PIDLookup.h
@@ -26,7 +26,7 @@ namespace eicrecon {
 
 using PIDLookupAlgorithm = algorithms::Algorithm<
     algorithms::Input<edm4hep::EventHeaderCollection, edm4eic::ReconstructedParticleCollection,
-                      edm4eic::MCRecoParticleAssociationCollection>,
+                      edm4eic::MCRecoParticleLinkCollection>,
     algorithms::Output<
         edm4eic::ReconstructedParticleCollection, edm4eic::MCRecoParticleLinkCollection,
         edm4eic::MCRecoParticleAssociationCollection, edm4hep::ParticleIDCollection>>;
@@ -37,7 +37,7 @@ public:
   PIDLookup(std::string_view name)
       : PIDLookupAlgorithm{
             name,
-            {"eventHeader", "inputParticlesCollection", "inputParticleAssociationsCollection"},
+            {"eventHeader", "inputParticlesCollection", "inputParticleLinksCollection"},
             {"outputParticlesCollection", "outputParticleLinks",
              "outputParticleAssociationsCollection", "outputParticleIDCollection"},
             ""} {}

--- a/src/detectors/B0ECAL/B0ECAL.cc
+++ b/src/detectors/B0ECAL/B0ECAL.cc
@@ -95,7 +95,7 @@ void InitPlugin(JApplication* app) {
       app));
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
-      "B0ECalClusters", {"B0ECalClustersWithoutShapes", "B0ECalClusterAssociationsWithoutShapes"},
+      "B0ECalClusters", {"B0ECalClustersWithoutShapes", "B0ECalClusterLinksWithoutShapes"},
       {"B0ECalClusters", "B0ECalClusterLinks", "B0ECalClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 3.6}, app));
 
@@ -114,7 +114,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "B0ECalTruthClusters",
-      {"B0ECalTruthClustersWithoutShapes", "B0ECalTruthClusterAssociationsWithoutShapes"},
+      {"B0ECalTruthClustersWithoutShapes", "B0ECalTruthClusterLinksWithoutShapes"},
       {"B0ECalTruthClusters", "B0ECalTruthClusterLinks", "B0ECalTruthClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
 }

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -461,7 +461,7 @@ void InitPlugin(JApplication* app) {
       ));
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalBarrelClusters",
-      {"EcalBarrelClustersWithoutShapes", "EcalBarrelClusterAssociationsWithoutShapes"},
+      {"EcalBarrelClustersWithoutShapes", "EcalBarrelClusterLinksWithoutShapes"},
       {"EcalBarrelClusters", "EcalBarrelClusterLinks", "EcalBarrelClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 6.2}, app));
   app->Add(new JOmniFactoryGeneratorT<TruthEnergyPositionClusterMerger_factory>(
@@ -474,7 +474,7 @@ void InitPlugin(JApplication* app) {
       ));
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalBarrelTruthClusters",
-      {"EcalBarrelTruthClustersWithoutShapes", "EcalBarrelTruthClusterAssociationsWithoutShapes"},
+      {"EcalBarrelTruthClustersWithoutShapes", "EcalBarrelTruthClusterLinksWithoutShapes"},
       {"EcalBarrelTruthClusters", "EcalBarrelTruthClusterLinks",
        "EcalBarrelTruthClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 6.2}, app));

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -349,8 +349,7 @@ void InitPlugin(JApplication* app) {
       ));
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalBarrelScFiTopoClusters",
-      {"EcalBarrelScFiTopoClustersWithoutShapes",
-       "EcalBarrelScFiTopoClusterLinksWithoutShapes"},
+      {"EcalBarrelScFiTopoClustersWithoutShapes", "EcalBarrelScFiTopoClusterLinksWithoutShapes"},
       {"EcalBarrelScFiTopoClusters", "EcalBarrelScFiTopoClusterLinks",
        "EcalBarrelScFiTopoClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 6.2}, app));

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -350,7 +350,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalBarrelScFiTopoClusters",
       {"EcalBarrelScFiTopoClustersWithoutShapes",
-       "EcalBarrelScFiTopoClusterAssociationsWithoutShapes"},
+       "EcalBarrelScFiTopoClusterLinksWithoutShapes"},
       {"EcalBarrelScFiTopoClusters", "EcalBarrelScFiTopoClusterLinks",
        "EcalBarrelScFiTopoClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 6.2}, app));

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -311,7 +311,7 @@ void InitPlugin(JApplication* app) {
       ));
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalBarrelScFiClusters",
-      {"EcalBarrelScFiClustersWithoutShapes", "EcalBarrelScFiClusterAssociationsWithoutShapes"},
+      {"EcalBarrelScFiClustersWithoutShapes", "EcalBarrelScFiClusterLinksWithoutShapes"},
       {"EcalBarrelScFiClusters", "EcalBarrelScFiClusterLinks", "EcalBarrelScFiClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 6.2}, app));
 
@@ -441,8 +441,7 @@ void InitPlugin(JApplication* app) {
       ));
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalBarrelImagingClusters",
-      {"EcalBarrelImagingClustersWithoutShapes",
-       "EcalBarrelImagingClusterAssociationsWithoutShapes"},
+      {"EcalBarrelImagingClustersWithoutShapes", "EcalBarrelImagingClusterLinksWithoutShapes"},
       {"EcalBarrelImagingClusters", "EcalBarrelImagingClusterLinks",
        "EcalBarrelImagingClusterAssociations"},
       {.longitudinalShowerInfoAvailable = false, .energyWeight = "log", .logWeightBase = 6.2},

--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -292,7 +292,7 @@ void InitPlugin(JApplication* app) {
       ));
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalBarrelScFiClusters",
-      {"EcalBarrelScFiClustersWithoutShapes", "EcalBarrelScFiClusterAssociationsWithoutShapes"},
+      {"EcalBarrelScFiClustersWithoutShapes", "EcalBarrelScFiClusterLinksWithoutShapes"},
       {"EcalBarrelScFiClusters", "EcalBarrelScFiClusterLinks", "EcalBarrelScFiClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 6.2}, app));
 
@@ -382,8 +382,7 @@ void InitPlugin(JApplication* app) {
       ));
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalBarrelImagingClusters",
-      {"EcalBarrelImagingClustersWithoutShapes",
-       "EcalBarrelImagingClusterAssociationsWithoutShapes"},
+      {"EcalBarrelImagingClustersWithoutShapes", "EcalBarrelImagingClusterLinksWithoutShapes"},
       {"EcalBarrelImagingClusters", "EcalBarrelImagingClusterLinks",
        "EcalBarrelImagingClusterAssociations"},
       {.longitudinalShowerInfoAvailable = false, .energyWeight = "log", .logWeightBase = 6.2},

--- a/src/detectors/BHCAL/BHCAL.cc
+++ b/src/detectors/BHCAL/BHCAL.cc
@@ -137,7 +137,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalBarrelClusters",
-      {"HcalBarrelClustersWithoutShapes", "HcalBarrelClusterAssociationsWithoutShapes"},
+      {"HcalBarrelClustersWithoutShapes", "HcalBarrelClusterLinksWithoutShapes"},
       {"HcalBarrelClusters", "HcalBarrelClusterLinks", "HcalBarrelClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
 
@@ -156,7 +156,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalBarrelTruthClusters",
-      {"HcalBarrelTruthClustersWithoutShapes", "HcalBarrelTruthClusterAssociationsWithoutShapes"},
+      {"HcalBarrelTruthClustersWithoutShapes", "HcalBarrelTruthClusterLinksWithoutShapes"},
       {"HcalBarrelTruthClusters", "HcalBarrelTruthClusterLinks",
        "HcalBarrelTruthClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
@@ -191,7 +191,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalBarrelSplitMergeClusters",
       {"HcalBarrelSplitMergeClustersWithoutShapes",
-       "HcalBarrelSplitMergeClusterAssociationsWithoutShapes"},
+       "HcalBarrelSplitMergeClusterLinksWithoutShapes"},
       {"HcalBarrelSplitMergeClusters", "HcalBarrelSplitMergeClusterLinks",
        "HcalBarrelSplitMergeClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));

--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -155,7 +155,7 @@ void InitPlugin(JApplication* app) {
       "EcalEndcapNParticleIDPreML",
       {
           "EcalEndcapNClustersWithoutPID",
-          "EcalEndcapNClusterAssociationsWithoutPID",
+          "EcalEndcapNClusterLinksWithoutPID",
       },
       {
           "EcalEndcapNParticleIDInput_features",
@@ -179,7 +179,7 @@ void InitPlugin(JApplication* app) {
       "EcalEndcapNParticleIDPostML",
       {
           "EcalEndcapNClustersWithoutPID",
-          "EcalEndcapNClusterAssociationsWithoutPID",
+          "EcalEndcapNClusterLinksWithoutPID",
           "EcalEndcapNParticleIDOutput_probability_tensor",
       },
 

--- a/src/detectors/EEMC/EEMC.cc
+++ b/src/detectors/EEMC/EEMC.cc
@@ -119,7 +119,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalEndcapNTruthClusters",
-      {"EcalEndcapNTruthClustersWithoutShapes", "EcalEndcapNTruthClusterAssociationsWithoutShapes"},
+      {"EcalEndcapNTruthClustersWithoutShapes", "EcalEndcapNTruthClusterLinksWithoutShapes"},
       {"EcalEndcapNTruthClusters", "EcalEndcapNTruthClusterLinks",
        "EcalEndcapNTruthClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 4.6}, app));
@@ -145,8 +145,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalEndcapNClustersWithoutPID",
-      {"EcalEndcapNClustersWithoutPIDAndShapes",
-       "EcalEndcapNClusterAssociationsWithoutPIDAndShapes"},
+      {"EcalEndcapNClustersWithoutPIDAndShapes", "EcalEndcapNClusterLinksWithoutPIDAndShapes"},
       {"EcalEndcapNClustersWithoutPID", "EcalEndcapNClusterLinksWithoutPID",
        "EcalEndcapNClusterAssociationsWithoutPID"},
       {.energyWeight = "log", .logWeightBase = 3.6}, app));
@@ -224,7 +223,7 @@ void InitPlugin(JApplication* app) {
       "EcalEndcapNSplitMergeClusters",
 
       {"EcalEndcapNSplitMergeClustersWithoutShapes",
-       "EcalEndcapNSplitMergeClusterAssociationsWithoutShapes"},
+       "EcalEndcapNSplitMergeClusterLinksWithoutShapes"},
       {"EcalEndcapNSplitMergeClusters", "EcalEndcapNSplitMergeClusterLinks",
        "EcalEndcapNSplitMergeClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 3.6}, app));

--- a/src/detectors/EHCAL/EHCAL.cc
+++ b/src/detectors/EHCAL/EHCAL.cc
@@ -116,7 +116,7 @@ void InitPlugin(JApplication* app) {
       ));
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalEndcapNTruthClusters",
-      {"HcalEndcapNTruthClustersWithoutShapes", "HcalEndcapNTruthClusterAssociationsWithoutShapes"},
+      {"HcalEndcapNTruthClustersWithoutShapes", "HcalEndcapNTruthClusterLinksWithoutShapes"},
       {"HcalEndcapNTruthClusters", "HcalEndcapNTruthClusterLinks",
        "HcalEndcapNTruthClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
@@ -139,7 +139,7 @@ void InitPlugin(JApplication* app) {
       ));
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalEndcapNClusters",
-      {"HcalEndcapNClustersWithoutShapes", "HcalEndcapNClusterAssociationsWithoutShapes"},
+      {"HcalEndcapNClustersWithoutShapes", "HcalEndcapNClusterLinksWithoutShapes"},
       {"HcalEndcapNClusters", "HcalEndcapNClusterLinks", "HcalEndcapNClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
   app->Add(new JOmniFactoryGeneratorT<TrackClusterMergeSplitter_factory>(
@@ -173,7 +173,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalEndcapNSplitMergeClusters",
       {"HcalEndcapNSplitMergeClustersWithoutShapes",
-       "HcalEndcapNSplitMergeClusterAssociationsWithoutShapes"},
+       "HcalEndcapNSplitMergeClusterLinksWithoutShapes"},
       {"HcalEndcapNSplitMergeClusters", "HcalEndcapNSplitMergeClusterLinks",
        "HcalEndcapNSplitMergeClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -177,7 +177,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalEndcapPTruthClusters",
-      {"EcalEndcapPTruthClustersWithoutShapes", "EcalEndcapPTruthClusterAssociationsWithoutShapes"},
+      {"EcalEndcapPTruthClustersWithoutShapes", "EcalEndcapPTruthClusterLinksWithoutShapes"},
       {"EcalEndcapPTruthClusters", "EcalEndcapPTruthClusterLinks",
        "EcalEndcapPTruthClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 6.2}, app));
@@ -202,7 +202,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalEndcapPClusters",
-      {"EcalEndcapPClustersWithoutShapes", "EcalEndcapPClusterAssociationsWithoutShapes"},
+      {"EcalEndcapPClustersWithoutShapes", "EcalEndcapPClusterLinksWithoutShapes"},
       {"EcalEndcapPClusters", "EcalEndcapPClusterLinks", "EcalEndcapPClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 3.6}, app));
 
@@ -241,7 +241,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalEndcapPSplitMergeClusters",
       {"EcalEndcapPSplitMergeClustersWithoutShapes",
-       "EcalEndcapPSplitMergeClusterAssociationsWithoutShapes"},
+       "EcalEndcapPSplitMergeClusterLinksWithoutShapes"},
       {"EcalEndcapPSplitMergeClusters", "EcalEndcapPSplitMergeClusterLinks",
        "EcalEndcapPSplitMergeClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 3.6}, app));

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -136,7 +136,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalEndcapPInsertTruthClusters",
       {"HcalEndcapPInsertTruthClustersWithoutShapes",
-       "HcalEndcapPInsertTruthClusterAssociationsWithoutShapes"},
+       "HcalEndcapPInsertTruthClusterLinksWithoutShapes"},
       {"HcalEndcapPInsertTruthClusters", "HcalEndcapPInsertTruthClusterLinks",
        "HcalEndcapPInsertTruthClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 3.6}, app));
@@ -161,8 +161,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalEndcapPInsertClusters",
-      {"HcalEndcapPInsertClustersWithoutShapes",
-       "HcalEndcapPInsertClusterAssociationsWithoutShapes"},
+      {"HcalEndcapPInsertClustersWithoutShapes", "HcalEndcapPInsertClusterLinksWithoutShapes"},
       {"HcalEndcapPInsertClusters", "HcalEndcapPInsertClusterLinks",
        "HcalEndcapPInsertClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true,
@@ -275,7 +274,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "LFHCALTruthClusters",
-      {"LFHCALTruthClustersWithoutShapes", "LFHCALTruthClusterAssociationsWithoutShapes"},
+      {"LFHCALTruthClustersWithoutShapes", "LFHCALTruthClusterLinksWithoutShapes"},
       {"LFHCALTruthClusters", "LFHCALTruthClusterLinks", "LFHCALTruthClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 4.5}, app));
 
@@ -298,7 +297,7 @@ void InitPlugin(JApplication* app) {
       ));
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
-      "LFHCALClusters", {"LFHCALClustersWithoutShapes", "LFHCALClusterAssociationsWithoutShapes"},
+      "LFHCALClusters", {"LFHCALClustersWithoutShapes", "LFHCALClusterLinksWithoutShapes"},
       {"LFHCALClusters", "LFHCALClusterLinks", "LFHCALClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 4.5}, app));
 
@@ -335,7 +334,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "LFHCALSplitMergeClusters",
-      {"LFHCALSplitMergeClustersWithoutShapes", "LFHCALSplitMergeClusterAssociationsWithoutShapes"},
+      {"LFHCALSplitMergeClustersWithoutShapes", "LFHCALSplitMergeClusterLinksWithoutShapes"},
       {"LFHCALSplitMergeClusters", "LFHCALSplitMergeClusterLinks",
        "LFHCALSplitMergeClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true}, app));

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -136,7 +136,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalEndcapPInsertTruthClusters",
       {"HcalEndcapPInsertTruthClustersWithoutShapes",
-       "HcalEndcapPInsertTruthClusterAssociationsWithoutShapes"},
+       "HcalEndcapPInsertTruthClusterLinksWithoutShapes"},
       {"HcalEndcapPInsertTruthClusters", "HcalEndcapPInsertTruthClusterLinks",
        "HcalEndcapPInsertTruthClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 3.6}, app));
@@ -161,8 +161,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalEndcapPInsertClusters",
-      {"HcalEndcapPInsertClustersWithoutShapes",
-       "HcalEndcapPInsertClusterAssociationsWithoutShapes"},
+      {"HcalEndcapPInsertClustersWithoutShapes", "HcalEndcapPInsertClusterLinksWithoutShapes"},
       {"HcalEndcapPInsertClusters", "HcalEndcapPInsertClusterLinks",
        "HcalEndcapPInsertClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true,
@@ -274,7 +273,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "LFHCALTruthClusters",
-      {"LFHCALTruthClustersWithoutShapes", "LFHCALTruthClusterAssociationsWithoutShapes"},
+      {"LFHCALTruthClustersWithoutShapes", "LFHCALTruthClusterLinksWithoutShapes"},
       {"LFHCALTruthClusters", "LFHCALTruthClusterLinks", "LFHCALTruthClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 4.5}, app));
 
@@ -297,7 +296,7 @@ void InitPlugin(JApplication* app) {
       ));
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
-      "LFHCALClusters", {"LFHCALClustersWithoutShapes", "LFHCALClusterAssociationsWithoutShapes"},
+      "LFHCALClusters", {"LFHCALClustersWithoutShapes", "LFHCALClusterLinksWithoutShapes"},
       {"LFHCALClusters", "LFHCALClusterLinks", "LFHCALClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 4.5}, app));
 
@@ -334,7 +333,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "LFHCALSplitMergeClusters",
-      {"LFHCALSplitMergeClustersWithoutShapes", "LFHCALSplitMergeClusterAssociationsWithoutShapes"},
+      {"LFHCALSplitMergeClustersWithoutShapes", "LFHCALSplitMergeClusterLinksWithoutShapes"},
       {"LFHCALSplitMergeClusters", "LFHCALSplitMergeClusterLinks",
        "LFHCALSplitMergeClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true}, app));

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -195,7 +195,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<FarDetectorTransportationPreML_factory>(
       "TaggerTrackerTransportationPreML",
-      {"TaggerTrackerLocalTracks", "TaggerTrackerLocalTrackAssociations", "MCBeamElectrons"},
+      {"TaggerTrackerLocalTracks", "TaggerTrackerLocalTrackLinks", "MCBeamElectrons"},
       {"TaggerTrackerFeatureTensor", "TaggerTrackerTargetTensor"},
       {
           .beamE = 10.0,

--- a/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
+++ b/src/detectors/LUMISPECCAL/LUMISPECCAL.cc
@@ -100,7 +100,7 @@ void InitPlugin(JApplication* app) {
       ));
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalLumiSpecClusters",
-      {"EcalLumiSpecClustersWithoutShapes", "EcalLumiSpecClusterAssociationsWithoutShapes"},
+      {"EcalLumiSpecClustersWithoutShapes", "EcalLumiSpecClusterLinksWithoutShapes"},
       {"EcalLumiSpecClusters", "EcalLumiSpecClusterLinks", "EcalLumiSpecClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 3.6}, app));
 
@@ -118,8 +118,7 @@ void InitPlugin(JApplication* app) {
       ));
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalLumiSpecTruthClusters",
-      {"EcalLumiSpecTruthClustersWithoutShapes",
-       "EcalLumiSpecTruthClusterAssociationsWithoutShapes"},
+      {"EcalLumiSpecTruthClustersWithoutShapes", "EcalLumiSpecTruthClusterLinksWithoutShapes"},
       {"EcalLumiSpecTruthClusters", "EcalLumiSpecTruthClusterLinks",
        "EcalLumiSpecTruthClusterAssociations"},
       {.energyWeight = "log", .logWeightBase = 4.6}, app));

--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -106,7 +106,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalFarForwardZDCTruthClusters",
       {"EcalFarForwardZDCTruthClustersWithoutShapes",
-       "EcalFarForwardZDCTruthClusterAssociationsWithoutShapes"},
+       "EcalFarForwardZDCTruthClusterLinksWithoutShapes"},
       {"EcalFarForwardZDCTruthClusters", "EcalFarForwardZDCTruthClusterLinks",
        "EcalFarForwardZDCTruthClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 3.6}, app));
@@ -131,8 +131,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalFarForwardZDCClusters",
-      {"EcalFarForwardZDCClustersWithoutShapes",
-       "EcalFarForwardZDCClusterAssociationsWithoutShapes"},
+      {"EcalFarForwardZDCClustersWithoutShapes", "EcalFarForwardZDCClusterLinksWithoutShapes"},
       {"EcalFarForwardZDCClusters", "EcalFarForwardZDCClusterLinks",
        "EcalFarForwardZDCClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 6.2}, app));
@@ -244,8 +243,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalFarForwardZDCClusters",
-      {"HcalFarForwardZDCClustersWithoutShapes",
-       "HcalFarForwardZDCClusterAssociationsWithoutShapes"},
+      {"HcalFarForwardZDCClustersWithoutShapes", "HcalFarForwardZDCClusterLinksWithoutShapes"},
       {"HcalFarForwardZDCClusters", "HcalFarForwardZDCClusterLinks",
        "HcalFarForwardZDCClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true,
@@ -301,7 +299,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalFarForwardZDCTruthClusters",
       {"HcalFarForwardZDCTruthClustersWithoutShapes",
-       "HcalFarForwardZDCTruthClusterAssociationsWithoutShapes"},
+       "HcalFarForwardZDCTruthClusterLinksWithoutShapes"},
       {"HcalFarForwardZDCTruthClusters", "HcalFarForwardZDCTruthClusterLinks",
        "HcalFarForwardZDCTruthClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 3.6}, app));
@@ -328,7 +326,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalFarForwardZDCClustersBaseline",
       {"HcalFarForwardZDCClustersBaselineWithoutShapes",
-       "HcalFarForwardZDCClusterAssociationsBaselineWithoutShapes"},
+       "HcalFarForwardZDCClusterLinksBaselineWithoutShapes"},
       {"HcalFarForwardZDCClustersBaseline", "HcalFarForwardZDCClusterLinksBaseline",
        "HcalFarForwardZDCClusterAssociationsBaseline"},
       {.longitudinalShowerInfoAvailable = true,

--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -107,7 +107,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalFarForwardZDCTruthClusters",
       {"EcalFarForwardZDCTruthClustersWithoutShapes",
-       "EcalFarForwardZDCTruthClusterAssociationsWithoutShapes"},
+       "EcalFarForwardZDCTruthClusterLinksWithoutShapes"},
       {"EcalFarForwardZDCTruthClusters", "EcalFarForwardZDCTruthClusterLinks",
        "EcalFarForwardZDCTruthClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 3.6}, app));
@@ -132,8 +132,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "EcalFarForwardZDCClusters",
-      {"EcalFarForwardZDCClustersWithoutShapes",
-       "EcalFarForwardZDCClusterAssociationsWithoutShapes"},
+      {"EcalFarForwardZDCClustersWithoutShapes", "EcalFarForwardZDCClusterLinksWithoutShapes"},
       {"EcalFarForwardZDCClusters", "EcalFarForwardZDCClusterLinks",
        "EcalFarForwardZDCClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 6.2}, app));
@@ -245,8 +244,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalFarForwardZDCClusters",
-      {"HcalFarForwardZDCClustersWithoutShapes",
-       "HcalFarForwardZDCClusterAssociationsWithoutShapes"},
+      {"HcalFarForwardZDCClustersWithoutShapes", "HcalFarForwardZDCClusterLinksWithoutShapes"},
       {"HcalFarForwardZDCClusters", "HcalFarForwardZDCClusterLinks",
        "HcalFarForwardZDCClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true,
@@ -303,7 +301,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalFarForwardZDCTruthClusters",
       {"HcalFarForwardZDCTruthClustersWithoutShapes",
-       "HcalFarForwardZDCTruthClusterAssociationsWithoutShapes"},
+       "HcalFarForwardZDCTruthClusterLinksWithoutShapes"},
       {"HcalFarForwardZDCTruthClusters", "HcalFarForwardZDCTruthClusterLinks",
        "HcalFarForwardZDCTruthClusterAssociations"},
       {.longitudinalShowerInfoAvailable = true, .energyWeight = "log", .logWeightBase = 3.6}, app));
@@ -330,7 +328,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterShape_factory>(
       "HcalFarForwardZDCClustersBaseline",
       {"HcalFarForwardZDCClustersBaselineWithoutShapes",
-       "HcalFarForwardZDCClusterAssociationsBaselineWithoutShapes"},
+       "HcalFarForwardZDCClusterLinksBaselineWithoutShapes"},
       {"HcalFarForwardZDCClustersBaseline", "HcalFarForwardZDCClusterLinksBaseline",
        "HcalFarForwardZDCClusterAssociationsBaseline"},
       {.longitudinalShowerInfoAvailable = true,

--- a/src/factories/calorimetry/CalorimeterClusterShape_factory.h
+++ b/src/factories/calorimetry/CalorimeterClusterShape_factory.h
@@ -22,7 +22,7 @@ private:
 
   // input collections
   PodioInput<edm4eic::Cluster> m_clusters_input{this};
-  PodioInput<edm4eic::MCRecoClusterParticleAssociation> m_assocs_input{this};
+  PodioInput<edm4eic::MCRecoClusterParticleLink> m_links_input{this};
 
   // output collections
   PodioOutput<edm4eic::Cluster> m_clusters_output{this};
@@ -52,7 +52,7 @@ public:
   }
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
-    m_algo->process({m_clusters_input(), m_assocs_input()},
+    m_algo->process({m_clusters_input(), m_links_input()},
                     {m_clusters_output().get(), m_links_output().get(), m_assocs_output().get()});
   }
 

--- a/src/factories/calorimetry/CalorimeterParticleIDPostML_factory.h
+++ b/src/factories/calorimetry/CalorimeterParticleIDPostML_factory.h
@@ -20,7 +20,7 @@ private:
   std::unique_ptr<AlgoT> m_algo;
 
   PodioInput<edm4eic::Cluster> m_cluster_input{this};
-  PodioInput<edm4eic::MCRecoClusterParticleAssociation> m_cluster_assoc_input{this};
+  PodioInput<edm4eic::MCRecoClusterParticleLink> m_cluster_link_input{this};
   PodioInput<edm4eic::Tensor> m_prediction_tensor_input{this};
 
   PodioOutput<edm4eic::Cluster> m_cluster_output{this};
@@ -37,7 +37,7 @@ public:
   }
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
-    m_algo->process({m_cluster_input(), m_cluster_assoc_input(), m_prediction_tensor_input()},
+    m_algo->process({m_cluster_input(), m_cluster_link_input(), m_prediction_tensor_input()},
                     {m_cluster_output().get(), m_cluster_links_output().get(),
                      m_cluster_assoc_output().get(), m_particle_id_output().get()});
   }

--- a/src/factories/calorimetry/CalorimeterParticleIDPreML_factory.h
+++ b/src/factories/calorimetry/CalorimeterParticleIDPreML_factory.h
@@ -19,7 +19,7 @@ private:
   std::unique_ptr<AlgoT> m_algo;
 
   PodioInput<edm4eic::Cluster> m_cluster_input{this};
-  PodioInput<edm4eic::MCRecoClusterParticleAssociation> m_cluster_assoc_input{this};
+  PodioInput<edm4eic::MCRecoClusterParticleLink> m_cluster_link_input{this};
 
   PodioOutput<edm4eic::Tensor> m_feature_tensor_output{this};
   PodioOutput<edm4eic::Tensor> m_target_tensor_output{this};
@@ -33,7 +33,7 @@ public:
   }
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
-    m_algo->process({m_cluster_input(), m_cluster_assoc_input()},
+    m_algo->process({m_cluster_input(), m_cluster_link_input()},
                     {m_feature_tensor_output().get(), m_target_tensor_output().get()});
   }
 };

--- a/src/factories/fardetectors/FarDetectorTransportationPreML_factory.h
+++ b/src/factories/fardetectors/FarDetectorTransportationPreML_factory.h
@@ -20,7 +20,7 @@ private:
   std::unique_ptr<AlgoT> m_algo;
 
   PodioInput<edm4eic::Track> m_track_input{this};
-  PodioInput<edm4eic::MCRecoTrackParticleAssociation> m_association_input{this};
+  PodioInput<edm4eic::MCRecoTrackParticleLink> m_link_input{this};
   PodioInput<edm4hep::MCParticle> m_beamelectrons_input{this};
 
   PodioOutput<edm4eic::Tensor> m_feature_tensor_output{this};
@@ -39,7 +39,7 @@ public:
   }
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
-    m_algo->process({m_track_input(), m_association_input(), m_beamelectrons_input()},
+    m_algo->process({m_track_input(), m_link_input(), m_beamelectrons_input()},
                     {m_feature_tensor_output().get(), m_target_tensor_output().get()});
   }
 };

--- a/src/factories/pid/MatchToRICHPID_factory.h
+++ b/src/factories/pid/MatchToRICHPID_factory.h
@@ -22,7 +22,7 @@ private:
   std::unique_ptr<AlgoT> m_algo;
 
   PodioInput<edm4eic::ReconstructedParticle> m_recoparticles_input{this};
-  PodioInput<edm4eic::MCRecoParticleAssociation> m_assocs_input{this};
+  PodioInput<edm4eic::MCRecoParticleLink> m_links_input{this};
   PodioInput<edm4eic::CherenkovParticleID> m_cherenkov_particle_ids_input{this};
   PodioOutput<edm4eic::ReconstructedParticle> m_recoparticles_output{this};
   PodioOutput<edm4eic::MCRecoParticleLink> m_links_output{this};
@@ -38,7 +38,7 @@ public:
   };
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
-    m_algo->process({m_recoparticles_input(), m_assocs_input(), m_cherenkov_particle_ids_input()},
+    m_algo->process({m_recoparticles_input(), m_links_input(), m_cherenkov_particle_ids_input()},
                     {m_recoparticles_output().get(), m_links_output().get(),
                      m_assocs_output().get(), m_pids_output().get()});
   }

--- a/src/factories/pid_lut/PIDLookup_factory.h
+++ b/src/factories/pid_lut/PIDLookup_factory.h
@@ -24,7 +24,7 @@ private:
 
   PodioInput<edm4hep::EventHeader> m_event_headers_input{this};
   PodioInput<edm4eic::ReconstructedParticle> m_recoparticles_input{this};
-  PodioInput<edm4eic::MCRecoParticleAssociation> m_recoparticle_assocs_input{this};
+  PodioInput<edm4eic::MCRecoParticleLink> m_recoparticle_links_input{this};
   PodioOutput<edm4eic::ReconstructedParticle> m_recoparticles_output{this};
   PodioOutput<edm4eic::MCRecoParticleLink> m_recoparticle_links_output{this};
   PodioOutput<edm4eic::MCRecoParticleAssociation> m_recoparticle_assocs_output{this};
@@ -46,7 +46,7 @@ public:
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process(
-        {m_event_headers_input(), m_recoparticles_input(), m_recoparticle_assocs_input()},
+        {m_event_headers_input(), m_recoparticles_input(), m_recoparticle_links_input()},
         {m_recoparticles_output().get(), m_recoparticle_links_output().get(),
          m_recoparticle_assocs_output().get(), m_particleids_output().get()});
   }

--- a/src/global/pid/pid.cc
+++ b/src/global/pid/pid.cc
@@ -22,9 +22,9 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<MatchToRICHPID_factory>(
       "ChargedParticlesWithAssociations",
       {
-          "ReconstructedChargedWithoutPIDParticles",            // edm4eic::ReconstructedParticle
-          "ReconstructedChargedWithoutPIDParticleAssociations", // edm4eic::MCRecoParticleAssociationCollection
-          "DRICHMergedIrtCherenkovParticleID",                  // edm4eic::CherenkovParticleID
+          "ReconstructedChargedWithoutPIDParticles",     // edm4eic::ReconstructedParticle
+          "ReconstructedChargedWithoutPIDParticleLinks", // edm4eic::MCRecoParticleLinkCollection
+          "DRICHMergedIrtCherenkovParticleID",           // edm4eic::CherenkovParticleID
       },
       {
           "ReconstructedChargedRealPIDParticles",     // edm4eic::ReconstructedParticle

--- a/src/global/pid_lut/pid_lut.cc
+++ b/src/global/pid_lut/pid_lut.cc
@@ -6,7 +6,9 @@
 #include <edm4eic/MCRecoParticleAssociation.h>
 #include <edm4eic/MCRecoParticleLinkCollection.h>
 #include <edm4eic/ReconstructedParticle.h>
+#include <podio/detail/Link.h>
 #include <cmath>
+#include <deque>
 #include <memory>
 #include <string>
 #include <vector>

--- a/src/global/pid_lut/pid_lut.cc
+++ b/src/global/pid_lut/pid_lut.cc
@@ -4,6 +4,7 @@
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <edm4eic/MCRecoParticleAssociation.h>
+#include <edm4eic/MCRecoParticleLinkCollection.h>
 #include <edm4eic/ReconstructedParticle.h>
 #include <cmath>
 #include <memory>
@@ -49,7 +50,7 @@ void InitPlugin(JApplication* app) {
       {
           "EventHeader",
           "ReconstructedTruthSeededChargedWithoutPIDParticles",
-          "ReconstructedTruthSeededChargedWithoutPIDParticleAssociations",
+          "ReconstructedTruthSeededChargedWithoutPIDParticleLinks",
       },
       {
           "ReconstructedTruthSeededChargedWithPFRICHPIDParticles",
@@ -64,7 +65,7 @@ void InitPlugin(JApplication* app) {
       {
           "EventHeader",
           "ReconstructedChargedWithoutPIDParticles",
-          "ReconstructedChargedWithoutPIDParticleAssociations",
+          "ReconstructedChargedWithoutPIDParticleLinks",
       },
       {
           "ReconstructedChargedWithPFRICHPIDParticles",
@@ -97,7 +98,7 @@ void InitPlugin(JApplication* app) {
       {
           "EventHeader",
           "ReconstructedTruthSeededChargedWithPFRICHPIDParticles",
-          "ReconstructedTruthSeededChargedWithPFRICHPIDParticleAssociations",
+          "ReconstructedTruthSeededChargedWithPFRICHPIDParticleLinks",
       },
       {
           "ReconstructedTruthSeededChargedWithPFRICHTOFPIDParticles",
@@ -112,7 +113,7 @@ void InitPlugin(JApplication* app) {
       {
           "EventHeader",
           "ReconstructedChargedWithPFRICHPIDParticles",
-          "ReconstructedChargedWithPFRICHPIDParticleAssociations",
+          "ReconstructedChargedWithPFRICHPIDParticleLinks",
       },
       {
           "ReconstructedChargedWithPFRICHTOFPIDParticles",
@@ -156,7 +157,7 @@ void InitPlugin(JApplication* app) {
       {
           "EventHeader",
           "ReconstructedTruthSeededChargedWithPFRICHTOFPIDParticles",
-          "ReconstructedTruthSeededChargedWithPFRICHTOFPIDParticleAssociations",
+          "ReconstructedTruthSeededChargedWithPFRICHTOFPIDParticleLinks",
       },
       {
           "ReconstructedTruthSeededChargedWithPFRICHTOFDIRCPIDParticles",
@@ -171,7 +172,7 @@ void InitPlugin(JApplication* app) {
       {
           "EventHeader",
           "ReconstructedChargedWithPFRICHTOFPIDParticles",
-          "ReconstructedChargedWithPFRICHTOFPIDParticleAssociations",
+          "ReconstructedChargedWithPFRICHTOFPIDParticleLinks",
       },
       {
           "ReconstructedChargedWithPFRICHTOFDIRCPIDParticles",
@@ -199,6 +200,13 @@ void InitPlugin(JApplication* app) {
        "TaggerTrackerReconstructedParticleAssociations"},
       {"ReconstructedChargedWithPFRICHTOFDIRCLOWQ2PIDParticleAssociations"}, app));
 
+  app->Add(
+      new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::MCRecoParticleLink, true>>(
+          "ReconstructedChargedWithPFRICHTOFDIRCLOWQ2PIDParticleLinks",
+          {"ReconstructedChargedWithPFRICHTOFDIRCPIDParticleLinks",
+           "TaggerTrackerReconstructedParticleLinks"},
+          {"ReconstructedChargedWithPFRICHTOFDIRCLOWQ2PIDParticleLinks"}, app));
+
   // And the same for truth seeded particles and associations
 
   app->Add(
@@ -214,6 +222,13 @@ void InitPlugin(JApplication* app) {
       {"ReconstructedTruthSeededChargedWithPFRICHTOFDIRCPIDParticleAssociations",
        "TaggerTrackerReconstructedParticleAssociations"},
       {"ReconstructedTruthSeededChargedWithPFRICHTOFDIRCLOWQ2PIDParticleAssociations"}, app));
+
+  app->Add(
+      new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::MCRecoParticleLink, true>>(
+          "ReconstructedTruthSeededChargedWithPFRICHTOFDIRCLOWQ2PIDParticleLinks",
+          {"ReconstructedTruthSeededChargedWithPFRICHTOFDIRCPIDParticleLinks",
+           "TaggerTrackerReconstructedParticleLinks"},
+          {"ReconstructedTruthSeededChargedWithPFRICHTOFDIRCLOWQ2PIDParticleLinks"}, app));
 
   //-------------------------------------------------------------------------
   // DRICH PID
@@ -249,7 +264,7 @@ void InitPlugin(JApplication* app) {
       {
           "EventHeader",
           "ReconstructedTruthSeededChargedWithPFRICHTOFDIRCLOWQ2PIDParticles",
-          "ReconstructedTruthSeededChargedWithPFRICHTOFDIRCLOWQ2PIDParticleAssociations",
+          "ReconstructedTruthSeededChargedWithPFRICHTOFDIRCLOWQ2PIDParticleLinks",
       },
       {
           "ReconstructedTruthSeededChargedParticles",
@@ -264,7 +279,7 @@ void InitPlugin(JApplication* app) {
       {
           "EventHeader",
           "ReconstructedWithPFRICHTOFDIRCLOWQ2PIDChargedParticles",
-          "ReconstructedChargedWithPFRICHTOFDIRCLOWQ2PIDParticleAssociations",
+          "ReconstructedChargedWithPFRICHTOFDIRCLOWQ2PIDParticleLinks",
       },
       {
           "ReconstructedChargedParticles",

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterShape.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterShape.cc
@@ -48,6 +48,7 @@ TEST_CASE("the calorimeter CoG algorithm runs", "[CalorimeterClusterShape]") {
   edm4eic::CalorimeterHitCollection hits_coll;
   edm4eic::MCRecoClusterParticleLinkCollection link_in_coll;
   edm4eic::ClusterCollection clust_in_coll;
+  edm4hep::MCParticleCollection mcparts_coll;
   auto assoc_out_coll = std::make_unique<edm4eic::MCRecoClusterParticleAssociationCollection>();
   auto link_out_coll  = std::make_unique<edm4eic::MCRecoClusterParticleLinkCollection>();
   auto clust_out_coll = std::make_unique<edm4eic::ClusterCollection>();
@@ -82,10 +83,12 @@ TEST_CASE("the calorimeter CoG algorithm runs", "[CalorimeterClusterShape]") {
   clust_in.setEnergy(hit1.getEnergy() + hit2.getEnergy());
   clust_in.setPosition((hit1.getPosition() + hit2.getPosition()) / 2);
 
+  auto mcpart_in = mcparts_coll.create();
+
   auto link_in = link_in_coll.create();
   link_in.setWeight(EXPECTED_WEIGHT);
   link_in.setFrom(clust_in);
-  // link_in.setTo(...);
+  link_in.setTo(mcpart_in);
 
   // Constructing input and output as per the algorithm's expected signature
   auto input  = std::make_tuple(&clust_in_coll, &link_in_coll);
@@ -110,8 +113,8 @@ TEST_CASE("the calorimeter CoG algorithm runs", "[CalorimeterClusterShape]") {
 
   // Check link from/to relationships - getFrom() should be the reconstructed cluster
   REQUIRE((*link_out_coll)[0].getFrom() == clust_out);
-  // Note: link_in.getTo() is not set in this test, so getTo() should return an invalid/null object
-  REQUIRE(!(*link_out_coll)[0].getTo().isAvailable());
+  REQUIRE((*link_out_coll)[0].getTo().isAvailable());
+  REQUIRE((*link_out_coll)[0].getTo() == mcpart_in);
 
   // Verify weight is propagated correctly
   REQUIRE((*link_out_coll)[0].getWeight() == EXPECTED_WEIGHT);

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterShape.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterShape.cc
@@ -9,7 +9,7 @@
 #include <edm4eic/MCRecoClusterParticleAssociationCollection.h>
 #include <edm4eic/MCRecoClusterParticleLinkCollection.h>
 #include <edm4eic/unit_system.h>
-#include <edm4hep/MCParticle.h>
+#include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <podio/detail/Link.h>

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterShape.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterShape.cc
@@ -45,9 +45,10 @@ TEST_CASE("the calorimeter CoG algorithm runs", "[CalorimeterClusterShape]") {
   algo.init();
 
   edm4eic::CalorimeterHitCollection hits_coll;
-  edm4eic::MCRecoClusterParticleAssociationCollection assoc_in_coll;
+  edm4eic::MCRecoClusterParticleLinkCollection link_in_coll;
   edm4eic::ClusterCollection clust_in_coll;
   auto assoc_out_coll = std::make_unique<edm4eic::MCRecoClusterParticleAssociationCollection>();
+  auto link_out_coll  = std::make_unique<edm4eic::MCRecoClusterParticleLinkCollection>();
   auto clust_out_coll = std::make_unique<edm4eic::ClusterCollection>();
 
   auto hit1 = hits_coll.create();
@@ -80,15 +81,14 @@ TEST_CASE("the calorimeter CoG algorithm runs", "[CalorimeterClusterShape]") {
   clust_in.setEnergy(hit1.getEnergy() + hit2.getEnergy());
   clust_in.setPosition((hit1.getPosition() + hit2.getPosition()) / 2);
 
-  auto assoc_in = assoc_in_coll.create();
-  assoc_in.setWeight(EXPECTED_WEIGHT);
-  assoc_in.setRec(clust_in);
-  // assoc_in.setSim(...);
+  auto link_in = link_in_coll.create();
+  link_in.setWeight(EXPECTED_WEIGHT);
+  link_in.setFrom(clust_in);
+  // link_in.setTo(...);
 
   // Constructing input and output as per the algorithm's expected signature
-  auto input = std::make_tuple(&clust_in_coll, &assoc_in_coll);
-  edm4eic::MCRecoClusterParticleLinkCollection link_out_coll;
-  auto output = std::make_tuple(clust_out_coll.get(), &link_out_coll, assoc_out_coll.get());
+  auto input  = std::make_tuple(&clust_in_coll, &link_in_coll);
+  auto output = std::make_tuple(clust_out_coll.get(), link_out_coll.get(), assoc_out_coll.get());
 
   algo.process(input, output);
 
@@ -102,16 +102,16 @@ TEST_CASE("the calorimeter CoG algorithm runs", "[CalorimeterClusterShape]") {
 
   REQUIRE(assoc_out_coll->size() == 1);
   REQUIRE((*assoc_out_coll)[0].getRec() == clust_out);
-  REQUIRE((*assoc_out_coll)[0].getWeight() == assoc_in.getWeight());
+  REQUIRE((*assoc_out_coll)[0].getWeight() == link_in.getWeight());
 
   // Validate links collection
-  REQUIRE(link_out_coll.size() == 1);
+  REQUIRE(link_out_coll->size() == 1);
 
   // Check link from/to relationships - getFrom() should be the reconstructed cluster
-  REQUIRE(link_out_coll[0].getFrom() == clust_out);
-  // Note: assoc_in.getSim() is not set in this test, so getTo() should return an invalid/null object
-  REQUIRE(!link_out_coll[0].getTo().isAvailable());
+  REQUIRE((*link_out_coll)[0].getFrom() == clust_out);
+  // Note: link_in.getTo() is not set in this test, so getTo() should return an invalid/null object
+  REQUIRE(!(*link_out_coll)[0].getTo().isAvailable());
 
   // Verify weight is propagated correctly
-  REQUIRE(link_out_coll[0].getWeight() == EXPECTED_WEIGHT);
+  REQUIRE((*link_out_coll)[0].getWeight() == EXPECTED_WEIGHT);
 }

--- a/src/tests/algorithms_test/calorimetry_CalorimeterClusterShape.cc
+++ b/src/tests/algorithms_test/calorimetry_CalorimeterClusterShape.cc
@@ -13,6 +13,7 @@
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <podio/detail/Link.h>
+#include <podio/detail/LinkCollectionImpl.h>
 #include <spdlog/common.h>
 #include <spdlog/logger.h>
 #include <spdlog/spdlog.h>

--- a/src/tests/algorithms_test/pid_lut_PIDLookup.cc
+++ b/src/tests/algorithms_test/pid_lut_PIDLookup.cc
@@ -93,8 +93,7 @@ TEST_CASE("particles acquire PID", "[PIDLookup]") {
     REQUIRE((*parts_in).size() == (*parts_out).size());
     REQUIRE(links_in.size() == (*assocs_out).size());
     REQUIRE(
-        0 ==
-        (*partids_out).size()); // Since our table is empty, there will not be a successful lookup
+        (*partids_out).empty()); // Since our table is empty, there will not be a successful lookup
 
     // Verify that links were created and match the associations
     REQUIRE(links_out.size() == (*assocs_out).size());

--- a/src/tests/algorithms_test/pid_lut_PIDLookup.cc
+++ b/src/tests/algorithms_test/pid_lut_PIDLookup.cc
@@ -51,9 +51,9 @@ TEST_CASE("particles acquire PID", "[PIDLookup]") {
     auto headers = std::make_unique<edm4hep::EventHeaderCollection>();
     auto header  = headers->create(1, 1, 12345678, 1.0);
 
-    auto parts_in  = std::make_unique<edm4eic::ReconstructedParticleCollection>();
-    auto assocs_in = std::make_unique<edm4eic::MCRecoParticleAssociationCollection>();
-    auto mcparts   = std::make_unique<edm4hep::MCParticleCollection>();
+    auto parts_in = std::make_unique<edm4eic::ReconstructedParticleCollection>();
+    auto mcparts  = std::make_unique<edm4hep::MCParticleCollection>();
+    edm4eic::MCRecoParticleLinkCollection links_in;
 
     parts_in->create(0,                                // std::int32_t type
                      0.5,                              // float energy
@@ -78,19 +78,20 @@ TEST_CASE("particles acquire PID", "[PIDLookup]") {
                     9                    // int32_t helicity (9 if unset)
     );
 
-    auto assoc_in = assocs_in->create();
-    assoc_in.setRec((*parts_in)[0]);
-    assoc_in.setSim((*mcparts)[0]);
+    auto link_in = links_in.create();
+    link_in.setFrom((*parts_in)[0]);
+    link_in.setTo((*mcparts)[0]);
+    link_in.setWeight(0.F);
 
     auto parts_out   = std::make_unique<edm4eic::ReconstructedParticleCollection>();
     auto assocs_out  = std::make_unique<edm4eic::MCRecoParticleAssociationCollection>();
     auto partids_out = std::make_unique<edm4hep::ParticleIDCollection>();
     edm4eic::MCRecoParticleLinkCollection links_out;
-    algo.process({headers.get(), parts_in.get(), assocs_in.get()},
+    algo.process({headers.get(), parts_in.get(), &links_in},
                  {parts_out.get(), &links_out, assocs_out.get(), partids_out.get()});
 
     REQUIRE((*parts_in).size() == (*parts_out).size());
-    REQUIRE((*assocs_in).size() == (*assocs_out).size());
+    REQUIRE(links_in.size() == (*assocs_out).size());
     REQUIRE(
         0 ==
         (*partids_out).size()); // Since our table is empty, there will not be a successful lookup


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This refactor removes duplicated truth-link lookup patterns and consolidates `podio::LinkNavigator` usage across reconstruction/PID paths. It adds a shared helper (`src/algorithms/interfaces/LinkTruthUtils.h`) for per-event navigator setup, weighted relation emission, and primary-particle extraction, then applies it to existing LinkNavigator-heavy algorithms while also migrating several downstream algorithms/factories/wiring from association-input to link-input contracts.

Concretely, this includes:
- Shared helper adoption in:
  - `CalorimeterClusterRecoCoG`
  - `ImagingClusterReco`
  - `FarDetectorLinearTracking`
- Link-input migration and wiring updates for:
  - `CalorimeterParticleIDPreML/PostML`
  - `PIDLookup`
  - `MatchToRICHPID`
  - `FarDetectorTransportationPreML`
- Global/detector wiring updates (`pid`, `pid_lut`, `LOWQ2`, `EEMC`) including LOWQ2 merged particle-link collectors.
- Test update for `pid_lut_PIDLookup` to the link-input interface.

It also hardens FarDetector behavior when link collections are missing/empty so we avoid invalid navigator dereference and keep association indexing aligned.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [x] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [x] other: Refactor / internal API cleanup for truth-link handling

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

AI usage: Copilot CLI was used to identify duplicated LinkNavigator setup/lookup patterns, implement the helper-based refactor, update wiring and tests, and run build validation.