### PR TITLE
hotfix: epic:/EVGEN only has up to minQ2 = 100

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -513,13 +513,13 @@ jobs:
       matrix:
         include:
           - beam: 10x100
-            minq2: 1000
+            minq2: 100
             detector_config: craterlake_tracking_only
           - beam: 10x100
-            minq2: 1000
+            minq2: 100
             detector_config: craterlake_tracking_2DStrip
           - beam: 18x275
-            minq2: 1000
+            minq2: 100
             detector_config: craterlake_18x275
     steps:
     - name: Retrieve simulation files


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR hotfixes the missing EVGEN files in rucio (https://github.com/eic/EICrecon/actions/runs/31416566438/job/93550640055). Let's reduce our expectations, to Q^2 of 100 GeV^2.

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/EICrecon/actions/runs/31416566438/job/93550640055)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

High priority since borked on main, https://github.com/eic/EICrecon/actions/runs/31416566438/job/93550640055.