### PR TITLE
fix: use std::map for deterministic digi raw hit ordering

### DIFF
--- a/src/algorithms/digi/MPGDTrackerDigi.cc
+++ b/src/algorithms/digi/MPGDTrackerDigi.cc
@@ -133,7 +133,6 @@
 #include <random>
 #include <stdexcept>
 #include <tuple>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -251,7 +250,7 @@ void MPGDTrackerDigi::process(const MPGDTrackerDigi::Input& input,
   std::normal_distribution<double> gaussian;
 
   // Maps of unique cellIDs with temporary structure RawHit
-  std::unordered_map<std::uint64_t, edm4eic::MutableRawTrackerHit> cell_hit_maps[2];
+  std::map<std::uint64_t, edm4eic::MutableRawTrackerHit> cell_hit_maps[2];
   // A map of strip cellIDs with vector of contributing cellIDs
   std::map<std::uint64_t, std::vector<std::uint64_t>> stripID2cIDs;
   // Prepare for strip segmentation
@@ -354,7 +353,7 @@ void MPGDTrackerDigi::process(const MPGDTrackerDigi::Input& input,
       // ***** APPLY THRESHOLD / STORE (sim_hit -> stripIDs) / ACCUMULATION
       // (Note: Threshold is applied first. See issue #1722 in
       // "https://github.com/eic/EICrecon/issues/1722".)
-      std::unordered_map<std::uint64_t, edm4eic::MutableRawTrackerHit>& cell_hit_map =
+      std::map<std::uint64_t, edm4eic::MutableRawTrackerHit>& cell_hit_map =
           gsl::at(cell_hit_maps, pn);
       double g = m_cfg.gain;
       for (auto clusterHit : cluster) {
@@ -396,10 +395,10 @@ void MPGDTrackerDigi::process(const MPGDTrackerDigi::Input& input,
 
   // ***** RawHit INSTANTIATION AND RawHit<-SimHits ASSOCIATION:
   for (auto& cell_hit_map : cell_hit_maps) {
-    for (auto item : cell_hit_map) {
-      raw_hits->push_back(item.second);
-      CellID stripID = item.first;
-      const auto is  = stripID2cIDs.find(stripID);
+    for (const auto& [stripID, hit] : cell_hit_map) {
+      raw_hits->push_back(hit);
+      const auto raw_hit = raw_hits->at(raw_hits->size() - 1);
+      const auto is      = stripID2cIDs.find(stripID);
       if (is == stripID2cIDs.end()) {
         error(R"(Inconsistency: CellID {:x} not found in "stripID2cIDs" map)", stripID);
         throw std::runtime_error(R"(Inconsistency in the handling of "stripID2cIDs" map)");
@@ -410,13 +409,13 @@ void MPGDTrackerDigi::process(const MPGDTrackerDigi::Input& input,
           if (sim_hit.getCellID() == cID) {
             // create link
             auto link = links->create();
-            link.setFrom(item.second);
+            link.setFrom(raw_hit);
             link.setTo(sim_hit);
             link.setWeight(1.0);
             // set association
             auto hitassoc = associations->create();
             hitassoc.setWeight(1.0);
-            hitassoc.setRawHit(item.second);
+            hitassoc.setRawHit(raw_hit);
             hitassoc.setSimHit(sim_hit);
           }
         }

--- a/src/algorithms/digi/SiliconTrackerDigi.cc
+++ b/src/algorithms/digi/SiliconTrackerDigi.cc
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <random>
 #include <tuple>

--- a/src/algorithms/digi/SiliconTrackerDigi.cc
+++ b/src/algorithms/digi/SiliconTrackerDigi.cc
@@ -13,7 +13,6 @@
 #include <memory>
 #include <random>
 #include <tuple>
-#include <unordered_map>
 #include <utility>
 
 #include "SiliconTrackerDigi.h"
@@ -35,7 +34,7 @@ void SiliconTrackerDigi::process(const SiliconTrackerDigi::Input& input,
   std::normal_distribution<double> gaussian;
 
   // A map of unique cellIDs with temporary structure RawHit
-  std::unordered_map<std::uint64_t, edm4eic::MutableRawTrackerHit> cell_hit_map;
+  std::map<std::uint64_t, edm4eic::MutableRawTrackerHit> cell_hit_map;
 
   for (const auto& sim_hit : *sim_hits) {
 
@@ -83,15 +82,15 @@ void SiliconTrackerDigi::process(const SiliconTrackerDigi::Input& input,
     }
   }
 
-  for (auto item : cell_hit_map) {
-    raw_hits->push_back(item.second);
+  for (const auto& [cell_id, hit] : cell_hit_map) {
+    raw_hits->push_back(hit);
     auto raw_hit = raw_hits->at(raw_hits->size() - 1);
 
     for (const auto& sim_hit : *sim_hits) {
-      if (item.first == sim_hit.getCellID()) {
+      if (cell_id == sim_hit.getCellID()) {
         // create link
         auto link = links->create();
-        link.setFrom(item.second);
+        link.setFrom(raw_hit);
         link.setTo(sim_hit);
         link.setWeight(1.0);
         // set association


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

Alternative to #2805: make raw-hit emission deterministic in `SiliconTrackerDigi` and `MPGDTrackerDigi` by replacing `std::unordered_map` with `std::map`. Because `std::map` iterates in ascending key order, the output ordering is deterministic with no extra code — only a one-word change at the declaration site.

**Comparison with #2805 (explicit sort approach)**

| Aspect | This PR (`std::map`) | #2805 (`unordered_map` + sort) |
|---|---|---|
| Code change | 1-word type change; removes `#include <unordered_map>` | Extra vector, populate loop, `std::ranges::sort` |
| Accumulation cost | O(log M) per insert/lookup | O(1) average per insert/lookup |
| Sort cost | None — order is intrinsic | O(M log M) separate pass |
| Overall (N hits, M unique cells) | O(N log M) | O(N) + O(M log M) |
| Readability | Intent expressed in type | Intent expressed in separate algorithm |
| Correctness risk | Lower — no extra loop, no index math | Slightly higher surface area |

In practice M ≤ N and for typical tracking events M ≈ N (few cells merge), so the complexities are equivalent. The `std::map` approach is favoured here because:
- It is a smaller, more readable diff.
- The ordering invariant is carried by the type, not by an auxiliary algorithm.
- There is no extra heap allocation (the intermediate `vector` in #2805 is gone).

The only scenario where `unordered_map` + explicit sort would be strictly faster is when M ≪ N (heavy merging), because accumulation stays O(1) and you pay only O(M log M) at the very end. That is not the typical case for digitization, but if profiling ever shows it matters, the other approach is available.

Both PRs also fix the pre-existing bug where links/associations referenced the temporary map value instead of the persisted `RawTrackerHit` object in the output collection.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

AI was used to inspect the two digi algorithms, implement the minimal `std::map` alternative fix, and draft this PR description including the comparative tradeoff table.
