### PR TITLE
docs(ai): clarify upstream branch policy for CI reliability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ EICrecon is a JANA2-based reconstruction software for the ePIC detector.
 
 ### PR Branch Hosting Policy
 
-Prefer pushing feature branches to the upstream `eic/EICrecon` remote and opening PRs from those upstream-hosted branches. Avoid fork-based PR branches by default, because CI execution reliability depends on upstream-hosted branches.
+If pull requests need to be opened, prefer pushing feature branches to the upstream `eic/EICrecon` remote and opening PRs from those upstream-hosted branches. Avoid fork-based PR branches by default, because CI execution reliability depends on upstream-hosted branches.
 
 ### Essential Setup: Use eic-shell Environment
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@ EICrecon is a JANA2-based reconstruction software for the ePIC detector.
 
 ## Working Effectively with EICrecon
 
+### PR Branch Hosting Policy
+
+Prefer pushing feature branches to the upstream `eic/EICrecon` remote and opening PRs from those upstream-hosted branches. Avoid fork-based PR branches by default, because CI execution reliability depends on upstream-hosted branches.
+
 ### Essential Setup: Use eic-shell Environment
 
 **Bootstrap the eic-shell environment:**


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
Adds a short policy section to `AGENTS.md` stating that feature branches should be pushed to the upstream `eic/EICrecon` remote and fork-based PR branches should be avoided by default, since CI reliability depends on upstream-hosted branches.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ ] Medium
- [x] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [x] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

AI usage: Copilot CLI drafted and applied the instruction text update in `AGENTS.md` and prepared this PR description.