### PR TITLE
fix: use correct event number type in factory

### DIFF
--- a/src/factories/reco/ChargedMCParticleSelector_factory.h
+++ b/src/factories/reco/ChargedMCParticleSelector_factory.h
@@ -31,7 +31,7 @@ public:
     m_algo->init();
   }
 
-  void Process(int32_t /* run_number */, int64_t /* event_number */) {
+  void Process(int32_t /* run_number */, uint64_t /* event_number */) {
     m_algo->process({m_pars_in()}, {m_pars_out().get()});
   }
 };


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
Event numbers are unsigned ints. Not sure why this didn't fail to compile; factory may be unused.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: incorrect signature)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
