### PR TITLE
HEXPLIT: adjust timing cut to respect t0

### DIFF
--- a/src/algorithms/calorimetry/HEXPLIT.cc
+++ b/src/algorithms/calorimetry/HEXPLIT.cc
@@ -102,17 +102,17 @@ void HEXPLIT::init() {
 void HEXPLIT::process(const HEXPLIT::Input& input, const HEXPLIT::Output& output) const {
 
   const auto [hits, mchitlinks] = input;
-  auto [subcellHits]             = output;
+  auto [subcellHits]            = output;
 
   std::optional<podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>> nav;
   if (mchitlinks != nullptr && !mchitlinks->empty()) {
     nav.emplace(*mchitlinks);
   }
 
-  double MIP      = m_cfg.MIP / dd4hep::GeV;
-  double delta    = m_cfg.delta_in_MIPs * MIP;
-  double Emin     = m_cfg.Emin_in_MIPs * MIP;
-  double max_dt   = m_cfg.max_time_to_truth_t0 / dd4hep::ns;
+  double MIP    = m_cfg.MIP / dd4hep::GeV;
+  double delta  = m_cfg.delta_in_MIPs * MIP;
+  double Emin   = m_cfg.Emin_in_MIPs * MIP;
+  double max_dt = m_cfg.max_time_to_truth_t0 / dd4hep::ns;
 
   auto volman = m_detector->volumeManager();
 
@@ -139,7 +139,8 @@ void HEXPLIT::process(const HEXPLIT::Input& input, const HEXPLIT::Output& output
         continue;
       }
       const auto other_t0 = nav.has_value() ? get_t0(other_hit, *nav) : std::nullopt;
-      if (other_hit.getEnergy() < Emin || (other_t0.has_value() && (other_hit.getTime() - *other_t0) > max_dt)) {
+      if (other_hit.getEnergy() < Emin ||
+          (other_t0.has_value() && (other_hit.getTime() - *other_t0) > max_dt)) {
         continue;
       }
       //difference in transverse position (in units of side lengths)
@@ -245,9 +246,9 @@ edm4hep::MCParticle HEXPLIT::get_primary(const edm4hep::MCParticle& particle) {
   return primary;
 }
 
-std::optional<double> HEXPLIT::get_t0(
-    const edm4eic::CalorimeterHit& hit,
-    const podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& nav) {
+std::optional<double>
+HEXPLIT::get_t0(const edm4eic::CalorimeterHit& hit,
+                const podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& nav) {
   for (const auto& [simhit, weight] : nav.getLinked(hit.getRawHit())) {
     for (const auto& contrib : simhit.getContributions()) {
       return get_primary(contrib).getTime();

--- a/src/algorithms/calorimetry/HEXPLIT.cc
+++ b/src/algorithms/calorimetry/HEXPLIT.cc
@@ -14,6 +14,8 @@
 #include <edm4eic/MCRecoCalorimeterHitLinkCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <podio/LinkNavigator.h>
+#include <podio/ObjectID.h>
+#include <unordered_map>
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
@@ -104,22 +106,24 @@ void HEXPLIT::process(const HEXPLIT::Input& input, const HEXPLIT::Output& output
   const auto [hits, mchitlinks] = input;
   auto [subcellHits]            = output;
 
+  double MIP      = m_cfg.MIP / dd4hep::GeV;
+  double delta    = m_cfg.delta_in_MIPs * MIP;
+  double Emin     = m_cfg.Emin_in_MIPs * MIP;
+  double max_dt   = m_cfg.max_time_to_truth_t0 / dd4hep::ns;
+
+  // Per-event t0 cache: populated lazily by get_t0(), keyed on hit ObjectID.
+  T0Cache t0_cache;
   std::optional<podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>> nav;
   if (mchitlinks != nullptr && !mchitlinks->empty()) {
     nav.emplace(*mchitlinks);
   }
 
-  double MIP    = m_cfg.MIP / dd4hep::GeV;
-  double delta  = m_cfg.delta_in_MIPs * MIP;
-  double Emin   = m_cfg.Emin_in_MIPs * MIP;
-  double max_dt = m_cfg.max_time_to_truth_t0 / dd4hep::ns;
-
   auto volman = m_detector->volumeManager();
 
   for (const auto& hit : *hits) {
+    const auto t0 = nav ? get_t0(hit, *nav, t0_cache) : std::nullopt;
     //skip hits that do not pass E and t cuts
-    const auto t0 = nav.has_value() ? get_t0(hit, *nav) : std::nullopt;
-    if (hit.getEnergy() < Emin || (t0.has_value() && (hit.getTime() - *t0) > max_dt)) {
+    if (hit.getEnergy() < Emin || (t0 && (hit.getTime() - *t0) > max_dt)) {
       continue;
     }
 
@@ -138,9 +142,8 @@ void HEXPLIT::process(const HEXPLIT::Input& input, const HEXPLIT::Output& output
       if (dz > 2 || dz == 0) {
         continue;
       }
-      const auto other_t0 = nav.has_value() ? get_t0(other_hit, *nav) : std::nullopt;
-      if (other_hit.getEnergy() < Emin ||
-          (other_t0.has_value() && (other_hit.getTime() - *other_t0) > max_dt)) {
+      const auto other_t0 = nav ? get_t0(other_hit, *nav, t0_cache) : std::nullopt;
+      if (other_hit.getEnergy() < Emin || (other_t0 && (other_hit.getTime() - *other_t0) > max_dt)) {
         continue;
       }
       //difference in transverse position (in units of side lengths)
@@ -246,15 +249,24 @@ edm4hep::MCParticle HEXPLIT::get_primary(const edm4hep::MCParticle& particle) {
   return primary;
 }
 
-std::optional<double>
-HEXPLIT::get_t0(const edm4eic::CalorimeterHit& hit,
-                const podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& nav) {
+std::optional<double> HEXPLIT::get_t0(
+    const edm4eic::CalorimeterHit& hit,
+    const podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& nav,
+    T0Cache& cache) {
+  const auto id = hit.getObjectID();
+  if (auto it = cache.find(id); it != cache.end()) {
+    return it->second;
+  }
+  std::optional<double> t0;
   for (const auto& [simhit, weight] : nav.getLinked(hit.getRawHit())) {
     for (const auto& contrib : simhit.getContributions()) {
-      return get_primary(contrib).getTime();
+      t0 = get_primary(contrib).getTime();
+      break;
     }
+    break;
   }
-  return std::nullopt;
+  cache.emplace(id, t0);
+  return t0;
 }
 
 } // namespace eicrecon

--- a/src/algorithms/calorimetry/HEXPLIT.cc
+++ b/src/algorithms/calorimetry/HEXPLIT.cc
@@ -11,7 +11,9 @@
 #include <Evaluator/DD4hepUnits.h>
 #include <Math/GenVector/Cartesian3D.h>
 #include <Math/GenVector/DisplacementVector3D.h>
+#include <edm4eic/MCRecoCalorimeterHitLinkCollection.h>
 #include <edm4hep/Vector3f.h>
+#include <podio/LinkNavigator.h>
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
@@ -99,19 +101,25 @@ void HEXPLIT::init() {
 
 void HEXPLIT::process(const HEXPLIT::Input& input, const HEXPLIT::Output& output) const {
 
-  const auto [hits]  = input;
-  auto [subcellHits] = output;
+  const auto [hits, mchitlinks] = input;
+  auto [subcellHits]             = output;
 
-  double MIP   = m_cfg.MIP / dd4hep::GeV;
-  double delta = m_cfg.delta_in_MIPs * MIP;
-  double Emin  = m_cfg.Emin_in_MIPs * MIP;
-  double tmax  = m_cfg.tmax / dd4hep::ns;
+  std::optional<podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>> nav;
+  if (mchitlinks != nullptr && !mchitlinks->empty()) {
+    nav.emplace(*mchitlinks);
+  }
+
+  double MIP      = m_cfg.MIP / dd4hep::GeV;
+  double delta    = m_cfg.delta_in_MIPs * MIP;
+  double Emin     = m_cfg.Emin_in_MIPs * MIP;
+  double max_dt   = m_cfg.max_time_to_truth_t0 / dd4hep::ns;
 
   auto volman = m_detector->volumeManager();
 
   for (const auto& hit : *hits) {
     //skip hits that do not pass E and t cuts
-    if (hit.getEnergy() < Emin || hit.getTime() > tmax) {
+    const auto t0 = nav.has_value() ? get_t0(hit, *nav) : std::nullopt;
+    if (hit.getEnergy() < Emin || (t0.has_value() && (hit.getTime() - *t0) > max_dt)) {
       continue;
     }
 
@@ -130,7 +138,8 @@ void HEXPLIT::process(const HEXPLIT::Input& input, const HEXPLIT::Output& output
       if (dz > 2 || dz == 0) {
         continue;
       }
-      if (other_hit.getEnergy() < Emin || other_hit.getTime() > tmax) {
+      const auto other_t0 = nav.has_value() ? get_t0(other_hit, *nav) : std::nullopt;
+      if (other_hit.getEnergy() < Emin || (other_t0.has_value() && (other_hit.getTime() - *other_t0) > max_dt)) {
         continue;
       }
       //difference in transverse position (in units of side lengths)
@@ -219,6 +228,32 @@ void HEXPLIT::process(const HEXPLIT::Input& input, const HEXPLIT::Output& output
                           local);
     }
   }
+}
+
+edm4hep::MCParticle HEXPLIT::get_primary(const edm4hep::CaloHitContribution& contrib) {
+  return get_primary(contrib.getParticle());
+}
+
+edm4hep::MCParticle HEXPLIT::get_primary(const edm4hep::MCParticle& particle) {
+  edm4hep::MCParticle primary = particle;
+  while (primary.parents_size() > 0) {
+    if (primary.getGeneratorStatus() != 0) {
+      break;
+    }
+    primary = primary.getParents(0);
+  }
+  return primary;
+}
+
+std::optional<double> HEXPLIT::get_t0(
+    const edm4eic::CalorimeterHit& hit,
+    const podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& nav) {
+  for (const auto& [simhit, weight] : nav.getLinked(hit.getRawHit())) {
+    for (const auto& contrib : simhit.getContributions()) {
+      return get_primary(contrib).getTime();
+    }
+  }
+  return std::nullopt;
 }
 
 } // namespace eicrecon

--- a/src/algorithms/calorimetry/HEXPLIT.cc
+++ b/src/algorithms/calorimetry/HEXPLIT.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Sebouh Paul
+// Copyright (C) 2023 - 2026 Sebouh Paul, ePIC Collaboration
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 // References:

--- a/src/algorithms/calorimetry/HEXPLIT.cc
+++ b/src/algorithms/calorimetry/HEXPLIT.cc
@@ -12,15 +12,19 @@
 #include <Math/GenVector/Cartesian3D.h>
 #include <Math/GenVector/DisplacementVector3D.h>
 #include <edm4eic/MCRecoCalorimeterHitLinkCollection.h>
+#include <edm4hep/RawCalorimeterHit.h>
+#include <edm4hep/SimCalorimeterHit.h>
 #include <edm4hep/Vector3f.h>
 #include <podio/LinkNavigator.h>
 #include <podio/ObjectID.h>
-#include <unordered_map>
+#include <podio/RelationRange.h>
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
 #include <numbers>
 #include <tuple>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "HEXPLIT.h"

--- a/src/algorithms/calorimetry/HEXPLIT.cc
+++ b/src/algorithms/calorimetry/HEXPLIT.cc
@@ -106,10 +106,10 @@ void HEXPLIT::process(const HEXPLIT::Input& input, const HEXPLIT::Output& output
   const auto [hits, mchitlinks] = input;
   auto [subcellHits]            = output;
 
-  double MIP      = m_cfg.MIP / dd4hep::GeV;
-  double delta    = m_cfg.delta_in_MIPs * MIP;
-  double Emin     = m_cfg.Emin_in_MIPs * MIP;
-  double max_dt   = m_cfg.max_time_to_truth_t0 / dd4hep::ns;
+  double MIP    = m_cfg.MIP / dd4hep::GeV;
+  double delta  = m_cfg.delta_in_MIPs * MIP;
+  double Emin   = m_cfg.Emin_in_MIPs * MIP;
+  double max_dt = m_cfg.max_time_to_truth_t0 / dd4hep::ns;
 
   // Per-event t0 cache: populated lazily by get_t0(), keyed on hit ObjectID.
   T0Cache t0_cache;
@@ -143,7 +143,8 @@ void HEXPLIT::process(const HEXPLIT::Input& input, const HEXPLIT::Output& output
         continue;
       }
       const auto other_t0 = nav ? get_t0(other_hit, *nav, t0_cache) : std::nullopt;
-      if (other_hit.getEnergy() < Emin || (other_t0 && (other_hit.getTime() - *other_t0) > max_dt)) {
+      if (other_hit.getEnergy() < Emin ||
+          (other_t0 && (other_hit.getTime() - *other_t0) > max_dt)) {
         continue;
       }
       //difference in transverse position (in units of side lengths)
@@ -249,10 +250,10 @@ edm4hep::MCParticle HEXPLIT::get_primary(const edm4hep::MCParticle& particle) {
   return primary;
 }
 
-std::optional<double> HEXPLIT::get_t0(
-    const edm4eic::CalorimeterHit& hit,
-    const podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& nav,
-    T0Cache& cache) {
+std::optional<double>
+HEXPLIT::get_t0(const edm4eic::CalorimeterHit& hit,
+                const podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& nav,
+                T0Cache& cache) {
   const auto id = hit.getObjectID();
   if (auto it = cache.find(id); it != cache.end()) {
     return it->second;

--- a/src/algorithms/calorimetry/HEXPLIT.h
+++ b/src/algorithms/calorimetry/HEXPLIT.h
@@ -115,10 +115,10 @@ private:
 
   using T0Cache = std::unordered_map<podio::ObjectID, std::optional<double>>;
 
-  static std::optional<double> get_t0(
-      const edm4eic::CalorimeterHit& hit,
-      const podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& nav,
-      T0Cache& cache);
+  static std::optional<double>
+  get_t0(const edm4eic::CalorimeterHit& hit,
+         const podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& nav,
+         T0Cache& cache);
 
 private:
   const dd4hep::Detector* m_detector{algorithms::GeoSvc::instance().detector()};

--- a/src/algorithms/calorimetry/HEXPLIT.h
+++ b/src/algorithms/calorimetry/HEXPLIT.h
@@ -28,10 +28,10 @@
 
 namespace eicrecon {
 
-using HEXPLITAlgorithm =
-    algorithms::Algorithm<algorithms::Input<const edm4eic::CalorimeterHitCollection,
-                                            std::optional<edm4eic::MCRecoCalorimeterHitLinkCollection>>,
-                          algorithms::Output<edm4eic::CalorimeterHitCollection>>;
+using HEXPLITAlgorithm = algorithms::Algorithm<
+    algorithms::Input<const edm4eic::CalorimeterHitCollection,
+                      std::optional<edm4eic::MCRecoCalorimeterHitLinkCollection>>,
+    algorithms::Output<edm4eic::CalorimeterHitCollection>>;
 
 class HEXPLIT : public HEXPLITAlgorithm, public WithPodConfig<HEXPLITConfig> {
 
@@ -111,9 +111,9 @@ private:
   static edm4hep::MCParticle get_primary(const edm4hep::CaloHitContribution& contrib);
   static edm4hep::MCParticle get_primary(const edm4hep::MCParticle& particle);
 
-  static std::optional<double> get_t0(
-      const edm4eic::CalorimeterHit& hit,
-      const podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& nav);
+  static std::optional<double>
+  get_t0(const edm4eic::CalorimeterHit& hit,
+         const podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& nav);
 
 private:
   const dd4hep::Detector* m_detector{algorithms::GeoSvc::instance().detector()};

--- a/src/algorithms/calorimetry/HEXPLIT.h
+++ b/src/algorithms/calorimetry/HEXPLIT.h
@@ -39,8 +39,10 @@ class HEXPLIT : public HEXPLITAlgorithm, public WithPodConfig<HEXPLITConfig> {
 
 public:
   HEXPLIT(std::string_view name)
-      : HEXPLITAlgorithm{
-            name, {"inputHits", "inputLinks"}, {"outputSubcellHits"}, "Split hits into subcell hits"} {}
+      : HEXPLITAlgorithm{name,
+                         {"inputHits", "inputLinks"},
+                         {"outputSubcellHits"},
+                         "Split hits into subcell hits"} {}
 
   void init() final;
   void process(const Input&, const Output&) const final;

--- a/src/algorithms/calorimetry/HEXPLIT.h
+++ b/src/algorithms/calorimetry/HEXPLIT.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2023 Sebouh Paul
+// Copyright (C) 2023 - 2026 Sebouh Paul, ePIC Collaboration
 
 // An algorithm for splitting calorimeter hits in overlapping cells into "subhits" based on the relative
 // energies of hits on neighboring layers
@@ -40,7 +40,7 @@ class HEXPLIT : public HEXPLITAlgorithm, public WithPodConfig<HEXPLITConfig> {
 public:
   HEXPLIT(std::string_view name)
       : HEXPLITAlgorithm{
-            name, {"inputHits"}, {"outputSubcellHits"}, "Split hits into subcell hits"} {}
+            name, {"inputHits", "inputLinks"}, {"outputSubcellHits"}, "Split hits into subcell hits"} {}
 
   void init() final;
   void process(const Input&, const Output&) const final;

--- a/src/algorithms/calorimetry/HEXPLIT.h
+++ b/src/algorithms/calorimetry/HEXPLIT.h
@@ -19,6 +19,8 @@
 #include <gsl/pointers>
 #include <optional>
 #include <podio/LinkNavigator.h>
+#include <podio/ObjectID.h>
+#include <unordered_map>
 #include <string>      // for basic_string
 #include <string_view> // for string_view
 #include <vector>
@@ -111,9 +113,12 @@ private:
   static edm4hep::MCParticle get_primary(const edm4hep::CaloHitContribution& contrib);
   static edm4hep::MCParticle get_primary(const edm4hep::MCParticle& particle);
 
-  static std::optional<double>
-  get_t0(const edm4eic::CalorimeterHit& hit,
-         const podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& nav);
+  using T0Cache = std::unordered_map<podio::ObjectID, std::optional<double>>;
+
+  static std::optional<double> get_t0(
+      const edm4eic::CalorimeterHit& hit,
+      const podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& nav,
+      T0Cache& cache);
 
 private:
   const dd4hep::Detector* m_detector{algorithms::GeoSvc::instance().detector()};

--- a/src/algorithms/calorimetry/HEXPLIT.h
+++ b/src/algorithms/calorimetry/HEXPLIT.h
@@ -13,7 +13,12 @@
 #include <algorithms/algorithm.h>
 #include <algorithms/geo.h>
 #include <edm4eic/CalorimeterHitCollection.h>
+#include <edm4eic/MCRecoCalorimeterHitLinkCollection.h>
+#include <edm4hep/CaloHitContribution.h>
+#include <edm4hep/MCParticle.h>
 #include <gsl/pointers>
+#include <optional>
+#include <podio/LinkNavigator.h>
 #include <string>      // for basic_string
 #include <string_view> // for string_view
 #include <vector>
@@ -24,7 +29,8 @@
 namespace eicrecon {
 
 using HEXPLITAlgorithm =
-    algorithms::Algorithm<algorithms::Input<const edm4eic::CalorimeterHitCollection>,
+    algorithms::Algorithm<algorithms::Input<const edm4eic::CalorimeterHitCollection,
+                                            std::optional<edm4eic::MCRecoCalorimeterHitLinkCollection>>,
                           algorithms::Output<edm4eic::CalorimeterHitCollection>>;
 
 class HEXPLIT : public HEXPLITAlgorithm, public WithPodConfig<HEXPLITConfig> {
@@ -101,6 +107,13 @@ private:
   };
 
   stagger_pattern stag = stag_H4;
+
+  static edm4hep::MCParticle get_primary(const edm4hep::CaloHitContribution& contrib);
+  static edm4hep::MCParticle get_primary(const edm4hep::MCParticle& particle);
+
+  static std::optional<double> get_t0(
+      const edm4eic::CalorimeterHit& hit,
+      const podio::LinkNavigator<edm4eic::MCRecoCalorimeterHitLinkCollection>& nav);
 
 private:
   const dd4hep::Detector* m_detector{algorithms::GeoSvc::instance().detector()};

--- a/src/algorithms/calorimetry/HEXPLITConfig.h
+++ b/src/algorithms/calorimetry/HEXPLITConfig.h
@@ -9,7 +9,7 @@ struct HEXPLITConfig {
   double MIP{472. * dd4hep::keV};
   double Emin_in_MIPs{0.1};
   double delta_in_MIPs{0.01};
-  double tmax{325 * dd4hep::ns};
+  double max_time_to_truth_t0{325 * dd4hep::ns};
   enum StaggerType { H4 = 0, H3 = 1, S2 = 2 } stag_type = H4;
 };
 

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -85,12 +85,12 @@ void InitPlugin(JApplication* app) {
       ));
 
   app->Add(new JOmniFactoryGeneratorT<HEXPLIT_factory>(
-      "HcalEndcapPInsertSubcellHits", {"HcalEndcapPInsertRecHits"},
+      "HcalEndcapPInsertSubcellHits", {"HcalEndcapPInsertRecHits", "HcalEndcapPInsertRawHitLinks"},
       {"HcalEndcapPInsertSubcellHits"},
       {
           .MIP          = 480. * dd4hep::keV,
           .Emin_in_MIPs = 0.5,
-          .tmax         = 162 * dd4hep::ns, //150 ns + (z at front face)/(speed of light)
+          .max_time_to_truth_t0 = 162 * dd4hep::ns, //150 ns + (z at front face)/(speed of light)
       },
       app // TODO: Remove me once fixed
       ));

--- a/src/detectors/FHCAL/FHCAL.cc
+++ b/src/detectors/FHCAL/FHCAL.cc
@@ -88,8 +88,8 @@ void InitPlugin(JApplication* app) {
       "HcalEndcapPInsertSubcellHits", {"HcalEndcapPInsertRecHits", "HcalEndcapPInsertRawHitLinks"},
       {"HcalEndcapPInsertSubcellHits"},
       {
-          .MIP          = 480. * dd4hep::keV,
-          .Emin_in_MIPs = 0.5,
+          .MIP                  = 480. * dd4hep::keV,
+          .Emin_in_MIPs         = 0.5,
           .max_time_to_truth_t0 = 162 * dd4hep::ns, //150 ns + (z at front face)/(speed of light)
       },
       app // TODO: Remove me once fixed

--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -175,13 +175,13 @@ void InitPlugin(JApplication* app) {
       ));
 
   app->Add(new JOmniFactoryGeneratorT<HEXPLIT_factory>(
-      "HcalFarForwardZDCSubcellHits", {"HcalFarForwardZDCRecHits"},
+      "HcalFarForwardZDCSubcellHits", {"HcalFarForwardZDCRecHits", "HcalFarForwardZDCRawHitLinks"},
       {"HcalFarForwardZDCSubcellHits"},
       {
           .MIP           = 630. * dd4hep::keV,
           .Emin_in_MIPs  = 0.5,
           .delta_in_MIPs = 0.01,
-          .tmax          = 269 * dd4hep::ns,
+          .max_time_to_truth_t0 = 269 * dd4hep::ns, //150 ns + (z at front face)/(speed of light)
           .stag_type     = HEXPLITConfig::StaggerType::S2,
       },
       app // TODO: Remove me once fixed

--- a/src/detectors/ZDC/ZDC.cc
+++ b/src/detectors/ZDC/ZDC.cc
@@ -178,11 +178,11 @@ void InitPlugin(JApplication* app) {
       "HcalFarForwardZDCSubcellHits", {"HcalFarForwardZDCRecHits", "HcalFarForwardZDCRawHitLinks"},
       {"HcalFarForwardZDCSubcellHits"},
       {
-          .MIP           = 630. * dd4hep::keV,
-          .Emin_in_MIPs  = 0.5,
-          .delta_in_MIPs = 0.01,
+          .MIP                  = 630. * dd4hep::keV,
+          .Emin_in_MIPs         = 0.5,
+          .delta_in_MIPs        = 0.01,
           .max_time_to_truth_t0 = 269 * dd4hep::ns, //150 ns + (z at front face)/(speed of light)
-          .stag_type     = HEXPLITConfig::StaggerType::S2,
+          .stag_type            = HEXPLITConfig::StaggerType::S2,
       },
       app // TODO: Remove me once fixed
       ));

--- a/src/factories/calorimetry/HEXPLIT_factory.h
+++ b/src/factories/calorimetry/HEXPLIT_factory.h
@@ -24,7 +24,8 @@ private:
   ParameterRef<double> m_MIP{this, "MIP", config().MIP};
   ParameterRef<double> m_Emin_in_MIPs{this, "Emin_in_MIPs", config().Emin_in_MIPs};
   ParameterRef<double> m_delta_in_MIPs{this, "delta_in_MIPs", config().delta_in_MIPs};
-  ParameterRef<double> m_max_time_to_truth_t0{this, "max_time_to_truth_t0", config().max_time_to_truth_t0};
+  ParameterRef<double> m_max_time_to_truth_t0{this, "max_time_to_truth_t0",
+                                              config().max_time_to_truth_t0};
 
   Service<AlgorithmsInit_service> m_algorithmsInit{this};
 

--- a/src/factories/calorimetry/HEXPLIT_factory.h
+++ b/src/factories/calorimetry/HEXPLIT_factory.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <edm4eic/MCRecoCalorimeterHitLinkCollection.h>
+
 #include "algorithms/calorimetry/HEXPLIT.h"
 #include "services/algorithms_init/AlgorithmsInit_service.h"
 #include "extensions/jana/JOmniFactory.h"
@@ -16,12 +18,13 @@ class HEXPLIT_factory : public JOmniFactory<HEXPLIT_factory, HEXPLITConfig> {
 private:
   std::unique_ptr<AlgoT> m_algo;
   PodioInput<edm4eic::CalorimeterHit> m_rec_hits_input{this};
+  PodioInput<edm4eic::MCRecoCalorimeterHitLink, true> m_mchitlinks_input{this};
   PodioOutput<edm4eic::CalorimeterHit> m_subcell_hits_output{this};
 
   ParameterRef<double> m_MIP{this, "MIP", config().MIP};
   ParameterRef<double> m_Emin_in_MIPs{this, "Emin_in_MIPs", config().Emin_in_MIPs};
   ParameterRef<double> m_delta_in_MIPs{this, "delta_in_MIPs", config().delta_in_MIPs};
-  ParameterRef<double> m_tmax{this, "tmax", config().tmax};
+  ParameterRef<double> m_max_time_to_truth_t0{this, "max_time_to_truth_t0", config().max_time_to_truth_t0};
 
   Service<AlgorithmsInit_service> m_algorithmsInit{this};
 
@@ -34,7 +37,7 @@ public:
   }
 
   void Process(int32_t /* run_number */, uint64_t /* event_number */) {
-    m_algo->process({m_rec_hits_input()}, {m_subcell_hits_output().get()});
+    m_algo->process({m_rec_hits_input(), m_mchitlinks_input()}, {m_subcell_hits_output().get()});
   }
 };
 

--- a/src/tests/algorithms_test/calorimetry_HEXPLIT.cc
+++ b/src/tests/algorithms_test/calorimetry_HEXPLIT.cc
@@ -28,6 +28,7 @@
 using eicrecon::HEXPLIT;
 using eicrecon::HEXPLITConfig;
 
+
 TEST_CASE("the subcell-splitting algorithm runs", "[HEXPLIT]") {
   HEXPLIT algo("HEXPLIT");
 
@@ -36,7 +37,7 @@ TEST_CASE("the subcell-splitting algorithm runs", "[HEXPLIT]") {
 
   HEXPLITConfig cfg;
   cfg.MIP  = 472. * dd4hep::keV;
-  cfg.tmax = 1000. * dd4hep::ns;
+  cfg.max_time_to_truth_t0 = 1000. * dd4hep::ns;
 
   auto detector = algorithms::GeoSvc::instance().detector();
   auto id_desc  = detector->readout("MockCalorimeterHits").idSpec();
@@ -79,7 +80,7 @@ TEST_CASE("the subcell-splitting algorithm runs", "[HEXPLIT]") {
   }
 
   auto subcellhits_coll = std::make_unique<edm4eic::CalorimeterHitCollection>();
-  algo.process({&hits_coll}, {subcellhits_coll.get()});
+  algo.process({&hits_coll, nullptr}, {subcellhits_coll.get()});
 
   //the number of subcell hits should be equal to the
   //number of subcells per cell (12) times the number of cells (5)
@@ -101,3 +102,58 @@ TEST_CASE("the subcell-splitting algorithm runs", "[HEXPLIT]") {
   // is in the subcell where the other hits overlap
   REQUIRE((*subcellhits_coll)[35].getEnergy() / E[2] > 0.95);
 }
+
+struct HEXPLITFixture {
+  HEXPLIT algo{"HEXPLIT"};
+  double side_length   = 31.3 * dd4hep::mm;
+  double layer_spacing = 25.1 * dd4hep::mm;
+  double thickness     = 3 * dd4hep::mm;
+  edm4hep::Vector3f dimension;
+  uint64_t cellID;
+
+  HEXPLITFixture() {
+    std::shared_ptr<spdlog::logger> logger = spdlog::default_logger()->clone("HEXPLIT");
+    logger->set_level(spdlog::level::warn);
+
+    HEXPLITConfig cfg;
+    cfg.MIP                  = 472. * dd4hep::keV;
+    cfg.max_time_to_truth_t0 = 500. * dd4hep::ns;
+    algo.applyConfig(cfg);
+    algo.init();
+
+    dimension = edm4hep::Vector3f(2 * side_length, std::numbers::sqrt3 * side_length, thickness);
+    auto id_desc = algorithms::GeoSvc::instance().detector()->readout("MockCalorimeterHits").idSpec();
+    cellID = id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}});
+  }
+
+  // 5 hits in consecutive layers at the given time, same positions as the main test.
+  edm4eic::CalorimeterHitCollection make_hits(float time_ns) {
+    std::array<double, 5> layer = {0, 1, 2, 3, 4};
+    std::array<double, 5> x     = {0, 0.75 * side_length, 0, 0.75 * side_length, 0};
+    std::array<double, 5> y     = {
+        std::numbers::sqrt3 / 2 * side_length, -0.25 * std::numbers::sqrt3 * side_length, 0,
+        0.25 * std::numbers::sqrt3 * side_length, std::numbers::sqrt3 / 2 * side_length};
+
+    edm4eic::CalorimeterHitCollection hits;
+    for (std::size_t i = 0; i < 5; i++) {
+      hits.create(
+          cellID, 50 * dd4hep::MeV, 0.f, time_ns, 0.f,
+          edm4hep::Vector3f(x[i], y[i], layer[i] * layer_spacing),
+          dimension, 0, layer[i],
+          edm4hep::Vector3f(x[i], y[i], layer[i] * layer_spacing));
+    }
+    return hits;
+  }
+};
+
+TEST_CASE("HEXPLIT timing cut: no MCParticles skips the cut", "[HEXPLIT]") {
+  HEXPLITFixture f;
+  // Hits are 1000 ns late — well outside the 500 ns window.
+  // Without a link collection the cut is skipped entirely.
+  auto hits = f.make_hits(1000.f);
+  auto out  = std::make_unique<edm4eic::CalorimeterHitCollection>();
+  f.algo.process({&hits, nullptr}, {out.get()});
+  REQUIRE(out->size() == 60);
+}
+
+

--- a/src/tests/algorithms_test/calorimetry_HEXPLIT.cc
+++ b/src/tests/algorithms_test/calorimetry_HEXPLIT.cc
@@ -1,155 +1,228 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2024, Sebouh Paul
+// Copyright (C) 2024 - 2026, Sebouh Paul, ePIC Collaboration
 
-#include <DD4hep/Detector.h>       // for Detector
-#include <DD4hep/IDDescriptor.h>   // for IDDescriptor
-#include <DD4hep/Readout.h>        // for Readout
-#include <Evaluator/DD4hepUnits.h> // for MeV, mm, keV, ns
+#include <DD4hep/Detector.h>
+#include <DD4hep/IDDescriptor.h>
+#include <DD4hep/Readout.h>
+#include <Evaluator/DD4hepUnits.h>
 #include <algorithms/geo.h>
-#include <catch2/catch_test_macros.hpp> // for AssertionHandler, operator""_catch_sr, StringRef, REQUIRE, operator<, operator==, operator>, TEST_CASE
-#include <edm4eic/CalorimeterHitCollection.h> // for CalorimeterHitCollection, MutableCalorimeterHit, CalorimeterHitMutableCollectionIterator
-#include <edm4hep/Vector3f.h> // for Vector3f
-#include <spdlog/common.h>    // for level_enum
-#include <spdlog/logger.h>    // for logger
-#include <spdlog/spdlog.h>    // for default_logger
-#include <array>              // for array
-#include <cmath>              // for sqrt, abs
+#include <catch2/catch_test_macros.hpp>
+#include <edm4eic/CalorimeterHitCollection.h>
+#include <edm4eic/MCRecoCalorimeterHitLinkCollection.h>
+#include <edm4hep/MCParticleCollection.h>
+#include <edm4hep/MutableCaloHitContribution.h>
+#include <edm4hep/MutableMCParticle.h>
+#include <edm4hep/RawCalorimeterHitCollection.h>
+#include <edm4hep/SimCalorimeterHitCollection.h>
+#include <edm4hep/Vector3f.h>
+#include <spdlog/spdlog.h>
+#include <array>
+#include <cmath>
 #include <cstddef>
-#include <gsl/pointers>
-#include <memory> // for allocator, unique_ptr, make_unique, shared_ptr, __shared_ptr_access
+#include <cstdint>
+#include <memory>
 #include <numbers>
-#include <string>
-#include <utility> // for pair
 #include <vector>
 
-#include "algorithms/calorimetry/HEXPLIT.h"       // for HEXPLIT
-#include "algorithms/calorimetry/HEXPLITConfig.h" // for HEXPLITConfig
+#include "algorithms/calorimetry/HEXPLIT.h"
+#include "algorithms/calorimetry/HEXPLITConfig.h"
 
 using eicrecon::HEXPLIT;
 using eicrecon::HEXPLITConfig;
 
-TEST_CASE("the subcell-splitting algorithm runs", "[HEXPLIT]") {
-  HEXPLIT algo("HEXPLIT");
+static constexpr double kSideLength   = 31.3 * dd4hep::mm;
+static constexpr double kLayerSpacing = 25.1 * dd4hep::mm;
+static constexpr double kThickness    = 3   * dd4hep::mm;
 
-  std::shared_ptr<spdlog::logger> logger = spdlog::default_logger()->clone("HEXPLIT");
-  logger->set_level(spdlog::level::trace);
+// Five hits in consecutive layers that all overlap in a single rhombus.
+static const std::array<double, 5> kX = {
+    0, 0.75*kSideLength, 0, 0.75*kSideLength, 0};
+static const std::array<double, 5> kY = {
+     std::numbers::sqrt3/2  * kSideLength,
+    -0.25*std::numbers::sqrt3 * kSideLength,
+     0,
+     0.25*std::numbers::sqrt3 * kSideLength,
+     std::numbers::sqrt3/2  * kSideLength};
 
+static edm4hep::Vector3f cell_dimension() {
+  return {(float)(2*kSideLength),
+          (float)(std::numbers::sqrt3*kSideLength),
+          (float)kThickness};
+}
+
+static uint64_t mock_cell_id() {
+  return algorithms::GeoSvc::instance()
+      .detector()->readout("MockCalorimeterHits")
+      .idSpec().encode({{"system", 255}, {"x", 0}, {"y", 0}});
+}
+
+// Configure and initialise the algorithm.
+static std::unique_ptr<HEXPLIT> make_algo(double max_time_to_truth_t0_ns) {
+  auto algo = std::make_unique<HEXPLIT>("HEXPLIT");
+  spdlog::default_logger()->clone("HEXPLIT")->set_level(spdlog::level::warn);
   HEXPLITConfig cfg;
   cfg.MIP                  = 472. * dd4hep::keV;
-  cfg.max_time_to_truth_t0 = 1000. * dd4hep::ns;
+  cfg.max_time_to_truth_t0 = max_time_to_truth_t0_ns * dd4hep::ns;
+  algo->applyConfig(cfg);
+  algo->init();
+  return algo;
+}
 
-  auto detector = algorithms::GeoSvc::instance().detector();
-  auto id_desc  = detector->readout("MockCalorimeterHits").idSpec();
+// Owns all PODIO collections that make up a single hit's truth chain:
+//   primary (status=1, time=t0_ns)
+//   └─ Geant4 secondary (status=0)
+//      └─ SimCalorimeterHit contribution
+//         ← MCRecoCalorimeterHitLink →
+//         RawCalorimeterHit
+//         └─ CalorimeterHit (hit_time_ns)
+struct TruthChain {
+  edm4hep::MCParticleCollection               mcparticles;
+  edm4hep::SimCalorimeterHitCollection        simhits;
+  edm4hep::RawCalorimeterHitCollection        rawhits;
+  edm4eic::MCRecoCalorimeterHitLinkCollection links;
+  edm4eic::CalorimeterHitCollection           rechits;
+};
 
-  //create a geometry for the fake detector.
-  double side_length   = 31.3 * dd4hep::mm;
-  double layer_spacing = 25.1 * dd4hep::mm;
-  double thickness     = 3 * dd4hep::mm;
+static TruthChain make_truth_chain(uint64_t cellID, float t0_ns, float hit_time_ns,
+                                   float energy, edm4hep::Vector3f pos,
+                                   edm4hep::Vector3f dim, int32_t layer) {
+  TruthChain c;
 
-  //dimension of a cell
-  auto dimension = edm4hep::Vector3f(2 * side_length, std::numbers::sqrt3 * side_length, thickness);
+  auto primary = c.mcparticles.create();
+  primary.setGeneratorStatus(1);
+  primary.setTime(t0_ns);
 
-  algo.applyConfig(cfg);
-  algo.init();
+  auto secondary = c.mcparticles.create();
+  secondary.setGeneratorStatus(0);
+  secondary.addToParents(primary);
+
+  auto simhit = c.simhits.create();
+  simhit.setCellID(cellID);
+  edm4hep::MutableCaloHitContribution contrib;
+  contrib.setParticle(secondary);
+  contrib.setTime(hit_time_ns);
+  contrib.setEnergy(energy);
+  simhit.addToContributions(contrib);
+
+  auto rawhit = c.rawhits.create();
+
+  auto link = c.links.create();
+  link.setFrom(rawhit);
+  link.setTo(simhit);
+
+  auto rechit = c.rechits.create(cellID, energy, 0.f, hit_time_ns, 0.f,
+                                  pos, dim, 0, layer, pos);
+  rechit.setRawHit(rawhit);
+
+  return c;
+}
+
+// Build the standard 5-hit geometry with truth links at the given t0 / hit time.
+// Returns (hits, links, chains) — chains must remain alive while hits/links are used,
+// since they own the rawhit/simhit collections that hits and links reference.
+static std::tuple<edm4eic::CalorimeterHitCollection,
+                  edm4eic::MCRecoCalorimeterHitLinkCollection,
+                  std::vector<TruthChain>>
+make_linked_hits(float t0_ns, float hit_time_ns) {
+  const uint64_t          cellID = mock_cell_id();
+  const edm4hep::Vector3f dim    = cell_dimension();
+  constexpr float         E      = 50 * dd4hep::MeV;
+
+  std::vector<TruthChain>                     chains;
+  edm4eic::CalorimeterHitCollection           hits;
+  edm4eic::MCRecoCalorimeterHitLinkCollection links;
+
+  for (std::size_t i = 0; i < 5; ++i) {
+    edm4hep::Vector3f pos(kX[i], kY[i], i * kLayerSpacing);
+    auto& c = chains.emplace_back(
+        make_truth_chain(cellID, t0_ns, hit_time_ns, E, pos, dim, (int32_t)i));
+
+    auto rh = hits.create(cellID, E, 0.f, hit_time_ns, 0.f, pos, dim, 0, (int32_t)i, pos);
+    rh.setRawHit(c.rawhits[0]);
+
+    auto lk = links.create();
+    lk.setFrom(c.rawhits[0]);
+    lk.setTo(c.simhits[0]);
+  }
+  return {std::move(hits), std::move(links), std::move(chains)};
+}
+
+TEST_CASE("the subcell-splitting algorithm runs", "[HEXPLIT]") {
+  auto algo = make_algo(/*max_time_to_truth_t0_ns=*/1000.);
+
+  const uint64_t          cellID = mock_cell_id();
+  const edm4hep::Vector3f dim    = cell_dimension();
 
   edm4eic::CalorimeterHitCollection hits_coll;
-
-  //create a set of 5 hits in consecutive layers, all of which overlap in a single rhombus,
-  // centered at (3/8, sqrt(3)/8)*side_length
-  std::array<double, 5> layer = {0, 1, 2, 3, 4};
-  std::array<double, 5> x     = {0, 0.75 * side_length, 0, 0.75 * side_length, 0};
-  std::array<double, 5> y     = {
-      std::numbers::sqrt3 / 2 * side_length, -0.25 * std::numbers::sqrt3 * side_length, 0,
-      0.25 * std::numbers::sqrt3 * side_length, std::numbers::sqrt3 / 2 * side_length};
-  std::array<double, 5> E = {50 * dd4hep::MeV, 50 * dd4hep::MeV, 50 * dd4hep::MeV, 50 * dd4hep::MeV,
-                             50 * dd4hep::MeV};
+  std::array<double, 5> E = {50*dd4hep::MeV, 50*dd4hep::MeV, 50*dd4hep::MeV,
+                              50*dd4hep::MeV, 50*dd4hep::MeV};
   for (std::size_t i = 0; i < 5; i++) {
-    hits_coll.create(
-        id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}}),   // std::uint64_t cellID,
-        E[i],                                                    // float energy,
-        0.0,                                                     // float energyError,
-        0.0,                                                     // float time,
-        0.0,                                                     // float timeError,
-        edm4hep::Vector3f(x[i], y[i], layer[i] * layer_spacing), // edm4hep::Vector3f position,
-        dimension,                                               // edm4hep::Vector3f dimension,
-        0,                                                       // std::int32_t sector,
-        layer[i],                                                // std::int32_t layer,
-        edm4hep::Vector3f(x[i], y[i], layer[i] * layer_spacing)  // edm4hep::Vector3f local
-    );
+    edm4hep::Vector3f pos(kX[i], kY[i], i * kLayerSpacing);
+    hits_coll.create(cellID, E[i], 0., 0., 0., pos, dim, 0, (int32_t)i, pos);
   }
 
   auto subcellhits_coll = std::make_unique<edm4eic::CalorimeterHitCollection>();
-  algo.process({&hits_coll, nullptr}, {subcellhits_coll.get()});
+  algo->process({&hits_coll, nullptr}, {subcellhits_coll.get()});
 
-  //the number of subcell hits should be equal to the
-  //number of subcells per cell (12) times the number of cells (5)
-  REQUIRE((*subcellhits_coll).size() == 60);
+  // 12 subcells per cell × 5 cells
+  REQUIRE(subcellhits_coll->size() == 60);
 
-  //next check that the sum of the hit energies equals the energy that I gave the hits
-  double tol  = 0.001;
-  double Esum = 0;
-  int i       = 0;
+  // energy is conserved per cell
+  double tol = 0.001, Esum = 0;
+  int    idx = 0;
   for (auto subcell : *subcellhits_coll) {
     Esum += subcell.getEnergy();
-    i++;
-    if (i % 12 == 0) {
-      REQUIRE(std::abs(Esum - E[i / 12 - 1]) / E[i / 12 - 1] < tol);
+    if (++idx % 12 == 0) {
+      REQUIRE(std::abs(Esum - E[idx/12 - 1]) / E[idx/12 - 1] < tol);
       Esum = 0;
     }
   }
-  // next check that almost all of the energy of the hit in the middle layer
-  // is in the subcell where the other hits overlap
+  // almost all energy of the middle-layer hit ends up in the overlapping subcell
   REQUIRE((*subcellhits_coll)[35].getEnergy() / E[2] > 0.95);
 }
 
-struct HEXPLITFixture {
-  HEXPLIT algo{"HEXPLIT"};
-  double side_length   = 31.3 * dd4hep::mm;
-  double layer_spacing = 25.1 * dd4hep::mm;
-  double thickness     = 3 * dd4hep::mm;
-  edm4hep::Vector3f dimension;
-  uint64_t cellID;
-
-  HEXPLITFixture() {
-    std::shared_ptr<spdlog::logger> logger = spdlog::default_logger()->clone("HEXPLIT");
-    logger->set_level(spdlog::level::warn);
-
-    HEXPLITConfig cfg;
-    cfg.MIP                  = 472. * dd4hep::keV;
-    cfg.max_time_to_truth_t0 = 500. * dd4hep::ns;
-    algo.applyConfig(cfg);
-    algo.init();
-
-    dimension = edm4hep::Vector3f(2 * side_length, std::numbers::sqrt3 * side_length, thickness);
-    auto id_desc =
-        algorithms::GeoSvc::instance().detector()->readout("MockCalorimeterHits").idSpec();
-    cellID = id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}});
-  }
-
-  // 5 hits in consecutive layers at the given time, same positions as the main test.
-  edm4eic::CalorimeterHitCollection make_hits(float time_ns) {
-    std::array<double, 5> layer = {0, 1, 2, 3, 4};
-    std::array<double, 5> x     = {0, 0.75 * side_length, 0, 0.75 * side_length, 0};
-    std::array<double, 5> y     = {
-        std::numbers::sqrt3 / 2 * side_length, -0.25 * std::numbers::sqrt3 * side_length, 0,
-        0.25 * std::numbers::sqrt3 * side_length, std::numbers::sqrt3 / 2 * side_length};
-
-    edm4eic::CalorimeterHitCollection hits;
-    for (std::size_t i = 0; i < 5; i++) {
-      hits.create(cellID, 50 * dd4hep::MeV, 0.f, time_ns, 0.f,
-                  edm4hep::Vector3f(x[i], y[i], layer[i] * layer_spacing), dimension, 0, layer[i],
-                  edm4hep::Vector3f(x[i], y[i], layer[i] * layer_spacing));
-    }
-    return hits;
-  }
-};
-
-TEST_CASE("HEXPLIT timing cut: no MCParticles skips the cut", "[HEXPLIT]") {
-  HEXPLITFixture f;
-  // Hits are 1000 ns late — well outside the 500 ns window.
-  // Without a link collection the cut is skipped entirely.
-  auto hits = f.make_hits(1000.f);
-  auto out  = std::make_unique<edm4eic::CalorimeterHitCollection>();
-  f.algo.process({&hits, nullptr}, {out.get()});
+TEST_CASE("HEXPLIT timing cut: no link collection skips the cut", "[HEXPLIT]") {
+  auto algo = make_algo(500.);
+  // Hits 1000 ns late — well outside the 500 ns window — but cut is skipped
+  // when no link collection is provided.
+  auto [hits, links, chains] = make_linked_hits(0.f, 1000.f);
+  auto out = std::make_unique<edm4eic::CalorimeterHitCollection>();
+  algo->process({&hits, nullptr}, {out.get()});
   REQUIRE(out->size() == 60);
+}
+
+TEST_CASE("HEXPLIT timing cut: hits within window pass", "[HEXPLIT]") {
+  auto algo = make_algo(500.);
+  // dt = 100 ns - 0 ns = 100 ns < 500 ns → all pass
+  auto [hits, links, chains] = make_linked_hits(/*t0=*/0.f, /*hit_time=*/100.f);
+  auto out = std::make_unique<edm4eic::CalorimeterHitCollection>();
+  algo->process({&hits, &links}, {out.get()});
+  REQUIRE(out->size() == 60);
+}
+
+TEST_CASE("HEXPLIT timing cut: hits outside window are rejected", "[HEXPLIT]") {
+  auto algo = make_algo(500.);
+  // dt = 1000 ns - 0 ns = 1000 ns > 500 ns → all rejected
+  auto [hits, links, chains] = make_linked_hits(/*t0=*/0.f, /*hit_time=*/1000.f);
+  auto out = std::make_unique<edm4eic::CalorimeterHitCollection>();
+  algo->process({&hits, &links}, {out.get()});
+  REQUIRE(out->size() == 0);
+}
+
+TEST_CASE("HEXPLIT timing cut: 1 us vertex offset correctly subtracted", "[HEXPLIT]") {
+  auto algo = make_algo(500.);
+  // dt = 1100 ns - 1000 ns = 100 ns < 500 ns → all pass
+  auto [hits, links, chains] = make_linked_hits(/*t0=*/1000.f, /*hit_time=*/1100.f);
+  auto out = std::make_unique<edm4eic::CalorimeterHitCollection>();
+  algo->process({&hits, &links}, {out.get()});
+  REQUIRE(out->size() == 60);
+}
+
+TEST_CASE("HEXPLIT timing cut: 1 us offset with late hits rejected", "[HEXPLIT]") {
+  auto algo = make_algo(500.);
+  // dt = 2000 ns - 1000 ns = 1000 ns > 500 ns → all rejected
+  auto [hits, links, chains] = make_linked_hits(/*t0=*/1000.f, /*hit_time=*/2000.f);
+  auto out = std::make_unique<edm4eic::CalorimeterHitCollection>();
+  algo->process({&hits, &links}, {out.get()});
+  REQUIRE(out->size() == 0);
 }

--- a/src/tests/algorithms_test/calorimetry_HEXPLIT.cc
+++ b/src/tests/algorithms_test/calorimetry_HEXPLIT.cc
@@ -11,17 +11,24 @@
 #include <edm4eic/MCRecoCalorimeterHitLinkCollection.h>
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/MutableCaloHitContribution.h>
-#include <edm4hep/MutableMCParticle.h>
 #include <edm4hep/RawCalorimeterHitCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
 #include <edm4hep/Vector3f.h>
+#include <podio/detail/Link.h>
+#include <spdlog/common.h>
+#include <spdlog/logger.h>
 #include <spdlog/spdlog.h>
 #include <array>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <deque>
+#include <gsl/pointers>
 #include <memory>
 #include <numbers>
+#include <string>
+#include <tuple>
+#include <utility>
 #include <vector>
 
 #include "algorithms/calorimetry/HEXPLIT.h"

--- a/src/tests/algorithms_test/calorimetry_HEXPLIT.cc
+++ b/src/tests/algorithms_test/calorimetry_HEXPLIT.cc
@@ -32,28 +32,24 @@ using eicrecon::HEXPLITConfig;
 
 static constexpr double kSideLength   = 31.3 * dd4hep::mm;
 static constexpr double kLayerSpacing = 25.1 * dd4hep::mm;
-static constexpr double kThickness    = 3   * dd4hep::mm;
+static constexpr double kThickness    = 3 * dd4hep::mm;
 
 // Five hits in consecutive layers that all overlap in a single rhombus.
-static const std::array<double, 5> kX = {
-    0, 0.75*kSideLength, 0, 0.75*kSideLength, 0};
+static const std::array<double, 5> kX = {0, 0.75 * kSideLength, 0, 0.75 * kSideLength, 0};
 static const std::array<double, 5> kY = {
-     std::numbers::sqrt3/2  * kSideLength,
-    -0.25*std::numbers::sqrt3 * kSideLength,
-     0,
-     0.25*std::numbers::sqrt3 * kSideLength,
-     std::numbers::sqrt3/2  * kSideLength};
+    std::numbers::sqrt3 / 2 * kSideLength, -0.25 * std::numbers::sqrt3* kSideLength, 0,
+    0.25 * std::numbers::sqrt3* kSideLength, std::numbers::sqrt3 / 2 * kSideLength};
 
 static edm4hep::Vector3f cell_dimension() {
-  return {(float)(2*kSideLength),
-          (float)(std::numbers::sqrt3*kSideLength),
-          (float)kThickness};
+  return {(float)(2 * kSideLength), (float)(std::numbers::sqrt3 * kSideLength), (float)kThickness};
 }
 
 static uint64_t mock_cell_id() {
   return algorithms::GeoSvc::instance()
-      .detector()->readout("MockCalorimeterHits")
-      .idSpec().encode({{"system", 255}, {"x", 0}, {"y", 0}});
+      .detector()
+      ->readout("MockCalorimeterHits")
+      .idSpec()
+      .encode({{"system", 255}, {"x", 0}, {"y", 0}});
 }
 
 // Configure and initialise the algorithm.
@@ -76,16 +72,15 @@ static std::unique_ptr<HEXPLIT> make_algo(double max_time_to_truth_t0_ns) {
 //         RawCalorimeterHit
 //         └─ CalorimeterHit (hit_time_ns)
 struct TruthChain {
-  edm4hep::MCParticleCollection               mcparticles;
-  edm4hep::SimCalorimeterHitCollection        simhits;
-  edm4hep::RawCalorimeterHitCollection        rawhits;
+  edm4hep::MCParticleCollection mcparticles;
+  edm4hep::SimCalorimeterHitCollection simhits;
+  edm4hep::RawCalorimeterHitCollection rawhits;
   edm4eic::MCRecoCalorimeterHitLinkCollection links;
-  edm4eic::CalorimeterHitCollection           rechits;
+  edm4eic::CalorimeterHitCollection rechits;
 };
 
-static TruthChain make_truth_chain(uint64_t cellID, float t0_ns, float hit_time_ns,
-                                   float energy, edm4hep::Vector3f pos,
-                                   edm4hep::Vector3f dim, int32_t layer) {
+static TruthChain make_truth_chain(uint64_t cellID, float t0_ns, float hit_time_ns, float energy,
+                                   edm4hep::Vector3f pos, edm4hep::Vector3f dim, int32_t layer) {
   TruthChain c;
 
   auto primary = c.mcparticles.create();
@@ -110,8 +105,7 @@ static TruthChain make_truth_chain(uint64_t cellID, float t0_ns, float hit_time_
   link.setFrom(rawhit);
   link.setTo(simhit);
 
-  auto rechit = c.rechits.create(cellID, energy, 0.f, hit_time_ns, 0.f,
-                                  pos, dim, 0, layer, pos);
+  auto rechit = c.rechits.create(cellID, energy, 0.f, hit_time_ns, 0.f, pos, dim, 0, layer, pos);
   rechit.setRawHit(rawhit);
 
   return c;
@@ -120,22 +114,21 @@ static TruthChain make_truth_chain(uint64_t cellID, float t0_ns, float hit_time_
 // Build the standard 5-hit geometry with truth links at the given t0 / hit time.
 // Returns (hits, links, chains) — chains must remain alive while hits/links are used,
 // since they own the rawhit/simhit collections that hits and links reference.
-static std::tuple<edm4eic::CalorimeterHitCollection,
-                  edm4eic::MCRecoCalorimeterHitLinkCollection,
+static std::tuple<edm4eic::CalorimeterHitCollection, edm4eic::MCRecoCalorimeterHitLinkCollection,
                   std::vector<TruthChain>>
 make_linked_hits(float t0_ns, float hit_time_ns) {
-  const uint64_t          cellID = mock_cell_id();
-  const edm4hep::Vector3f dim    = cell_dimension();
-  constexpr float         E      = 50 * dd4hep::MeV;
+  const uint64_t cellID       = mock_cell_id();
+  const edm4hep::Vector3f dim = cell_dimension();
+  constexpr float E           = 50 * dd4hep::MeV;
 
-  std::vector<TruthChain>                     chains;
-  edm4eic::CalorimeterHitCollection           hits;
+  std::vector<TruthChain> chains;
+  edm4eic::CalorimeterHitCollection hits;
   edm4eic::MCRecoCalorimeterHitLinkCollection links;
 
   for (std::size_t i = 0; i < 5; ++i) {
     edm4hep::Vector3f pos(kX[i], kY[i], i * kLayerSpacing);
-    auto& c = chains.emplace_back(
-        make_truth_chain(cellID, t0_ns, hit_time_ns, E, pos, dim, (int32_t)i));
+    auto& c =
+        chains.emplace_back(make_truth_chain(cellID, t0_ns, hit_time_ns, E, pos, dim, (int32_t)i));
 
     auto rh = hits.create(cellID, E, 0.f, hit_time_ns, 0.f, pos, dim, 0, (int32_t)i, pos);
     rh.setRawHit(c.rawhits[0]);
@@ -150,12 +143,12 @@ make_linked_hits(float t0_ns, float hit_time_ns) {
 TEST_CASE("the subcell-splitting algorithm runs", "[HEXPLIT]") {
   auto algo = make_algo(/*max_time_to_truth_t0_ns=*/1000.);
 
-  const uint64_t          cellID = mock_cell_id();
-  const edm4hep::Vector3f dim    = cell_dimension();
+  const uint64_t cellID       = mock_cell_id();
+  const edm4hep::Vector3f dim = cell_dimension();
 
   edm4eic::CalorimeterHitCollection hits_coll;
-  std::array<double, 5> E = {50*dd4hep::MeV, 50*dd4hep::MeV, 50*dd4hep::MeV,
-                              50*dd4hep::MeV, 50*dd4hep::MeV};
+  std::array<double, 5> E = {50 * dd4hep::MeV, 50 * dd4hep::MeV, 50 * dd4hep::MeV, 50 * dd4hep::MeV,
+                             50 * dd4hep::MeV};
   for (std::size_t i = 0; i < 5; i++) {
     edm4hep::Vector3f pos(kX[i], kY[i], i * kLayerSpacing);
     hits_coll.create(cellID, E[i], 0., 0., 0., pos, dim, 0, (int32_t)i, pos);
@@ -169,11 +162,11 @@ TEST_CASE("the subcell-splitting algorithm runs", "[HEXPLIT]") {
 
   // energy is conserved per cell
   double tol = 0.001, Esum = 0;
-  int    idx = 0;
+  int idx = 0;
   for (auto subcell : *subcellhits_coll) {
     Esum += subcell.getEnergy();
     if (++idx % 12 == 0) {
-      REQUIRE(std::abs(Esum - E[idx/12 - 1]) / E[idx/12 - 1] < tol);
+      REQUIRE(std::abs(Esum - E[idx / 12 - 1]) / E[idx / 12 - 1] < tol);
       Esum = 0;
     }
   }
@@ -186,7 +179,7 @@ TEST_CASE("HEXPLIT timing cut: no link collection skips the cut", "[HEXPLIT]") {
   // Hits 1000 ns late — well outside the 500 ns window — but cut is skipped
   // when no link collection is provided.
   auto [hits, links, chains] = make_linked_hits(0.f, 1000.f);
-  auto out = std::make_unique<edm4eic::CalorimeterHitCollection>();
+  auto out                   = std::make_unique<edm4eic::CalorimeterHitCollection>();
   algo->process({&hits, nullptr}, {out.get()});
   REQUIRE(out->size() == 60);
 }
@@ -195,7 +188,7 @@ TEST_CASE("HEXPLIT timing cut: hits within window pass", "[HEXPLIT]") {
   auto algo = make_algo(500.);
   // dt = 100 ns - 0 ns = 100 ns < 500 ns → all pass
   auto [hits, links, chains] = make_linked_hits(/*t0=*/0.f, /*hit_time=*/100.f);
-  auto out = std::make_unique<edm4eic::CalorimeterHitCollection>();
+  auto out                   = std::make_unique<edm4eic::CalorimeterHitCollection>();
   algo->process({&hits, &links}, {out.get()});
   REQUIRE(out->size() == 60);
 }
@@ -204,7 +197,7 @@ TEST_CASE("HEXPLIT timing cut: hits outside window are rejected", "[HEXPLIT]") {
   auto algo = make_algo(500.);
   // dt = 1000 ns - 0 ns = 1000 ns > 500 ns → all rejected
   auto [hits, links, chains] = make_linked_hits(/*t0=*/0.f, /*hit_time=*/1000.f);
-  auto out = std::make_unique<edm4eic::CalorimeterHitCollection>();
+  auto out                   = std::make_unique<edm4eic::CalorimeterHitCollection>();
   algo->process({&hits, &links}, {out.get()});
   REQUIRE(out->size() == 0);
 }
@@ -213,7 +206,7 @@ TEST_CASE("HEXPLIT timing cut: 1 us vertex offset correctly subtracted", "[HEXPL
   auto algo = make_algo(500.);
   // dt = 1100 ns - 1000 ns = 100 ns < 500 ns → all pass
   auto [hits, links, chains] = make_linked_hits(/*t0=*/1000.f, /*hit_time=*/1100.f);
-  auto out = std::make_unique<edm4eic::CalorimeterHitCollection>();
+  auto out                   = std::make_unique<edm4eic::CalorimeterHitCollection>();
   algo->process({&hits, &links}, {out.get()});
   REQUIRE(out->size() == 60);
 }
@@ -222,7 +215,7 @@ TEST_CASE("HEXPLIT timing cut: 1 us offset with late hits rejected", "[HEXPLIT]"
   auto algo = make_algo(500.);
   // dt = 2000 ns - 1000 ns = 1000 ns > 500 ns → all rejected
   auto [hits, links, chains] = make_linked_hits(/*t0=*/1000.f, /*hit_time=*/2000.f);
-  auto out = std::make_unique<edm4eic::CalorimeterHitCollection>();
+  auto out                   = std::make_unique<edm4eic::CalorimeterHitCollection>();
   algo->process({&hits, &links}, {out.get()});
   REQUIRE(out->size() == 0);
 }

--- a/src/tests/algorithms_test/calorimetry_HEXPLIT.cc
+++ b/src/tests/algorithms_test/calorimetry_HEXPLIT.cc
@@ -28,7 +28,6 @@
 using eicrecon::HEXPLIT;
 using eicrecon::HEXPLITConfig;
 
-
 TEST_CASE("the subcell-splitting algorithm runs", "[HEXPLIT]") {
   HEXPLIT algo("HEXPLIT");
 
@@ -36,7 +35,7 @@ TEST_CASE("the subcell-splitting algorithm runs", "[HEXPLIT]") {
   logger->set_level(spdlog::level::trace);
 
   HEXPLITConfig cfg;
-  cfg.MIP  = 472. * dd4hep::keV;
+  cfg.MIP                  = 472. * dd4hep::keV;
   cfg.max_time_to_truth_t0 = 1000. * dd4hep::ns;
 
   auto detector = algorithms::GeoSvc::instance().detector();
@@ -122,7 +121,8 @@ struct HEXPLITFixture {
     algo.init();
 
     dimension = edm4hep::Vector3f(2 * side_length, std::numbers::sqrt3 * side_length, thickness);
-    auto id_desc = algorithms::GeoSvc::instance().detector()->readout("MockCalorimeterHits").idSpec();
+    auto id_desc =
+        algorithms::GeoSvc::instance().detector()->readout("MockCalorimeterHits").idSpec();
     cellID = id_desc.encode({{"system", 255}, {"x", 0}, {"y", 0}});
   }
 
@@ -136,11 +136,9 @@ struct HEXPLITFixture {
 
     edm4eic::CalorimeterHitCollection hits;
     for (std::size_t i = 0; i < 5; i++) {
-      hits.create(
-          cellID, 50 * dd4hep::MeV, 0.f, time_ns, 0.f,
-          edm4hep::Vector3f(x[i], y[i], layer[i] * layer_spacing),
-          dimension, 0, layer[i],
-          edm4hep::Vector3f(x[i], y[i], layer[i] * layer_spacing));
+      hits.create(cellID, 50 * dd4hep::MeV, 0.f, time_ns, 0.f,
+                  edm4hep::Vector3f(x[i], y[i], layer[i] * layer_spacing), dimension, 0, layer[i],
+                  edm4hep::Vector3f(x[i], y[i], layer[i] * layer_spacing));
     }
     return hits;
   }
@@ -155,5 +153,3 @@ TEST_CASE("HEXPLIT timing cut: no MCParticles skips the cut", "[HEXPLIT]") {
   f.algo.process({&hits, nullptr}, {out.get()});
   REQUIRE(out->size() == 60);
 }
-
-


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

150 ns excess cut is relatively large for big chunk hadronic interactions, but we need to support case when t0 != 0, or this removes hits completely.

Related to #2081
Closes: #2802

### What is the urgency of this PR?
- [x] High (please describe reason below)
  For meson structure group
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [x] This PR introduces breaking changes. Please describe changes users need to make below.
  Old `plugin:factory:tmax` name is replaced by `plugin:factory:max_time_to_truth_t0`
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.
  Claude