### PR TITLE
feat: add MC(Non)?ScatteredElectronLinks

### DIFF
--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -9,8 +9,11 @@
 #include <edm4eic/InclusiveKinematics.h>
 #include <edm4eic/MCRecoClusterParticleAssociation.h>
 #include <edm4eic/MCRecoParticleAssociation.h>
+#include <edm4eic/MCRecoParticleLinkCollection.h>
 #include <edm4eic/ReconstructedParticle.h>
 #include <edm4hep/MCParticle.h>
+#include <podio/detail/Link.h>
+#include <deque>
 #include <map>
 #include <memory>
 #include <string>
@@ -51,7 +54,12 @@ void InitPlugin(JApplication* app) {
 
   using namespace eicrecon;
 
-  // Finds associations matched to initial scattered electrons
+  // Finds links/associations matched to initial scattered electrons
+  app->Add(new JOmniFactoryGeneratorT<FilterMatching_factory<
+               edm4eic::MCRecoParticleLink, [](auto* obj) { return obj->getTo().getObjectID(); },
+               edm4hep::MCParticle, [](auto* obj) { return obj->getObjectID(); }>>(
+      "MCScatteredElectronLinks", {"ReconstructedChargedParticleLinks", "MCScatteredElectrons"},
+      {"MCScatteredElectronLinks", "MCNonScatteredElectronLinks"}, app));
   app->Add(
       new JOmniFactoryGeneratorT<FilterMatching_factory<
           edm4eic::MCRecoParticleAssociation, [](auto* obj) { return obj->getSim().getObjectID(); },

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -233,9 +233,11 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       "ReconstructedChargedRealPIDParticleIDs",
       "ReconstructedChargedParticles",
       "ReconstructedChargedParticleLinks",
-      "ReconstructedChargedParticleAssociations",
-      "MCScatteredElectronAssociations",    // Remove if/when used internally
-      "MCNonScatteredElectronAssociations", // Remove if/when used internally
+      "ReconstructedChargedParticleAssociations", // Used by associations below
+      "MCScatteredElectronLinks",                 // Remove if/when used internally
+      "MCScatteredElectronAssociations",          // Remove if/when used internally
+      "MCNonScatteredElectronLinks",              // Remove if/when used internally
+      "MCNonScatteredElectronAssociations",       // Remove if/when used internally
       "ReconstructedBreitFrameParticles",
 
       "ReconstructedNeutralParticles",


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This pull request updates the list of input collections in the `JEventProcessorPODIO` constructor to support new association and link collections, and adds clarifying comments about their usage and possible removal.

Input collection updates:

* Added `MCScatteredElectronLinks` and `MCNonScatteredElectronLinks` to the list of input collections, with comments indicating they can be removed if not used internally.

Documentation improvements:

* Added comments to clarify the usage of `ReconstructedChargedParticleAssociations`, `MCScatteredElectronLinks`, `MCScatteredElectronAssociations`, `MCNonScatteredElectronLinks`, and `MCNonScatteredElectronAssociations`, specifying when they may be removed.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: MC(Non)?ScatteredElectronLinks)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
