### PR TITLE
fix: fmt::format to std::format wherever easily possible

### DIFF
--- a/src/algorithms/calorimetry/CalorimeterHitDigi.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitDigi.cc
@@ -20,7 +20,7 @@
 #include <algorithms/service.h>
 #include <edm4eic/MCRecoCalorimeterHitAssociationCollection.h>
 #include <edm4hep/CaloHitContributionCollection.h>
-#include <fmt/format.h>
+#include <format>
 #include <podio/RelationRange.h>
 #include <podio/detail/Link.h>
 #include <podio/detail/LinkCollectionImpl.h>
@@ -96,7 +96,7 @@ void CalorimeterHitDigi::init() {
     // pollutes output for geometries that are less than complete.
     // We could save an exception and throw it from process.
     debug("Failed to load ID decoder for {}", m_cfg.readout);
-    throw std::runtime_error(fmt::format("Failed to load ID decoder for {}", m_cfg.readout));
+    throw std::runtime_error(std::format("Failed to load ID decoder for {}", m_cfg.readout));
   }
 
   decltype(id_mask) id_inverse_mask = 0;
@@ -129,7 +129,7 @@ void CalorimeterHitDigi::init() {
                                                    {"sipm", kSipmReadout}};
   if (not readoutTypes.count(m_cfg.readoutType)) {
     error("Invalid readoutType \"{}\"", m_cfg.readoutType);
-    throw std::runtime_error(fmt::format("Invalid readoutType \"{}\"", m_cfg.readoutType));
+    throw std::runtime_error(std::format("Invalid readoutType \"{}\"", m_cfg.readoutType));
   }
   readoutType = readoutTypes.at(m_cfg.readoutType);
 }

--- a/src/algorithms/calorimetry/CalorimeterHitsMerger.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitsMerger.cc
@@ -22,13 +22,12 @@
 #include <algorithms/service.h>
 #include <edm4hep/RawCalorimeterHit.h>
 #include <edm4hep/Vector3f.h>
-#include <fmt/core.h>
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
 #include <format>
-#include <gsl/pointers>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
 #include <vector>

--- a/src/algorithms/calorimetry/CalorimeterHitsMerger.cc
+++ b/src/algorithms/calorimetry/CalorimeterHitsMerger.cc
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <format>
 #include <gsl/pointers>
 #include <string>
 #include <unordered_map>
@@ -73,7 +74,7 @@ void CalorimeterHitsMerger::init() {
       const short index [[maybe_unused]] = id_decoder->index(field);
     }
   } catch (...) {
-    auto mess = fmt::format("Failed to load ID decoder for {}", m_cfg.readout);
+    auto mess = std::format("Failed to load ID decoder for {}", m_cfg.readout);
     warning(mess);
     return;
   }

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -12,9 +12,7 @@
 #include <edm4hep/Vector2f.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <fmt/format.h>
 #include <fmt/ranges.h>
-#include <algorithm>
 #include <cmath>
 #include <format>
 #include <iterator>

--- a/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
+++ b/src/algorithms/calorimetry/CalorimeterIslandCluster.cc
@@ -13,7 +13,7 @@
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <fmt/core.h>
-#include <fmt/format.h>
+#include <format>
 #include <algorithm>
 #include <cmath>
 #include <iterator>
