### PR TITLE
fix: extract multilambda into detail header and consolidate use

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -30,15 +30,12 @@
 
 #include "CalorimeterIslandCluster.h"
 #include "algorithms/calorimetry/CalorimeterIslandClusterConfig.h"
+#include "algorithms/interfaces/detail/multilambda.h"
 #include "services/evaluator/EvaluatorSvc.h"
 
 using namespace edm4eic;
 
 namespace eicrecon {
-template <typename... L> struct multilambda : L... {
-  using L::operator()...;
-  constexpr multilambda(L... lambda) : L(std::move(lambda))... {}
-};
 
 static double Phi_mpi_pi(double phi) { return std::remainder(phi, 2 * M_PI); }
 

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -12,9 +12,8 @@
 #include <edm4hep/Vector2f.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <fmt/core.h>
 #include <fmt/format.h>
-#include <algorithm>
+#include <fmt/ranges.h>
 #include <cmath>
 #include <iterator>
 #include <map>

--- a/src/algorithms/calorimetry/ImagingTopoCluster.cc
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.cc
@@ -34,12 +34,9 @@
 #include <vector>
 
 #include "algorithms/calorimetry/ImagingTopoClusterConfig.h"
+#include "algorithms/interfaces/detail/multilambda.h"
 
 namespace eicrecon {
-template <typename... L> struct multilambda : L... {
-  using L::operator()...;
-  constexpr multilambda(L... lambda) : L(std::move(lambda))... {}
-};
 
 void ImagingTopoCluster::init() {
 

--- a/src/algorithms/calorimetry/ImagingTopoCluster.cc
+++ b/src/algorithms/calorimetry/ImagingTopoCluster.cc
@@ -29,7 +29,6 @@
 #include <cstdlib>
 #include <stdexcept>
 #include <tuple>
-#include <utility>
 #include <variant>
 #include <vector>
 

--- a/src/algorithms/interfaces/detail/multilambda.h
+++ b/src/algorithms/interfaces/detail/multilambda.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <utility>
+
 namespace eicrecon {
 
 // A helper class to combine multiple lambdas into a single callable object.

--- a/src/algorithms/interfaces/detail/multilambda.h
+++ b/src/algorithms/interfaces/detail/multilambda.h
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 Wouter Deconinck
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+namespace eicrecon {
+
+// A helper class to combine multiple lambdas into a single callable object.
+//
+//  multilambda _toDouble = {
+//      [](const std::string& v) { return dd4hep::_toDouble(v); },
+//      [](const double& v) { return v; },
+//  };
+//
+template <typename... L> struct multilambda : L... {
+  using L::operator()...;
+  constexpr multilambda(L... lambda) : L(std::move(lambda))... {}
+};
+
+} // namespace eicrecon

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -51,17 +51,13 @@
 #include <utility>
 #include <variant>
 
+#include "algorithms/interfaces/detail/multilambda.h"
 #include "algorithms/tracking/ActsGeometryProvider.h"
 #include "algorithms/tracking/TrackPropagation.h"
 #include "algorithms/tracking/TrackPropagationConfig.h"
 #include "extensions/spdlog/SpdlogToActs.h"
 
 namespace eicrecon {
-
-template <typename... L> struct multilambda : L... {
-  using L::operator()...;
-  constexpr multilambda(L... lambda) : L(std::move(lambda))... {}
-};
 
 void TrackPropagation::init() {
   const auto* detector = m_detector;

--- a/src/algorithms/tracking/TrackPropagation.cc
+++ b/src/algorithms/tracking/TrackPropagation.cc
@@ -5,6 +5,7 @@
 #include <Acts/Definitions/Direction.hpp>
 #include <Acts/Definitions/TrackParametrization.hpp>
 #include <Acts/Definitions/Units.hpp>
+#include <Acts/Utilities/MathHelpers.hpp>
 #if Acts_VERSION_MAJOR >= 46
 #include <Acts/EventData/BoundTrackParameters.hpp>
 #else


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR refactors the usage of the `multilambda` helper class by moving its definition to a new header file and updating all relevant algorithm files to include this shared implementation. This change improves code maintainability and reduces duplication by centralizing the `multilambda` utility.

**Refactoring and code deduplication:**

* Introduced a new header file, `algorithms/interfaces/detail/multilambda.h`, containing the definition of the `multilambda` helper class for combining multiple lambdas into a single callable object.
* Removed local definitions of the `multilambda` struct from `CalorimeterIslandCluster.cc`, `ImagingTopoCluster.cc`, and `TrackPropagation.cc`, replacing them with includes of the new shared header. [[1]](diffhunk://#diff-57b413772a7a45d51cd383a3e763c8f739f1783ff05c234a7fdd130dd23d3045R33-L41) [[2]](diffhunk://#diff-32a8763d1466d371b447ad7031a8b07c5d7cd52ebafc6eb4d06b20c1de51fbe8R37-L42) [[3]](diffhunk://#diff-8d72010a235f53e207b8ccc1bccc1579c12a373bc56bf3dbc13798aa45827564R54-L65)

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ ] Medium
- [x] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: duplication)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

PR description.