### PR TITLE
fix: rm pre-Acts 44 ConvertDD4hepDetector handling

### DIFF
--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -219,8 +219,8 @@ void ActsGeometryProvider::initialize(const dd4hep::Detector* dd4hep_geo, std::s
       const auto* placement   = surface->surfacePlacement();
       const auto* det_element = dynamic_cast<const ActsPlugins::DD4hepDetectorElement*>(placement);
 #else
-      const auto* det_element =
-          dynamic_cast<const ActsPlugins::DD4hepDetectorElement*>(surface->associatedDetectorElement());
+      const auto* det_element = dynamic_cast<const ActsPlugins::DD4hepDetectorElement*>(
+          surface->associatedDetectorElement());
 #endif
 
       if (det_element == nullptr) {

--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -15,19 +15,11 @@
 #include <Acts/Utilities/Logger.hpp>
 #include <boost/container/detail/std_fwd.hpp>
 #include <fmt/format.h>
-#if __has_include(<ActsPlugins/DD4hep/ConvertDD4hepDetector.hpp>)
 #include <ActsPlugins/DD4hep/ConvertDD4hepDetector.hpp>
 #include <ActsPlugins/DD4hep/DD4hepDetectorElement.hpp>
 #include <ActsPlugins/DD4hep/DD4hepFieldAdapter.hpp>
 #include <ActsPlugins/Json/JsonMaterialDecorator.hpp>
 #include <ActsPlugins/Json/MaterialMapJsonConverter.hpp>
-#else
-#include <Acts/Plugins/DD4hep/ConvertDD4hepDetector.hpp>
-#include <Acts/Plugins/DD4hep/DD4hepDetectorElement.hpp>
-#include <Acts/Plugins/DD4hep/DD4hepFieldAdapter.hpp>
-#include <Acts/Plugins/Json/JsonMaterialDecorator.hpp>
-#include <Acts/Plugins/Json/MaterialMapJsonConverter.hpp>
-#endif
 #include <Acts/Surfaces/Surface.hpp>
 #include <Acts/Utilities/BinningType.hpp>
 #include <Acts/Utilities/Result.hpp>
@@ -55,21 +47,6 @@
 template <typename T>
 struct fmt::formatter<T, std::enable_if_t<std::is_base_of_v<Eigen::MatrixBase<T>, T>, char>>
     : fmt::ostream_formatter {};
-
-// Ensure ActsPlugins namespace is used when present
-#if __has_include(<ActsPlugins/DD4hep/ConvertDD4hepDetector.hpp>)
-// Acts_MAJOR_VERSION >= 44
-using DD4hepDetectorElement = ActsPlugins::DD4hepDetectorElement;
-using ActsPlugins::convertDD4hepDetector;
-using ActsPlugins::DD4hepFieldAdapter;
-using ActsPlugins::sortDetElementsByID;
-#else
-// Acts_MAJOR_VERSION < 44
-using DD4hepDetectorElement = Acts::DD4hepDetectorElement;
-using Acts::convertDD4hepDetector;
-using Acts::DD4hepFieldAdapter;
-using Acts::sortDetElementsByID;
-#endif
 
 /// @brief Material decorator wrapper that tracks per-layer material assignment
 ///
@@ -167,10 +144,10 @@ void ActsGeometryProvider::initialize(const dd4hep::Detector* dd4hep_geo, std::s
                                                 const Acts::Surface& surface) const override {
 #if Acts_VERSION_MAJOR >= 45
       const auto* placement          = surface.surfacePlacement();
-      const auto* dd4hep_det_element = dynamic_cast<const DD4hepDetectorElement*>(placement);
+      const auto* dd4hep_det_element = dynamic_cast<const ActsPlugins::DD4hepDetectorElement*>(placement);
 #else
       const auto* dd4hep_det_element =
-          dynamic_cast<const DD4hepDetectorElement*>(surface.associatedDetectorElement());
+          dynamic_cast<const ActsPlugins::DD4hepDetectorElement*>(surface.associatedDetectorElement());
 #endif
       if (dd4hep_det_element == nullptr) {
         return identifier;
@@ -193,9 +170,9 @@ void ActsGeometryProvider::initialize(const dd4hep::Detector* dd4hep_geo, std::s
 
   try {
     m_trackingGeo =
-        convertDD4hepDetector(m_dd4hepDetector->world(), *logger, bTypePhi, bTypeR, bTypeZ,
+        ActsPlugins::convertDD4hepDetector(m_dd4hepDetector->world(), *logger, bTypePhi, bTypeR, bTypeZ,
                               layerEnvelopeR, layerEnvelopeZ, defaultLayerThickness,
-                              sortDetElementsByID, m_trackingGeoCtx, materialDeco, geometryIdHook);
+                              ActsPlugins::sortDetElementsByID, m_trackingGeoCtx, materialDeco, geometryIdHook);
   } catch (std::exception& ex) {
     m_init_log->error("Error during DD4Hep -> ACTS geometry conversion: {}", ex.what());
     m_init_log->info("Set parameter acts:LogLevel=trace to see conversion info and possibly "
@@ -270,7 +247,7 @@ void ActsGeometryProvider::initialize(const dd4hep::Detector* dd4hep_geo, std::s
 
   // Load ACTS magnetic field
   m_init_log->info("Loading magnetic field...");
-  m_magneticField = std::make_shared<DD4hepFieldAdapter>(m_dd4hepDetector->field());
+  m_magneticField = std::make_shared<ActsPlugins::DD4hepFieldAdapter>(m_dd4hepDetector->field());
   auto bCache     = m_magneticField->makeCache(Acts::MagneticFieldContext{});
   for (int z : {0, 500, 1000, 1500, 2000, 3000, 4000}) {
     auto b = m_magneticField->getField({0.0, 0.0, double(z)}, bCache).value();

--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -143,11 +143,12 @@ void ActsGeometryProvider::initialize(const dd4hep::Detector* dd4hep_geo, std::s
     Acts::GeometryIdentifier decorateIdentifier(Acts::GeometryIdentifier identifier,
                                                 const Acts::Surface& surface) const override {
 #if Acts_VERSION_MAJOR >= 45
-      const auto* placement          = surface.surfacePlacement();
-      const auto* dd4hep_det_element = dynamic_cast<const ActsPlugins::DD4hepDetectorElement*>(placement);
-#else
+      const auto* placement = surface.surfacePlacement();
       const auto* dd4hep_det_element =
-          dynamic_cast<const ActsPlugins::DD4hepDetectorElement*>(surface.associatedDetectorElement());
+          dynamic_cast<const ActsPlugins::DD4hepDetectorElement*>(placement);
+#else
+      const auto* dd4hep_det_element = dynamic_cast<const ActsPlugins::DD4hepDetectorElement*>(
+          surface.associatedDetectorElement());
 #endif
       if (dd4hep_det_element == nullptr) {
         return identifier;
@@ -169,10 +170,10 @@ void ActsGeometryProvider::initialize(const dd4hep::Detector* dd4hep_geo, std::s
   double defaultLayerThickness = Acts::UnitConstants::fm;
 
   try {
-    m_trackingGeo =
-        ActsPlugins::convertDD4hepDetector(m_dd4hepDetector->world(), *logger, bTypePhi, bTypeR, bTypeZ,
-                              layerEnvelopeR, layerEnvelopeZ, defaultLayerThickness,
-                              ActsPlugins::sortDetElementsByID, m_trackingGeoCtx, materialDeco, geometryIdHook);
+    m_trackingGeo = ActsPlugins::convertDD4hepDetector(
+        m_dd4hepDetector->world(), *logger, bTypePhi, bTypeR, bTypeZ, layerEnvelopeR,
+        layerEnvelopeZ, defaultLayerThickness, ActsPlugins::sortDetElementsByID, m_trackingGeoCtx,
+        materialDeco, geometryIdHook);
   } catch (std::exception& ex) {
     m_init_log->error("Error during DD4Hep -> ACTS geometry conversion: {}", ex.what());
     m_init_log->info("Set parameter acts:LogLevel=trace to see conversion info and possibly "

--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -217,10 +217,10 @@ void ActsGeometryProvider::initialize(const dd4hep::Detector* dd4hep_geo, std::s
       }
 #if Acts_VERSION_MAJOR >= 45
       const auto* placement   = surface->surfacePlacement();
-      const auto* det_element = dynamic_cast<const DD4hepDetectorElement*>(placement);
+      const auto* det_element = dynamic_cast<const ActsPlugins::DD4hepDetectorElement*>(placement);
 #else
       const auto* det_element =
-          dynamic_cast<const DD4hepDetectorElement*>(surface->associatedDetectorElement());
+          dynamic_cast<const ActsPlugins::DD4hepDetectorElement*>(surface->associatedDetectorElement());
 #endif
 
       if (det_element == nullptr) {

--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -174,7 +174,7 @@ void ActsGeometryProvider::initialize(const dd4hep::Detector* dd4hep_geo, std::s
         m_dd4hepDetector->world(), *logger, bTypePhi, bTypeR, bTypeZ, layerEnvelopeR,
         layerEnvelopeZ, defaultLayerThickness, ActsPlugins::sortDetElementsByID, m_trackingGeoCtx,
         materialDeco, geometryIdHook);
-  } catch (std::exception& ex) {
+  } catch (const std::exception& ex) {
     m_init_log->error("Error during DD4Hep -> ACTS geometry conversion: {}", ex.what());
     m_init_log->info("Set parameter acts:LogLevel=trace to see conversion info and possibly "
                      "identify failing geometry");


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR removes pre-Acts v44 handling of the DD4hep conversion. We are now requiring Acts v44 so the old branch is dead.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: tech debt)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
