### PR TITLE
bugfix: Imaging cluster phi calculation

### DIFF
--- a/src/algorithms/calorimetry/ImagingClusterReco.cc
+++ b/src/algorithms/calorimetry/ImagingClusterReco.cc
@@ -161,7 +161,8 @@ ImagingClusterReco::reconstruct_cluster(const edm4eic::ProtoCluster& pcl) const 
   double time        = 0.;
   double timeError   = 0.;
   double meta        = 0.;
-  double mphi        = 0.;
+  double mx          = 0.;
+  double my          = 0.;
   double r           = 9999 * dd4hep::cm;
   for (unsigned i = 0; i < hits.size(); ++i) {
     const auto& hit    = hits[i];
@@ -173,7 +174,8 @@ ImagingClusterReco::reconstruct_cluster(const edm4eic::ProtoCluster& pcl) const 
     time += hit.getTime() * energyWeight;
     timeError += std::pow(hit.getTimeError() * energyWeight, 2);
     meta += edm4hep::utils::eta(hit.getPosition()) * energyWeight;
-    mphi += edm4hep::utils::angleAzimuthal(hit.getPosition()) * energyWeight;
+    mx += hit.getPosition().x * energyWeight;
+    my += hit.getPosition().y * energyWeight;
     r = std::min(edm4hep::utils::magnitude(hit.getPosition()), r);
     cluster.addToHits(hit);
   }
@@ -182,8 +184,9 @@ ImagingClusterReco::reconstruct_cluster(const edm4eic::ProtoCluster& pcl) const 
   cluster.setTime(time / energy);
   cluster.setTimeError(std::sqrt(timeError) / energy);
   cluster.setNhits(hits.size());
-  cluster.setPosition(edm4hep::utils::sphericalToVector(
-      r, edm4hep::utils::etaToAngle(meta / energy), mphi / energy));
+  cluster.setPosition(
+      edm4hep::utils::sphericalToVector(r, edm4hep::utils::etaToAngle(meta / energy),
+                                        (mx != 0. || my != 0.) ? std::atan2(my, mx) : 0.));
 
   // Shape parameters are calculated separately by CalorimeterClusterShape algorithm
 


### PR DESCRIPTION
This PR fixes an issue with Imaging cluster reconstruction which returned a buggy value for clusters whose hit constituents spanned the phi = +pi -> -pi wraparound. Discussed briefly in this Mattermost thread: https://chat.epic-eic.org/main/pl/3d5g4tq9k7f8iqfsr4yq478iky and then in Issue 2803 referenced below.

### What is the urgency of this PR?
- [x] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #2803) https://github.com/eic/EICrecon/issues/2803 

### Please check if any of the following apply
- [x] This PR changes default behavior. The Imaging cluster phi will now be determined based on the energy-weighted cluster (x,y) coordinates.
- [x] AI was used in preparing this PR. I noticed this issue from diagnostic plots made while exploring the data using Claude Code, then used Claude Code to track down the source of the problem and discuss possible solutions.