### PR TITLE
fix(reco): replace dangling PODIO proxy pointer comparison in FarForwardNeutralsReconstruction

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,13 +22,4 @@ Checks: '
   -cppcoreguidelines-narrowing-conversions,
   -cppcoreguidelines-owning-memory
 '
-# Note: bugprone-dangling-handle (enabled via bugprone-*) catches dangling
-# string_view / span handles bound to temporaries, but does NOT catch the
-# pattern of storing raw pointers to PODIO proxy objects obtained from a
-# range-for loop (e.g. `push_back(&cl)` where `cl` is a by-value proxy
-# returned by the iterator).  No clang-tidy check in the versions used by
-# CI reliably catches that pattern without excessive false positives.
-# The fix is to use PODIO object IDs (podio::ObjectID / getObjectID()) for
-# identity comparisons instead of pointer identity.  See:
-# src/algorithms/reco/FarForwardNeutralsReconstruction.cc for an example.
 FormatStyle: file

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,4 +22,13 @@ Checks: '
   -cppcoreguidelines-narrowing-conversions,
   -cppcoreguidelines-owning-memory
 '
+# Note: bugprone-dangling-handle (enabled via bugprone-*) catches dangling
+# string_view / span handles bound to temporaries, but does NOT catch the
+# pattern of storing raw pointers to PODIO proxy objects obtained from a
+# range-for loop (e.g. `push_back(&cl)` where `cl` is a by-value proxy
+# returned by the iterator).  No clang-tidy check in the versions used by
+# CI reliably catches that pattern without excessive false positives.
+# The fix is to use PODIO object IDs (podio::ObjectID / getObjectID()) for
+# identity comparisons instead of pointer identity.  See:
+# src/algorithms/reco/FarForwardNeutralsReconstruction.cc for an example.
 FormatStyle: file

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,8 +172,6 @@ When making physics algorithm changes:
 
    Alternatively, store collection **indices** (`size_t`) and access via `(*collection)[idx]` at the point of use.
 
-   > **Note:** `bugprone-dangling-handle` in clang-tidy (enabled via `bugprone-*`) targets handle types such as `std::string_view` and `std::span` bound to temporaries. It does **not** catch `push_back(&proxy)` for PODIO value-proxy objects. There is no low-false-positive clang-tidy check that reliably catches this pattern; reviewers must flag it manually.
-
 ## Avoiding Dangling PODIO References in Output
 
 PODIO relations are stored as `(collectionID, index)`. If an output collection references another collection that is not written to the file, the reference becomes dangling. When adding output collections or trimming `podio:output_collections`, make sure every collection reached via relations is also included.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,32 @@ When making physics algorithm changes:
 
 2. **PODIO object keys:** Maps with PODIO objects (edm4hep, edm4eic) as keys use pointer-based default ordering. When iterating such maps, provide explicit ordering (e.g., by object ID or physics properties) to ensure reproducible results.
 
+3. **Dangling pointers to PODIO proxy objects:** PODIO collection objects (e.g. `edm4eic::Cluster`, `edm4hep::MCParticle`) are lightweight value-type proxies returned by collection iterators and `operator[]`. Their lifetime is scoped to the loop body or the expression that produced them — **they must not be stored as raw pointers** (`&cl`, `push_back(&cl)`) for use after the enclosing scope ends.
+
+   The canonical failure pattern is:
+   ```cpp
+   std::vector<const edm4eic::Cluster*> used;
+   for (const auto& cl : *clusters) {   // cl is a temporary proxy
+       used.push_back(&cl);             // ← stores dangling address after loop body
+   }
+   // used[i] is now a dangling pointer — UB, non-deterministic in MT
+   if (used[i] == &other_cl) { ... }   // ← pointer identity on dangling ptr
+   ```
+
+   **Fix:** use `podio::ObjectID` for stable identity:
+   ```cpp
+   #include <podio/ObjectID.h>
+   std::vector<podio::ObjectID> used;
+   for (const auto& cl : *clusters) {
+       used.push_back(cl.getObjectID());   // value-stable across loop iterations
+   }
+   // compare with cl.getObjectID() == id
+   ```
+
+   Alternatively, store collection **indices** (`size_t`) and access via `(*collection)[idx]` at the point of use.
+
+   > **Note:** `bugprone-dangling-handle` in clang-tidy (enabled via `bugprone-*`) targets handle types such as `std::string_view` and `std::span` bound to temporaries. It does **not** catch `push_back(&proxy)` for PODIO value-proxy objects. There is no low-false-positive clang-tidy check that reliably catches this pattern; reviewers must flag it manually.
+
 ## Avoiding Dangling PODIO References in Output
 
 PODIO relations are stored as `(collectionID, index)`. If an output collection references another collection that is not written to the file, the reference becomes dangling. When adding output collections or trimming `podio:output_collections`, make sure every collection reached via relations is also included.

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
@@ -197,8 +197,9 @@ int FarForwardNeutralsReconstruction::processNeutralCalo(
     }
   }
 
