### PR TITLE
fix: prevent unphysical boost in UndoAfterBurner when only one beam found

### DIFF
--- a/src/algorithms/reco/UndoAfterBurner.cc
+++ b/src/algorithms/reco/UndoAfterBurner.cc
@@ -93,8 +93,8 @@ void eicrecon::UndoAfterBurner::process(const UndoAfterBurner::Input& input,
     }
   }
 
-  // Bail out if still no beam particles, since this leads to division by zero
-  if (!hasBeamHadron && !hasBeamLepton) {
+  // Bail out if either beam is missing, since this leads to division by zero or unphysical boosts
+  if (!hasBeamHadron || !hasBeamLepton) {
     return;
   }
 


### PR DESCRIPTION
## Fix MCParticlesHeadOnFrameNoBeamFX overflow for particle gun events

**Stacked on:** #2887 (acts-event-data-seed-deprecated-declarations)

### Problem
Single-electron gun events with secondary neutrons produce extreme momentum values (~10³⁰⁸ GeV) in `MCParticlesHeadOnFrameNoBeamFX`, causing CI failures in capybara histogram generation:
- https://github.com/eic/EICrecon/actions/runs/32655851820/job/97236980632?pr=2887

### Root Cause
The fallback logic (lines 67-75) incorrectly treats **secondary hadrons** from particle gun events as beam particles:

1. Electron gun event produces secondary neutron (E=0.94 GeV) from showering
2. Fallback finds neutron → sets `hasBeamHadron=true`, leaves `hasBeamLepton=false`
3. Old check `if (!hasBeamHadron && !hasBeamLepton)` only returns if **BOTH** are false
4. Code proceeds with:
   - `e_beam = (0,0,0,0)` (uninitialized)
   - `h_beam = (0.024, 0, 0.94, 0.94)` (from secondary neutron)
5. Boost calculation: β = (-0.024/0.94, 0, -0.94/0.94) = (-0.026, 0, **-1.0**)
6. **β² = 1.0006 > 1** → unphysical (faster than light) → extreme Lorentz factors → 10³⁰⁸ GeV

### Solution
**One-character fix:** Change `&&` to `||` on line 98.

```cpp
// Old (buggy):
if (!hasBeamHadron && !hasBeamLepton) {  // Only returns if BOTH false
  return;
}

// New (correct):
if (!hasBeamHadron || !hasBeamLepton) {  // Returns if EITHER false
  return;
}
```

This is consistent with the check at line 62 and prevents unphysical boost calculations.

### Effect
- **Particle gun events** (with or without secondary hadrons): `MCParticlesHeadOnFrameNoBeamFX` will be **empty** (no valid collision frame)
- **DIS events** (both beams present): Boost transformation applied correctly as before

### Testing
Verified with `rec_e_1GeV_20GeV_craterlake.edm4eic.root`:
- **Before fix:** Events 7, 11, 61, 95 have momentum ~10³⁰⁸ GeV or NaN
- **Input MCParticles:** Normal momentum ~1.4 GeV
- **Expected after fix:** No extreme values (empty output collection for gun events)