### PR TITLE
fix: sort space points before Acts seeding to ensure MT reproducibility

### DIFF
--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -102,8 +102,8 @@ void TrackSeeding::process(const Input& input, const Output& output) const {
 
   std::vector<const eicrecon::SpacePoint*> spacePoints = getSpacePoints(*trk_hits);
   std::stable_sort(spacePoints.begin(), spacePoints.end(), [](const auto* lhs, const auto* rhs) {
-    const auto lhsPositionKey = std::tuple{lhs->r(), lhs->phi(), lhs->z(), lhs->x(), lhs->y()};
-    const auto rhsPositionKey = std::tuple{rhs->r(), rhs->phi(), rhs->z(), rhs->x(), rhs->y()};
+    const auto lhsPositionKey = std::tuple{lhs->r(), lhs->z(), lhs->x(), lhs->y()};
+    const auto rhsPositionKey = std::tuple{rhs->r(), rhs->z(), rhs->x(), rhs->y()};
     if (lhsPositionKey != rhsPositionKey) {
       return lhsPositionKey < rhsPositionKey;
     }

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <compare>
 #include <limits>
 #include <tuple>
 

--- a/src/algorithms/tracking/TrackSeeding.cc
+++ b/src/algorithms/tracking/TrackSeeding.cc
@@ -24,6 +24,7 @@
 #include <edm4hep/Vector3f.h>
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <limits>
@@ -100,6 +101,17 @@ void TrackSeeding::process(const Input& input, const Output& output) const {
   auto [trk_seeds, trk_params] = output;
 
   std::vector<const eicrecon::SpacePoint*> spacePoints = getSpacePoints(*trk_hits);
+  std::stable_sort(spacePoints.begin(), spacePoints.end(), [](const auto* lhs, const auto* rhs) {
+    const auto lhsPositionKey = std::tuple{lhs->r(), lhs->phi(), lhs->z(), lhs->x(), lhs->y()};
+    const auto rhsPositionKey = std::tuple{rhs->r(), rhs->phi(), rhs->z(), rhs->x(), rhs->y()};
+    if (lhsPositionKey != rhsPositionKey) {
+      return lhsPositionKey < rhsPositionKey;
+    }
+
+    const auto lhsId = lhs->getObjectID();
+    const auto rhsId = rhs->getObjectID();
+    return std::tie(lhsId.collectionID, lhsId.index) < std::tie(rhsId.collectionID, rhsId.index);
+  });
 
   Acts::SeedFinderOrthogonal<proxy_type> finder(m_seedFinderConfig); // FIXME move into class scope
 


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This introduces a deterministic pre-sort of `spacePoints` in `TrackSeeding::process` before constructing the Acts space-point container and calling `Acts::SeedFinderOrthogonal`.

The sort is `std::stable_sort` with lexicographic key `(r, phi, z, x, y)` and a final `ObjectID(collectionID, index)` tie-breaker for exact coordinate ties. This canonicalizes seeding input order across runs.

Motivation/background:
- `compare-single-multi-threaded` investigations showed ~1 ULP ST/MT differences in `CentralCKFTracksUnfiltered` / `CentralCKFTrackParametersUnfiltered` due to ordering sensitivity in the seed/track chain.
- `Acts::SeedFinderOrthogonal` uses KDTree internals whose split behavior (`std::partition`) can be input-order sensitive for near-equal coordinates.
- This is a defense-in-depth layer on top of the SiliconTrackerDigi/MPGDTrackerDigi deterministic ordering fix (`wdconinc-fix-digi-determinism`, commit `cc20d099e`).
- A principled upstream ACTS/KDTree fix is being tracked separately.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

AI usage: assisted with implementing the deterministic stable sort, preparing commit/PR text, and running targeted local build/configuration checks.