### PR TITLE
fix: change npe to unsigned long

### DIFF
--- a/src/algorithms/calorimetry/EdepToNpeConversion.cc
+++ b/src/algorithms/calorimetry/EdepToNpeConversion.cc
@@ -104,9 +104,9 @@ void EdepToNpeConversion::process(const EdepToNpeConversion::Input& input,
   for (const auto& hit : *inhits) {
     // Edep-to-Npe conversion & Apply Poisson smearing
     const double mean_npe = hit.getEnergy() * get_edep_to_npe_factor(hit);
-    long npe              = 0;
+    unsigned long npe     = 0;
     if (mean_npe > 0) {
-      std::poisson_distribution<long> poisson(mean_npe);
+      std::poisson_distribution<unsigned long> poisson(mean_npe);
       npe = poisson(generator);
     }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR is an alternative solution to #2871. Since `npe` is inherently positive we should just have used unsigned long (let's keep the question "why long" for another day).

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: incorrect type for inherently positive value)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

Currently fails on main.