### PR TITLE
fix: uint16_t => std::uint16_t

### DIFF
--- a/src/tests/algorithms_test/digi_CALOROCDigitization.cc
+++ b/src/tests/algorithms_test/digi_CALOROCDigitization.cc
@@ -50,7 +50,7 @@ TEST_CASE("Test TOA calculation", "[CALOROCDigitization][TOACalculation]") {
   const double pulse_dt     = 1.;
 
   for (std::size_t i = 0; i < n_tests; i++) {
-    uint16_t TOA_expected = 23 - i;
+    std::uint16_t TOA_expected = 23 - i;
 
     edm4eic::SimPulseCollection pulses;
     auto pulse = pulses.create();

--- a/src/tests/algorithms_test/digi_CALOROCDigitization.cc
+++ b/src/tests/algorithms_test/digi_CALOROCDigitization.cc
@@ -4,8 +4,8 @@
 #include <catch2/catch_test_macros.hpp>
 #include <edm4eic/EDM4eicVersion.h>
 #include <podio/RelationRange.h>
-#include <stdint.h>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 
 #if EDM4EIC_VERSION_MAJOR > 8 || (EDM4EIC_VERSION_MAJOR == 8 && EDM4EIC_VERSION_MINOR >= 7)


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This changes a [C type](https://en.cppreference.com/c/types/integer) to a [C++ type](https://en.cppreference.com/cpp/types/integer). This cuts down on the clang-tidy/IWYU warnings about stdint.h vs cstdint.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ ] Medium
- [x] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
