### PR TITLE
tsan.supp: ignore TSAN false-positive for lgamma in std::poisson_distribution

### DIFF
--- a/.github/tsan.supp
+++ b/.github/tsan.supp
@@ -1,6 +1,6 @@
 # https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
 
-# std::lgamma is not thread-safe but used in thread-safe way by std::binomial_distribution
+# std::lgamma is not thread-safe but used in thread-safe way in stdlib's bits/random.tcc
 race:std::binomial_distribution<int>::param_type::_M_initialize
 race:std::binomial_distribution<int>::operator()
 race:std::poisson_distribution<unsigned long>::param_type::_M_initialize

--- a/.github/tsan.supp
+++ b/.github/tsan.supp
@@ -3,6 +3,8 @@
 # std::lgamma is not thread-safe but used in thread-safe way by std::binomial_distribution
 race:std::binomial_distribution<int>::param_type::_M_initialize
 race:std::binomial_distribution<int>::operator()
+race:std::poisson_distribution<unsigned long>::param_type::_M_initialize
+race:std::poisson_distribution<unsigned long>::operator()
 
 # false positives in RNTuple reads, https://github.com/root-project/root/issues/22153
 race:ROOT::Internal::RCluster


### PR DESCRIPTION
Same motivation from https://github.com/eic/EICrecon/commit/54bf5bdc29c514d64c6aa1219223479360a1864c applies

### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

Adds an addition TSAN exception

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix Closes: #2831
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
