### PR TITLE
hotfix: allow deprecated-declarations; continue-on-error for 2DStrip; fix UndoAfterBurner

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -97,11 +97,11 @@ jobs:
             release: nightly
         include:
           - CXX: g++
-            # -Wno-error=deprecated-declarations for deprecated seeding data model in Acts v46
+            # TODO(#2524): remove -Wno-error=deprecated-declarations once seeding migrates to Acts Seeding2 (Acts v46 deprecations)
             # -Wno-error=maybe-uninitialized for GCC only as it has issues with /usr/include/c++/12/bits/std_function.h
             CXXFLAGS: -Werror -Wall -Wextra -Wundef -Wno-error=deprecated-declarations -Wno-error=maybe-uninitialized
           - CXX: clang++
-            # -Wno-error=deprecated-declarations for deprecated seeding data model in Acts v46
+            # TODO(#2524): remove -Wno-error=deprecated-declarations once seeding migrates to Acts Seeding2 (Acts v46 deprecations)
             CXXFLAGS: -Werror -Wall -Wextra -Wundef -Wno-error=deprecated-declarations
           # include clang++ Debug with profile CXXFLAGS
           - CXX: clang++

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -97,10 +97,12 @@ jobs:
             release: nightly
         include:
           - CXX: g++
+            # -Wno-error=deprecated-declarations for deprecated seeding data model in Acts v46
             # -Wno-error=maybe-uninitialized for GCC only as it has issues with /usr/include/c++/12/bits/std_function.h
-            CXXFLAGS: -Werror -Wall -Wextra -Wundef -Wno-error=maybe-uninitialized
+            CXXFLAGS: -Werror -Wall -Wextra -Wundef -Wno-error=deprecated-declarations -Wno-error=maybe-uninitialized
           - CXX: clang++
-            CXXFLAGS: -Werror -Wall -Wextra -Wundef
+            # -Wno-error=deprecated-declarations for deprecated seeding data model in Acts v46
+            CXXFLAGS: -Werror -Wall -Wextra -Wundef -Wno-error=deprecated-declarations
           # include clang++ Debug with profile CXXFLAGS
           - CXX: clang++
             CMAKE_BUILD_TYPE: Debug

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -1146,6 +1146,7 @@ jobs:
 
   eicrecon-dis:
     runs-on: ubuntu-24.04
+    continue-on-error: ${{ matrix['continue-on-error'] || false }}
     needs:
     - build
     - npsim-dis
@@ -1186,6 +1187,7 @@ jobs:
           minq2: 100
           detector_config: craterlake_tracking_2DStrip
           sanitizer: ASAN
+          continue-on-error: true
         - CXX: clang++
           beam: 10x130
           minq2: 1

--- a/src/algorithms/reco/UndoAfterBurner.cc
+++ b/src/algorithms/reco/UndoAfterBurner.cc
@@ -93,8 +93,8 @@ void eicrecon::UndoAfterBurner::process(const UndoAfterBurner::Input& input,
     }
   }
 
-  // Bail out if still no beam particles, since this leads to division by zero
-  if (!hasBeamHadron && !hasBeamLepton) {
+  // Bail out if either beam is missing, since this leads to division by zero or unphysical boosts
+  if (!hasBeamHadron || !hasBeamLepton) {
     return;
   }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
In https://github.com/eic/containers/pull/387 we bumped Acts to v46.8.1, but this deprecates the seeding data model (as is fixed in #2524, but that's now not ready for merging). Because we build some jobs with `-Werror` we have to allow the deprecated declarations to get CI to complete. See e.g. https://github.com/eic/EICrecon/actions/runs/32506264064/job/97200314068#step:7:571.

This PR also includes the following stacked PRs:
- #2889 
  This pull request updates the workflow configuration in .github/workflows/linux-eic-shell.yml to improve control over job error handling in the eicrecon-dis job. The main changes introduce a continue-on-error setting to the job matrix, allowing certain job runs (2DStrip in particular) to proceed even if errors occur.
- #2891 
  Single-electron gun events with secondary neutrons produce extreme momentum values (~10³⁰⁸ GeV) in MCParticlesHeadOnFrameNoBeamFX, causing CI failures in capybara histogram generation, because the fallback logic incorrectly treats secondary hadrons from particle gun events as beam particles.

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

CI is currently broken on `main`.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/EICrecon/actions/runs/32506264064/job/97200314068#step:7:571)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