-  if (!canDetectNeutrons)
+  if (!canDetectNeutrons) {
     return 0;
+  }
 
   double En_raw = 0.0;
   edm4hep::Vector3f n_pos{0, 0, 0};

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
@@ -165,12 +165,7 @@ int FarForwardNeutralsReconstruction::processNeutralCalo(
   // gammaMode == None => nothing
   auto is_used_as_gamma = [&](const edm4eic::Cluster& cl) {
     const auto id = cl.getObjectID();
-    for (const auto& gid : gamma_used) {
-      if (gid == id) {
-        return true;
-      }
-    }
-    return false;
+    return std::ranges::any_of(gamma_used, [&](const auto& gid) { return gid == id; });
   };
 
   // Neutron cluster bookkeeping uses collection indices to avoid dangling

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
@@ -6,6 +6,7 @@
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
+#include <podio/ObjectID.h>
 #include <stddef.h>
 #include <algorithm>
 #include <cmath>
@@ -108,7 +109,9 @@ int FarForwardNeutralsReconstruction::processNeutralCalo(
     rec.addToClusters(cl);
   };
 
-  std::vector<const edm4eic::Cluster*> gamma_used;
+  // Use ObjectIDs rather than raw pointers to avoid dangling references to
+  // PODIO proxy objects whose lifetime is tied to the range-for loop body.
+  std::vector<podio::ObjectID> gamma_used;
   gamma_used.reserve(clusters->size());
 
   // gammaMode == LeaderOnly
@@ -140,7 +143,7 @@ int FarForwardNeutralsReconstruction::processNeutralCalo(
     for (size_t k = 0; k < std::min(Nkeep, idx.size()); ++k) {
       const auto& cl = (*clusters)[idx[k]];
       makeGamma(cl);
-      gamma_used.push_back(&cl);
+      gamma_used.push_back(cl.getObjectID());
     }
 
   }
@@ -153,28 +156,31 @@ int FarForwardNeutralsReconstruction::processNeutralCalo(
         continue;
       if (isGamma(cl)) {
         makeGamma(cl);
-        gamma_used.push_back(&cl);
+        gamma_used.push_back(cl.getObjectID());
       }
     }
   }
 
   // gammaMode == None => nothing
   auto is_used_as_gamma = [&](const edm4eic::Cluster& cl) {
-    for (auto* p : gamma_used)
-      if (p == &cl)
+    const auto id = cl.getObjectID();
+    for (const auto& gid : gamma_used)
+      if (gid == id)
         return true;
     return false;
   };
 
-  // neutrons from clusters
-  const edm4eic::Cluster* leaderN = nullptr;
-  double E_leader                 = -1.0;
+  // Neutron cluster bookkeeping uses collection indices to avoid dangling
+  // pointers to PODIO proxy objects that expire at each loop-body end.
+  size_t leaderN_idx = clusters->size(); // sentinel: no leader yet
+  double E_leader    = -1.0;
 
   double E_sum = 0.0;
-  std::vector<const edm4eic::Cluster*> kept;
+  std::vector<size_t> kept;
   kept.reserve(clusters->size());
 