@@ -204,14 +204,14 @@ void CalorimeterIslandCluster::init() {
         distMethods, [&](auto& p) { return m_cfg.transverseEnergyProfileMetric == p.first; });
     if (transverseEnergyProfileMetric_it == distMethods.end()) {
       throw std::runtime_error(
-          fmt::format(R"(Unsupported value "{}" for "transverseEnergyProfileMetric")",
+          std::format(R"(Unsupported value "{}" for "transverseEnergyProfileMetric")",
                       m_cfg.transverseEnergyProfileMetric));
     }
     transverseEnergyProfileMetric = std::get<0>(transverseEnergyProfileMetric_it->second);
     std::vector<double>& units    = std::get<1>(transverseEnergyProfileMetric_it->second);
     for (auto unit : units) {
       if (unit != units[0]) {
-        throw std::runtime_error(fmt::format("Metric {} has incompatible dimension units",
+        throw std::runtime_error(std::format("Metric {} has incompatible dimension units",
                                              m_cfg.transverseEnergyProfileMetric));
       }
     }

--- a/src/algorithms/calorimetry/EdepToNpeConversion.cc
+++ b/src/algorithms/calorimetry/EdepToNpeConversion.cc
@@ -4,9 +4,10 @@
 #include <DD4hep/Detector.h>
 #include <DD4hep/Readout.h>
 #include <DDSegmentation/BitFieldCoder.h>
-#include <format>
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <cstddef>
+#include <format>
 #include <fstream>
 #include <random>
 #include <sstream>

--- a/src/algorithms/calorimetry/EdepToNpeConversion.cc
+++ b/src/algorithms/calorimetry/EdepToNpeConversion.cc
@@ -4,7 +4,7 @@
 #include <DD4hep/Detector.h>
 #include <DD4hep/Readout.h>
 #include <DDSegmentation/BitFieldCoder.h>
-#include <fmt/format.h>
+#include <format>
 #include <fmt/ranges.h>
 #include <cstddef>
 #include <fstream>
@@ -43,18 +43,18 @@ void EdepToNpeConversion::init() {
   try {
     m_id_spec = m_detector->readout(m_cfg.readout).idSpec();
   } catch (...) {
-    throw std::runtime_error(fmt::format("Failed to get idSpec for readout {}", m_cfg.readout));
+    throw std::runtime_error(std::format("Failed to get idSpec for readout {}", m_cfg.readout));
   }
   m_id_dec = m_id_spec.decoder();
   if (m_id_dec == nullptr) {
-    throw std::runtime_error(fmt::format("Failed to get ID decoder for readout {}", m_cfg.readout));
+    throw std::runtime_error(std::format("Failed to get ID decoder for readout {}", m_cfg.readout));
   }
   for (const auto& field : m_cfg.edep_to_npe_fields) {
     try {
       m_field_idxs.push_back(m_id_dec->index(field));
     } catch (...) {
       throw std::runtime_error(
-          fmt::format("Field {} not found in idSpec of readout {}", field, m_cfg.readout));
+          std::format("Field {} not found in idSpec of readout {}", field, m_cfg.readout));
     }
   }
 
@@ -62,7 +62,7 @@ void EdepToNpeConversion::init() {
   std::string filename = m_cfg.edep_to_npe_filename;
   std::ifstream infile(filename);
   if (!infile) {
-    throw std::runtime_error(fmt::format("Unable to open LUT file: {}", filename));
+    throw std::runtime_error(std::format("Unable to open LUT file: {}", filename));
   }
   std::string line;
   std::size_t lineno = 0;
@@ -70,26 +70,26 @@ void EdepToNpeConversion::init() {
     lineno++;
     if (line.empty()) {
       throw std::runtime_error(
-          fmt::format("Empty line in LUT file {} at line {}", filename, lineno));
+          std::format("Empty line in LUT file {} at line {}", filename, lineno));
     }
     std::istringstream iss(line);
     std::vector<int> key(m_cfg.edep_to_npe_fields.size());
     double factor;
     for (auto& value : key) {
       if (!(iss >> value)) {
-        throw std::runtime_error(fmt::format("Malformed LUT file {} at line {}", filename, lineno));
+        throw std::runtime_error(std::format("Malformed LUT file {} at line {}", filename, lineno));
       }
     }
     if (!(iss >> factor)) {
-      throw std::runtime_error(fmt::format("Malformed LUT file {} at line {}", filename, lineno));
+      throw std::runtime_error(std::format("Malformed LUT file {} at line {}", filename, lineno));
     }
     if (!m_edep_to_npe_lut.emplace(std::move(key), factor).second) {
       throw std::runtime_error(
-          fmt::format("Duplicate key in LUT file {} at line {}", filename, lineno));
+          std::format("Duplicate key in LUT file {} at line {}", filename, lineno));
     }
   }
   if (m_edep_to_npe_lut.empty()) {
-    throw std::runtime_error(fmt::format("LUT file {} contains no entries", filename));
+    throw std::runtime_error(std::format("LUT file {} contains no entries", filename));
   }
 } // EdepToNpeConversion:init
 

--- a/src/algorithms/calorimetry/SimCalorimeterHitProcessor.cc
+++ b/src/algorithms/calorimetry/SimCalorimeterHitProcessor.cc
@@ -12,7 +12,7 @@
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <fmt/format.h>
+#include <format>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
 #include <cmath>
@@ -107,7 +107,7 @@ void SimCalorimeterHitProcessor::init() {
     m_id_spec = m_geo.detector()->readout(m_cfg.readout).idSpec();
   } catch (...) {
     debug("Failed to load ID decoder for {}", m_cfg.readout);
-    throw std::runtime_error(fmt::format("Failed to load ID decoder for {}", m_cfg.readout));
+    throw std::runtime_error(std::format("Failed to load ID decoder for {}", m_cfg.readout));
   }
 
   // get m_hit_id_mask for adding up hits with the same dimensions that are merged over

--- a/src/algorithms/digi/MPGDTrackerDigi.cc
+++ b/src/algorithms/digi/MPGDTrackerDigi.cc
@@ -117,7 +117,7 @@
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
-#include <fmt/format.h>
+#include <format>
 #include <podio/detail/Link.h>
 #include <podio/detail/LinkCollectionImpl.h>
 #include <algorithm>
@@ -1819,7 +1819,7 @@ double getRef2Cur(DetElement refVol, DetElement curVol) {
 std::string inconsistency(const edm4hep::EventHeader& event, unsigned int status, CellID cID,
                           const double* lpos, const double* lmom) {
   using edm4eic::unit::GeV, dd4hep::mm;
-  return fmt::format("Event {}#{}, SimHit 0x{:016x} @ {:.2f},{:.2f},{:.2f} mm, P = "
+  return std::format("Event {}#{}, SimHit 0x{:016x} @ {:.2f},{:.2f},{:.2f} mm, P = "
                      "{:.2f},{:.2f},{:.2f} GeV inconsistency 0x{:x}",
                      event.getRunNumber(), event.getEventNumber(), cID, lpos[0] / mm, lpos[1] / mm,
                      lpos[2] / mm, lmom[0] / GeV, lmom[1] / GeV, lmom[2] / GeV, status);
@@ -1828,7 +1828,7 @@ std::string oddity(const edm4hep::EventHeader& event, unsigned int status, doubl
                    const double* lpos, const double* lmom, CellID cJD, const double* lpoj,
                    const double* lmoj) {
   using edm4eic::unit::GeV, dd4hep::mm;
-  return fmt::format("Event {}#{}, Bizarre SimHit sequence: 0x{:016x} @ {:.4f},{:.4f},{:.4f} mm, P "
+  return std::format("Event {}#{}, Bizarre SimHit sequence: 0x{:016x} @ {:.4f},{:.4f},{:.4f} mm, P "
                      "= {:.2f},{:.2f},{:.2f} GeV and 0x{:016x} @ {:.4f},{:.4f},{:.4f} mm, P = "
                      "{:.2f},{:.2f},{:.2f} GeV: status 0x{:x}, distance {:.4f}",
                      event.getRunNumber(), event.getEventNumber(), cID, lpos[0] / mm, lpos[1] / mm,

--- a/src/algorithms/digi/PhotoMultiplierHitDigi.h
+++ b/src/algorithms/digi/PhotoMultiplierHitDigi.h
@@ -26,7 +26,7 @@
 #include <edm4eic/RawTrackerHitCollection.h>
 #include <edm4hep/EventHeaderCollection.h>
 #include <edm4hep/SimTrackerHitCollection.h>
-#include <fmt/format.h> // IWYU pragma: keep
+#include <format> // IWYU pragma: keep
 #include <stdint.h>
 #include <cstddef>
 #include <functional>

--- a/src/algorithms/digi/PhotoMultiplierHitDigiConfig.h
+++ b/src/algorithms/digi/PhotoMultiplierHitDigiConfig.h
@@ -57,9 +57,9 @@ public:
 };
 
 std::ostream& operator<<(std::ostream& os, const PhotoMultiplierHitDigiConfig& cfg) {
-  os << fmt::format("{:=^60}", " PhotoMultiplierHitDigiConfig Settings ") << std::endl;
+  os << std::format("{:=^60}", " PhotoMultiplierHitDigiConfig Settings ") << std::endl;
   auto print_param = [&os](auto name, auto val) {
-    os << fmt::format("  {:>20} = {:<}", name, val) << std::endl;
+    os << std::format("  {:>20} = {:<}", name, val) << std::endl;
   };
   print_param("hitTimeWindow", cfg.hitTimeWindow);
   print_param("timeResolution", cfg.timeResolution);
@@ -72,9 +72,9 @@ std::ostream& operator<<(std::ostream& os, const PhotoMultiplierHitDigiConfig& c
   print_param("enableNoise", cfg.enableNoise);
   print_param("noiseRate", cfg.noiseRate);
   print_param("noiseTimeWindow", cfg.noiseTimeWindow);
-  os << fmt::format("{:-^60}", " Quantum Efficiency vs. Wavelength ") << std::endl;
+  os << std::format("{:-^60}", " Quantum Efficiency vs. Wavelength ") << std::endl;
   for (auto& [wl, qe] : cfg.quantumEfficiency)
-    os << fmt::format("  {:>10} {:<}", wl, qe) << std::endl;
+    os << std::format("  {:>10} {:<}", wl, qe) << std::endl;
   return os;
 }
 

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2023 - 2025, Simon Gardner
 
-#include <DD4hep/Handle.h>
 #include <DD4hep/IDDescriptor.h>
 #include <DD4hep/Objects.h>
 #include <DD4hep/Readout.h>
@@ -13,10 +12,11 @@
 #include <algorithms/geo.h>
 #include <edm4eic/Cov3f.h>
 #include <edm4hep/Vector2f.h>
-#include <format>
 #include <cstddef>
+#include <format>
 #include <gsl/pointers>
 #include <stdexcept>
+#include <tuple>
 
 #include "algorithms/fardetectors/FarDetectorTrackerCluster.h"
 #include "algorithms/fardetectors/FarDetectorTrackerClusterConfig.h"

--- a/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
+++ b/src/algorithms/fardetectors/FarDetectorTrackerCluster.cc
@@ -13,7 +13,7 @@
 #include <algorithms/geo.h>
 #include <edm4eic/Cov3f.h>
 #include <edm4hep/Vector2f.h>
-#include <fmt/format.h>
+#include <format>
 #include <cstddef>
 #include <gsl/pointers>
 #include <stdexcept>
@@ -43,7 +43,7 @@ void FarDetectorTrackerCluster::init() {
     }
   } catch (...) {
     error("Failed to load ID decoder for {}", m_cfg.readout);
-    throw std::runtime_error(fmt::format("Failed to load ID decoder for {}", m_cfg.readout));
+    throw std::runtime_error(std::format("Failed to load ID decoder for {}", m_cfg.readout));
   }
 }
 

--- a/src/algorithms/fardetectors/FarDetectorTransportationPostML.cc
+++ b/src/algorithms/fardetectors/FarDetectorTransportationPostML.cc
@@ -2,7 +2,7 @@
 // Copyright (C) 2024 - 2025 Simon Gardner
 
 #include <edm4hep/Vector3f.h>
-#include <fmt/format.h>
+#include <format>
 #include <podio/RelationRange.h>
 #include <podio/detail/Link.h>
 #include <podio/detail/LinkCollectionImpl.h>
@@ -57,21 +57,21 @@ void FarDetectorTransportationPostML::process(
   if (prediction_tensor.shape_size() != 2) {
     error("Expected tensor rank to be 2, but it is {}", prediction_tensor.shape_size());
     throw std::runtime_error(
-        fmt::format("Expected tensor rank to be 2, but it is {}", prediction_tensor.shape_size()));
+        std::format("Expected tensor rank to be 2, but it is {}", prediction_tensor.shape_size()));
   }
 
   if (prediction_tensor.getShape(1) != 3) {
     error("Expected 2 values per cluster in the output tensor, got {}",
           prediction_tensor.getShape(0));
     throw std::runtime_error(
-        fmt::format("Expected 2 values per cluster in the output tensor, got {}",
+        std::format("Expected 2 values per cluster in the output tensor, got {}",
                     prediction_tensor.getShape(0)));
   }
 
   if (prediction_tensor.getElementType() != 1) { // 1 - float
     error("Expected a tensor of floats, but element type is {}",
           prediction_tensor.getElementType());
-    throw std::runtime_error(fmt::format("Expected a tensor of floats, but element type is {}",
+    throw std::runtime_error(std::format("Expected a tensor of floats, but element type is {}",
                                          prediction_tensor.getElementType()));
   }
 

--- a/src/algorithms/fardetectors/PolynomialMatrixReconstruction.cc
+++ b/src/algorithms/fardetectors/PolynomialMatrixReconstruction.cc
@@ -16,7 +16,7 @@
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <fmt/format.h>
+#include <format>
 #include <cmath>
 #include <filesystem>
 #include <gsl/pointers>
@@ -142,7 +142,7 @@ void eicrecon::PolynomialMatrixReconstruction::process(
   //xL table filled here from LUT -- Graph2D used for nice interpolation functionality and simple loading of LUT file
 
   thread_local std::string filename(
-      fmt::format("calibrations/RP_60_xL_100_beamEnergy_{:.0f}.xL.lut", nomMomentum));
+      std::format("calibrations/RP_60_xL_100_beamEnergy_{:.0f}.xL.lut", nomMomentum));
   thread_local std::unique_ptr<TGraph2D> xLGraph{nullptr};
   if (xLGraph == nullptr) {
     if (std::filesystem::exists(filename)) {
@@ -365,7 +365,7 @@ double PolynomialMatrixReconstruction::calculateOffsetFromXL(int whichOffset, do
                                                              double beamEnergy) const {
 
   if (whichOffset >= 4) {
-    throw std::runtime_error(fmt::format("Bad offset index {}", whichOffset));
+    throw std::runtime_error(std::format("Bad offset index {}", whichOffset));
   }
 
   double offset_value_and_par[4][3];
@@ -410,7 +410,7 @@ double PolynomialMatrixReconstruction::calculateOffsetFromXL(int whichOffset, do
     offset_value_and_par[1][1] = 0.391292;
     offset_value_and_par[1][2] = -0.001063;
   } else
-    throw std::runtime_error(fmt::format("Unknown beamEnergy {}", beamEnergy));
+    throw std::runtime_error(std::format("Unknown beamEnergy {}", beamEnergy));
 
   return (offset_value_and_par[whichOffset][0] + offset_value_and_par[whichOffset][1] * x_L +
           offset_value_and_par[whichOffset][2] * x_L * x_L);
@@ -422,7 +422,7 @@ double PolynomialMatrixReconstruction::calculateMatrixValueFromXL(int whichEleme
   double matrix_value_and_par[8][3];
 
   if ((whichElement < 0) || (whichElement > 7)) {
-    throw std::runtime_error(fmt::format("Bad Array index(ces)", whichElement));
+    throw std::runtime_error(std::format("Bad Array index(ces)", whichElement));
   }
 
   if (beamEnergy == 275) { //275 GeV
@@ -526,7 +526,7 @@ double PolynomialMatrixReconstruction::calculateMatrixValueFromXL(int whichEleme
     matrix_value_and_par[7][1] = 0.155002;
     matrix_value_and_par[7][2] = -0.000708;
   } else
-    throw std::runtime_error(fmt::format("Unknown beamEnergy {}", beamEnergy));
+    throw std::runtime_error(std::format("Unknown beamEnergy {}", beamEnergy));
 
   return (matrix_value_and_par[whichElement][0] + matrix_value_and_par[whichElement][1] * x_L +
           matrix_value_and_par[whichElement][2] * x_L * x_L);

--- a/src/algorithms/fardetectors/PolynomialMatrixReconstruction.cc
+++ b/src/algorithms/fardetectors/PolynomialMatrixReconstruction.cc
@@ -16,12 +16,12 @@
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <format>
 #include <cmath>
 #include <filesystem>
-#include <gsl/pointers>
+#include <format>
 #include <memory>
 #include <stdexcept>
+#include <tuple>
 #include <vector>
 
 #include "algorithms/fardetectors/PolynomialMatrixReconstructionConfig.h"

--- a/src/algorithms/interfaces/UniqueIDGenSvc.h
+++ b/src/algorithms/interfaces/UniqueIDGenSvc.h
@@ -13,6 +13,7 @@
 #include <algorithms/logger.h>
 #include <algorithms/service.h>
 #include <bitset>
+#include <format>
 #include <map>
 #include <memory>
 #include <string>
@@ -80,7 +81,7 @@ public:
       if (!inserted) {
         const auto& [id_evt, id_run, id_name] = it->second;
         // TODO log to error
-        throw std::runtime_error(fmt::format(
+        throw std::runtime_error(std::format(
             "Duplicate ID for event number, run number and algorithm name: {}, {}, \"{}\". "
             "ID already assigned to: {}, {}, \"{}\"",
             evt_num, run_num, name, id_evt, id_run, id_name));

--- a/src/algorithms/onnx/CalorimeterParticleIDPostML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPostML.cc
@@ -2,7 +2,7 @@
 // Copyright (C) 2024 Dmitry Kalinkin
 
 #include <edm4hep/MCParticle.h>
-#include <fmt/format.h>
+#include <format>
 #include <podio/detail/Link.h>
 #include <podio/detail/LinkCollectionImpl.h>
 #include <cstddef>
@@ -33,14 +33,14 @@ void CalorimeterParticleIDPostML::process(const CalorimeterParticleIDPostML::Inp
   if (prediction_tensor.shape_size() != 2) {
     error("Expected tensor rank to be 2, but it is {}", prediction_tensor.shape_size());
     throw std::runtime_error(
-        fmt::format("Expected tensor rank to be 2, but it is {}", prediction_tensor.shape_size()));
+        std::format("Expected tensor rank to be 2, but it is {}", prediction_tensor.shape_size()));
   }
 
   if (prediction_tensor.getShape(0) != static_cast<long>(in_clusters->size())) {
     error("Length mismatch between tensor's 0th axis and number of clusters: {} != {}",
           prediction_tensor.getShape(0), in_clusters->size());
     throw std::runtime_error(
-        fmt::format("Length mismatch between tensor's 0th axis and number of clusters: {} != {}",
+        std::format("Length mismatch between tensor's 0th axis and number of clusters: {} != {}",
                     prediction_tensor.getShape(0), in_clusters->size()));
   }
 
@@ -48,14 +48,14 @@ void CalorimeterParticleIDPostML::process(const CalorimeterParticleIDPostML::Inp
     error("Expected 2 values per cluster in the output tensor, got {}",
           prediction_tensor.getShape(0));
     throw std::runtime_error(
-        fmt::format("Expected 2 values per cluster in the output tensor, got {}",
+        std::format("Expected 2 values per cluster in the output tensor, got {}",
                     prediction_tensor.getShape(0)));
   }
 
   if (prediction_tensor.getElementType() != 1) { // 1 - float
     error("Expected a tensor of floats, but element type is {}",
           prediction_tensor.getElementType());
-    throw std::runtime_error(fmt::format("Expected a tensor of floats, but element type is {}",
+    throw std::runtime_error(std::format("Expected a tensor of floats, but element type is {}",
                                          prediction_tensor.getElementType()));
   }
 

--- a/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
@@ -1,16 +1,15 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2024 Dmitry Kalinkin
 
-#include <cstddef>
-#include <cstdint>
 #include <edm4hep/MCParticle.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
 #include <format>
 #include <stdexcept>
-
-#include <gsl/pointers>
+#include <tuple>
 
 #include "CalorimeterParticleIDPreML.h"
 

--- a/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
+++ b/src/algorithms/onnx/CalorimeterParticleIDPreML.cc
@@ -6,8 +6,8 @@
 #include <edm4hep/MCParticle.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <fmt/core.h>
 #include <cmath>
+#include <format>
 #include <stdexcept>
 
 #include <gsl/pointers>
@@ -93,7 +93,7 @@ void CalorimeterParticleIDPreML::process(const CalorimeterParticleIDPreML::Input
     error("Inconsistent output tensor shape and element count: {} != {}",
           feature_tensor.floatData_size(), expected_num_entries);
     throw std::runtime_error(
-        fmt::format("Inconsistent output tensor shape and element count: {} != {}",
+        std::format("Inconsistent output tensor shape and element count: {} != {}",
                     feature_tensor.floatData_size(), expected_num_entries));
   }
 }

--- a/src/algorithms/onnx/ONNXInference.cc
+++ b/src/algorithms/onnx/ONNXInference.cc
@@ -6,6 +6,7 @@
 #include <onnxruntime_cxx_api.h>
 #include <algorithm>
 #include <cstddef>
+#include <format>
 #include <gsl/pointers>
 #include <iterator>
 #include <sstream>
@@ -109,7 +110,7 @@ void ONNXInference::process(const ONNXInference::Input& input,
     error("The ONNX model requires {} tensors, whereas {} were provided", m_input_names.size(),
           in_tensors.size());
     throw std::runtime_error(
-        fmt::format("The ONNX model requires {} tensors, whereas {} were provided",
+        std::format("The ONNX model requires {} tensors, whereas {} were provided",
                     m_input_names.size(), in_tensors.size()));
   }
 
@@ -134,7 +135,7 @@ void ONNXInference::process(const ONNXInference::Input& input,
     if (!check_shape_consistency(input_shape, input_expected_shape)) {
       error("Input tensor shape incorrect {} != {}", print_shape(input_shape),
             print_shape(input_expected_shape));
-      throw std::runtime_error(fmt::format("Input tensor shape incorrect {} != {}",
+      throw std::runtime_error(std::format("Input tensor shape incorrect {} != {}",
                                            print_shape(input_shape),
                                            print_shape(input_expected_shape)));
     }

--- a/src/algorithms/onnx/ONNXInference.cc
+++ b/src/algorithms/onnx/ONNXInference.cc
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022 - 2024 Wouter Deconinck, Tooba Ali, Dmitry Kalinkin
 
-#include <fmt/core.h>
 #include <onnxruntime_c_api.h>
 #include <onnxruntime_cxx_api.h>
 #include <algorithm>
@@ -11,6 +10,7 @@
 #include <iterator>
 #include <sstream>
 #include <stdexcept>
+#include <tuple>
 
 #include "ONNXInference.h"
 

--- a/src/algorithms/pid/IrtCherenkovParticleID.cc
+++ b/src/algorithms/pid/IrtCherenkovParticleID.cc
@@ -18,7 +18,7 @@
 #include <edm4hep/Vector2f.h>
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
-#include <fmt/format.h>
+#include <format>
 #include <fmt/ranges.h>
 #include <podio/ObjectID.h>
 #include <podio/RelationRange.h>
@@ -176,7 +176,7 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
   std::size_t num_charged_particles = in_charged_particle_size_distribution.begin()->first;
   for (std::size_t i_charged_particle = 0; i_charged_particle < num_charged_particles;
        i_charged_particle++) {
-    trace("{:-<70}", fmt::format("--- charged particle #{} ", i_charged_particle));
+    trace("{:-<70}", std::format("--- charged particle #{} ", i_charged_particle));
 
     // start an `irt_particle`, for `IRT`
     auto irt_particle = std::make_unique<ChargedParticle>();
@@ -253,7 +253,7 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
             continue; // skip this photon, if not from radiator `irt_rad`
           }
           trace(Tools::PrintTVector3(
-              fmt::format("cheat: radiator '{}' determined from photon vertex", rad_name), vtx));
+              std::format("cheat: radiator '{}' determined from photon vertex", rad_name), vtx));
         }
 
         // get sensor and pixel info
@@ -368,7 +368,7 @@ void IrtCherenkovParticleID::process(const IrtCherenkovParticleID::Input& input,
 
         // trace logging
         trace(
-            Tools::PrintTVector3(fmt::format("- sensor_id={:#X}: hit", irt_photon->GetVolumeCopy()),
+            Tools::PrintTVector3(std::format("- sensor_id={:#X}: hit", irt_photon->GetVolumeCopy()),
                                  irt_photon->GetDetectionPosition()));
         trace(Tools::PrintTVector3("photon vertex", irt_photon->GetVertexPosition()));
 

--- a/src/algorithms/pid/IrtCherenkovParticleIDConfig.h
+++ b/src/algorithms/pid/IrtCherenkovParticleIDConfig.h
@@ -51,24 +51,24 @@ public:
 
   // stream all parameters
   friend std::ostream& operator<<(std::ostream& os, const IrtCherenkovParticleIDConfig& cfg) {
-    os << fmt::format("{:=^60}", " IrtCherenkovParticleIDConfig Settings ") << std::endl;
+    os << std::format("{:=^60}", " IrtCherenkovParticleIDConfig Settings ") << std::endl;
     auto print_param = [&os](auto name, auto val) {
-      os << fmt::format("  {:>20} = {:<}", name, val) << std::endl;
+      os << std::format("  {:>20} = {:<}", name, val) << std::endl;
     };
     print_param("numRIndexBins", cfg.numRIndexBins);
     print_param("cheatPhotonVertex", cfg.cheatPhotonVertex);
     print_param("cheatTrueRadiator", cfg.cheatTrueRadiator);
     os << "pdgList:" << std::endl;
     for (const auto& pdg : cfg.pdgList)
-      os << fmt::format("  {}", pdg) << std::endl;
+      os << std::format("  {}", pdg) << std::endl;
     for (const auto& [name, rad] : cfg.radiators) {
-      os << fmt::format("{:-<60}", fmt::format("--- {} config ", name)) << std::endl;
+      os << std::format("{:-<60}", std::format("--- {} config ", name)) << std::endl;
       print_param("smearingMode", rad.smearingMode);
       print_param("smearing", rad.smearing);
       print_param("referenceRIndex", rad.referenceRIndex);
       print_param("attenuation", rad.attenuation);
     }
-    os << fmt::format("{:=^60}", "") << std::endl;
+    os << std::format("{:=^60}", "") << std::endl;
     return os;
   };
 };

--- a/src/algorithms/pid/MergeParticleIDConfig.h
+++ b/src/algorithms/pid/MergeParticleIDConfig.h
@@ -24,12 +24,12 @@ public:
   // stream all parameters
   friend std::ostream& operator<<(std::ostream& os, const MergeParticleIDConfig& cfg) {
     // print all parameters
-    os << fmt::format("{:=^60}", " MergeParticleIDConfig Settings ") << std::endl;
+    os << std::format("{:=^60}", " MergeParticleIDConfig Settings ") << std::endl;
     auto print_param = [&os](auto name, auto val) {
-      os << fmt::format("  {:>20} = {:<}", name, val) << std::endl;
+      os << std::format("  {:>20} = {:<}", name, val) << std::endl;
     };
     print_param("mergeMode", cfg.mergeMode);
-    os << fmt::format("{:=^60}", "") << std::endl;
+    os << std::format("{:=^60}", "") << std::endl;
     return os;
   }
 };

--- a/src/algorithms/pid/MergeTracks.cc
+++ b/src/algorithms/pid/MergeTracks.cc
@@ -3,14 +3,14 @@
 
 #include "MergeTracks.h"
 
+#include <edm4eic/TrackPoint.h>
+#include <fmt/ranges.h>
+#include <podio/RelationRange.h>
 #include <algorithm>
 #include <cstddef>
-#include <edm4eic/TrackPoint.h>
-#include <fmt/core.h>
-#include <format>
 #include <gsl/pointers>
 #include <iterator>
-#include <podio/RelationRange.h>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
 

--- a/src/algorithms/pid/MergeTracks.cc
+++ b/src/algorithms/pid/MergeTracks.cc
@@ -7,7 +7,7 @@
 #include <cstddef>
 #include <edm4eic/TrackPoint.h>
 #include <fmt/core.h>
-#include <fmt/format.h>
+#include <format>
 #include <gsl/pointers>
 #include <iterator>
 #include <podio/RelationRange.h>

--- a/src/algorithms/pid/Tools.h
+++ b/src/algorithms/pid/Tools.h
@@ -39,7 +39,7 @@ namespace Tools {
     try {
       name = GetRadiatorIDs().at(id);
     } catch (const std::out_of_range& e) {
-      throw std::runtime_error(fmt::format(
+      throw std::runtime_error(std::format(
           "RUNTIME ERROR: unknown radiator ID={} in algorithms/pid/Tools::GetRadiatorName", id));
     }
     return name;
@@ -49,7 +49,7 @@ namespace Tools {
     for (auto& [id, name_tmp] : GetRadiatorIDs())
       if (name == name_tmp)
         return id;
-    throw std::runtime_error(fmt::format(
+    throw std::runtime_error(std::format(
         "RUNTIME ERROR: unknown radiator '{}' in algorithms/pid/Tools::GetRadiatorID", name));
     return -1;
   }
@@ -142,22 +142,22 @@ namespace Tools {
 
   // printing: vectors
   inline std::string PrintTVector3(std::string name, TVector3 vec, int nameBuffer = 30) {
-    return fmt::format("{:>{}} = ( {:>10.2f} {:>10.2f} {:>10.2f} )", name, nameBuffer, vec.x(),
+    return std::format("{:>{}} = ( {:>10.2f} {:>10.2f} {:>10.2f} )", name, nameBuffer, vec.x(),
                        vec.y(), vec.z());
   }
 
   // printing: hypothesis tables
   inline std::string HypothesisTableHead(int indent = 4) {
-    return fmt::format("{:{}}{:>6}  {:>10}  {:>10}", "", indent, "PDG", "Weight", "NPE");
+    return std::format("{:{}}{:>6}  {:>10}  {:>10}", "", indent, "PDG", "Weight", "NPE");
   }
   inline std::string HypothesisTableLine(edm4eic::CherenkovParticleIDHypothesis hyp,
                                          int indent = 4) {
-    return fmt::format("{:{}}{:>6}  {:>10.8}  {:>10.8}", "", indent, hyp.PDG, hyp.weight, hyp.npe);
+    return std::format("{:{}}{:>6}  {:>10.8}  {:>10.8}", "", indent, hyp.PDG, hyp.weight, hyp.npe);
   }
   inline std::string HypothesisTableLine(edm4hep::ParticleID hyp, int indent = 4) {
     float npe =
         hyp.parameters_size() > 0 ? hyp.getParameters(0) : -1; // assume NPE is the first parameter
-    return fmt::format("{:{}}{:>6}  {:>10.8}  {:>10.8}", "", indent, hyp.getPDG(),
+    return std::format("{:{}}{:>6}  {:>10.8}  {:>10.8}", "", indent, hyp.getPDG(),
                        hyp.getLikelihood(), npe);
   }
 

--- a/src/algorithms/reco/Beam.h
+++ b/src/algorithms/reco/Beam.h
@@ -7,7 +7,7 @@
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <algorithm>
-#include <fmt/format.h>
+#include <format>
 #include <set>
 #include <stdexcept>
 #include <vector>
@@ -82,7 +82,7 @@ PxPyPzEVector round_beam_four_momentum(const Vector3& p_in, const float mass,
   }
   if (!found_match) {
     throw std::runtime_error(
-        fmt::format("round_beam_four_momentum: no match for beam momentum {:.3f} GeV within 10% "
+        std::format("round_beam_four_momentum: no match for beam momentum {:.3f} GeV within 10% "
                     "of any of the allowed values",
                     p_in.z));
   }

--- a/src/algorithms/reco/JetReconstruction.cc
+++ b/src/algorithms/reco/JetReconstruction.cc
@@ -17,7 +17,7 @@
 // for fastjet objects
 #include <fastjet/PseudoJet.hh>
 #include <fastjet/contrib/Centauro.hh>
-#include <fmt/format.h>
+#include <format>
 #include <cstdint>
 #include <stdexcept>
 #include <tuple>
@@ -39,7 +39,7 @@ template <typename InputT> void JetReconstruction<InputT>::init() {
     m_mapJetAlgo.at(m_cfg.jetAlgo);
   } catch (std::out_of_range& out) {
     this->error(" Unknown jet algorithm \"{}\" specified!", m_cfg.jetAlgo);
-    throw std::runtime_error(fmt::format("Unknown jet algorithm \"{}\" specified!", m_cfg.jetAlgo));
+    throw std::runtime_error(std::format("Unknown jet algorithm \"{}\" specified!", m_cfg.jetAlgo));
   }
 
   try {
@@ -47,14 +47,14 @@ template <typename InputT> void JetReconstruction<InputT>::init() {
   } catch (std::out_of_range& out) {
     this->error(" Unknown recombination scheme \"{}\" specified!", m_cfg.recombScheme);
     throw std::runtime_error(
-        fmt::format("Unknown recombination scheme \"{}\" specified!", m_cfg.recombScheme));
+        std::format("Unknown recombination scheme \"{}\" specified!", m_cfg.recombScheme));
   }
 
   try {
     m_mapAreaType.at(m_cfg.areaType);
   } catch (std::out_of_range& out) {
     this->error(" Unknown area type \"{}\" specified!", m_cfg.areaType);
-    throw std::runtime_error(fmt::format("Unknown area type \"{}\" specified!", m_cfg.areaType));
+    throw std::runtime_error(std::format("Unknown area type \"{}\" specified!", m_cfg.areaType));
   }
 
   // Choose jet definition based on no. of parameters
@@ -69,7 +69,7 @@ template <typename InputT> void JetReconstruction<InputT>::init() {
       m_jet_def    = std::make_unique<JetDefinition>(m_jet_plugin.get());
     } else {
       this->error(" Unknown contributed FastJet algorithm \"{}\" specified!", m_cfg.jetContribAlgo);
-      throw std::runtime_error(fmt::format(
+      throw std::runtime_error(std::format(
           "Unknown contributed FastJet algorithm \"{}\" specified!", m_cfg.jetContribAlgo));
     }
     break;

--- a/src/algorithms/reco/TrackClusterMatch.cc
+++ b/src/algorithms/reco/TrackClusterMatch.cc
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2025 Tristan Protzman
 
+#include <DD4hep/Detector.h>
+#include <edm4eic/ClusterCollection.h>
 #include <edm4eic/Track.h>
-#include <fmt/core.h>
+#include <edm4eic/TrackPoint.h>
+#include <edm4hep/Vector3f.h>
+#include <edm4hep/utils/vector_utils.h>
 #include <podio/RelationRange.h>
 #include <cstdint>
 #include <format>
@@ -10,13 +14,8 @@
 #include <optional>
 #include <set>
 #include <stdexcept>
+#include <tuple>
 #include <vector>
-
-#include <DD4hep/Detector.h>
-#include <edm4eic/ClusterCollection.h>
-#include <edm4eic/TrackPoint.h>
-#include <edm4hep/Vector3f.h>
-#include <edm4hep/utils/vector_utils.h>
 
 #include "algorithms/reco/TrackClusterMatch.h"
 #include "algorithms/reco/TrackClusterMatchConfig.h"

--- a/src/algorithms/reco/TrackClusterMatch.cc
+++ b/src/algorithms/reco/TrackClusterMatch.cc
@@ -5,6 +5,7 @@
 #include <fmt/core.h>
 #include <podio/RelationRange.h>
 #include <cstdint>
+#include <format>
 #include <gsl/pointers>
 #include <optional>
 #include <set>
@@ -29,7 +30,7 @@ void TrackClusterMatch::process(const TrackClusterMatch::Input& input,
 
   // Validate the configuration
   if (m_cfg.matching_distance <= 0) {
-    throw std::runtime_error(fmt::format("Invalid matching distance: {}", m_cfg.matching_distance));
+    throw std::runtime_error(std::format("Invalid matching distance: {}", m_cfg.matching_distance));
   }
   if (m_cfg.calo_id.empty()) {
     throw std::runtime_error("Calorimeter ID must be set in the configuration");

--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -9,26 +9,26 @@
 #include <Acts/Geometry/TrackingVolume.hpp>
 #include <Acts/MagneticField/MagneticFieldContext.hpp>
 #include <Acts/Material/IMaterialDecorator.hpp>
+#include <fmt/format.h>
 #if Acts_VERSION_MAJOR >= 45
 #include <Acts/Surfaces/SurfacePlacementBase.hpp>
 #endif
+#include <Acts/Surfaces/Surface.hpp>
+#include <Acts/Utilities/BinningType.hpp>
 #include <Acts/Utilities/Logger.hpp>
-#include <boost/container/detail/std_fwd.hpp>
-#include <format>
+#include <Acts/Utilities/Result.hpp>
+#include <Acts/Visualization/GeometryView3D.hpp>
+#include <Acts/Visualization/ObjVisualization3D.hpp>
+#include <Acts/Visualization/PlyVisualization3D.hpp>
 #include <ActsPlugins/DD4hep/ConvertDD4hepDetector.hpp>
 #include <ActsPlugins/DD4hep/DD4hepDetectorElement.hpp>
 #include <ActsPlugins/DD4hep/DD4hepFieldAdapter.hpp>
 #include <ActsPlugins/Json/JsonMaterialDecorator.hpp>
 #include <ActsPlugins/Json/MaterialMapJsonConverter.hpp>
-#include <Acts/Surfaces/Surface.hpp>
-#include <Acts/Utilities/BinningType.hpp>
-#include <Acts/Utilities/Result.hpp>
-#include <Acts/Visualization/GeometryView3D.hpp>
-#include <Acts/Visualization/ObjVisualization3D.hpp>
-#include <Acts/Visualization/PlyVisualization3D.hpp>
 #include <DD4hep/DetElement.h>
 #include <DD4hep/VolumeManager.h>
 #include <TGeoManager.h>
+#include <boost/container/detail/std_fwd.hpp>
 #include <fmt/ostream.h>
 #include <spdlog/common.h>
 // Formatter for Eigen matrices

--- a/src/algorithms/tracking/ActsGeometryProvider.cc
+++ b/src/algorithms/tracking/ActsGeometryProvider.cc
@@ -14,7 +14,7 @@
 #endif
 #include <Acts/Utilities/Logger.hpp>
 #include <boost/container/detail/std_fwd.hpp>
-#include <fmt/format.h>
+#include <format>
 #include <ActsPlugins/DD4hep/ConvertDD4hepDetector.hpp>
 #include <ActsPlugins/DD4hep/DD4hepDetectorElement.hpp>
 #include <ActsPlugins/DD4hep/DD4hepFieldAdapter.hpp>

--- a/src/algorithms/tracking/TrackProjector.cc
+++ b/src/algorithms/tracking/TrackProjector.cc
@@ -20,7 +20,6 @@
 #include <edm4hep/Vector2f.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
-#include <format>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 #include <Eigen/Core>

--- a/src/algorithms/tracking/TrackProjector.cc
+++ b/src/algorithms/tracking/TrackProjector.cc
@@ -20,6 +20,7 @@
 #include <edm4hep/Vector2f.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/vector_utils.h>
+#include <format>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 #include <Eigen/Core>

--- a/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.cc
@@ -23,7 +23,7 @@
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
 #include <fmt/core.h>
-#include <fmt/format.h>
+#include <format>
 #include <podio/RelationRange.h>
 #include <algorithm>
 #include <cmath>

--- a/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/femc_studies/femc_studiesProcessor.cc
@@ -22,8 +22,7 @@
 #include <edm4hep/SimCalorimeterHitCollection.h>
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
-#include <fmt/core.h>
-#include <format>
+#include <fmt/format.h>
 #include <podio/RelationRange.h>
 #include <algorithm>
 #include <cmath>
@@ -31,7 +30,6 @@
 #include <gsl/pointers>
 #include <iostream>
 #include <limits>
-#include <map>
 #include <stdexcept>
 #include <vector>
 

--- a/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
@@ -23,7 +23,7 @@
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
 #include <fmt/core.h>
-#include <fmt/format.h>
+#include <format>
 #include <podio/RelationRange.h>
 #include <algorithm>
 #include <cmath>

--- a/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
+++ b/src/benchmarks/reconstruction/lfhcal_studies/lfhcal_studiesProcessor.cc
@@ -22,8 +22,7 @@
 #include <edm4hep/SimCalorimeterHitCollection.h>
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
-#include <fmt/core.h>
-#include <format>
+#include <fmt/format.h>
 #include <podio/RelationRange.h>
 #include <algorithm>
 #include <cmath>
@@ -31,7 +30,6 @@
 #include <gsl/pointers>
 #include <iostream>
 #include <limits>
-#include <map>
 #include <stdexcept>
 #include <vector>
 

--- a/src/benchmarks/reconstruction/tracking_efficiency/TrackingEfficiency_processor.cc
+++ b/src/benchmarks/reconstruction/tracking_efficiency/TrackingEfficiency_processor.cc
@@ -1,7 +1,6 @@
 #include "TrackingEfficiency_processor.h"
 
 #include <Acts/Definitions/TrackParametrization.hpp>
-#include <Acts/EventData/TrackContainer.hpp>
 #include <Acts/EventData/TrackProxy.hpp>
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
 #include <Acts/EventData/VectorTrackContainer.hpp>
@@ -16,9 +15,8 @@
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
-#include <format>
+#include <fmt/format.h>
 #include <spdlog/logger.h>
-#include <Eigen/Core>
 #include <cassert>
 #include <cmath>
 #include <cstddef>

--- a/src/benchmarks/reconstruction/tracking_efficiency/TrackingEfficiency_processor.cc
+++ b/src/benchmarks/reconstruction/tracking_efficiency/TrackingEfficiency_processor.cc
@@ -16,7 +16,7 @@
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
-#include <fmt/format.h>
+#include <format>
 #include <spdlog/logger.h>
 #include <Eigen/Core>
 #include <cassert>

--- a/src/detectors/FEMC/FEMC.cc
+++ b/src/detectors/FEMC/FEMC.cc
@@ -6,7 +6,7 @@
 #include <JANA/JApplication.h>
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JTypeInfo.h>
-#include <fmt/format.h>
+#include <format>
 #include <spdlog/logger.h>
 #include <cmath>
 #include <gsl/pointers>
@@ -47,7 +47,7 @@ void InitPlugin(JApplication* app) {
       10 * dd4hep::picosecond;
   const double EcalEndcapP_sampFrac = 0.029043; // updated with ratio to ScFi model
   decltype(CalorimeterHitDigiConfig::corrMeanScale) EcalEndcapP_corrMeanScale =
-      fmt::format("{}", 1.0 / EcalEndcapP_sampFrac); //only used for ScFi model
+      std::format("{}", 1.0 / EcalEndcapP_sampFrac); //only used for ScFi model
   const double EcalEndcapP_nPhotonPerGeV          = 1500;
   const double EcalEndcapP_PhotonCollectionEff    = 0.285;
   const unsigned long long EcalEndcapP_totalPixel = 4 * 159565ULL;

--- a/src/detectors/LOWQ2/LOWQ2.cc
+++ b/src/detectors/LOWQ2/LOWQ2.cc
@@ -13,7 +13,7 @@
 #include <edm4eic/TrackerHit.h>
 #include <edm4eic/unit_system.h>
 #include <edm4hep/SimTrackerHit.h>
-#include <fmt/format.h> // IWYU pragma: keep
+#include <format> // IWYU pragma: keep
 #include <podio/detail/Link.h>
 #include <cmath>
 #include <cstddef>
@@ -120,17 +120,17 @@ void InitPlugin(JApplication* app) {
   std::vector<std::vector<std::string>> moduleClusterTags;
 
   for (int mod_id : moduleIDs) {
-    outputTrackTags.push_back(fmt::format("TaggerTrackerM{}LocalTracks", mod_id));
-    outputTrackLinkTags.push_back(fmt::format("TaggerTrackerM{}LocalTrackLinks", mod_id));
+    outputTrackTags.push_back(std::format("TaggerTrackerM{}LocalTracks", mod_id));
+    outputTrackLinkTags.push_back(std::format("TaggerTrackerM{}LocalTrackLinks", mod_id));
     outputTrackAssociationTags.push_back(
-        fmt::format("TaggerTrackerM{}LocalTrackAssociations", mod_id));
+        std::format("TaggerTrackerM{}LocalTrackAssociations", mod_id));
     moduleClusterTags.emplace_back();
     for (int lay_id : layerIDs) {
       geometryDivisions.push_back({mod_id, lay_id});
       geometryDivisionCollectionNames.push_back(
-          fmt::format("TaggerTrackerM{}L{}RecHits", mod_id, lay_id));
+          std::format("TaggerTrackerM{}L{}RecHits", mod_id, lay_id));
       outputClusterCollectionNames.push_back(
-          fmt::format("TaggerTrackerM{}L{}ClusterPositions", mod_id, lay_id));
+          std::format("TaggerTrackerM{}L{}ClusterPositions", mod_id, lay_id));
       moduleClusterTags.back().push_back(outputClusterCollectionNames.back());
     }
   }

--- a/src/detectors/MPGD/MPGD.cc
+++ b/src/detectors/MPGD/MPGD.cc
@@ -9,7 +9,7 @@
 #include <JANA/JApplicationFwd.h>
 #include <JANA/JException.h>
 #include <JANA/Utils/JTypeInfo.h>
-#include <format>
+#include <fmt/format.h>
 #include <spdlog/logger.h>
 #include <array>
 #include <gsl/pointers>

--- a/src/detectors/MPGD/MPGD.cc
+++ b/src/detectors/MPGD/MPGD.cc
@@ -9,7 +9,7 @@
 #include <JANA/JApplicationFwd.h>
 #include <JANA/JException.h>
 #include <JANA/Utils/JTypeInfo.h>
-#include <fmt/format.h>
+#include <format>
 #include <spdlog/logger.h>
 #include <array>
 #include <gsl/pointers>

--- a/src/extensions/spdlog/SpdlogExtensions.h
+++ b/src/extensions/spdlog/SpdlogExtensions.h
@@ -31,7 +31,7 @@ inline spdlog::level::level_enum ParseLogLevel(const std::string& input) {
   if (lc_input == "off" || lc_input == std::to_string(SPDLOG_LEVEL_OFF))
     return spdlog::level::off;
 
-  auto err_msg = fmt::format("ParseLogLevel can't parse input string: '{}'", input);
+  auto err_msg = std::format("ParseLogLevel can't parse input string: '{}'", input);
   throw std::runtime_error(err_msg);
 }
 
@@ -60,7 +60,7 @@ inline std::string LogLevelToString(spdlog::level::level_enum input) {
   }
 
   auto err_msg =
-      fmt::format("LogLevelToString doesn't know this log level: '{}'", fmt::underlying(input));
+      std::format("LogLevelToString doesn't know this log level: '{}'", fmt::underlying(input));
   throw std::runtime_error(err_msg);
 }
 } // namespace eicrecon

--- a/src/extensions/spdlog/SpdlogToActs.h
+++ b/src/extensions/spdlog/SpdlogToActs.h
@@ -37,7 +37,7 @@ inline Acts::Logging::Level SpdlogToActsLevel(spdlog::level::level_enum input) {
     return kSpdlogToActsLevel.left.at(input);
   } catch (...) {
     auto err_msg =
-        fmt::format("SpdlogToActsLevel doesn't know this log level: '{}'", fmt::underlying(input));
+        std::format("SpdlogToActsLevel doesn't know this log level: '{}'", fmt::underlying(input));
     throw std::runtime_error(err_msg);
   }
 }
@@ -47,7 +47,7 @@ inline spdlog::level::level_enum ActsToSpdlogLevel(Acts::Logging::Level input) {
     return kSpdlogToActsLevel.right.at(input);
   } catch (...) {
     auto err_msg =
-        fmt::format("ActsToSpdlogLevel doesn't know this log level: '{}'", fmt::underlying(input));
+        std::format("ActsToSpdlogLevel doesn't know this log level: '{}'", fmt::underlying(input));
     throw std::runtime_error(err_msg);
   }
 }

--- a/src/services/evaluator/EvaluatorSvc.cc
+++ b/src/services/evaluator/EvaluatorSvc.cc
@@ -3,7 +3,7 @@
 
 #include <TInterpreter.h>
 #include <TInterpreterValue.h>
-#include <fmt/format.h>
+#include <format>
 #include <memory>
 #include <sstream>
 
@@ -21,7 +21,7 @@ std::function<double(const std::unordered_map<std::string, double>&)>
 EvaluatorSvc::_compile(const std::string& expr, const std::vector<std::string>& params) {
   std::lock_guard<std::mutex> guard(m_interpreter_mutex);
 
-  std::string func_name = fmt::format("_eicrecon_{}", m_function_id++);
+  std::string func_name = std::format("_eicrecon_{}", m_function_id++);
   std::ostringstream sstr;
   sstr << "double " << func_name << "(double params[]){";
   for (unsigned int param_ix = 0; const auto& p : params) {

--- a/src/services/geometry/dd4hep/DD4hep_service.cc
+++ b/src/services/geometry/dd4hep/DD4hep_service.cc
@@ -8,11 +8,11 @@
 #include <Parsers/Printout.h>
 #include <TGeoManager.h>
 #include <fmt/color.h>
-#include <fmt/core.h>
-#include <format>
+#include <fmt/format.h>
 #include <cstdlib>
 #include <exception>
 #include <filesystem>
+#include <format>
 #include <iostream>
 #include <stdexcept>
 #include <utility>

--- a/src/services/geometry/dd4hep/DD4hep_service.cc
+++ b/src/services/geometry/dd4hep/DD4hep_service.cc
@@ -9,7 +9,7 @@
 #include <TGeoManager.h>
 #include <fmt/color.h>
 #include <fmt/core.h>
-#include <fmt/format.h>
+#include <format>
 #include <cstdlib>
 #include <exception>
 #include <filesystem>
@@ -151,7 +151,7 @@ void DD4hep_service::Initialize() {
     m_log->info("Geometry successfully loaded.");
   } catch (std::exception& e) {
     m_log->error("Problem loading geometry: {}", e.what());
-    throw std::runtime_error(fmt::format("Problem loading geometry: {}", e.what()));
+    throw std::runtime_error(std::format("Problem loading geometry: {}", e.what()));
   }
 
   // Restore the ticker setting

--- a/src/services/geometry/richgeo/ActsGeo.cc
+++ b/src/services/geometry/richgeo/ActsGeo.cc
@@ -8,8 +8,7 @@
 #include <Math/GenVector/Cartesian3D.h>
 #include <Math/GenVector/DisplacementVector3D.h>
 #include <edm4hep/Vector3f.h>
-#include <fmt/core.h>
-#include <format>
+#include <fmt/format.h>
 #include <algorithm>
 #include <cmath>
 #include <utility>

--- a/src/services/geometry/richgeo/ActsGeo.cc
+++ b/src/services/geometry/richgeo/ActsGeo.cc
@@ -9,7 +9,7 @@
 #include <Math/GenVector/DisplacementVector3D.h>
 #include <edm4hep/Vector3f.h>
 #include <fmt/core.h>
-#include <fmt/format.h>
+#include <format>
 #include <algorithm>
 #include <cmath>
 #include <utility>

--- a/src/services/geometry/richgeo/IrtGeo.cc
+++ b/src/services/geometry/richgeo/IrtGeo.cc
@@ -11,7 +11,7 @@
 #include <TString.h>
 #include <TVector3.h>
 #include <fmt/core.h>
-#include <fmt/format.h>
+#include <format>
 #include <cmath>
 #include <cstdint>
 #include <functional>

--- a/src/services/geometry/richgeo/IrtGeo.cc
+++ b/src/services/geometry/richgeo/IrtGeo.cc
@@ -10,8 +10,7 @@
 #include <TGDMLMatrix.h>
 #include <TString.h>
 #include <TVector3.h>
-#include <fmt/core.h>
-#include <format>
+#include <fmt/format.h>
 #include <cmath>
 #include <cstdint>
 #include <functional>

--- a/src/services/geometry/richgeo/IrtGeoDRICH.cc
+++ b/src/services/geometry/richgeo/IrtGeoDRICH.cc
@@ -16,9 +16,9 @@
 #include <Math/GenVector/DisplacementVector3D.h>
 #include <Parsers/Primitives.h>
 #include <TRef.h>
-#include <fmt/core.h>
-#include <format>
+#include <fmt/format.h>
 #include <cstdint>
+#include <format>
 #include <map>
 #include <stdexcept>
 #include <string>

--- a/src/services/geometry/richgeo/IrtGeoDRICH.cc
+++ b/src/services/geometry/richgeo/IrtGeoDRICH.cc
@@ -17,7 +17,7 @@
 #include <Parsers/Primitives.h>
 #include <TRef.h>
 #include <fmt/core.h>
-#include <fmt/format.h>
+#include <format>
 #include <cstdint>
 #include <map>
 #include <stdexcept>
@@ -156,7 +156,7 @@ void richgeo::IrtGeoDRICH::DD4hep_to_IRT() {
         auto* const detSensorPars = detSensor.extension<dd4hep::rec::VariantParameters>(true);
         if (detSensorPars == nullptr) {
           throw std::runtime_error(
-              fmt::format("sensor '{}' does not have VariantParameters", de_name));
+              std::format("sensor '{}' does not have VariantParameters", de_name));
         }
         // - sensor surface position
         auto posSensor =

--- a/src/services/geometry/richgeo/IrtGeoPFRICH.cc
+++ b/src/services/geometry/richgeo/IrtGeoPFRICH.cc
@@ -18,7 +18,7 @@
 #include <TRef.h>
 #include <TVector3.h>
 #include <fmt/core.h>
-#include <fmt/format.h>
+#include <format>
 #include <cmath>
 #include <cstdint>
 #include <map>

--- a/src/services/geometry/richgeo/IrtGeoPFRICH.cc
+++ b/src/services/geometry/richgeo/IrtGeoPFRICH.cc
@@ -17,8 +17,7 @@
 #include <TGeoNode.h>
 #include <TRef.h>
 #include <TVector3.h>
-#include <fmt/core.h>
-#include <format>
+#include <fmt/format.h>
 #include <cmath>
 #include <cstdint>
 #include <map>

--- a/src/services/geometry/richgeo/ReadoutGeo.cc
+++ b/src/services/geometry/richgeo/ReadoutGeo.cc
@@ -17,7 +17,7 @@
 #include <RtypesCore.h>
 #include <TGeoMatrix.h>
 #include <fmt/core.h>
-#include <fmt/format.h>
+#include <format>
 #include <cmath>
 #include <map>
 #include <utility>

--- a/src/services/geometry/richgeo/ReadoutGeo.cc
+++ b/src/services/geometry/richgeo/ReadoutGeo.cc
@@ -16,10 +16,8 @@
 #include <Math/GenVector/DisplacementVector3D.h>
 #include <RtypesCore.h>
 #include <TGeoMatrix.h>
-#include <fmt/core.h>
-#include <format>
+#include <fmt/format.h>
 #include <cmath>
-#include <map>
 #include <utility>
 
 #include "services/geometry/richgeo/RichGeo.h"

--- a/src/services/geometry/richgeo/RichGeo.h
+++ b/src/services/geometry/richgeo/RichGeo.h
@@ -5,7 +5,7 @@
 
 #include <string>
 #include <iostream>
-#include <fmt/format.h>
+#include <format>
 #include <spdlog/spdlog.h>
 #include <edm4hep/SimTrackerHitData.h>
 

--- a/src/services/geometry/richgeo/RichGeo_service.cc
+++ b/src/services/geometry/richgeo/RichGeo_service.cc
@@ -5,8 +5,8 @@
 
 #include <JANA/JException.h>
 #include <JANA/Services/JServiceLocator.h>
-#include <fmt/core.h>
 #include <exception>
+#include <format>
 #include <gsl/pointers>
 
 #include "services/geometry/dd4hep/DD4hep_service.h"

--- a/src/services/geometry/richgeo/RichGeo_service.cc
+++ b/src/services/geometry/richgeo/RichGeo_service.cc
@@ -47,7 +47,7 @@ richgeo::IrtGeo* RichGeo_service::GetIrtGeo(std::string detector_name) {
       } else if (which_rich == "RICHEndcapN") {
         m_irtGeo = new richgeo::IrtGeoPFRICH(m_dd4hepGeo, m_converter, m_log);
       } else {
-        throw JException(fmt::format("IrtGeo is not defined for detector '{}'", detector_name));
+        throw JException(std::format("IrtGeo is not defined for detector '{}'", detector_name));
       }
     };
     std::lock_guard<std::mutex> lock(m_init_lock);

--- a/src/services/io/podio/JEventProcessorManagedPODIO.cc
+++ b/src/services/io/podio/JEventProcessorManagedPODIO.cc
@@ -5,8 +5,7 @@
 #include <JANA/JEventSource.h>
 #include <JANA/Services/JComponentManager.h>
 #include <JANA/Utils/JTypeInfo.h>
-#include <cerrno>
-#include <format>
+#include <fmt/format.h>
 #include <nlohmann/detail/json_ref.hpp>
 #include <nlohmann/json.hpp>
 #include <podio/Writer.h>
@@ -15,10 +14,12 @@
 #include <zmq.hpp>
 #include <algorithm>
 #include <cctype>
+#include <cerrno>
 #include <chrono>
 #include <cstring>
 #include <exception>
 #include <filesystem>
+#include <format>
 #include <map>
 #include <stdexcept>
 #include <thread>

--- a/src/services/io/podio/JEventProcessorManagedPODIO.cc
+++ b/src/services/io/podio/JEventProcessorManagedPODIO.cc
@@ -6,7 +6,7 @@
 #include <JANA/Services/JComponentManager.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <cerrno>
-#include <fmt/format.h>
+#include <format>
 #include <nlohmann/detail/json_ref.hpp>
 #include <nlohmann/json.hpp>
 #include <podio/Writer.h>
@@ -61,7 +61,7 @@ void JEventProcessorManagedPODIO::Init() {
         std::filesystem::remove(m_socket_path);
         m_log->debug("Removed existing socket file: {}", m_socket_path);
       } else {
-        throw std::runtime_error(fmt::format("Path exists but is not a socket: {}", m_socket_path));
+        throw std::runtime_error(std::format("Path exists but is not a socket: {}", m_socket_path));
       }
     }
 
@@ -76,7 +76,7 @@ void JEventProcessorManagedPODIO::Init() {
         std::make_unique<std::thread>(&JEventProcessorManagedPODIO::ListenForMessages, this);
 
   } catch (const std::exception& e) {
-    throw std::runtime_error(fmt::format("Failed to initialize ZeroMQ: {}", e.what()));
+    throw std::runtime_error(std::format("Failed to initialize ZeroMQ: {}", e.what()));
   }
 
   // Don't call parent Init() since we'll manage the writer ourselves
@@ -126,7 +126,7 @@ void JEventProcessorManagedPODIO::ListenForMessages() {
           } catch (const std::exception& e) {
             m_log->error("Failed to parse JSON request: {}", e.what());
             SendResponse(
-                {{"status", "error"}, {"message", fmt::format("Invalid JSON: {}", e.what())}});
+                {{"status", "error"}, {"message", std::format("Invalid JSON: {}", e.what())}});
           }
         }
       }
@@ -211,7 +211,7 @@ void JEventProcessorManagedPODIO::ProcessFileRequest(const nlohmann::json& reque
 
   } catch (const std::exception& e) {
     m_log->error("Error processing file request: {}", e.what());
-    SendResponse({{"status", "error"}, {"message", fmt::format("Processing error: {}", e.what())}});
+    SendResponse({{"status", "error"}, {"message", std::format("Processing error: {}", e.what())}});
   }
 }
 
@@ -249,7 +249,7 @@ void JEventProcessorManagedPODIO::OpenOutputFile(const std::string& output_file)
     m_writer = std::make_unique<podio::Writer>(podio::makeWriter(output_file, backend_lower));
   } catch (const std::exception& e) {
     throw std::runtime_error(
-        fmt::format("Failed to create writer for file '{}' with backend '{}': {}", output_file,
+        std::format("Failed to create writer for file '{}' with backend '{}': {}", output_file,
                     m_output_backend, e.what()));
   }
 }
@@ -293,7 +293,7 @@ nlohmann::json JEventProcessorManagedPODIO::CloseOutputFile() {
   } catch (const std::exception& e) {
     m_log->error("Error closing output file: {}", e.what());
     m_writer.reset();
-    return {{"status", "error"}, {"message", fmt::format("Error closing file: {}", e.what())}};
+    return {{"status", "error"}, {"message", std::format("Error closing file: {}", e.what())}};
   }
 }
 

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -6,7 +6,7 @@
 #include <JANA/Services/JComponentManager.h>
 #include <JANA/Services/JParameterManager.h>
 #include <JANA/Utils/JTypeInfo.h>
-#include <fmt/format.h>
+#include <format>
 #include <podio/CollectionBase.h>
 #include <podio/Frame.h>
 #include <podio/Writer.h>
@@ -563,7 +563,7 @@ void JEventProcessorPODIO::Init() {
     m_writer = std::make_unique<podio::Writer>(podio::makeWriter(m_output_file, backend_lower));
   } catch (const std::exception& e) {
     throw std::runtime_error(
-        fmt::format("Failed to create writer with backend '{}': {}", backend_lower, e.what()));
+        std::format("Failed to create writer with backend '{}': {}", backend_lower, e.what()));
   }
 }
 

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -6,7 +6,7 @@
 #include <JANA/Services/JComponentManager.h>
 #include <JANA/Services/JParameterManager.h>
 #include <JANA/Utils/JTypeInfo.h>
-#include <format>
+#include <fmt/format.h>
 #include <podio/CollectionBase.h>
 #include <podio/Frame.h>
 #include <podio/Writer.h>
@@ -14,6 +14,7 @@
 #include <cctype>
 #include <cstddef>
 #include <exception>
+#include <format>
 #include <functional>
 #include <iterator>
 #include <regex>

--- a/src/services/io/podio/JEventSourceManagedPODIO.cc
+++ b/src/services/io/podio/JEventSourceManagedPODIO.cc
@@ -2,7 +2,7 @@
 
 #include <JANA/JApplication.h>
 #include <JANA/Utils/JTypeInfo.h>
-#include <format>
+#include <fmt/format.h>
 #include <podio/Reader.h>
 #include <spdlog/logger.h>
 #include <exception>

--- a/src/services/io/podio/JEventSourceManagedPODIO.cc
+++ b/src/services/io/podio/JEventSourceManagedPODIO.cc
@@ -2,7 +2,7 @@
 
 #include <JANA/JApplication.h>
 #include <JANA/Utils/JTypeInfo.h>
-#include <fmt/format.h>
+#include <format>
 #include <podio/Reader.h>
 #include <spdlog/logger.h>
 #include <exception>

--- a/src/services/io/podio/JEventSourcePODIO.cc
+++ b/src/services/io/podio/JEventSourcePODIO.cc
@@ -14,6 +14,7 @@
 #include <TFile.h>
 #include <TObject.h>
 #include <edm4hep/EventHeaderCollection.h>
+#include <format>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 #include <podio/CollectionBase.h>
@@ -33,7 +34,7 @@
 #include "services/log/Log_service.h"
 
 // Formatter for podio::version::Version
-template <> struct fmt::formatter<podio::version::Version> : ostream_formatter {};
+template <> struct fmt::formatter<podio::version::Version> : fmt::ostream_formatter {};
 
 //------------------------------------------------------------------------------
 // InsertingVisitor
@@ -153,7 +154,7 @@ void JEventSourcePODIO::Open() {
     }
   } catch (std::exception& e) {
     m_log->error(e.what());
-    throw JException(fmt::format("Problem opening file \"{}\"", GetResourceName()));
+    throw JException(std::format("Problem opening file \"{}\"", GetResourceName()));
   }
 }
 

--- a/src/services/io/podio/datamodel_glue.h
+++ b/src/services/io/podio/datamodel_glue.h
@@ -16,7 +16,7 @@
 #include <string_view>
 #include <unordered_map>
 #include <type_traits>
-#include <fmt/format.h>
+#include <format>
 #include <podio/CollectionBase.h>
 #include <podio/utilities/TypeHelpers.h>
 // Include umbrella headers for TypeList support
@@ -132,7 +132,7 @@ template <typename Visitor> struct VisitPodioCollection {
     if (it != visitorMap.getMap().end()) {
       it->second(visitor, collection);
     } else {
-      throw std::runtime_error(fmt::format(
+      throw std::runtime_error(std::format(
           "Unrecognized podio typename: {}.\n"
           "This type was not found in the supported datamodels (EDM4hep, EDM4eic).\n"
           "Possible causes:\n"

--- a/src/tests/track_propagation_test/TrackPropagationTest_processor.cc
+++ b/src/tests/track_propagation_test/TrackPropagationTest_processor.cc
@@ -1,6 +1,5 @@
 
 #include <Acts/Definitions/Algebra.hpp>
-#include <Acts/EventData/TrackContainer.hpp>
 #include <Acts/EventData/TrackProxy.hpp>
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
 #include <Acts/EventData/VectorTrackContainer.hpp>
@@ -16,7 +15,7 @@
 #include <edm4eic/TrackCollection.h>
 #include <edm4eic/TrackPoint.h>
 #include <edm4hep/Vector3f.h>
-#include <format>
+#include <fmt/format.h>
 #include <spdlog/logger.h>
 #include <Eigen/Geometry>
 #include <exception>

--- a/src/tests/track_propagation_test/TrackPropagationTest_processor.cc
+++ b/src/tests/track_propagation_test/TrackPropagationTest_processor.cc
@@ -16,7 +16,7 @@
 #include <edm4eic/TrackCollection.h>
 #include <edm4eic/TrackPoint.h>
 #include <edm4hep/Vector3f.h>
-#include <fmt/format.h>
+#include <format>
 #include <spdlog/logger.h>
 #include <Eigen/Geometry>
 #include <exception>

--- a/src/tests/tracking_test/TrackingTest_processor.cc
+++ b/src/tests/tracking_test/TrackingTest_processor.cc
@@ -13,7 +13,7 @@
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
-#include <format>
+#include <fmt/format.h>
 #include <podio/ObjectID.h>
 #include <spdlog/logger.h>
 #include <cstddef>

--- a/src/tests/tracking_test/TrackingTest_processor.cc
+++ b/src/tests/tracking_test/TrackingTest_processor.cc
@@ -13,7 +13,7 @@
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/Vector3f.h>
-#include <fmt/format.h>
+#include <format>
 #include <podio/ObjectID.h>
 #include <spdlog/logger.h>
 #include <cstddef>

--- a/src/utilities/dump_flags/DumpFlags_processor.cc
+++ b/src/utilities/dump_flags/DumpFlags_processor.cc
@@ -4,8 +4,7 @@
 #include <JANA/JApplicationFwd.h>
 #include <JANA/JException.h>
 #include <JANA/Services/JParameterManager.h>
-#include <fmt/core.h>
-#include <format>
+#include <fmt/format.h>
 #include <spdlog/common.h>
 #include <spdlog/logger.h>
 #include <spdlog/spdlog.h>
@@ -13,6 +12,7 @@
 #include <cstddef>
 #include <cstring>
 #include <exception>
+#include <format>
 #include <fstream>
 #include <map>
 #include <memory>

--- a/src/utilities/dump_flags/DumpFlags_processor.cc
+++ b/src/utilities/dump_flags/DumpFlags_processor.cc
@@ -5,7 +5,7 @@
 #include <JANA/JException.h>
 #include <JANA/Services/JParameterManager.h>
 #include <fmt/core.h>
-#include <fmt/format.h>
+#include <format>
 #include <spdlog/common.h>
 #include <spdlog/logger.h>
 #include <spdlog/spdlog.h>
@@ -82,13 +82,13 @@ void DumpFlags_processor::Finish() {
     // form python content string
     std::string python_escaped_descr = param->GetDescription();
     std::ranges::replace(python_escaped_descr, '\'', '`');
-    python_content += fmt::format(
-        "    ({:{}} {:{}} '{}'),\n", fmt::format("'{}',", param->GetKey()), max_name_len + 3,
-        fmt::format("'{}',", param->GetDefault()), max_default_val_len + 3, python_escaped_descr);
+    python_content += std::format(
+        "    ({:{}} {:{}} '{}'),\n", std::format("'{}',", param->GetKey()), max_name_len + 3,
+        std::format("'{}',", param->GetDefault()), max_default_val_len + 3, python_escaped_descr);
 
     // form json content string
     json_content +=
-        fmt::format("    {}[\"{}\", \"{}\", \"{}\", \"{}\"]\n", line_num++ == 0 ? ' ' : ',',
+        std::format("    {}[\"{}\", \"{}\", \"{}\", \"{}\"]\n", line_num++ == 0 ? ' ' : ',',
                     json_escape(param->GetKey()), json_escape(param->GetValue()),
                     json_escape(param->GetDefault()), json_escape(param->GetDescription()));
 


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR migrates fmt::format to std::format wherever possible. Since we required C++20, this should(!) be available. Compiler support may be lacking, though...

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ ] Medium
- [x] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: use standards where available)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
