### PR TITLE
feat(geometry): add non-throwing readout API and producer-side reduced-geometry gating

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -40,6 +40,7 @@
 #include <vector>
 
 #include "algorithms/calorimetry/CalorimeterHitDigiConfig.h"
+#include "algorithms/interfaces/GeometryUtils.h"
 #include "services/evaluator/EvaluatorSvc.h"
 
 using namespace dd4hep;
@@ -88,16 +89,14 @@ void CalorimeterHitDigi::init() {
     throw std::runtime_error("readoutClass is not provided");
   }
 
-  // get decoders
-  try {
-    id_spec = m_geo.detector()->readout(m_cfg.readout).idSpec();
-  } catch (...) {
-    // Can not be more verbose. In JANA2, this will be attempted at each event, which
-    // pollutes output for geometries that are less than complete.
-    // We could save an exception and throw it from process.
-    debug("Failed to load ID decoder for {}", m_cfg.readout);
-    throw std::runtime_error(fmt::format("Failed to load ID decoder for {}", m_cfg.readout));
+  if (!eicrecon::geo::hasReadout(*m_geo.detector(), m_cfg.readout)) {
+    warning("Readout '{}' is absent in the loaded geometry. Disabling {} and emitting empty "
+            "outputs.",
+            m_cfg.readout, name());
+    m_readout_available = false;
+    return;
   }
+  id_spec = m_geo.detector()->readout(m_cfg.readout).idSpec();
 
   decltype(id_mask) id_inverse_mask = 0;
   // all these are for signal sum at digitization level
@@ -139,6 +138,9 @@ void CalorimeterHitDigi::process(const CalorimeterHitDigi::Input& input,
 
   const auto [headers, simhits]    = input;
   auto [rawhits, links, rawassocs] = output;
+  if (!m_readout_available) {
+    return;
+  }
 
   // local random generator
   auto seed = m_uid.getUniqueID(*headers, name());

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -89,7 +89,13 @@ void CalorimeterHitDigi::init() {
     throw std::runtime_error("readoutClass is not provided");
   }
 
+  const auto missing_readout_policy =
+      eicrecon::geo::parseMissingReadoutPolicy(m_cfg.missingReadoutPolicy);
   if (!eicrecon::geo::hasReadout(*m_geo.detector(), m_cfg.readout)) {
+    if (missing_readout_policy == eicrecon::geo::MissingReadoutPolicy::Throw) {
+      throw std::runtime_error("Readout '" + m_cfg.readout +
+                               "' is absent in the loaded geometry for " + std::string(name()));
+    }
     warning("Readout '{}' is absent in the loaded geometry. Disabling {} and emitting empty "
             "outputs.",
             m_cfg.readout, name());

--- a/src/algorithms/calorimetry/CalorimeterHitDigi.h
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.h
@@ -68,6 +68,7 @@ private:
 private:
   const algorithms::GeoSvc& m_geo         = algorithms::GeoSvc::instance();
   const algorithms::UniqueIDGenSvc& m_uid = algorithms::UniqueIDGenSvc::instance();
+  bool m_readout_available                = true;
 };
 
 } // namespace eicrecon

--- a/src/algorithms/calorimetry/CalorimeterHitDigiConfig.h
+++ b/src/algorithms/calorimetry/CalorimeterHitDigiConfig.h
@@ -36,6 +36,7 @@ struct CalorimeterHitDigiConfig {
 
   // signal sums
   std::string readout{""};
+  std::string missingReadoutPolicy{"disable"};
   std::vector<std::string> fields{};
 };
 

--- a/src/algorithms/calorimetry/CalorimeterHitsMerger.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitsMerger.cc
@@ -27,6 +27,7 @@
 #include <cmath>
 #include <cstddef>
 #include <exception>
+#include <stdexcept>
 #include <string>
 #include <tuple>
 #include <unordered_map>

--- a/src/algorithms/calorimetry/CalorimeterHitsMerger.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitsMerger.cc
@@ -33,6 +33,7 @@
 #include <vector>
 
 #include "algorithms/calorimetry/CalorimeterHitsMergerConfig.h"
+#include "algorithms/interfaces/GeometryUtils.h"
 #include "services/evaluator/EvaluatorSvc.h"
 
 namespace eicrecon {
@@ -41,6 +42,14 @@ void CalorimeterHitsMerger::init() {
 
   if (m_cfg.readout.empty()) {
     error("readoutClass is not provided, it is needed to know the fields in readout ids");
+    m_readout_available = false;
+    return;
+  }
+  if (!eicrecon::geo::hasReadout(*m_detector, m_cfg.readout)) {
+    warning("Readout '{}' is absent in the loaded geometry. Disabling {} and emitting empty "
+            "outputs.",
+            m_cfg.readout, name());
+    m_readout_available = false;
     return;
   }
 
@@ -60,21 +69,16 @@ void CalorimeterHitsMerger::init() {
   }
 
   // initialize descriptor + decoders
-  // First, try and get the IDDescriptor. This will throw an exception if it fails.
-  try {
-    id_desc = m_detector->readout(m_cfg.readout).idSpec();
-  } catch (...) {
-    warning("Failed to get idSpec for {}", m_cfg.readout);
-    return;
-  }
+  id_desc = m_detector->readout(m_cfg.readout).idSpec();
   try {
     id_decoder = id_desc.decoder();
     for (const std::string& field : fields) {
       const short index [[maybe_unused]] = id_decoder->index(field);
     }
-  } catch (...) {
+  } catch (const std::exception&) {
     auto mess = fmt::format("Failed to load ID decoder for {}", m_cfg.readout);
     warning(mess);
+    m_readout_available = false;
     return;
   }
 
@@ -109,6 +113,9 @@ void CalorimeterHitsMerger::process(const CalorimeterHitsMerger::Input& input,
 
   const auto [in_hits] = input;
   auto [out_hits]      = output;
+  if (!m_readout_available) {
+    return;
+  }
 
   // find the hits that belong to the same group (for merging)
   MergeMap merge_map;

--- a/src/algorithms/calorimetry/CalorimeterHitsMerger.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitsMerger.cc
@@ -45,7 +45,13 @@ void CalorimeterHitsMerger::init() {
     m_readout_available = false;
     return;
   }
+  const auto missing_readout_policy =
+      eicrecon::geo::parseMissingReadoutPolicy(m_cfg.missingReadoutPolicy);
   if (!eicrecon::geo::hasReadout(*m_detector, m_cfg.readout)) {
+    if (missing_readout_policy == eicrecon::geo::MissingReadoutPolicy::Throw) {
+      throw std::runtime_error("Readout '" + m_cfg.readout +
+                               "' is absent in the loaded geometry for " + std::string(name()));
+    }
     warning("Readout '{}' is absent in the loaded geometry. Disabling {} and emitting empty "
             "outputs.",
             m_cfg.readout, name());

--- a/src/algorithms/calorimetry/CalorimeterHitsMerger.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitsMerger.cc
@@ -22,12 +22,13 @@
 #include <algorithms/service.h>
 #include <edm4hep/RawCalorimeterHit.h>
 #include <edm4hep/Vector3f.h>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
-#include <gsl/pointers>
+#include <exception>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
 #include <vector>

--- a/src/algorithms/calorimetry/CalorimeterHitsMerger.h
+++ b/src/algorithms/calorimetry/CalorimeterHitsMerger.h
@@ -68,6 +68,7 @@ private:
   const dd4hep::Detector* m_detector{algorithms::GeoSvc::instance().detector()};
   const dd4hep::rec::CellIDPositionConverter* m_converter{
       algorithms::GeoSvc::instance().cellIDPositionConverter()};
+  bool m_readout_available{true};
 
 private:
   void build_merge_map(const edm4eic::CalorimeterHitCollection* in_hits, MergeMap& merge_map) const;

--- a/src/algorithms/calorimetry/CalorimeterHitsMergerConfig.h
+++ b/src/algorithms/calorimetry/CalorimeterHitsMergerConfig.h
@@ -11,6 +11,7 @@ namespace eicrecon {
 struct CalorimeterHitsMergerConfig {
 
   std::string readout{""};
+  std::string missingReadoutPolicy{"disable"};
   std::vector<std::string> fieldTransformations{};
 };
 

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -12,8 +12,8 @@
 #include <edm4hep/Vector2f.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <fmt/core.h>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <algorithm>
 #include <cmath>
 #include <iterator>

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -148,6 +148,8 @@ void CalorimeterIslandCluster::init() {
     return params;
   };
 
+  const auto missing_readout_policy =
+      eicrecon::geo::parseMissingReadoutPolicy(m_cfg.missingReadoutPolicy);
   if (m_cfg.readout.empty()) {
     if ((!m_cfg.adjacencyMatrix.empty()) || (!m_cfg.peakNeighbourhoodMatrix.empty())) {
       throw std::runtime_error(
@@ -155,6 +157,10 @@ void CalorimeterIslandCluster::init() {
     }
   } else {
     if (!eicrecon::geo::hasReadout(*m_detector, m_cfg.readout)) {
+      if (missing_readout_policy == eicrecon::geo::MissingReadoutPolicy::Throw) {
+        throw std::runtime_error("Readout '" + m_cfg.readout +
+                                 "' is absent in the loaded geometry for " + std::string(name()));
+      }
       warning("Readout '{}' is absent in the loaded geometry. Disabling {} and emitting empty "
               "outputs.",
               m_cfg.readout, name());

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -30,6 +30,7 @@
 
 #include "CalorimeterIslandCluster.h"
 #include "algorithms/calorimetry/CalorimeterIslandClusterConfig.h"
+#include "algorithms/interfaces/GeometryUtils.h"
 #include "services/evaluator/EvaluatorSvc.h"
 
 using namespace edm4eic;
@@ -153,6 +154,13 @@ void CalorimeterIslandCluster::init() {
           "'readout' is not provided, it is needed to know the fields in readout ids");
     }
   } else {
+    if (!eicrecon::geo::hasReadout(*m_detector, m_cfg.readout)) {
+      warning("Readout '{}' is absent in the loaded geometry. Disabling {} and emitting empty "
+              "outputs.",
+              m_cfg.readout, name());
+      m_readout_available = false;
+      return;
+    }
     m_idSpec = m_detector->readout(m_cfg.readout).idSpec();
   }
 
@@ -224,6 +232,9 @@ void CalorimeterIslandCluster::process(const CalorimeterIslandCluster::Input& in
 
   const auto [hits]     = input;
   auto [proto_clusters] = output;
+  if (!m_readout_available) {
+    return;
+  }
 
   // group neighboring hits
   std::vector<std::set<std::size_t>> groups;

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.h
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.h
@@ -68,6 +68,7 @@ public:
 
   // Pointer to the geometry service
   dd4hep::IDDescriptor m_idSpec;
+  bool m_readout_available{true};
 
 private:
   // grouping function with Breadth-First Search

--- a/src/algorithms/calorimetry/CalorimeterIslandClusterConfig.h
+++ b/src/algorithms/calorimetry/CalorimeterIslandClusterConfig.h
@@ -13,6 +13,7 @@ struct CalorimeterIslandClusterConfig {
   std::string adjacencyMatrix;
   std::string peakNeighbourhoodMatrix;
   std::string readout;
+  std::string missingReadoutPolicy{"disable"};
 
   // neighbour checking distances
   double sectorDist;

--- a/src/algorithms/calorimetry/SimCalorimeterHitProcessor.cc
+++ b/src/algorithms/calorimetry/SimCalorimeterHitProcessor.cc
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include "algorithms/calorimetry/SimCalorimeterHitProcessorConfig.h"
+#include "algorithms/interfaces/GeometryUtils.h"
 
 using namespace dd4hep;
 
@@ -102,13 +103,14 @@ void SimCalorimeterHitProcessor::init() {
     throw std::runtime_error("readoutClass is not provided");
   }
 
-  // get decoders
-  try {
-    m_id_spec = m_geo.detector()->readout(m_cfg.readout).idSpec();
-  } catch (...) {
-    debug("Failed to load ID decoder for {}", m_cfg.readout);
-    throw std::runtime_error(fmt::format("Failed to load ID decoder for {}", m_cfg.readout));
+  if (!eicrecon::geo::hasReadout(*m_geo.detector(), m_cfg.readout)) {
+    warning("Readout '{}' is absent in the loaded geometry. Disabling {} and emitting empty "
+            "outputs.",
+            m_cfg.readout, name());
+    m_readout_available = false;
+    return;
   }
+  m_id_spec = m_geo.detector()->readout(m_cfg.readout).idSpec();
 
   // get m_hit_id_mask for adding up hits with the same dimensions that are merged over
   {
@@ -148,6 +150,9 @@ void SimCalorimeterHitProcessor::process(const SimCalorimeterHitProcessor::Input
 
   const auto [in_hits]              = input;
   auto [out_hits, out_hit_contribs] = output;
+  if (!m_readout_available) {
+    return;
+  }
 
   // Map for staging output information. We have 2 levels of structure:
   //   - top level: (MCParticle, Merged Hit CellID)

--- a/src/algorithms/calorimetry/SimCalorimeterHitProcessor.cc
+++ b/src/algorithms/calorimetry/SimCalorimeterHitProcessor.cc
@@ -103,7 +103,13 @@ void SimCalorimeterHitProcessor::init() {
     throw std::runtime_error("readoutClass is not provided");
   }
 
+  const auto missing_readout_policy =
+      eicrecon::geo::parseMissingReadoutPolicy(m_cfg.missingReadoutPolicy);
   if (!eicrecon::geo::hasReadout(*m_geo.detector(), m_cfg.readout)) {
+    if (missing_readout_policy == eicrecon::geo::MissingReadoutPolicy::Throw) {
+      throw std::runtime_error("Readout '" + m_cfg.readout +
+                               "' is absent in the loaded geometry for " + std::string(name()));
+    }
     warning("Readout '{}' is absent in the loaded geometry. Disabling {} and emitting empty "
             "outputs.",
             m_cfg.readout, name());

--- a/src/algorithms/calorimetry/SimCalorimeterHitProcessor.cc
+++ b/src/algorithms/calorimetry/SimCalorimeterHitProcessor.cc
@@ -12,7 +12,6 @@
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <fmt/format.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
 #include <cmath>

--- a/src/algorithms/calorimetry/SimCalorimeterHitProcessor.h
+++ b/src/algorithms/calorimetry/SimCalorimeterHitProcessor.h
@@ -45,6 +45,7 @@ private:
   dd4hep::IDDescriptor m_id_spec;
 
   const algorithms::GeoSvc& m_geo = algorithms::GeoSvc::instance();
+  bool m_readout_available        = true;
 
   // a reference value for attenuation
   std::optional<double> m_attenuationReferencePosition;

--- a/src/algorithms/calorimetry/SimCalorimeterHitProcessorConfig.h
+++ b/src/algorithms/calorimetry/SimCalorimeterHitProcessorConfig.h
@@ -17,6 +17,7 @@ struct SimCalorimeterHitProcessorConfig {
   std::vector<double> attenuationParameters{0};
 
   std::string readout{""};
+  std::string missingReadoutPolicy{"disable"};
   std::string attenuationReferencePositionName{""};
   // fields for merging hits
   std::vector<std::string> hitMergeFields{};

--- a/src/algorithms/digi/MPGDTrackerDigi.cc
+++ b/src/algorithms/digi/MPGDTrackerDigi.cc
@@ -138,6 +138,7 @@
 #include <vector>
 
 #include "algorithms/digi/MPGDTrackerDigiConfig.h"
+#include "algorithms/interfaces/GeometryUtils.h"
 
 using namespace dd4hep;
 
@@ -149,6 +150,13 @@ void MPGDTrackerDigi::init() {
 
   if (m_cfg.readout.empty()) {
     throw std::runtime_error("Readout is empty");
+  }
+  if (!eicrecon::geo::hasReadout(*m_detector, m_cfg.readout)) {
+    warning("Readout '{}' is absent in the loaded geometry. Disabling {} and emitting empty "
+            "outputs.",
+            m_cfg.readout, name());
+    m_readout_available = false;
+    return;
   }
   try {
     m_seg    = m_detector->readout(m_cfg.readout).segmentation();
@@ -244,6 +252,9 @@ void MPGDTrackerDigi::process(const MPGDTrackerDigi::Input& input,
 
   const auto [headers, sim_hits]       = input;
   auto [raw_hits, links, associations] = output;
+  if (!m_readout_available) {
+    return;
+  }
 
   // local random generator
   auto seed = m_uid.getUniqueID(*headers, name());

--- a/src/algorithms/digi/MPGDTrackerDigi.cc
+++ b/src/algorithms/digi/MPGDTrackerDigi.cc
@@ -151,7 +151,13 @@ void MPGDTrackerDigi::init() {
   if (m_cfg.readout.empty()) {
     throw std::runtime_error("Readout is empty");
   }
+  const auto missing_readout_policy =
+      eicrecon::geo::parseMissingReadoutPolicy(m_cfg.missingReadoutPolicy);
   if (!eicrecon::geo::hasReadout(*m_detector, m_cfg.readout)) {
+    if (missing_readout_policy == eicrecon::geo::MissingReadoutPolicy::Throw) {
+      throw std::runtime_error("Readout '" + m_cfg.readout +
+                               "' is absent in the loaded geometry for " + std::string(name()));
+    }
     warning("Readout '{}' is absent in the loaded geometry. Disabling {} and emitting empty "
             "outputs.",
             m_cfg.readout, name());

--- a/src/algorithms/digi/MPGDTrackerDigi.h
+++ b/src/algorithms/digi/MPGDTrackerDigi.h
@@ -97,6 +97,7 @@ private:
   /** Segmentation */
   const dd4hep::Detector* m_detector{nullptr};
   dd4hep::Segmentation m_seg;
+  bool m_readout_available{true};
   // IDDescriptor
   const dd4hep::BitFieldCoder* m_id_dec{nullptr};
   static constexpr const char* m_fieldNames[5] = // "volume": excluding channel specification

--- a/src/algorithms/digi/MPGDTrackerDigiConfig.h
+++ b/src/algorithms/digi/MPGDTrackerDigiConfig.h
@@ -12,6 +12,7 @@ struct MPGDTrackerDigiConfig {
 
   // Readout identifiers for tagging 1st and 2nd coord. of 2D-strip readout
   std::string readout{""};
+  std::string missingReadoutPolicy{"disable"};
 
   // - MPGD digitization parameters should come in pairs: one parameter per
   //  strip coordinate.

--- a/src/algorithms/digi/PulseCombiner.cc
+++ b/src/algorithms/digi/PulseCombiner.cc
@@ -36,10 +36,16 @@ void PulseCombiner::init() {
   if (m_cfg.readout.empty()) {
     throw std::runtime_error("Readout is required when combine_field is configured");
   }
+  const auto missing_readout_policy =
+      eicrecon::geo::parseMissingReadoutPolicy(m_cfg.missingReadoutPolicy);
 
   // Get the detector readout and set CellID bit mask if set
   auto detector = algorithms::GeoSvc::instance().detector();
   if (!eicrecon::geo::hasReadout(*detector, m_cfg.readout)) {
+    if (missing_readout_policy == eicrecon::geo::MissingReadoutPolicy::Throw) {
+      throw std::runtime_error("Readout '" + m_cfg.readout +
+                               "' is absent in the loaded geometry for " + std::string(name()));
+    }
     warning("Readout '{}' is absent in the loaded geometry. Disabling {} and emitting empty "
             "outputs.",
             m_cfg.readout, name());

--- a/src/algorithms/digi/PulseCombiner.cc
+++ b/src/algorithms/digi/PulseCombiner.cc
@@ -23,33 +23,39 @@
 #include <utility>
 #include <vector>
 
+#include "algorithms/interfaces/GeometryUtils.h"
 #include "PulseCombiner.h"
 
 namespace eicrecon {
 
 void PulseCombiner::init() {
 
+  if (m_cfg.readout.empty() && m_cfg.combine_field.empty()) {
+    return;
+  }
+  if (m_cfg.readout.empty()) {
+    throw std::runtime_error("Readout is required when combine_field is configured");
+  }
+
   // Get the detector readout and set CellID bit mask if set
-  if (!(m_cfg.readout.empty() && m_cfg.combine_field.empty())) {
-    try {
-      auto detector      = algorithms::GeoSvc::instance().detector();
-      auto id_spec       = detector->readout(m_cfg.readout).idSpec();
-      m_detector_bitmask = 0;
+  auto detector = algorithms::GeoSvc::instance().detector();
+  if (!eicrecon::geo::hasReadout(*detector, m_cfg.readout)) {
+    warning("Readout '{}' is absent in the loaded geometry. Disabling {} and emitting empty "
+            "outputs.",
+            m_cfg.readout, name());
+    m_readout_available = false;
+    return;
+  }
+  auto id_spec       = detector->readout(m_cfg.readout).idSpec();
+  m_detector_bitmask = 0;
 
-      for (const auto& field : id_spec.fields()) {
-        // Get the field name
-        std::string field_name = field.first;
-        // Check if the field is the one we want to combine
-        m_detector_bitmask |= id_spec.field(field_name)->mask();
-        if (field_name == m_cfg.combine_field) {
-          break;
-        }
-      }
-
-    } catch (...) {
-      error("Failed set bitshift for detector {} with segmentation id {}", m_cfg.readout,
-            m_cfg.combine_field);
-      throw std::runtime_error("Failed to load ID decoder");
+  for (const auto& field : id_spec.fields()) {
+    // Get the field name
+    std::string field_name = field.first;
+    // Check if the field is the one we want to combine
+    m_detector_bitmask |= id_spec.field(field_name)->mask();
+    if (field_name == m_cfg.combine_field) {
+      break;
     }
   }
 }
@@ -58,6 +64,9 @@ void PulseCombiner::process(const PulseCombiner::Input& input,
                             const PulseCombiner::Output& output) const {
   const auto [inPulses] = input;
   auto [outPulses]      = output;
+  if (!m_readout_available) {
+    return;
+  }
 
   // Create map containing vector of pulses from each CellID
   std::map<uint64_t, std::vector<PulseType>> cell_pulses;

--- a/src/algorithms/digi/PulseCombiner.h
+++ b/src/algorithms/digi/PulseCombiner.h
@@ -36,6 +36,7 @@ private:
   std::vector<std::vector<PulseType>> clusterPulses(const std::vector<PulseType> pulses) const;
   static std::vector<float> sumPulses(const std::vector<PulseType> pulses);
   uint64_t m_detector_bitmask = 0xFFFFFFFFFFFFFFFF;
+  bool m_readout_available{true};
 };
 
 } // namespace eicrecon

--- a/src/algorithms/digi/PulseCombinerConfig.h
+++ b/src/algorithms/digi/PulseCombinerConfig.h
@@ -10,7 +10,8 @@ namespace eicrecon {
 struct PulseCombinerConfig {
   double minimum_separation =
       50 * edm4eic::unit::ns; // Minimum distance between pulses to keep separate
-  std::string readout       = "";
+  std::string readout = "";
+  std::string missingReadoutPolicy{"disable"};
   std::string combine_field = "";
 };
 

--- a/src/algorithms/digi/SiliconChargeSharing.cc
+++ b/src/algorithms/digi/SiliconChargeSharing.cc
@@ -33,18 +33,33 @@
 #include "DD4hep/Detector.h"
 #include "SiliconChargeSharing.h"
 #include "algorithms/digi/SiliconChargeSharingConfig.h"
+#include "algorithms/interfaces/GeometryUtils.h"
 
 namespace eicrecon {
 
 void SiliconChargeSharing::init() {
-  m_converter = algorithms::GeoSvc::instance().cellIDPositionConverter();
-  m_seg       = algorithms::GeoSvc::instance().detector()->readout(m_cfg.readout).segmentation();
+  m_converter   = algorithms::GeoSvc::instance().cellIDPositionConverter();
+  auto detector = algorithms::GeoSvc::instance().detector();
+  if (m_cfg.readout.empty()) {
+    throw std::runtime_error("Readout is empty");
+  }
+  if (!eicrecon::geo::hasReadout(*detector, m_cfg.readout)) {
+    warning("Readout '{}' is absent in the loaded geometry. Disabling {} and emitting empty "
+            "outputs.",
+            m_cfg.readout, name());
+    m_readout_available = false;
+    return;
+  }
+  m_seg = detector->readout(m_cfg.readout).segmentation();
 }
 
 void SiliconChargeSharing::process(const SiliconChargeSharing::Input& input,
                                    const SiliconChargeSharing::Output& output) const {
   const auto [simhits] = input;
   auto [sharedHits]    = output;
+  if (!m_readout_available) {
+    return;
+  }
 
   for (const auto& hit : *simhits) {
 

--- a/src/algorithms/digi/SiliconChargeSharing.cc
+++ b/src/algorithms/digi/SiliconChargeSharing.cc
@@ -43,7 +43,13 @@ void SiliconChargeSharing::init() {
   if (m_cfg.readout.empty()) {
     throw std::runtime_error("Readout is empty");
   }
+  const auto missing_readout_policy =
+      eicrecon::geo::parseMissingReadoutPolicy(m_cfg.missingReadoutPolicy);
   if (!eicrecon::geo::hasReadout(*detector, m_cfg.readout)) {
+    if (missing_readout_policy == eicrecon::geo::MissingReadoutPolicy::Throw) {
+      throw std::runtime_error("Readout '" + m_cfg.readout +
+                               "' is absent in the loaded geometry for " + std::string(name()));
+    }
     warning("Readout '{}' is absent in the loaded geometry. Disabling {} and emitting empty "
             "outputs.",
             m_cfg.readout, name());

--- a/src/algorithms/digi/SiliconChargeSharing.h
+++ b/src/algorithms/digi/SiliconChargeSharing.h
@@ -64,6 +64,7 @@ private:
       m_xy_range_map;
   const dd4hep::rec::CellIDPositionConverter* m_converter = nullptr;
   dd4hep::Segmentation m_seg;
+  bool m_readout_available{true};
 };
 
 } // namespace eicrecon

--- a/src/algorithms/digi/SiliconChargeSharingConfig.h
+++ b/src/algorithms/digi/SiliconChargeSharingConfig.h
@@ -15,6 +15,7 @@ struct SiliconChargeSharingConfig {
   float sigma_sharingy;
   float min_edep;
   std::string readout;
+  std::string missingReadoutPolicy{"disable"};
 };
 
 std::istream& operator>>(std::istream& in, SiliconChargeSharingConfig::ESigmaMode& sigmaMode) {

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2023 - 2025, Simon Gardner
 
-#include <DD4hep/Handle.h>
 #include <DD4hep/IDDescriptor.h>
 #include <DD4hep/Objects.h>
 #include <DD4hep/Readout.h>
@@ -17,6 +16,7 @@
 #include <cstddef>
 #include <gsl/pointers>
 #include <stdexcept>
+#include <tuple>
 
 #include "algorithms/fardetectors/FarDetectorTrackerCluster.h"
 #include "algorithms/fardetectors/FarDetectorTrackerClusterConfig.h"

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
@@ -20,6 +20,7 @@
 
 #include "algorithms/fardetectors/FarDetectorTrackerCluster.h"
 #include "algorithms/fardetectors/FarDetectorTrackerClusterConfig.h"
+#include "algorithms/interfaces/GeometryUtils.h"
 
 namespace eicrecon {
 
@@ -29,6 +30,13 @@ void FarDetectorTrackerCluster::init() {
 
   if (m_cfg.readout.empty()) {
     throw std::runtime_error("Readout is empty");
+  }
+  if (!eicrecon::geo::hasReadout(*m_detector, m_cfg.readout)) {
+    warning("Readout '{}' is absent in the loaded geometry. Disabling {} and emitting empty "
+            "outputs.",
+            m_cfg.readout, name());
+    m_readout_available = false;
+    return;
   }
   try {
     m_seg    = m_detector->readout(m_cfg.readout).segmentation();
@@ -52,6 +60,9 @@ void FarDetectorTrackerCluster::process(const FarDetectorTrackerCluster::Input& 
 
   const auto [inputHitsCollections] = input;
   auto [outputClustersCollection]   = output;
+  if (!m_readout_available) {
+    return;
+  }
 
   // Loop over input and output collections - Any collection should only contain hits from a single
   // surface

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
@@ -31,7 +31,13 @@ void FarDetectorTrackerCluster::init() {
   if (m_cfg.readout.empty()) {
     throw std::runtime_error("Readout is empty");
   }
+  const auto missing_readout_policy =
+      eicrecon::geo::parseMissingReadoutPolicy(m_cfg.missingReadoutPolicy);
   if (!eicrecon::geo::hasReadout(*m_detector, m_cfg.readout)) {
+    if (missing_readout_policy == eicrecon::geo::MissingReadoutPolicy::Throw) {
+      throw std::runtime_error("Readout '" + m_cfg.readout +
+                               "' is absent in the loaded geometry for " + std::string(name()));
+    }
     warning("Readout '{}' is absent in the loaded geometry. Disabling {} and emitting empty "
             "outputs.",
             m_cfg.readout, name());

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.h
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.h
@@ -46,6 +46,7 @@ private:
   const dd4hep::Detector* m_detector{nullptr};
   const dd4hep::BitFieldCoder* m_id_dec{nullptr};
   dd4hep::Segmentation m_seg;
+  bool m_readout_available{true};
 
   int m_x_idx{0};
   int m_y_idx{0};

--- a/src/algorithms/fardetectors/FarDetectorTrackerClusterConfig.h
+++ b/src/algorithms/fardetectors/FarDetectorTrackerClusterConfig.h
@@ -10,6 +10,7 @@ struct FarDetectorTrackerClusterConfig {
 
   // Readout identifiers for dividing detector
   std::string readout{""};
+  std::string missingReadoutPolicy{"disable"};
   std::string x_field{"x"};
   std::string y_field{"y"};
 

--- a/src/algorithms/interfaces/GeometryUtils.h
+++ b/src/algorithms/interfaces/GeometryUtils.h
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Wouter Deconinck
+
+#pragma once
+
+#include <DD4hep/Detector.h>
+#include <DD4hep/IDDescriptor.h>
+#include <DD4hep/Readout.h>
+#include <DD4hep/Segmentations.h>
+#include <optional>
+#include <string>
+
+namespace eicrecon::geo {
+
+/**
+ * Non-throwing geometry lookup helpers.
+ *
+ * DD4hep's `dd4hep::Detector::readout(name)` throws (deep in `getRefChild`) when the named
+ * readout is not present in the loaded geometry. That is undesirable when running a
+ * reconstruction that is wider than the loaded geometry: e.g. a reduced-geometry detector
+ * (such as `epic_craterlake_tracking_only`) legitimately does not contain every readout that
+ * an algorithm might be configured for. In that situation "the readout is absent" is a valid
+ * configuration, not an error, and callers need to be able to distinguish it from a genuine
+ * failure without catching a broad exception.
+ *
+ * These helpers query geometry without throwing on absence: presence is reported via a boolean
+ * or via `std::optional` emptiness, so callers can gracefully disable a detector-specific code
+ * path (e.g. produce empty output) instead of letting an exception propagate through the JANA2
+ * dataflow. A thrown exception continues to mean a genuine failure.
+ *
+ * They operate on a plain `dd4hep::Detector` reference so they can be used from both the
+ * framework-independent algorithms (via `algorithms::GeoSvc::instance().detector()`) and from
+ * JANA services (via `DD4hep_service::detector()`).
+ */
+
+/// Returns true if a readout with the given name exists in the detector, false otherwise.
+/// Does not throw.
+inline bool hasReadout(const dd4hep::Detector& detector, const std::string& readout_name) {
+  const auto& readouts = detector.readouts();
+  return readouts.find(readout_name) != readouts.end();
+}
+
+/// Returns the ID descriptor for the named readout, or std::nullopt if the readout is absent
+/// (or present but does not carry a valid ID descriptor). Does not throw on absence.
+inline std::optional<dd4hep::IDDescriptor> readoutIdSpec(const dd4hep::Detector& detector,
+                                                         const std::string& readout_name) {
+  if (!hasReadout(detector, readout_name)) {
+    return std::nullopt;
+  }
+  const dd4hep::IDDescriptor id_spec = detector.readout(readout_name).idSpec();
+  if (!id_spec.isValid()) {
+    return std::nullopt;
+  }
+  return id_spec;
+}
+
+/// Returns the segmentation for the named readout, or std::nullopt if the readout is absent
+/// (or present but does not carry a valid segmentation). Does not throw on absence.
+inline std::optional<dd4hep::Segmentation> readoutSegmentation(const dd4hep::Detector& detector,
+                                                               const std::string& readout_name) {
+  if (!hasReadout(detector, readout_name)) {
+    return std::nullopt;
+  }
+  const dd4hep::Segmentation segmentation = detector.readout(readout_name).segmentation();
+  if (!segmentation.isValid()) {
+    return std::nullopt;
+  }
+  return segmentation;
+}
+
+} // namespace eicrecon::geo

--- a/src/algorithms/interfaces/GeometryUtils.h
+++ b/src/algorithms/interfaces/GeometryUtils.h
@@ -8,9 +8,13 @@
 #include <DD4hep/Readout.h>
 #include <DD4hep/Segmentations.h>
 #include <optional>
+#include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace eicrecon::geo {
+
+enum class MissingReadoutPolicy { Disable, Throw };
 
 /**
  * Non-throwing geometry lookup helpers.
@@ -38,6 +42,20 @@ namespace eicrecon::geo {
 inline bool hasReadout(const dd4hep::Detector& detector, const std::string& readout_name) {
   const auto& readouts = detector.readouts();
   return readouts.find(readout_name) != readouts.end();
+}
+
+/// Parse the policy for handling geometry readouts that are absent from the loaded detector.
+/// - "disable" (or empty) => disable the producer and emit empty output collections
+/// - "throw" => fail loudly with an exception
+inline MissingReadoutPolicy parseMissingReadoutPolicy(std::string_view policy) {
+  if (policy.empty() || policy == "disable") {
+    return MissingReadoutPolicy::Disable;
+  }
+  if (policy == "throw") {
+    return MissingReadoutPolicy::Throw;
+  }
+  throw std::runtime_error("Invalid missingReadoutPolicy value '" + std::string(policy) +
+                           "'. Expected 'disable' or 'throw'.");
 }
 
 /// Returns the ID descriptor for the named readout, or std::nullopt if the readout is absent

--- a/src/algorithms/tracking/LGADHitClustering.cc
+++ b/src/algorithms/tracking/LGADHitClustering.cc
@@ -45,7 +45,13 @@ void LGADHitClustering::init() {
   if (m_cfg.readout.empty()) {
     throw std::runtime_error("Readout is empty");
   }
+  const auto missing_readout_policy =
+      eicrecon::geo::parseMissingReadoutPolicy(m_cfg.missingReadoutPolicy);
   if (!eicrecon::geo::hasReadout(*m_detector, m_cfg.readout)) {
+    if (missing_readout_policy == eicrecon::geo::MissingReadoutPolicy::Throw) {
+      throw std::runtime_error("Readout '" + m_cfg.readout +
+                               "' is absent in the loaded geometry for " + std::string(name()));
+    }
     warning("Readout '{}' is absent in the loaded geometry. Disabling {} and emitting empty "
             "outputs.",
             m_cfg.readout, name());

--- a/src/algorithms/tracking/LGADHitClustering.cc
+++ b/src/algorithms/tracking/LGADHitClustering.cc
@@ -33,14 +33,25 @@
 
 #include "ActsGeometryProvider.h"
 #include "algorithms/interfaces/ActsSvc.h"
+#include "algorithms/interfaces/GeometryUtils.h"
 #include "algorithms/tracking/LGADHitClusteringConfig.h"
 
 namespace eicrecon {
 
 void LGADHitClustering::init() {
 
-  m_converter    = algorithms::GeoSvc::instance().cellIDPositionConverter();
-  m_detector     = algorithms::GeoSvc::instance().detector();
+  m_converter = algorithms::GeoSvc::instance().cellIDPositionConverter();
+  m_detector  = algorithms::GeoSvc::instance().detector();
+  if (m_cfg.readout.empty()) {
+    throw std::runtime_error("Readout is empty");
+  }
+  if (!eicrecon::geo::hasReadout(*m_detector, m_cfg.readout)) {
+    warning("Readout '{}' is absent in the loaded geometry. Disabling {} and emitting empty "
+            "outputs.",
+            m_cfg.readout, name());
+    m_readout_available = false;
+    return;
+  }
   m_seg          = m_detector->readout(m_cfg.readout).segmentation();
   auto type      = m_seg.type();
   m_decoder      = m_seg.decoder();
@@ -154,6 +165,9 @@ void LGADHitClustering::_calcCluster(const Output& output,
 void LGADHitClustering::process(const LGADHitClustering::Input& input,
                                 const LGADHitClustering::Output& output) const {
   const auto [calibrated_hits] = input;
+  if (!m_readout_available) {
+    return;
+  }
 
   // use unordered map to efficiently search for hits by CellID
   // store the index of hits instead of the hit itself

--- a/src/algorithms/tracking/LGADHitClustering.h
+++ b/src/algorithms/tracking/LGADHitClustering.h
@@ -53,6 +53,7 @@ private:
   const dd4hep::Detector* m_detector = nullptr;
 
   dd4hep::Segmentation m_seg;
+  bool m_readout_available{true};
 
   std::shared_ptr<const ActsGeometryProvider> m_acts_context;
 

--- a/src/algorithms/tracking/LGADHitClusteringConfig.h
+++ b/src/algorithms/tracking/LGADHitClusteringConfig.h
@@ -7,7 +7,8 @@
 namespace eicrecon {
 struct LGADHitClusteringConfig {
   std::string readout = "TOFBarrelHits";
-  double deltaT       = 1 * edm4eic::unit::ns;
-  bool useAve         = false;
+  std::string missingReadoutPolicy{"disable"};
+  double deltaT = 1 * edm4eic::unit::ns;
+  bool useAve   = false;
 };
 } // namespace eicrecon

--- a/src/algorithms/tracking/MPGDHitReconstruction.cc
+++ b/src/algorithms/tracking/MPGDHitReconstruction.cc
@@ -25,6 +25,7 @@
 #include <tuple>
 #include <vector>
 
+#include "algorithms/interfaces/GeometryUtils.h"
 using namespace dd4hep;
 
 namespace eicrecon {
@@ -36,6 +37,13 @@ void MPGDHitReconstruction::init() {
   const dd4hep::Detector* detector = m_geo.detector();
   if (m_cfg.readout.empty()) {
     throw std::runtime_error("Readout is empty");
+  }
+  if (!eicrecon::geo::hasReadout(*detector, m_cfg.readout)) {
+    warning("Readout '{}' is absent in the loaded geometry. Disabling {} and emitting empty "
+            "outputs.",
+            m_cfg.readout, name());
+    m_readout_available = false;
+    return;
   }
   try {
     m_id_dec = detector->readout(m_cfg.readout).idSpec().decoder();
@@ -51,6 +59,9 @@ void MPGDHitReconstruction::process(const Input& input, const Output& output) co
 
   const auto [raw_hits] = input;
   auto [rec_hits]       = output;
+  if (!m_readout_available) {
+    return;
+  }
 
   // Reorder input raw_hits
   // Sort them in ascending order of channel# on a per SUBVOLUME * (p|n) basis.

--- a/src/algorithms/tracking/MPGDHitReconstruction.cc
+++ b/src/algorithms/tracking/MPGDHitReconstruction.cc
@@ -38,7 +38,13 @@ void MPGDHitReconstruction::init() {
   if (m_cfg.readout.empty()) {
     throw std::runtime_error("Readout is empty");
   }
+  const auto missing_readout_policy =
+      eicrecon::geo::parseMissingReadoutPolicy(m_cfg.missingReadoutPolicy);
   if (!eicrecon::geo::hasReadout(*detector, m_cfg.readout)) {
+    if (missing_readout_policy == eicrecon::geo::MissingReadoutPolicy::Throw) {
+      throw std::runtime_error("Readout '" + m_cfg.readout +
+                               "' is absent in the loaded geometry for " + std::string(name()));
+    }
     warning("Readout '{}' is absent in the loaded geometry. Disabling {} and emitting empty "
             "outputs.",
             m_cfg.readout, name());

--- a/src/algorithms/tracking/MPGDHitReconstruction.h
+++ b/src/algorithms/tracking/MPGDHitReconstruction.h
@@ -45,6 +45,7 @@ private:
   const algorithms::GeoSvc& m_geo{algorithms::GeoSvc::instance()};
   const dd4hep::rec::CellIDPositionConverter* m_converter{m_geo.cellIDPositionConverter()};
   const dd4hep::BitFieldCoder* m_id_dec;
+  bool m_readout_available{true};
   // CellIDs specifying IDDescriptor fields.
   void parseIDDescriptor();
   int m_coordOffsets[2];          // Offsets of coordinate fields

--- a/src/algorithms/tracking/MPGDHitReconstructionConfig.h
+++ b/src/algorithms/tracking/MPGDHitReconstructionConfig.h
@@ -9,6 +9,7 @@ struct MPGDHitReconstructionConfig {
 
   // Readout identifiers for dividing detector
   std::string readout{""};
+  std::string missingReadoutPolicy{"disable"};
   float timeResolution                  = 10;
   std::array<float, 2> stripResolutions = {150 * dd4hep::um, 150 * dd4hep::um};
 };

--- a/src/factories/calorimetry/CalorimeterHitDigi_factory.h
+++ b/src/factories/calorimetry/CalorimeterHitDigi_factory.h
@@ -35,6 +35,8 @@ private:
   ParameterRef<std::string> m_corrMeanScale{this, "scaleResponse", config().corrMeanScale};
   ParameterRef<std::vector<std::string>> m_fields{this, "signalSumFields", config().fields};
   ParameterRef<std::string> m_readout{this, "readoutClass", config().readout};
+  ParameterRef<std::string> m_missing_readout_policy{this, "missingReadoutPolicy",
+                                                     config().missingReadoutPolicy};
   ParameterRef<std::string> m_readoutType{this, "readoutType", config().readoutType};
   ParameterRef<double> m_lightYield{this, "lightYield", config().lightYield};
   ParameterRef<double> m_photonDetectionEfficiency{this, "photonDetectionEfficiency",

--- a/src/factories/calorimetry/CalorimeterHitsMerger_factory.h
+++ b/src/factories/calorimetry/CalorimeterHitsMerger_factory.h
@@ -22,6 +22,8 @@ private:
   PodioOutput<edm4eic::CalorimeterHit> m_hits_output{this};
 
   ParameterRef<std::string> m_readout{this, "readout", config().readout};
+  ParameterRef<std::string> m_missing_readout_policy{this, "missingReadoutPolicy",
+                                                     config().missingReadoutPolicy};
   ParameterRef<std::vector<std::string>> m_field_transformations{this, "fieldTransformations",
                                                                  config().fieldTransformations};
 

--- a/src/factories/calorimetry/CalorimeterIslandCluster_factory.h
+++ b/src/factories/calorimetry/CalorimeterIslandCluster_factory.h
@@ -32,6 +32,8 @@ private:
                                                             config().dimScaledLocalDistXY};
   ParameterRef<std::string> m_adjacencyMatrix{this, "adjacencyMatrix", config().adjacencyMatrix};
   ParameterRef<std::string> m_readout{this, "readoutClass", config().readout};
+  ParameterRef<std::string> m_missing_readout_policy{this, "missingReadoutPolicy",
+                                                     config().missingReadoutPolicy};
   ParameterRef<bool> m_splitCluster{this, "splitCluster", config().splitCluster};
   ParameterRef<double> m_minClusterHitEdep{this, "minClusterHitEdep", config().minClusterHitEdep};
   ParameterRef<double> m_minClusterCenterEdep{this, "minClusterCenterEdep",

--- a/src/factories/calorimetry/SimCalorimeterHitProcessor_factory.h
+++ b/src/factories/calorimetry/SimCalorimeterHitProcessor_factory.h
@@ -31,6 +31,8 @@ private:
   ParameterRef<std::vector<std::string>> m_contributionMergeFields{
       this, "contributionMergeFields", config().contributionMergeFields};
   ParameterRef<std::string> m_readout{this, "readout", config().readout};
+  ParameterRef<std::string> m_missing_readout_policy{this, "missingReadoutPolicy",
+                                                     config().missingReadoutPolicy};
   ParameterRef<double> m_inversePropagationSpeed{this, "inversePropagationSpeed",
                                                  config().inversePropagationSpeed};
   ParameterRef<double> m_fixedTimeDelay{this, "fixedTimeDelay", config().fixedTimeDelay};

--- a/src/factories/digi/MPGDTrackerDigi_factory.h
+++ b/src/factories/digi/MPGDTrackerDigi_factory.h
@@ -36,6 +36,8 @@ private:
   ParameterRef<std::array<int, 2>> m_stripNumbers{this, "stripNumbers", config().stripNumbers,
                                                   "Number of p/n strips per module"};
   ParameterRef<std::string> m_readout{this, "readoutClass", config().readout};
+  ParameterRef<std::string> m_missing_readout_policy{this, "missingReadoutPolicy",
+                                                     config().missingReadoutPolicy};
 
 public:
   void Configure() {

--- a/src/factories/digi/PulseCombiner_factory.h
+++ b/src/factories/digi/PulseCombiner_factory.h
@@ -23,6 +23,8 @@ private:
 
   ParameterRef<double> m_minimum_separation{this, "minimumSeperation", config().minimum_separation};
   ParameterRef<std::string> m_readout{this, "readout", config().readout};
+  ParameterRef<std::string> m_missing_readout_policy{this, "missingReadoutPolicy",
+                                                     config().missingReadoutPolicy};
   ParameterRef<std::string> m_combine_field{this, "combineField", config().combine_field};
 
   Service<AlgorithmsInit_service> m_algorithmsInit{this};

--- a/src/factories/digi/SiliconChargeSharing_factory.h
+++ b/src/factories/digi/SiliconChargeSharing_factory.h
@@ -26,6 +26,8 @@ private:
   ParameterRef<float> m_sigma_sharingy{this, "sigmaSharingY", config().sigma_sharingy};
   ParameterRef<float> m_min_edep{this, "minEDep", config().min_edep};
   ParameterRef<std::string> m_readout{this, "readout", config().readout};
+  ParameterRef<std::string> m_missing_readout_policy{this, "missingReadoutPolicy",
+                                                     config().missingReadoutPolicy};
   ParameterRef<eicrecon::SiliconChargeSharingConfig::ESigmaMode> m_sigma_mode{this, "sigmaMode",
                                                                               config().sigma_mode};
 

--- a/src/factories/fardetectors/FarDetectorTrackerCluster_factory.h
+++ b/src/factories/fardetectors/FarDetectorTrackerCluster_factory.h
@@ -24,6 +24,8 @@ private:
   Service<AlgorithmsInit_service> m_algorithmsInit{this};
 
   ParameterRef<std::string> m_readout{this, "readoutClass", config().readout};
+  ParameterRef<std::string> m_missing_readout_policy{this, "missingReadoutPolicy",
+                                                     config().missingReadoutPolicy};
   ParameterRef<std::string> m_x_field{this, "xField", config().x_field};
   ParameterRef<std::string> m_y_field{this, "yField", config().y_field};
   ParameterRef<double> m_hit_time_limit{this, "hitTimeLimit", config().hit_time_limit};

--- a/src/factories/tracking/LGADHitClustering_factory.h
+++ b/src/factories/tracking/LGADHitClustering_factory.h
@@ -18,6 +18,8 @@ private:
   PodioOutput<edm4eic::Measurement2D> m_clusters_output{this};
 
   ParameterRef<std::string> m_readout{this, "readout", config().readout};
+  ParameterRef<std::string> m_missing_readout_policy{this, "missingReadoutPolicy",
+                                                     config().missingReadoutPolicy};
   ParameterRef<double> m_deltaT{this, "deltaT", config().deltaT};
   ParameterRef<bool> m_useAve{this, "useAve", config().useAve};
 

--- a/src/factories/tracking/MPGDHitReconstruction_factory.h
+++ b/src/factories/tracking/MPGDHitReconstruction_factory.h
@@ -22,6 +22,8 @@ private:
   PodioOutput<edm4eic::TrackerHit> m_rec_hits_output{this};
 
   ParameterRef<float> m_timeResolution{this, "timeResolution", config().timeResolution};
+  ParameterRef<std::string> m_missing_readout_policy{this, "missingReadoutPolicy",
+                                                     config().missingReadoutPolicy};
 
   Service<DD4hep_service> m_geoSvc{this};
 

--- a/src/tests/algorithms_test/CMakeLists.txt
+++ b/src/tests/algorithms_test/CMakeLists.txt
@@ -23,7 +23,8 @@ add_executable(
   pid_MergeParticleID.cc
   pid_lut_PIDLookup.cc
   meta_SortSubsetCollection.cc
-  reco_ClustersToParticles.cc)
+  reco_ClustersToParticles.cc
+  interfaces_GeometryUtils.cc)
 
 # Explicit linking to podio::podio is needed due to
 # https://github.com/JeffersonLab/JANA2/issues/151

--- a/src/tests/algorithms_test/interfaces_GeometryUtils.cc
+++ b/src/tests/algorithms_test/interfaces_GeometryUtils.cc
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Wouter Deconinck
+
+#include <DD4hep/Detector.h>
+#include <DD4hep/IDDescriptor.h>
+#include <DD4hep/Segmentations.h>
+#include <algorithms/geo.h>
+#include <catch2/catch_test_macros.hpp>
+#include <optional>
+#include <string>
+
+#include "algorithms/interfaces/GeometryUtils.h"
+
+// The mock detector is set up by the global algorithmsInitListener (algorithmsInit.cc) and
+// exposes the readouts "MockCalorimeterHits", "MockTrackerHits", "MockSiliconHits" and
+// "MockMPGDHits". "MockTrackerHits", "MockSiliconHits" and "MockMPGDHits" carry segmentations.
+
+TEST_CASE("hasReadout reports presence without throwing", "[GeometryUtils]") {
+  const dd4hep::Detector* detector = algorithms::GeoSvc::instance().detector();
+
+  SECTION("present readouts are found") {
+    REQUIRE(eicrecon::geo::hasReadout(*detector, "MockCalorimeterHits"));
+    REQUIRE(eicrecon::geo::hasReadout(*detector, "MockTrackerHits"));
+  }
+
+  SECTION("absent readout is reported as missing, not by throwing") {
+    REQUIRE_NOTHROW(eicrecon::geo::hasReadout(*detector, "NonexistentHits"));
+    REQUIRE_FALSE(eicrecon::geo::hasReadout(*detector, "NonexistentHits"));
+  }
+}
+
+TEST_CASE("readoutIdSpec returns the descriptor or nullopt", "[GeometryUtils]") {
+  const dd4hep::Detector* detector = algorithms::GeoSvc::instance().detector();
+
+  SECTION("present readout yields a valid descriptor") {
+    const auto id_spec = eicrecon::geo::readoutIdSpec(*detector, "MockCalorimeterHits");
+    REQUIRE(id_spec.has_value());
+    // "system:8,layer:8,x:8,y:8" -> four fields
+    REQUIRE(id_spec->fields().size() == 4);
+  }
+
+  SECTION("absent readout yields nullopt without throwing") {
+    REQUIRE_NOTHROW(eicrecon::geo::readoutIdSpec(*detector, "NonexistentHits"));
+    REQUIRE_FALSE(eicrecon::geo::readoutIdSpec(*detector, "NonexistentHits").has_value());
+  }
+}
+
+TEST_CASE("readoutSegmentation returns the segmentation or nullopt", "[GeometryUtils]") {
+  const dd4hep::Detector* detector = algorithms::GeoSvc::instance().detector();
+
+  SECTION("present readout with a segmentation yields a valid segmentation") {
+    const auto segmentation = eicrecon::geo::readoutSegmentation(*detector, "MockTrackerHits");
+    REQUIRE(segmentation.has_value());
+    REQUIRE(segmentation->isValid());
+  }
+
+  SECTION("absent readout yields nullopt without throwing") {
+    REQUIRE_NOTHROW(eicrecon::geo::readoutSegmentation(*detector, "NonexistentHits"));
+    REQUIRE_FALSE(eicrecon::geo::readoutSegmentation(*detector, "NonexistentHits").has_value());
+  }
+}
+
+TEST_CASE("helpers are non-throwing where raw DD4hep lookup would throw", "[GeometryUtils]") {
+  const dd4hep::Detector* detector = algorithms::GeoSvc::instance().detector();
+
+  // Raw DD4hep lookup of an absent readout throws (this is the behavior these helpers shield):
+  REQUIRE_THROWS(detector->readout("NonexistentHits"));
+
+  // The helpers report absence instead of throwing:
+  REQUIRE_NOTHROW(eicrecon::geo::hasReadout(*detector, "NonexistentHits"));
+  REQUIRE_NOTHROW(eicrecon::geo::readoutIdSpec(*detector, "NonexistentHits"));
+  REQUIRE_NOTHROW(eicrecon::geo::readoutSegmentation(*detector, "NonexistentHits"));
+}

--- a/src/tests/algorithms_test/interfaces_GeometryUtils.cc
+++ b/src/tests/algorithms_test/interfaces_GeometryUtils.cc
@@ -71,3 +71,16 @@ TEST_CASE("helpers are non-throwing where raw DD4hep lookup would throw", "[Geom
   REQUIRE_NOTHROW(eicrecon::geo::readoutIdSpec(*detector, "NonexistentHits"));
   REQUIRE_NOTHROW(eicrecon::geo::readoutSegmentation(*detector, "NonexistentHits"));
 }
+
+TEST_CASE("missing-readout policy parser accepts supported values", "[GeometryUtils]") {
+  using eicrecon::geo::MissingReadoutPolicy;
+  using eicrecon::geo::parseMissingReadoutPolicy;
+
+  REQUIRE(parseMissingReadoutPolicy("disable") == MissingReadoutPolicy::Disable);
+  REQUIRE(parseMissingReadoutPolicy("throw") == MissingReadoutPolicy::Throw);
+  REQUIRE(parseMissingReadoutPolicy("") == MissingReadoutPolicy::Disable);
+}
+
+TEST_CASE("missing-readout policy parser rejects invalid values", "[GeometryUtils]") {
+  REQUIRE_THROWS(eicrecon::geo::parseMissingReadoutPolicy("invalid"));
+}

--- a/src/tests/algorithms_test/interfaces_GeometryUtils.cc
+++ b/src/tests/algorithms_test/interfaces_GeometryUtils.cc
@@ -6,6 +6,7 @@
 #include <DD4hep/Segmentations.h>
 #include <algorithms/geo.h>
 #include <catch2/catch_test_macros.hpp>
+#include <gsl/pointers>
 #include <optional>
 #include <string>
 


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

This PR hardens geometry-dependent reconstruction in partial/reduced geometries while preserving strict failure behavior when desired.

It introduces:
- Non-throwing geometry helpers in `src/algorithms/interfaces/GeometryUtils.h`:
  - `hasReadout(...)`
  - `readoutIdSpec(...)`
  - `readoutSegmentation(...)`
  - `parseMissingReadoutPolicy(...)` with `MissingReadoutPolicy::{Disable, Throw}`
- A configurable `missingReadoutPolicy` knob (`disable` default, `throw` optional) on readout-dependent producer configs and factory parameters.
- Producer-side handling for absent readouts in:
  - `CalorimeterHitDigi`
  - `SimCalorimeterHitProcessor`
  - `CalorimeterIslandCluster`
  - `CalorimeterHitsMerger`
  - `MPGDTrackerDigi`
  - `MPGDHitReconstruction`
  - `LGADHitClustering`
  - `SiliconChargeSharing`
  - `PulseCombiner`
  - `FarDetectorTrackerCluster`

Behavior:
- `missingReadoutPolicy=disable` (default): log a clear warning and emit empty outputs for that producer.
- `missingReadoutPolicy=throw`: raise a runtime error when the configured readout is absent.

Motivation:
- Reduced geometries legitimately omit some subdetector readouts; previously this could surface as exceptions during upstream factory creation and cascade into downstream collection omissions.
- This change distinguishes expected geometry absence from genuine algorithm failures and keeps optional-input semantics consistent.

Validation:
- `cmake --build build --target install -- -j8`
- `ctest --test-dir build -V -R '^t_algorithms_test$'`
- Reduced-geometry smoke run (`epic_craterlake_tracking_only`, 2 events, CI gun flags):
  - default policy reproduced the local baseline omission set
  - `missingReadoutPolicy=throw` propagated missing-readout failures as expected

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: N/A)
- [x] New feature (issue: N/A)
- [ ] Optimization (issue #__)
- [x] Updated parameters, constants (issue: N/A)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [x] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

Default-behavior change:
- For the affected readout-dependent producers, when a configured readout is absent in the loaded geometry, the default behavior is now to disable that producer and emit empty outputs (`missingReadoutPolicy=disable`) instead of propagating a readout lookup exception.

AI usage:
- Copilot CLI was used to implement/refactor the code changes, update tests, run local build/test/smoke validation commands, and draft this PR description.
