### PR TITLE
fix: expand track seeding default cfg into non-sqrt values

### DIFF
--- a/src/algorithms/tracking/TrackSeedingConfig.h
+++ b/src/algorithms/tracking/TrackSeedingConfig.h
@@ -205,7 +205,7 @@ struct TrackSeedingConfig {
   float phiError    = 0.1414 * Acts::UnitConstants::rad;
   float thetaError  = 0.0447 * Acts::UnitConstants::rad;
   float qOverPError = 1. / (6.325 * Acts::UnitConstants::GeV);
-  float timeError   = 5.475 * Acts::UnitConstants::ns;
+  float timeError   = 0.183 * Acts::UnitConstants::ns;
 };
 
 inline std::istream& operator>>(std::istream& in,

--- a/src/algorithms/tracking/TrackSeedingConfig.h
+++ b/src/algorithms/tracking/TrackSeedingConfig.h
@@ -200,16 +200,12 @@ struct TrackSeedingConfig {
   //////////////////////////////////////////////////////////////////////////
   /// TRACK PARAMETER ESTIMATION COVARIANCE
 
-  float locaError   = std::sqrt(1.5) * Acts::UnitConstants::mm;
-  float locbError   = std::sqrt(1.5) * Acts::UnitConstants::mm;
-  float phiError    = std::sqrt(0.02) * Acts::UnitConstants::rad;
-  float thetaError  = std::sqrt(0.002) * Acts::UnitConstants::rad;
-  float qOverPError = std::sqrt(0.025) / Acts::UnitConstants::GeV;
-  float timeError =
-      std::sqrt(0.1 * Acts::UnitConstants::mm / Acts::UnitConstants::ns) * Acts::UnitConstants::ns;
-  // FIXME timeError is currently set to 0.0183 = 5.5 ns in these units since:
-  // Acts::UnitConstants::mm = 1
-  // Acts::UnitConstants::ns = 299.792458
+  float locaError   = 1.225 * Acts::UnitConstants::mm;
+  float locbError   = 1.225 * Acts::UnitConstants::mm;
+  float phiError    = 0.1414 * Acts::UnitConstants::rad;
+  float thetaError  = 0.0447 * Acts::UnitConstants::rad;
+  float qOverPError = 1. / (6.325 * Acts::UnitConstants::GeV);
+  float timeError   = 5.475 * Acts::UnitConstants::ns;
 };
 
 inline std::istream& operator>>(std::istream& in,

--- a/src/algorithms/tracking/TrackSeedingConfig.h
+++ b/src/algorithms/tracking/TrackSeedingConfig.h
@@ -205,7 +205,7 @@ struct TrackSeedingConfig {
   float phiError    = 0.1414 * Acts::UnitConstants::rad;
   float thetaError  = 0.0447 * Acts::UnitConstants::rad;
   float qOverPError = 1. / (6.325 * Acts::UnitConstants::GeV);
-  float timeError   = 0.183 * Acts::UnitConstants::ns;
+  float timeError   = 0.0183 * Acts::UnitConstants::ns;
 };
 
 inline std::istream& operator>>(std::istream& in,


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR updates the default error values used for track parameter estimation in the `TrackSeedingConfig` struct. The changes replace expressions involving square roots and unit conversions with their precomputed numerical values, making the code clearer. The numerical values are essentially identical (up to 4th digit rounding) to what was there before, just more easily interpretable. No major changes are expected by this PR.

**Track parameter estimation error updates:**

* Replaced computed expressions for `locaError`, `locbError`, `phiError`, `thetaError`, `qOverPError`, and `timeError` with their evaluated numerical values in the `TrackSeedingConfig` struct. This change clarifies the default error settings and removes the need for runtime computation.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: weird units removed)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
