### PR TITLE
fix: remove refs to obsolete Acts:InitLogLevel

### DIFF
--- a/docs/design/flags/acts.md
+++ b/docs/design/flags/acts.md
@@ -1,35 +1,6 @@
 ## ACTS flags
 
-### Logging
-
-ACTS has two loggers controlled by two flags:
-
-- **acts:LogLevel** - General Acts logger. Is used for logging during ACTS reconstruction
-- **acts:InitLogLevel** - Initialization Acts logger. Is used for geometry initialization.
-  By default, its level is the same as for general logger, but user can set
-  it explicitly to only look extended printout of DD4Hep->Acts geometry conversion and other
-  initialization steps
-
-The reason for such level split is: it might be important to have a verbose log during initialization
-to view geometry conversion printout; while there is no need for full printout of each track reconstruction.
-And wise versa.
-
-Examples:
-
-```yaml
-# ACTS initialization and reconstruction log is set to maximum level:
-acts:LogLevel = "trace"
-
-# But now initialization set to "info", no print of geometry import in details
-acts:InitLogLevel = "info"
-
-# Don't print verbose messages during reconstruction,
-# but print full info on initial geometry conversion
-acts:LogLevel = "info"
-acts:InitLogLevel = "trace"
-```
-
-#### Material map
+### Material map
 
 Material map in JSon format can be loaded with **acts:MaterialMap** flag:
 

--- a/docs/design/flags/acts.md
+++ b/docs/design/flags/acts.md
@@ -1,5 +1,10 @@
 ## ACTS flags
 
+
+### Logging
+
+The `acts:LogLevel` sets log level for most operations. Currently, some may require source code changes to update the verbosity.
+
 ### Material map
 
 Material map in JSon format can be loaded with **acts:MaterialMap** flag:

--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -198,7 +198,7 @@ void ActsGeometryProvider::initialize(const dd4hep::Detector* dd4hep_geo, std::s
                               sortDetElementsByID, m_trackingGeoCtx, materialDeco, geometryIdHook);
   } catch (std::exception& ex) {
     m_init_log->error("Error during DD4Hep -> ACTS geometry conversion: {}", ex.what());
-    m_init_log->info("Set parameter acts::InitLogLevel=trace to see conversion info and possibly "
+    m_init_log->info("Set parameter acts:LogLevel=trace to see conversion info and possibly "
                      "identify failing geometry");
     throw;
   }


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR removes obsolete references to the `acts:InitLogLevel` parameter.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ ] Medium
- [x] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: `acts:InitLogLevel` doesn't exist anymore)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
