### PR TITLE
fix: HcalEndcapN{'' => SplitMerge}ClustersWithoutShapes

### DIFF
--- a/src/detectors/EHCAL/EHCAL.cc
+++ b/src/detectors/EHCAL/EHCAL.cc
@@ -155,7 +155,7 @@ void InitPlugin(JApplication* app) {
       app // TODO: remove me once fixed
       ));
   app->Add(new JOmniFactoryGeneratorT<CalorimeterClusterRecoCoG_factory>(
-      "HcalEndcapNClustersWithoutShapes",
+      "HcalEndcapNSplitMergeClustersWithoutShapes",
       {"HcalEndcapNSplitMergeProtoClusters",
        "HcalEndcapNRawHitLinks", // edm4eic::MCRecoCalorimeterHitLink
        "HcalEndcapNRawHitAssociations"},


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR fixes a duplicate factory name in the EHCAL plugin. Symptom in https://github.com/eic/EICrecon/actions/runs/32874771535/job/97892285555?pr=2524#step:7:292.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: duplicate factory name)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