-  for (const auto& cl : *clusters) {
+  for (size_t i = 0; i < clusters->size(); ++i) {
+    const auto& cl = (*clusters)[i];
     if (gammaMode != GammaMode::None && is_used_as_gamma(cl))
       continue;
 
@@ -183,11 +189,11 @@ int FarForwardNeutralsReconstruction::processNeutralCalo(
       continue;
 
     E_sum += E;
-    kept.push_back(&cl);
+    kept.push_back(i);
 
     if (E > E_leader) {
-      E_leader = E;
-      leaderN  = &cl;
+      E_leader    = E;
+      leaderN_idx = i;
     }
   }
 
@@ -198,20 +204,20 @@ int FarForwardNeutralsReconstruction::processNeutralCalo(
   edm4hep::Vector3f n_pos{0, 0, 0};
 
   if (neutronMode == NeutronMode::LeaderOnly) {
-    if (!leaderN || E_leader <= 0.0)
+    if (leaderN_idx >= clusters->size() || E_leader <= 0.0)
       return 0;
     En_raw = E_leader;
-    n_pos  = leaderN->getPosition();
+    n_pos  = (*clusters)[leaderN_idx].getPosition();
 
     kept.clear();
-    kept.push_back(leaderN);
+    kept.push_back(leaderN_idx);
   } else if (neutronMode == NeutronMode::SumAll) {
     if (E_sum <= 0.0 || kept.empty())
       return 0;
     En_raw = E_sum;
-    if (!leaderN || E_leader <= 0.0)
+    if (leaderN_idx >= clusters->size() || E_leader <= 0.0)
       return 0;
-    n_pos = leaderN->getPosition();
+    n_pos = (*clusters)[leaderN_idx].getPosition();
   } else {
     return 0;
   }
@@ -236,8 +242,8 @@ int FarForwardNeutralsReconstruction::processNeutralCalo(
     for (const auto& cl : *clusters)
       rec.addToClusters(cl);
   } else {
-    for (auto* clp : kept)
-      rec.addToClusters(*clp);
+    for (size_t idx : kept)
+      rec.addToClusters((*clusters)[idx]);
   }
 
   return 1;

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
@@ -164,10 +164,11 @@ int FarForwardNeutralsReconstruction::processNeutralCalo(
   // gammaMode == None => nothing
   auto is_used_as_gamma = [&](const edm4eic::Cluster& cl) {
     const auto id = cl.getObjectID();
-    for (const auto& gid : gamma_used)
+    for (const auto& gid : gamma_used) {
       if (gid == id) {
         return true;
       }
+}
     return false;
   };
 

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
@@ -152,8 +152,9 @@ int FarForwardNeutralsReconstruction::processNeutralCalo(
   else if (gammaMode == GammaMode::AllPassing) {
     for (const auto& cl : *clusters) {
       const double E = cl.getEnergy();
-      if (E < clusterEmin)
+      if (E < clusterEmin) {
         continue;
+      }
       if (isGamma(cl)) {
         makeGamma(cl);
         gamma_used.push_back(cl.getObjectID());
@@ -188,8 +189,9 @@ int FarForwardNeutralsReconstruction::processNeutralCalo(
     }
 
     const double E = cl.getEnergy();
-    if (E < clusterEmin)
+    if (E < clusterEmin) {
       continue;
+    }
 
     E_sum += E;
     kept.push_back(i);

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
@@ -168,7 +168,7 @@ int FarForwardNeutralsReconstruction::processNeutralCalo(
       if (gid == id) {
         return true;
       }
-}
+    }
     return false;
   };
 

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
@@ -7,7 +7,7 @@
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <podio/ObjectID.h>
-#include <stddef.h>
+#include <cstddef>
 #include <algorithm>
 #include <cmath>
 #include <stdexcept>

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
@@ -167,7 +167,7 @@ int FarForwardNeutralsReconstruction::processNeutralCalo(
     for (const auto& gid : gamma_used)
       if (gid == id) {
         return true;
-}
+      }
     return false;
   };
 
@@ -184,7 +184,7 @@ int FarForwardNeutralsReconstruction::processNeutralCalo(
     const auto& cl = (*clusters)[i];
     if (gammaMode != GammaMode::None && is_used_as_gamma(cl)) {
       continue;
-}
+    }
 
     const double E = cl.getEnergy();
     if (E < clusterEmin)
@@ -208,7 +208,7 @@ int FarForwardNeutralsReconstruction::processNeutralCalo(
   if (neutronMode == NeutronMode::LeaderOnly) {
     if (leaderN_idx >= clusters->size() || E_leader <= 0.0) {
       return 0;
-}
+    }
     En_raw = E_leader;
     n_pos  = (*clusters)[leaderN_idx].getPosition();
 
@@ -217,7 +217,7 @@ int FarForwardNeutralsReconstruction::processNeutralCalo(
   } else if (neutronMode == NeutronMode::SumAll) {
     if (E_sum <= 0.0 || kept.empty()) {
       return 0;
-}
+    }
     En_raw = E_sum;
     if (leaderN_idx >= clusters->size() || E_leader <= 0.0)
       return 0;
@@ -245,7 +245,7 @@ int FarForwardNeutralsReconstruction::processNeutralCalo(
   if (associateAllClustersToNeutron) {
     for (const auto& cl : *clusters) {
       rec.addToClusters(cl);
-}
+    }
   } else {
     for (size_t idx : kept)
       rec.addToClusters((*clusters)[idx]);

--- a/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
+++ b/src/algorithms/reco/FarForwardNeutralsReconstruction.cc
@@ -165,8 +165,9 @@ int FarForwardNeutralsReconstruction::processNeutralCalo(
   auto is_used_as_gamma = [&](const edm4eic::Cluster& cl) {
     const auto id = cl.getObjectID();
     for (const auto& gid : gamma_used)
-      if (gid == id)
+      if (gid == id) {
         return true;
+}
     return false;
   };
 
@@ -181,8 +182,9 @@ int FarForwardNeutralsReconstruction::processNeutralCalo(
 
   for (size_t i = 0; i < clusters->size(); ++i) {
     const auto& cl = (*clusters)[i];
-    if (gammaMode != GammaMode::None && is_used_as_gamma(cl))
+    if (gammaMode != GammaMode::None && is_used_as_gamma(cl)) {
       continue;
+}
 
     const double E = cl.getEnergy();
     if (E < clusterEmin)
@@ -204,16 +206,18 @@ int FarForwardNeutralsReconstruction::processNeutralCalo(
   edm4hep::Vector3f n_pos{0, 0, 0};
 
   if (neutronMode == NeutronMode::LeaderOnly) {
-    if (leaderN_idx >= clusters->size() || E_leader <= 0.0)
+    if (leaderN_idx >= clusters->size() || E_leader <= 0.0) {
       return 0;
+}
     En_raw = E_leader;
     n_pos  = (*clusters)[leaderN_idx].getPosition();
 
     kept.clear();
     kept.push_back(leaderN_idx);
   } else if (neutronMode == NeutronMode::SumAll) {
-    if (E_sum <= 0.0 || kept.empty())
+    if (E_sum <= 0.0 || kept.empty()) {
       return 0;
+}
     En_raw = E_sum;
     if (leaderN_idx >= clusters->size() || E_leader <= 0.0)
       return 0;
@@ -239,8 +243,9 @@ int FarForwardNeutralsReconstruction::processNeutralCalo(
   rec.setReferencePoint(n_pos);
 
   if (associateAllClustersToNeutron) {
-    for (const auto& cl : *clusters)
+    for (const auto& cl : *clusters) {
       rec.addToClusters(cl);
+}
   } else {
     for (size_t idx : kept)
       rec.addToClusters((*clusters)[idx]);


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

Fixes a multithreaded non-reproducibility bug in `FarForwardNeutralsReconstruction`. In `processNeutralCalo`, raw pointers to PODIO proxy objects were stored in `gamma_used`, `kept`, and `leaderN` after the loop body in which the proxies were created. PODIO proxy objects (e.g. `edm4eic::Cluster`) are temporary value-type wrappers returned by the collection iterator; their lifetime ends at the loop-body boundary. Storing `&cl` and later comparing pointer identity is undefined behaviour and non-deterministic across threads.

Symptom observed in CI job https://github.com/eic/EICrecon/actions/runs/30384180668/job/90427680928#step:5:1011: `ReconstructedHcalFarForwardZDCNeutrals` produced `[PDG=22, PDG=2112]` in single-thread mode but only `[PDG=22]` in multi-thread mode, with downstream effects on `ReconstructedLambdas` and `ReconstructedLambdaDecayProductsCM`.

**Fix:**
- `gamma_used`: `std::vector<const Cluster*>` → `std::vector<podio::ObjectID>`; store `cl.getObjectID()` and compare with `==`.
- `kept` / `leaderN`: raw pointers → `std::vector<size_t>` / `size_t` collection indices; access via `(*clusters)[idx]` at point of use.

Also adds item 3 to the "Code Review Guidelines for Reproducibility" section of `AGENTS.md` documenting the pattern and the fix.

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

Causes non-reproducible physics output between single-thread and multi-thread runs. The neutron candidate in the ZDC is silently dropped in MT mode.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [x] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

GitHub Copilot (Claude Sonnet 4.6) identified the root cause and implemented the fix.
