### PR TITLE
fix(pid): DRICH IRT link migration

### DIFF
--- a/src/algorithms/pid/IrtCherenkovParticleID.cc
+++ b/src/algorithms/pid/IrtCherenkovParticleID.cc
@@ -228,15 +228,16 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
         bool mc_photon_found = false;
         if (m_cfg.cheatPhotonVertex || m_cfg.cheatTrueRadiator) {
           for (const auto& hit_link : *in_hit_links) {
-            if (hit_link.getRawHit().isAvailable()) {
-              if (hit_link.getRawHit().id() == raw_hit.id()) {
-                mc_photon       = hit_link.getSimHit().getParticle();
-                mc_photon_found = true;
-                if (mc_photon.getPDG() != -22) {
-                  warning("non-opticalphoton hit: PDG = {}", mc_photon.getPDG());
-                }
-                break;
+            if (!hit_link.getFrom().isAvailable() || !hit_link.getTo().isAvailable()) {
+              continue;
+            }
+            if (hit_link.getFrom().id() == raw_hit.id()) {
+              mc_photon       = hit_link.getTo().getParticle();
+              mc_photon_found = true;
+              if (mc_photon.getPDG() != -22) {
+                warning("non-opticalphoton hit: PDG = {}", mc_photon.getPDG());
               }
+              break;
             }
           }
         }

--- a/src/algorithms/pid/IrtCherenkovParticleID.cc
+++ b/src/algorithms/pid/IrtCherenkovParticleID.cc
@@ -134,14 +134,14 @@ void IrtCherenkovParticleID::init(CherenkovDetectorCollection* irt_det_coll) {
 
 void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
                                      const IrtCherenkovParticleID::Output& output) const {
-  const auto [in_aerogel_tracks, in_gas_tracks, in_merged_tracks, in_raw_hits, in_hit_assocs] =
+  const auto [in_aerogel_tracks, in_gas_tracks, in_merged_tracks, in_raw_hits, in_hit_links] =
       input;
   auto [out_aerogel_particleIDs, out_gas_particleIDs] = output;
 
   // logging
   trace("{:=^70}", " call IrtCherenkovParticleID::AlgorithmProcess ");
   trace("number of raw sensor hits: {}", in_raw_hits->size());
-  trace("number of raw sensor hit with associated photons: {}", in_hit_assocs->size());
+  trace("number of raw sensor hit with associated photons: {}", in_hit_links->size());
 
   std::map<std::string, const edm4eic::TrackSegmentCollection*> in_charged_particles{
       {"Aerogel", in_aerogel_tracks},
@@ -227,10 +227,10 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
         edm4hep::MCParticle mc_photon;
         bool mc_photon_found = false;
         if (m_cfg.cheatPhotonVertex || m_cfg.cheatTrueRadiator) {
-          for (const auto& hit_assoc : *in_hit_assocs) {
-            if (hit_assoc.getRawHit().isAvailable()) {
-              if (hit_assoc.getRawHit().id() == raw_hit.id()) {
-                mc_photon       = hit_assoc.getSimHit().getParticle();
+          for (const auto& hit_link : *in_hit_links) {
+            if (hit_link.getRawHit().isAvailable()) {
+              if (hit_link.getRawHit().id() == raw_hit.id()) {
+                mc_photon       = hit_link.getSimHit().getParticle();
                 mc_photon_found = true;
                 if (mc_photon.getPDG() != -22) {
                   warning("non-opticalphoton hit: PDG = {}", mc_photon.getPDG());
@@ -464,8 +464,8 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
       }
 
       // relate hit associations
-      for (const auto& hit_assoc : *in_hit_assocs) {
-        out_cherenkov_pid.addToRawHitAssociations(hit_assoc);
+      for (const auto& hit_link : *in_hit_links) {
+        out_cherenkov_pid.addToRawHitAssociations(hit_link);
       }
 
     } // end radiator loop

--- a/src/algorithms/pid/IrtCherenkovParticleID.cc
+++ b/src/algorithms/pid/IrtCherenkovParticleID.cc
@@ -141,7 +141,7 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
   // logging
   trace("{:=^70}", " call IrtCherenkovParticleID::AlgorithmProcess ");
   trace("number of raw sensor hits: {}", in_raw_hits->size());
-  trace("number of raw sensor hit with associated photons: {}", in_hit_links->size());
+  trace("number of raw sensor hits with associated photons: {}", in_hit_links->size());
 
   std::map<std::string, const edm4eic::TrackSegmentCollection*> in_charged_particles{
       {"Aerogel", in_aerogel_tracks},
@@ -222,7 +222,7 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
       for (const auto& raw_hit : *in_raw_hits) {
 
         // get MC photon(s), typically only used by cheat modes or trace logging
-        // - loop over `in_hit_assocs`, searching for the matching hit association
+        // - loop over `in_hit_links`, searching for the matching raw-hit ↔ sim-hit link
         // - will not exist for noise hits
         edm4hep::MCParticle mc_photon;
         bool mc_photon_found = false;
@@ -312,7 +312,7 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
          * a region of sensors where we expect to see this `irt_particle`'s
          * Cherenkov photons; this should also combat sensor noise
          */
-      } // end `in_hit_assocs` loop
+      } // end `in_raw_hits` loop
 
     } // end radiator loop
 

--- a/src/algorithms/pid/IrtCherenkovParticleID.cc
+++ b/src/algorithms/pid/IrtCherenkovParticleID.cc
@@ -134,8 +134,8 @@ void IrtCherenkovParticleID::init(CherenkovDetectorCollection* irt_det_coll) {
 
 void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
                                      const IrtCherenkovParticleID::Output& output) const {
-  const auto [in_aerogel_tracks, in_gas_tracks, in_merged_tracks, in_raw_hits, in_hit_links] =
-      input;
+  const auto [in_aerogel_tracks, in_gas_tracks, in_merged_tracks, in_raw_hits, in_hit_links,
+              in_hit_assocs]                          = input;
   auto [out_aerogel_particleIDs, out_gas_particleIDs] = output;
 
   // logging
@@ -463,9 +463,9 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
         error("Cannot find radiator 'Merged' in `in_charged_particles`");
       }
 
-      // relate hit associations
-      for (const auto& hit_link : *in_hit_links) {
-        out_cherenkov_pid.addToRawHitAssociations(hit_link);
+      // keep the legacy association relation while consuming links for MC truth lookup
+      for (const auto& hit_assoc : *in_hit_assocs) {
+        out_cherenkov_pid.addToRawHitAssociations(hit_assoc);
       }
 
     } // end radiator loop

--- a/src/algorithms/pid/IrtCherenkovParticleID.cc
+++ b/src/algorithms/pid/IrtCherenkovParticleID.cc
@@ -22,6 +22,8 @@
 #include <fmt/ranges.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
+#include <podio/detail/LinkCollectionImpl.h>
+#include <podio/detail/LinkCollectionIterator.h>
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
@@ -30,6 +32,7 @@
 #include <memory>
 #include <set>
 #include <stdexcept>
+#include <tuple>
 #include <utility>
 #include <vector>
 

--- a/src/algorithms/pid/IrtCherenkovParticleID.h
+++ b/src/algorithms/pid/IrtCherenkovParticleID.h
@@ -27,8 +27,9 @@
 namespace eicrecon {
 
 // - `in_raw_hits` is a collection of digitized (raw) sensor hits, possibly including noise hits
-// - `in_hit_links` is a collection of digitized (raw) sensor hits, associated with MC (simulated) hits;
-//   noise hits are not included since there is no associated simulated photon
+// - `in_hit_links` is a collection of raw-hit ↔ sim-hit link objects
+//   (`edm4eic::MCRecoTrackerHitLink`); noise hits are not included since they have no associated
+//   simulated photon
 // - `in_hit_assocs` is the association collection for compatibility with
 //   CherenkovParticleID::rawHitAssociations output relations
 // - `in_charged_particles` is a map of a radiator name to a collection of TrackSegments

--- a/src/algorithms/pid/IrtCherenkovParticleID.h
+++ b/src/algorithms/pid/IrtCherenkovParticleID.h
@@ -8,7 +8,7 @@
 #include <IRT/CherenkovRadiator.h>
 #include <algorithms/algorithm.h>
 #include <edm4eic/CherenkovParticleIDCollection.h>
-#include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
+#include <edm4eic/MCRecoTrackerHitLinkCollection.h>
 #include <edm4eic/RawTrackerHitCollection.h>
 #include <edm4eic/TrackSegmentCollection.h>
 #include <stdint.h>
@@ -26,7 +26,7 @@
 namespace eicrecon {
 
 // - `in_raw_hits` is a collection of digitized (raw) sensor hits, possibly including noise hits
-// - `in_hit_assocs` is a collection of digitized (raw) sensor hits, associated with MC (simulated) hits;
+// - `in_hit_links` is a collection of digitized (raw) sensor hits, associated with MC (simulated) hits;
 //   noise hits are not included since there is no associated simulated photon
 // - `in_charged_particles` is a map of a radiator name to a collection of TrackSegments
 //   - each TrackSegment has a list of TrackPoints: the propagation of reconstructed track (trajectory) points
@@ -34,7 +34,7 @@ namespace eicrecon {
 using IrtCherenkovParticleIDAlgorithm = algorithms::Algorithm<
     algorithms::Input<const edm4eic::TrackSegmentCollection, const edm4eic::TrackSegmentCollection,
                       const edm4eic::TrackSegmentCollection, const edm4eic::RawTrackerHitCollection,
-                      const edm4eic::MCRecoTrackerHitAssociationCollection>,
+                      const edm4eic::MCRecoTrackerHitLinkCollection>,
     algorithms::Output<edm4eic::CherenkovParticleIDCollection,
                        edm4eic::CherenkovParticleIDCollection>>;
 
@@ -46,7 +46,7 @@ public:
       : IrtCherenkovParticleIDAlgorithm{name,
                                         {"inputAerogelTrackSegments", "inputGasTrackSegments",
                                          "inputMergedTrackSegments", "inputRawHits",
-                                         "inputRawHitAssociations"},
+                                         "inputRawHitLinks"},
                                         {"outputAerogelParticleIDs", "outputGasParticleIDs"},
                                         "Effectively 'zip' the input particle IDs"} {}
 

--- a/src/algorithms/pid/IrtCherenkovParticleID.h
+++ b/src/algorithms/pid/IrtCherenkovParticleID.h
@@ -8,6 +8,7 @@
 #include <IRT/CherenkovRadiator.h>
 #include <algorithms/algorithm.h>
 #include <edm4eic/CherenkovParticleIDCollection.h>
+#include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
 #include <edm4eic/MCRecoTrackerHitLinkCollection.h>
 #include <edm4eic/RawTrackerHitCollection.h>
 #include <edm4eic/TrackSegmentCollection.h>
@@ -28,13 +29,16 @@ namespace eicrecon {
 // - `in_raw_hits` is a collection of digitized (raw) sensor hits, possibly including noise hits
 // - `in_hit_links` is a collection of digitized (raw) sensor hits, associated with MC (simulated) hits;
 //   noise hits are not included since there is no associated simulated photon
+// - `in_hit_assocs` is the association collection for compatibility with
+//   CherenkovParticleID::rawHitAssociations output relations
 // - `in_charged_particles` is a map of a radiator name to a collection of TrackSegments
 //   - each TrackSegment has a list of TrackPoints: the propagation of reconstructed track (trajectory) points
 // - the output is a map: radiator name -> collection of particle ID objects
 using IrtCherenkovParticleIDAlgorithm = algorithms::Algorithm<
     algorithms::Input<const edm4eic::TrackSegmentCollection, const edm4eic::TrackSegmentCollection,
                       const edm4eic::TrackSegmentCollection, const edm4eic::RawTrackerHitCollection,
-                      const edm4eic::MCRecoTrackerHitLinkCollection>,
+                      const edm4eic::MCRecoTrackerHitLinkCollection,
+                      const edm4eic::MCRecoTrackerHitAssociationCollection>,
     algorithms::Output<edm4eic::CherenkovParticleIDCollection,
                        edm4eic::CherenkovParticleIDCollection>>;
 
@@ -46,7 +50,7 @@ public:
       : IrtCherenkovParticleIDAlgorithm{name,
                                         {"inputAerogelTrackSegments", "inputGasTrackSegments",
                                          "inputMergedTrackSegments", "inputRawHits",
-                                         "inputRawHitLinks"},
+                                         "inputRawHitLinks", "inputRawHitAssociations"},
                                         {"outputAerogelParticleIDs", "outputGasParticleIDs"},
                                         "Effectively 'zip' the input particle IDs"} {}
 

--- a/src/detectors/DRICH/DRICH.cc
+++ b/src/detectors/DRICH/DRICH.cc
@@ -137,7 +137,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<IrtCherenkovParticleID_factory>(
       "DRICHIrtCherenkovParticleID",
       {"DRICHAerogelTracks", "DRICHGasTracks", "DRICHMergedTracks", "DRICHRawHits",
-       "DRICHRawHitsLinks"},
+       "DRICHRawHitsLinks", "DRICHRawHitsAssociations"},
       {"DRICHAerogelIrtCherenkovParticleID", "DRICHGasIrtCherenkovParticleID"}, irt_cfg, app));
 
   // merge aerogel and gas PID results

--- a/src/detectors/DRICH/DRICH.cc
+++ b/src/detectors/DRICH/DRICH.cc
@@ -137,7 +137,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<IrtCherenkovParticleID_factory>(
       "DRICHIrtCherenkovParticleID",
       {"DRICHAerogelTracks", "DRICHGasTracks", "DRICHMergedTracks", "DRICHRawHits",
-       "DRICHRawHitsAssociations"},
+       "DRICHRawHitsLinks"},
       {"DRICHAerogelIrtCherenkovParticleID", "DRICHGasIrtCherenkovParticleID"}, irt_cfg, app));
 
   // merge aerogel and gas PID results

--- a/src/factories/pid/IrtCherenkovParticleID_factory.h
+++ b/src/factories/pid/IrtCherenkovParticleID_factory.h
@@ -6,6 +6,7 @@
 #include <IRT/CherenkovDetectorCollection.h>
 #include <JANA/JEvent.h>
 #include <edm4eic/CherenkovParticleIDCollection.h>
+#include <edm4eic/MCRecoTrackerHitLinkCollection.h>
 #include <algorithm>
 #include <memory>
 #include <string>
@@ -31,7 +32,7 @@ private:
   PodioInput<edm4eic::TrackSegment> m_gas_tracks_input{this};
   PodioInput<edm4eic::TrackSegment> m_merged_tracks_input{this};
   PodioInput<edm4eic::RawTrackerHit> m_raw_hits_input{this};
-  PodioInput<edm4eic::MCRecoTrackerHitAssociation> m_raw_hit_assoc_input{this};
+  PodioInput<edm4eic::MCRecoTrackerHitLink> m_raw_hit_links_input{this};
   PodioOutput<edm4eic::CherenkovParticleID> m_aerogel_particleIDs_output{this};
   PodioOutput<edm4eic::CherenkovParticleID> m_gas_particleIDs_output{this};
 
@@ -71,7 +72,7 @@ public:
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_aerogel_tracks_input(), m_gas_tracks_input(), m_merged_tracks_input(),
-                     m_raw_hits_input(), m_raw_hit_assoc_input()},
+                     m_raw_hits_input(), m_raw_hit_links_input()},
                     {m_aerogel_particleIDs_output().get(), m_gas_particleIDs_output().get()});
   }
 };

--- a/src/factories/pid/IrtCherenkovParticleID_factory.h
+++ b/src/factories/pid/IrtCherenkovParticleID_factory.h
@@ -6,6 +6,7 @@
 #include <IRT/CherenkovDetectorCollection.h>
 #include <JANA/JEvent.h>
 #include <edm4eic/CherenkovParticleIDCollection.h>
+#include <edm4eic/MCRecoTrackerHitAssociationCollection.h>
 #include <edm4eic/MCRecoTrackerHitLinkCollection.h>
 #include <algorithm>
 #include <memory>
@@ -33,6 +34,7 @@ private:
   PodioInput<edm4eic::TrackSegment> m_merged_tracks_input{this};
   PodioInput<edm4eic::RawTrackerHit> m_raw_hits_input{this};
   PodioInput<edm4eic::MCRecoTrackerHitLink> m_raw_hit_links_input{this};
+  PodioInput<edm4eic::MCRecoTrackerHitAssociation> m_raw_hit_assoc_input{this};
   PodioOutput<edm4eic::CherenkovParticleID> m_aerogel_particleIDs_output{this};
   PodioOutput<edm4eic::CherenkovParticleID> m_gas_particleIDs_output{this};
 
@@ -72,7 +74,7 @@ public:
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_aerogel_tracks_input(), m_gas_tracks_input(), m_merged_tracks_input(),
-                     m_raw_hits_input(), m_raw_hit_links_input()},
+                     m_raw_hits_input(), m_raw_hit_links_input(), m_raw_hit_assoc_input()},
                     {m_aerogel_particleIDs_output().get(), m_gas_particleIDs_output().get()});
   }
 };


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR isolates the DRICH IRT link migration from #2822 into a standalone change for focused review. It updates IrtCherenkovParticleID to consume `DRICHRawHitsLinks` (using `getFrom()/getTo()` for link access) while preserving `addToRawHitAssociations` output behavior by still using association objects. DRICH wiring/factory inputs are updated to pass both links and associations.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.
Used Copilot CLI to split the change, apply review-requested fixes, and update wording/comments for correctness.