### PR TITLE
fix(ci): suppress TSAN in poisson_distribution<long>

### DIFF
--- a/.github/tsan.supp
+++ b/.github/tsan.supp
@@ -3,6 +3,8 @@
 # std::lgamma is not thread-safe but used in thread-safe way in stdlib's bits/random.tcc
 race:std::binomial_distribution<int>::param_type::_M_initialize
 race:std::binomial_distribution<int>::operator()
+race:std::poisson_distribution<long>::param_type::_M_initialize
+race:std::poisson_distribution<long>::operator()
 race:std::poisson_distribution<unsigned long>::param_type::_M_initialize
 race:std::poisson_distribution<unsigned long>::operator()
 


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR suppresses TSAN reports in `poisson_distribution<long>`, see e.g. https://github.com/eic/EICrecon/actions/runs/31724271335/job/94533513685#step:7:798. Same as #2832.

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/EICrecon/actions/runs/31724271335/job/94533513685#step:7:798)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

Fails on main right now.