### PR TITLE
Allow truth seeder to work with secondary particles

### DIFF
--- a/src/algorithms/tracking/TrackParamTruthInit.cc
+++ b/src/algorithms/tracking/TrackParamTruthInit.cc
@@ -40,12 +40,6 @@ void TrackParamTruthInit::process(const Input& input, const Output& output) cons
   // Loop over input particles
   for (const auto& mcparticle : *mcparticles) {
 
-    // require generatorStatus == 1 for stable generated particles in HepMC3 and DDSim gun
-    if (mcparticle.getGeneratorStatus() != 1) {
-      trace("ignoring particle with generatorStatus = {}", mcparticle.getGeneratorStatus());
-      continue;
-    }
-
     // require close to interaction vertex
     auto v = mcparticle.getVertex();
     if (std::abs(v.x) * dd4hep::mm > m_cfg.maxVertexX ||

--- a/src/algorithms/tracking/TrackParamTruthInit.cc
+++ b/src/algorithms/tracking/TrackParamTruthInit.cc
@@ -13,13 +13,12 @@
 #include <edm4hep/Vector2f.h>
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
-#include <Eigen/Core>
 #include <cmath>
 #include <cstdlib>
-#include <gsl/pointers>
 #include <limits>
 #include <memory>
 #include <random>
+#include <tuple>
 
 #include "extensions/spdlog/SpdlogFormatters.h" // IWYU pragma: keep
 

--- a/src/algorithms/tracking/TrackParamTruthInit.cc
+++ b/src/algorithms/tracking/TrackParamTruthInit.cc
@@ -39,6 +39,14 @@ void TrackParamTruthInit::process(const Input& input, const Output& output) cons
   // Loop over input particles
   for (const auto& mcparticle : *mcparticles) {
 
+    // accept generator-stable particles (HepMC3/DDSim gun) or Geant4-produced
+    // secondaries; reject generator intermediates (partons, resonances, beams)
+    if (!(mcparticle.getGeneratorStatus() == 1 || mcparticle.getSimulatorStatus() != 0)) {
+      trace("ignoring particle with generatorStatus = {}, simulatorStatus = {}",
+            mcparticle.getGeneratorStatus(), mcparticle.getSimulatorStatus());
+      continue;
+    }
+
     // require close to interaction vertex
     auto v = mcparticle.getVertex();
     if (std::abs(v.x) * dd4hep::mm > m_cfg.maxVertexX ||


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

Should fix part 1 of #2746 - allow TruthSeeder to seed secondary particles from e.g. lambdas

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

Current setup makes B0 not working for any decay products, for which (arguably) it is intended. In our case, for example, we can't see the most of Sullivan lambdas via proton+pi- channel (which is ~75% of lambda decays that leave a trace in our detector)

### What kind of change does this PR introduce?
- [x] Bug fix (issue #2746)

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [x] This PR changes default behavior. Please describe changes below.
  Truth finder cuts 
   1. any particles with status != 1, i.e. primary particles coming from event generator.
   2. require close to interaction vertex
   3. require minimum momentum
   4. require minimum pseudorapidity
   So 1 and 2 must go and 4 probably be changed in order to start seeding secondaries. But this will probably change all pictures that use TruthSeeding and this must be especially seen in background populated frames reconstruction
- [ ] AI was used in preparing this PR. - not yet... 