### PR TITLE
fix: continue-on-error for 2DStrip

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -1146,7 +1146,7 @@ jobs:
 
   eicrecon-dis:
     runs-on: ubuntu-24.04
-    continue-on-error: ${{ matrix.continue-on-error }}
+    continue-on-error: ${{ matrix['continue-on-error'] || false }}
     needs:
     - build
     - npsim-dis

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -1154,7 +1154,6 @@ jobs:
     - npsim-minbias
     strategy:
       matrix:
-        continue-on-error: [false]
         include:
         - CXX: clang++
           beam: 5x41

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -1146,6 +1146,7 @@ jobs:
 
   eicrecon-dis:
     runs-on: ubuntu-24.04
+    continue-on-error: ${{ matrix.continue-on-error }}
     needs:
     - build
     - npsim-dis
@@ -1153,6 +1154,7 @@ jobs:
     - npsim-minbias
     strategy:
       matrix:
+        continue-on-error: [false]
         include:
         - CXX: clang++
           beam: 5x41
@@ -1186,6 +1188,7 @@ jobs:
           minq2: 100
           detector_config: craterlake_tracking_2DStrip
           sanitizer: ASAN
+          continue-on-error: true
         - CXX: clang++
           beam: 10x130
           minq2: 1


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This pull request updates the workflow configuration in `.github/workflows/linux-eic-shell.yml` to improve control over job error handling in the `eicrecon-dis` job. The main changes introduce a `continue-on-error` setting to the job matrix, allowing certain job runs (2DStrip in particular) to proceed even if errors occur.

Workflow configuration improvements:

* Added a `continue-on-error` parameter to the `eicrecon-dis` job, making it configurable per matrix entry.
* Updated the job matrix to include `continue-on-error: [false]` by default, and set `continue-on-error: true` for the configuration using `sanitizer: ASAN`, allowing that job to continue on error. [[1]](diffhunk://#diff-1979202099e4ebc6d02b6dbd6ade89a6d9895896cd610bb3829b3b84f5239b38R1149-R1157) [[2]](diffhunk://#diff-1979202099e4ebc6d02b6dbd6ade89a6d9895896cd610bb3829b3b84f5239b38R1191)

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

In Acts v46, the 2DStrip geometry is not compatible with the existing non-2DStrip material map anymore (I.e. it probably never was compatible but now it's a hard failure).

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
