### PR TITLE
fix: Use finite deltaZMin/deltaZMax to avoid JANA2 parameter bug

### DIFF
--- a/src/algorithms/tracking/TrackSeedingConfig.h
+++ b/src/algorithms/tracking/TrackSeedingConfig.h
@@ -95,9 +95,11 @@ struct TrackSeedingConfig {
   float deltaRMaxBottomSP = 200. * Acts::UnitConstants::mm;
 
   /// Minimum z-distance between doublet space points (Seeding2 only)
-  float deltaZMin = -std::numeric_limits<float>::infinity();
+  /// Note: Cannot use infinity due to JANA2 parameter bug that converts inf->0
+  float deltaZMin = -std::numeric_limits<float>::max();
   /// Maximum z-distance between doublet space points (Seeding2 only)
-  float deltaZMax = std::numeric_limits<float>::infinity();
+  /// Note: Cannot use infinity due to JANA2 parameter bug that converts inf->0
+  float deltaZMax = std::numeric_limits<float>::max();
 
   /// Maximum impact parameter allowed for doublet/seed candidates
   float impactMax = 3. * Acts::UnitConstants::mm;
@@ -188,6 +190,7 @@ struct TrackSeedingConfig {
   /// PHYSICS / FIELD PARAMETERS
 
   /// Magnetic field in z (GeV/[e*mm] = T in Acts units)
+  /// Magnetic field  Z component (for helix-based cuts) [Acts units]
   float bFieldInZ = 1.7 * Acts::UnitConstants::T;
   /// Beam position x offset
   float beamPosX = 0.;


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

JANA2 parameter system converts infinity to zero during string round-trip:
- infinity -> "inf" (string) -> 0 (parsed back)
- This causes 'loses equality with itself after stringification' warnings
- Acts Seeding2 receives deltaZMax=0 instead of infinity
- With deltaZMax=0, no doublets satisfy |dz| < 0, resulting in 0 seeds

Root cause identified via test showing stringstream >> fails to parse "inf":
  std::stringstream ss("inf"); float f; ss >> f;  // f == 0, not infinity

Solution: Use large finite values (`std::numeric_limits<>::max`) that stringify/parse correctly.
Testing: deltaZMax=infinity → 0 seeds, deltaZMax=max → 91 seeds

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: zero seeds with seeding2)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
