### PR TITLE
hotfix: suppress leaky TGeoTessellated::BuildBVH

### DIFF
--- a/.github/lsan.supp
+++ b/.github/lsan.supp
@@ -9,3 +9,4 @@ leak:libCling.so
 leak:libCore.so
 leak:libonnxruntime.so
 leak:ROOT::new_ROOTcLcLRNTuple
+leak:TGeoTessellated::BuildBVH


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR suppresses a new LSAN error that has appeared, e.g. https://github.com/eic/EICrecon/actions/runs/31203973826/job/92951247301#step:8:3386. Likely due to the new DD4hep patches which may activate a new path in the ROOT code.

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/EICrecon/actions/runs/31203973826/job/92951247301#step:8:3386)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

CI broken on main.