### PR TITLE
fix: stabilize tracker digi raw hit ordering

### DIFF
--- a/src/algorithms/digi/MPGDTrackerDigi.cc
+++ b/src/algorithms/digi/MPGDTrackerDigi.cc
@@ -401,7 +401,7 @@ void MPGDTrackerDigi::process(const MPGDTrackerDigi::Input& input,
     for (const auto& [cell_id, hit] : cell_hit_map) {
       ordered_cell_ids.push_back(cell_id);
     }
-    std::sort(ordered_cell_ids.begin(), ordered_cell_ids.end());
+    std::ranges::sort(ordered_cell_ids);
 
     for (const auto stripID : ordered_cell_ids) {
       const auto& hit = cell_hit_map.at(stripID);

--- a/src/algorithms/digi/MPGDTrackerDigi.cc
+++ b/src/algorithms/digi/MPGDTrackerDigi.cc
@@ -406,7 +406,8 @@ void MPGDTrackerDigi::process(const MPGDTrackerDigi::Input& input,
     for (const auto stripID : ordered_cell_ids) {
       const auto& hit = cell_hit_map.at(stripID);
       raw_hits->push_back(hit);
-      const auto is = stripID2cIDs.find(stripID);
+      const auto raw_hit = raw_hits->at(raw_hits->size() - 1);
+      const auto is      = stripID2cIDs.find(stripID);
       if (is == stripID2cIDs.end()) {
         error(R"(Inconsistency: CellID {:x} not found in "stripID2cIDs" map)", stripID);
         throw std::runtime_error(R"(Inconsistency in the handling of "stripID2cIDs" map)");
@@ -417,13 +418,13 @@ void MPGDTrackerDigi::process(const MPGDTrackerDigi::Input& input,
           if (sim_hit.getCellID() == cID) {
             // create link
             auto link = links->create();
-            link.setFrom(hit);
+            link.setFrom(raw_hit);
             link.setTo(sim_hit);
             link.setWeight(1.0);
             // set association
             auto hitassoc = associations->create();
             hitassoc.setWeight(1.0);
-            hitassoc.setRawHit(hit);
+            hitassoc.setRawHit(raw_hit);
             hitassoc.setSimHit(sim_hit);
           }
         }

--- a/src/algorithms/digi/MPGDTrackerDigi.cc
+++ b/src/algorithms/digi/MPGDTrackerDigi.cc
@@ -396,10 +396,17 @@ void MPGDTrackerDigi::process(const MPGDTrackerDigi::Input& input,
 
   // ***** RawHit INSTANTIATION AND RawHit<-SimHits ASSOCIATION:
   for (auto& cell_hit_map : cell_hit_maps) {
-    for (auto item : cell_hit_map) {
-      raw_hits->push_back(item.second);
-      CellID stripID = item.first;
-      const auto is  = stripID2cIDs.find(stripID);
+    std::vector<std::uint64_t> ordered_cell_ids;
+    ordered_cell_ids.reserve(cell_hit_map.size());
+    for (const auto& [cell_id, hit] : cell_hit_map) {
+      ordered_cell_ids.push_back(cell_id);
+    }
+    std::sort(ordered_cell_ids.begin(), ordered_cell_ids.end());
+
+    for (const auto stripID : ordered_cell_ids) {
+      const auto& hit = cell_hit_map.at(stripID);
+      raw_hits->push_back(hit);
+      const auto is = stripID2cIDs.find(stripID);
       if (is == stripID2cIDs.end()) {
         error(R"(Inconsistency: CellID {:x} not found in "stripID2cIDs" map)", stripID);
         throw std::runtime_error(R"(Inconsistency in the handling of "stripID2cIDs" map)");
@@ -410,13 +417,13 @@ void MPGDTrackerDigi::process(const MPGDTrackerDigi::Input& input,
           if (sim_hit.getCellID() == cID) {
             // create link
             auto link = links->create();
-            link.setFrom(item.second);
+            link.setFrom(hit);
             link.setTo(sim_hit);
             link.setWeight(1.0);
             // set association
             auto hitassoc = associations->create();
             hitassoc.setWeight(1.0);
-            hitassoc.setRawHit(item.second);
+            hitassoc.setRawHit(hit);
             hitassoc.setSimHit(sim_hit);
           }
         }

--- a/src/algorithms/digi/SiliconTrackerDigi.cc
+++ b/src/algorithms/digi/SiliconTrackerDigi.cc
@@ -100,7 +100,7 @@ void SiliconTrackerDigi::process(const SiliconTrackerDigi::Input& input,
       if (cell_id == sim_hit.getCellID()) {
         // create link
         auto link = links->create();
-        link.setFrom(hit);
+        link.setFrom(raw_hit);
         link.setTo(sim_hit);
         link.setWeight(1.0);
         // set association

--- a/src/algorithms/digi/SiliconTrackerDigi.cc
+++ b/src/algorithms/digi/SiliconTrackerDigi.cc
@@ -15,6 +15,7 @@
 #include <tuple>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include "SiliconTrackerDigi.h"
 #include "algorithms/digi/SiliconTrackerDigiConfig.h"
@@ -83,15 +84,23 @@ void SiliconTrackerDigi::process(const SiliconTrackerDigi::Input& input,
     }
   }
 
-  for (auto item : cell_hit_map) {
-    raw_hits->push_back(item.second);
+  std::vector<std::uint64_t> ordered_cell_ids;
+  ordered_cell_ids.reserve(cell_hit_map.size());
+  for (const auto& [cell_id, hit] : cell_hit_map) {
+    ordered_cell_ids.push_back(cell_id);
+  }
+  std::sort(ordered_cell_ids.begin(), ordered_cell_ids.end());
+
+  for (const auto cell_id : ordered_cell_ids) {
+    const auto& hit = cell_hit_map.at(cell_id);
+    raw_hits->push_back(hit);
     auto raw_hit = raw_hits->at(raw_hits->size() - 1);
 
     for (const auto& sim_hit : *sim_hits) {
-      if (item.first == sim_hit.getCellID()) {
+      if (cell_id == sim_hit.getCellID()) {
         // create link
         auto link = links->create();
-        link.setFrom(item.second);
+        link.setFrom(hit);
         link.setTo(sim_hit);
         link.setWeight(1.0);
         // set association

--- a/src/algorithms/digi/SiliconTrackerDigi.cc
+++ b/src/algorithms/digi/SiliconTrackerDigi.cc
@@ -89,7 +89,7 @@ void SiliconTrackerDigi::process(const SiliconTrackerDigi::Input& input,
   for (const auto& [cell_id, hit] : cell_hit_map) {
     ordered_cell_ids.push_back(cell_id);
   }
-  std::sort(ordered_cell_ids.begin(), ordered_cell_ids.end());
+  std::ranges::sort(ordered_cell_ids);
 
   for (const auto cell_id : ordered_cell_ids) {
     const auto& hit = cell_hit_map.at(cell_id);


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR makes raw-hit emission deterministic in `SiliconTrackerDigi` and `MPGDTrackerDigi` by preserving the existing `unordered_map`-based hit aggregation and sorting the final output cell IDs in ascending order before emitting raw hits, links, and associations.

This addresses one specific MT reproducibility issue in tracking digitization, but it is **not sufficient by itself to resolve all determinism issues** in the broader CKF unfiltered path. Additional nondeterministic ordering or aggregation points may still exist elsewhere in the chain.

Computationally, the change adds a sort over the unique output cell IDs after aggregation. That changes the final emission step from hash-iteration order to `O(N log N)` ordering over the number of unique cells, while leaving the main accumulation logic unchanged. Expected impact is small because the extra work is limited to the already-reduced set of unique output channels per event.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

AI was used to inspect the two digi algorithms, implement the minimal deterministic-ordering fix, run a targeted build/test in the EIC container environment, and draft this PR description.
