### PR TITLE
Add ChargedLambdaReconstruction: far-forward Lambda -> p pi- candidates

### DIFF
--- a/src/algorithms/reco/ChargedLambdaReconstruction.cc
+++ b/src/algorithms/reco/ChargedLambdaReconstruction.cc
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dmitry Romanov
+
+#include <TVector3.h>
+#include <edm4hep/Vector3f.h>
+#include <cmath>
+#include <vector>
+
+#include "ChargedLambdaReconstruction.h"
+
+namespace {
+
+/** Closest approach of two straight lines r + t*d (d normalized).
+ *
+ * Returns the distance and the midpoint between the two closest points. For
+ * near-parallel lines (a degenerate pairing, not a physical V0) the closest points
+ * are ill-defined; fall back to the perpendicular distance between the lines and the
+ * midpoint of the reference points. */
+struct LineApproach {
+  double distance;
+  TVector3 midpoint;
+};
+
+LineApproach closestApproach(const TVector3& r1, const TVector3& d1, const TVector3& r2,
+                             const TVector3& d2) {
+  const TVector3 cross = d1.Cross(d2);
+  const double denom   = cross.Mag2();
+  const TVector3 dr    = r2 - r1;
+  if (denom < 1e-12) {
+    const TVector3 perp = dr - dr.Dot(d1) * d1;
+    return {perp.Mag(), 0.5 * (r1 + r2)};
+  }
+  const double t1   = dr.Cross(d2).Dot(cross) / denom;
+  const double t2   = dr.Cross(d1).Dot(cross) / denom;
+  const TVector3 p1 = r1 + t1 * d1;
+  const TVector3 p2 = r2 + t2 * d2;
+  return {(p2 - p1).Mag(), 0.5 * (p1 + p2)};
+}
+
+} // namespace
+
+namespace eicrecon {
+
+void ChargedLambdaReconstruction::init() {
+  m_proton_mass = m_particleSvc.particle(2212).mass;
+  m_pion_mass   = m_particleSvc.particle(211).mass;
+  m_lambda_mass = m_particleSvc.particle(3122).mass;
+}
+
+void ChargedLambdaReconstruction::process(const ChargedLambdaReconstruction::Input& input,
+                                          const ChargedLambdaReconstruction::Output& output) const {
+  const auto [charged, roman_pots, off_momentum] = input;
+  auto [out_lambdas]                             = output;
+
+  using ParticleT = edm4eic::ReconstructedParticle;
+
+  // --------------------------------------------------------------------------
+  // Collect the daughter pools. Roman-Pot and off-momentum candidates are
+  // transfer-matrix reconstructions under the proton hypothesis, so all of them
+  // enter the proton pool; tracking candidates are routed by charge.
+  // --------------------------------------------------------------------------
+
+  std::vector<ParticleT> protons;
+  std::vector<ParticleT> pions;
+
+  for (const auto& part : *charged) {
+    if (part.getCharge() > 0) {
+      protons.push_back(part);
+    } else if (part.getCharge() < 0) {
+      pions.push_back(part);
+    }
+  }
+  for (const edm4eic::ReconstructedParticleCollection* coll :
+       {roman_pots.get(), off_momentum.get()}) {
+    for (const auto& part : *coll) {
+      protons.push_back(part);
+    }
+  }
+
+  if (protons.empty() || pions.empty()) {
+    debug("no pairs to build: {} proton candidates, {} pion candidates", protons.size(),
+          pions.size());
+    return;
+  }
+
+  // --------------------------------------------------------------------------
+  // Evaluate every (p, pi-) pairing with the V0 cut chain.
+  // --------------------------------------------------------------------------
+
+  for (const auto& proton : protons) {
+    const auto pp = proton.getMomentum();
+    const auto rp = proton.getReferencePoint();
+    const TVector3 p_mom(pp.x, pp.y, pp.z);
+    const TVector3 p_ref(rp.x, rp.y, rp.z);
+    const double p_mag = p_mom.Mag();
+    if (p_mag < 1e-9) {
+      continue;
+    }
+
+    for (const auto& pion : pions) {
+      const auto pip = pion.getMomentum();
+      const auto rip = pion.getReferencePoint();
+      const TVector3 pi_mom(pip.x, pip.y, pip.z);
+      const TVector3 pi_ref(rip.x, rip.y, rip.z);
+      const double pi_mag = pi_mom.Mag();
+      if (pi_mag < 1e-9) {
+        continue;
+      }
+
+      const double opening = p_mom.Angle(pi_mom);
+      if (opening > m_cfg.openingAngleMax) {
+        continue;
+      }
+
+      const TVector3 pair_mom = p_mom + pi_mom;
+      if (pair_mom.Theta() > m_cfg.pairThetaMax) {
+        continue;
+      }
+
+      const auto approach =
+          closestApproach(p_ref, p_mom.Unit(), pi_ref, pi_mom.Unit()); // [mm], EDM units
+      if (approach.distance > m_cfg.dcaMax) {
+        continue;
+      }
+      if (approach.midpoint.Z() < m_cfg.vertexZMin || approach.midpoint.Z() > m_cfg.vertexZMax) {
+        continue;
+      }
+
+      if (approach.midpoint.Mag() > 1e-9 && pair_mom.Angle(approach.midpoint) > m_cfg.pointingMax) {
+        continue;
+      }
+
+      const double mom_asym = (p_mag - pi_mag) / (p_mag + pi_mag);
+      if (mom_asym < m_cfg.momAsymMin) {
+        continue;
+      }
+
+      // invariant mass under the (m_p, m_pi) hypothesis; input energies are not used
+      // because tracking-based candidates carry no mass assignment
+      const double energy = std::sqrt(p_mag * p_mag + m_proton_mass * m_proton_mass) +
+                            std::sqrt(pi_mag * pi_mag + m_pion_mass * m_pion_mass);
+      const double mass2  = energy * energy - pair_mom.Mag2();
+      const double mass   = std::sqrt(std::max(0.0, mass2));
+      if (std::abs(mass - m_lambda_mass) > m_cfg.massWindow) {
+        continue;
+      }
+
+      auto lambda = out_lambdas->create();
+      lambda.setPDG(3122);
+      lambda.setCharge(0);
+      lambda.setMass(mass);
+      lambda.setEnergy(energy);
+      lambda.setMomentum({static_cast<float>(pair_mom.X()), static_cast<float>(pair_mom.Y()),
+                          static_cast<float>(pair_mom.Z())});
+      lambda.setReferencePoint({static_cast<float>(approach.midpoint.X()),
+                                static_cast<float>(approach.midpoint.Y()),
+                                static_cast<float>(approach.midpoint.Z())});
+      lambda.addToParticles(proton);
+      lambda.addToParticles(pion);
+
+      trace("Lambda candidate: m = {:.4f} GeV, p = {:.2f} GeV, decay-z proxy = {:.0f} mm, "
+            "dca = {:.1f} mm, opening = {:.1f} mrad",
+            mass, pair_mom.Mag(), approach.midpoint.Z(), approach.distance, opening * 1e3);
+    }
+  }
+
+  debug("built {} Lambda candidates from {} proton and {} pion candidates", out_lambdas->size(),
+        protons.size(), pions.size());
+}
+
+} // namespace eicrecon

--- a/src/algorithms/reco/ChargedLambdaReconstruction.cc
+++ b/src/algorithms/reco/ChargedLambdaReconstruction.cc
@@ -97,7 +97,7 @@ void ChargedLambdaReconstruction::process(const ChargedLambdaReconstruction::Inp
     const TVector3 p_mom(pp.x, pp.y, pp.z);
     const TVector3 p_ref(rp.x, rp.y, rp.z);
     const double p_mag = p_mom.Mag();
-    if (p_mag < 1e-9) {
+    if (p_mag < std::numeric_limits<float>::epsilon) {
       continue;
     }
 

--- a/src/algorithms/reco/ChargedLambdaReconstruction.cc
+++ b/src/algorithms/reco/ChargedLambdaReconstruction.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cmath>
 #include <initializer_list>
+#include <limits>
 #include <tuple>
 #include <vector>
 
@@ -30,7 +31,7 @@ LineApproach closestApproach(const TVector3& r1, const TVector3& d1, const TVect
   const TVector3 cross = d1.Cross(d2);
   const double denom   = cross.Mag2();
   const TVector3 dr    = r2 - r1;
-  if (denom < std::numeric_limits<float>::epsilon) {
+  if (denom < std::numeric_limits<float>::epsilon()) {
     const TVector3 perp = dr - dr.Dot(d1) * d1;
     return {perp.Mag(), 0.5 * (r1 + r2)};
   }
@@ -46,9 +47,10 @@ LineApproach closestApproach(const TVector3& r1, const TVector3& d1, const TVect
 namespace eicrecon {
 
 void ChargedLambdaReconstruction::init() {
-  m_proton_mass = m_particleSvc.particle(2212).mass;
-  m_pion_mass   = m_particleSvc.particle(211).mass;
-  m_lambda_mass = m_particleSvc.particle(3122).mass;
+  const double mass_min = std::max(0.0, m_lambda_mass - m_cfg.massWindow);
+  const double mass_max = m_lambda_mass + m_cfg.massWindow;
+  m_mass2_min           = mass_min * mass_min;
+  m_mass2_max           = mass_max * mass_max;
 }
 
 void ChargedLambdaReconstruction::process(const ChargedLambdaReconstruction::Input& input,
@@ -97,7 +99,7 @@ void ChargedLambdaReconstruction::process(const ChargedLambdaReconstruction::Inp
     const TVector3 p_mom(pp.x, pp.y, pp.z);
     const TVector3 p_ref(rp.x, rp.y, rp.z);
     const double p_mag = p_mom.Mag();
-    if (p_mag < std::numeric_limits<float>::epsilon) {
+    if (p_mag < std::numeric_limits<float>::epsilon()) {
       continue;
     }
 
@@ -107,7 +109,7 @@ void ChargedLambdaReconstruction::process(const ChargedLambdaReconstruction::Inp
       const TVector3 pi_mom(pip.x, pip.y, pip.z);
       const TVector3 pi_ref(rip.x, rip.y, rip.z);
       const double pi_mag = pi_mom.Mag();
-      if (pi_mag < 1e-9) {
+      if (pi_mag < std::numeric_limits<float>::epsilon()) {
         continue;
       }
 
@@ -130,7 +132,8 @@ void ChargedLambdaReconstruction::process(const ChargedLambdaReconstruction::Inp
         continue;
       }
 
-      if (approach.midpoint.Mag() > 1e-9 && pair_mom.Angle(approach.midpoint) > m_cfg.pointingMax) {
+      if (approach.midpoint.Mag() > std::numeric_limits<float>::epsilon() &&
+          pair_mom.Angle(approach.midpoint) > m_cfg.pointingMax) {
         continue;
       }
 
@@ -141,13 +144,12 @@ void ChargedLambdaReconstruction::process(const ChargedLambdaReconstruction::Inp
 
       // invariant mass under the (m_p, m_pi) hypothesis; input energies are not used
       // because tracking-based candidates carry no mass assignment
-      const double energy = std::sqrt(p_mag * p_mag + m_proton_mass * m_proton_mass) +
-                            std::sqrt(pi_mag * pi_mag + m_pion_mass * m_pion_mass);
+      const double energy = std::hypot(p_mag, m_proton_mass) + std::hypot(pi_mag, m_pion_mass);
       const double mass2  = energy * energy - pair_mom.Mag2();
-      const double mass   = std::sqrt(std::max(0.0, mass2));
-      if (std::abs(mass - m_lambda_mass) > m_cfg.massWindow) {
+      if (mass2 < m_mass2_min || mass2 > m_mass2_max) {
         continue;
       }
+      const double mass = std::sqrt(mass2);
 
       auto lambda = out_lambdas->create();
       lambda.setPDG(3122);

--- a/src/algorithms/reco/ChargedLambdaReconstruction.cc
+++ b/src/algorithms/reco/ChargedLambdaReconstruction.cc
@@ -30,7 +30,7 @@ LineApproach closestApproach(const TVector3& r1, const TVector3& d1, const TVect
   const TVector3 cross = d1.Cross(d2);
   const double denom   = cross.Mag2();
   const TVector3 dr    = r2 - r1;
-  if (denom < 1e-12) {
+  if (denom < std::numeric_limits<float>::epsilon) {
     const TVector3 perp = dr - dr.Dot(d1) * d1;
     return {perp.Mag(), 0.5 * (r1 + r2)};
   }

--- a/src/algorithms/reco/ChargedLambdaReconstruction.cc
+++ b/src/algorithms/reco/ChargedLambdaReconstruction.cc
@@ -2,8 +2,12 @@
 // Copyright (C) 2026 Dmitry Romanov
 
 #include <TVector3.h>
+#include <edm4eic/Vertex.h>
 #include <edm4hep/Vector3f.h>
+#include <algorithm>
 #include <cmath>
+#include <initializer_list>
+#include <tuple>
 #include <vector>
 
 #include "ChargedLambdaReconstruction.h"

--- a/src/algorithms/reco/ChargedLambdaReconstruction.cc
+++ b/src/algorithms/reco/ChargedLambdaReconstruction.cc
@@ -35,11 +35,11 @@ LineApproach closestApproach(const TVector3& r1, const TVector3& d1, const TVect
     const TVector3 perp = dr - dr.Dot(d1) * d1;
     return {perp.Mag(), 0.5 * (r1 + r2)};
   }
-  const double t1   = dr.Cross(d2).Dot(cross) / denom;
-  const double t2   = dr.Cross(d1).Dot(cross) / denom;
-  const TVector3 p1 = r1 + t1 * d1;
-  const TVector3 p2 = r2 + t2 * d2;
-  return {(p2 - p1).Mag(), 0.5 * (p1 + p2)};
+  const double t1       = dr.Cross(d2).Dot(cross) / denom;
+  const double t2       = dr.Cross(d1).Dot(cross) / denom;
+  const TVector3 point1 = r1 + t1 * d1;
+  const TVector3 point2 = r2 + t2 * d2;
+  return {(point2 - point1).Mag(), 0.5 * (point1 + point2)};
 }
 
 } // namespace
@@ -55,8 +55,8 @@ void ChargedLambdaReconstruction::init() {
 
 void ChargedLambdaReconstruction::process(const ChargedLambdaReconstruction::Input& input,
                                           const ChargedLambdaReconstruction::Output& output) const {
-  const auto [charged, roman_pots, off_momentum] = input;
-  auto [out_lambdas]                             = output;
+  const auto [charged_particles, roman_pots, off_momentum] = input;
+  auto [out_lambdas]                                       = output;
 
   using ParticleT = edm4eic::ReconstructedParticle;
 
@@ -69,17 +69,17 @@ void ChargedLambdaReconstruction::process(const ChargedLambdaReconstruction::Inp
   std::vector<ParticleT> protons;
   std::vector<ParticleT> pions;
 
-  for (const auto& part : *charged) {
-    if (part.getCharge() > 0) {
-      protons.push_back(part);
-    } else if (part.getCharge() < 0) {
-      pions.push_back(part);
+  for (const auto& particle : *charged_particles) {
+    if (particle.getCharge() > 0) {
+      protons.push_back(particle);
+    } else if (particle.getCharge() < 0) {
+      pions.push_back(particle);
     }
   }
-  for (const edm4eic::ReconstructedParticleCollection* coll :
+  for (const edm4eic::ReconstructedParticleCollection* far_forward_coll :
        {roman_pots.get(), off_momentum.get()}) {
-    for (const auto& part : *coll) {
-      protons.push_back(part);
+    for (const auto& particle : *far_forward_coll) {
+      protons.push_back(particle);
     }
   }
 
@@ -94,20 +94,20 @@ void ChargedLambdaReconstruction::process(const ChargedLambdaReconstruction::Inp
   // --------------------------------------------------------------------------
 
   for (const auto& proton : protons) {
-    const auto pp = proton.getMomentum();
-    const auto rp = proton.getReferencePoint();
-    const TVector3 p_mom(pp.x, pp.y, pp.z);
-    const TVector3 p_ref(rp.x, rp.y, rp.z);
+    const auto proton_mom = proton.getMomentum();
+    const auto proton_ref = proton.getReferencePoint();
+    const TVector3 p_mom(proton_mom.x, proton_mom.y, proton_mom.z);
+    const TVector3 p_ref(proton_ref.x, proton_ref.y, proton_ref.z);
     const double p_mag = p_mom.Mag();
     if (p_mag < std::numeric_limits<float>::epsilon()) {
       continue;
     }
 
     for (const auto& pion : pions) {
-      const auto pip = pion.getMomentum();
-      const auto rip = pion.getReferencePoint();
-      const TVector3 pi_mom(pip.x, pip.y, pip.z);
-      const TVector3 pi_ref(rip.x, rip.y, rip.z);
+      const auto pion_mom = pion.getMomentum();
+      const auto pion_ref = pion.getReferencePoint();
+      const TVector3 pi_mom(pion_mom.x, pion_mom.y, pion_mom.z);
+      const TVector3 pi_ref(pion_ref.x, pion_ref.y, pion_ref.z);
       const double pi_mag = pi_mom.Mag();
       if (pi_mag < std::numeric_limits<float>::epsilon()) {
         continue;
@@ -123,8 +123,7 @@ void ChargedLambdaReconstruction::process(const ChargedLambdaReconstruction::Inp
         continue;
       }
 
-      const auto approach =
-          closestApproach(p_ref, p_mom.Unit(), pi_ref, pi_mom.Unit()); // [mm], EDM units
+      const auto approach = closestApproach(p_ref, p_mom.Unit(), pi_ref, pi_mom.Unit()); // [mm], EDM units
       if (approach.distance > m_cfg.dcaMax) {
         continue;
       }
@@ -164,8 +163,7 @@ void ChargedLambdaReconstruction::process(const ChargedLambdaReconstruction::Inp
       lambda.addToParticles(proton);
       lambda.addToParticles(pion);
 
-      trace("Lambda candidate: m = {:.4f} GeV, p = {:.2f} GeV, decay-z proxy = {:.0f} mm, "
-            "dca = {:.1f} mm, opening = {:.1f} mrad",
+      trace("Lambda candidate: m = {:.4f} GeV, p = {:.2f} GeV, decay-z proxy = {:.0f} mm, dca = {:.1f} mm, opening = {:.1f} mrad",
             mass, pair_mom.Mag(), approach.midpoint.Z(), approach.distance, opening * 1e3);
     }
   }

--- a/src/algorithms/reco/ChargedLambdaReconstruction.cc
+++ b/src/algorithms/reco/ChargedLambdaReconstruction.cc
@@ -123,7 +123,8 @@ void ChargedLambdaReconstruction::process(const ChargedLambdaReconstruction::Inp
         continue;
       }
 
-      const auto approach = closestApproach(p_ref, p_mom.Unit(), pi_ref, pi_mom.Unit()); // [mm], EDM units
+      const auto approach =
+          closestApproach(p_ref, p_mom.Unit(), pi_ref, pi_mom.Unit()); // [mm], EDM units
       if (approach.distance > m_cfg.dcaMax) {
         continue;
       }
@@ -163,7 +164,8 @@ void ChargedLambdaReconstruction::process(const ChargedLambdaReconstruction::Inp
       lambda.addToParticles(proton);
       lambda.addToParticles(pion);
 
-      trace("Lambda candidate: m = {:.4f} GeV, p = {:.2f} GeV, decay-z proxy = {:.0f} mm, dca = {:.1f} mm, opening = {:.1f} mrad",
+      trace("Lambda candidate: m = {:.4f} GeV, p = {:.2f} GeV, decay-z proxy = {:.0f} mm, dca = "
+            "{:.1f} mm, opening = {:.1f} mrad",
             mass, pair_mom.Mag(), approach.midpoint.Z(), approach.distance, opening * 1e3);
     }
   }

--- a/src/algorithms/reco/ChargedLambdaReconstruction.h
+++ b/src/algorithms/reco/ChargedLambdaReconstruction.h
@@ -65,9 +65,12 @@ public:
 
 private:
   const algorithms::ParticleSvc& m_particleSvc = algorithms::ParticleSvc::instance();
-  double m_proton_mass{0};
-  double m_pion_mass{0};
-  double m_lambda_mass{0};
+  const double m_proton_mass{m_particleSvc.particle(2212).mass};
+  const double m_pion_mass{m_particleSvc.particle(211).mass};
+  const double m_lambda_mass{m_particleSvc.particle(3122).mass};
+  /** squared invariant-mass window bounds, computed from the config in init() */
+  double m_mass2_min{0};
+  double m_mass2_max{0};
 };
 
 } // namespace eicrecon

--- a/src/algorithms/reco/ChargedLambdaReconstruction.h
+++ b/src/algorithms/reco/ChargedLambdaReconstruction.h
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dmitry Romanov
+
+#pragma once
+
+#include <algorithms/algorithm.h>
+#include <edm4eic/ReconstructedParticleCollection.h>
+#include <string>      // for basic_string
+#include <string_view> // for string_view
+
+#include "algorithms/interfaces/WithPodConfig.h"
+#include "algorithms/reco/ChargedLambdaReconstructionConfig.h"
+#include "services/particle/ParticleSvc.h"
+
+namespace eicrecon {
+
+using ChargedLambdaReconstructionAlgorithm =
+    algorithms::Algorithm<algorithms::Input<const edm4eic::ReconstructedParticleCollection,
+                                            const edm4eic::ReconstructedParticleCollection,
+                                            const edm4eic::ReconstructedParticleCollection>,
+                          algorithms::Output<edm4eic::ReconstructedParticleCollection>>;
+
+/**
+ * Reconstruct Lambda candidates in the charged decay channel Lambda -> p pi-.
+ *
+ * Lambdas produced in ep collisions are strongly forward boosted and typically decay
+ * meters downstream of the interaction point, so the daughters land in the far-forward
+ * detectors: the proton in the Roman Pots, the off-momentum tracker or the B0 tracker,
+ * the pi- in the B0 tracker (occasionally in the central detector). The algorithm
+ * therefore combines three input collections:
+ *
+ * 1. charged particles from tracking (central + B0): positive candidates enter the
+ *    proton pool, negative candidates enter the pion pool;
+ * 2. Roman-Pot candidates: all enter the proton pool (transfer-matrix reconstruction
+ *    under the proton hypothesis);
+ * 3. off-momentum candidates: all enter the proton pool, same reasoning.
+ *
+ * Every (p, pi-) pairing is evaluated with a classic V0 cut chain computed from
+ * momenta and reference points only:
+ *   - opening angle between the daughters and polar angle of the summed momentum;
+ *   - distance of closest approach between the two straight track lines, and the z of
+ *     the closest-approach midpoint (a decay-vertex proxy);
+ *   - pointing of the summed momentum along the origin-to-vertex-proxy direction
+ *     (disabled by default, see ChargedLambdaReconstructionConfig::pointingMax);
+ *   - momentum asymmetry (the proton carries most of the Lambda momentum);
+ *   - invariant mass window under the (m_p, m_pi) hypothesis.
+ *
+ * All pairings that pass are stored as Lambda candidates with the daughters attached
+ * via the particles relation; no best-candidate choice is made here, so analyses keep
+ * the full candidate set and the mass sidebands within the configured window.
+ */
+class ChargedLambdaReconstruction : public ChargedLambdaReconstructionAlgorithm,
+                                    public WithPodConfig<ChargedLambdaReconstructionConfig> {
+public:
+  ChargedLambdaReconstruction(std::string_view name)
+      : ChargedLambdaReconstructionAlgorithm{
+            name,
+            {"inputChargedParticles", "inputRomanPotParticles", "inputOffMomentumParticles"},
+            {"outputLambdas"},
+            "Reconstructs Lambda -> p pi- candidates from charged and far-forward "
+            "particles with V0 topology and kinematics cuts"} {}
+
+  void init() final;
+  void process(const Input&, const Output&) const final;
+
+private:
+  const algorithms::ParticleSvc& m_particleSvc = algorithms::ParticleSvc::instance();
+  double m_proton_mass{0};
+  double m_pion_mass{0};
+  double m_lambda_mass{0};
+};
+
+} // namespace eicrecon

--- a/src/algorithms/reco/ChargedLambdaReconstructionConfig.h
+++ b/src/algorithms/reco/ChargedLambdaReconstructionConfig.h
@@ -3,7 +3,8 @@
 
 #pragma once
 
-#include <cmath>
+#include <edm4eic/unit_system.h>
+#include <numbers>
 
 namespace eicrecon {
 
@@ -15,21 +16,21 @@ struct ChargedLambdaReconstructionConfig {
    *  that decay in the far-forward region are within tens of mrad of the beam */
   double pairThetaMax = 57e-3;
   /** maximum distance of closest approach between the two daughter track lines [mm] */
-  double dcaMax = 90.0;
+  double dcaMax = 90.0 * edm4eic::unit::mm;
   /** accepted z range of the two-line closest-approach midpoint (decay-vertex proxy) [mm] */
-  double vertexZMin = -1500.0;
-  double vertexZMax = 32000.0;
+  double vertexZMin = -1.5 * edm4eic::unit::m;
+  double vertexZMax = 32.0 * edm4eic::unit::m;
   /** maximum angle between the pair momentum and the direction from the origin to the
    *  decay-vertex proxy [rad]. Disabled by default (pi): Roman-Pot and off-momentum
    *  candidates are transfer-matrix reconstructions whose track line passes through the
    *  origin, which degenerates this classic V0 variable until far-forward candidates
    *  carry an independent vertex estimate. */
-  double pointingMax = M_PI;
+  double pointingMax = std::numbers::pi;
   /** minimum momentum asymmetry (|p_p| - |p_pi|) / (|p_p| + |p_pi|); the proton carries
    *  approximately m_p/m_Lambda of the Lambda momentum, so signal sits at 0.7-0.9 */
   double momAsymMin = 0.47;
   /** half-width of the accepted invariant-mass window around the Lambda mass [GeV] */
-  double massWindow = 0.025;
+  double massWindow = 25.0 * edm4eic::unit::MeV;
 };
 
 } // namespace eicrecon

--- a/src/algorithms/reco/ChargedLambdaReconstructionConfig.h
+++ b/src/algorithms/reco/ChargedLambdaReconstructionConfig.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dmitry Romanov
+
+#pragma once
+
+#include <cmath>
+
+namespace eicrecon {
+
+struct ChargedLambdaReconstructionConfig {
+
+  /** maximum opening angle between the two daughter momenta [rad] */
+  double openingAngleMax = 34e-3;
+  /** maximum polar angle of the summed pair momentum [rad]; Lambdas from ep events
+   *  that decay in the far-forward region are within tens of mrad of the beam */
+  double pairThetaMax = 57e-3;
+  /** maximum distance of closest approach between the two daughter track lines [mm] */
+  double dcaMax = 90.0;
+  /** accepted z range of the two-line closest-approach midpoint (decay-vertex proxy) [mm] */
+  double vertexZMin = -1500.0;
+  double vertexZMax = 32000.0;
+  /** maximum angle between the pair momentum and the direction from the origin to the
+   *  decay-vertex proxy [rad]. Disabled by default (pi): Roman-Pot and off-momentum
+   *  candidates are transfer-matrix reconstructions whose track line passes through the
+   *  origin, which degenerates this classic V0 variable until far-forward candidates
+   *  carry an independent vertex estimate. */
+  double pointingMax = M_PI;
+  /** minimum momentum asymmetry (|p_p| - |p_pi|) / (|p_p| + |p_pi|); the proton carries
+   *  approximately m_p/m_Lambda of the Lambda momentum, so signal sits at 0.7-0.9 */
+  double momAsymMin = 0.47;
+  /** half-width of the accepted invariant-mass window around the Lambda mass [GeV] */
+  double massWindow = 0.025;
+};
+
+} // namespace eicrecon

--- a/src/factories/reco/ChargedLambdaReconstruction_factory.h
+++ b/src/factories/reco/ChargedLambdaReconstruction_factory.h
@@ -25,14 +25,22 @@ private:
 
   PodioOutput<edm4eic::ReconstructedParticle> m_lambda_output{this};
 
-  ParameterRef<double> m_opening_angle_max{this, "openingAngleMax", config().openingAngleMax};
-  ParameterRef<double> m_pair_theta_max{this, "pairThetaMax", config().pairThetaMax};
-  ParameterRef<double> m_dca_max{this, "dcaMax", config().dcaMax};
-  ParameterRef<double> m_vertex_z_min{this, "vertexZMin", config().vertexZMin};
-  ParameterRef<double> m_vertex_z_max{this, "vertexZMax", config().vertexZMax};
-  ParameterRef<double> m_pointing_max{this, "pointingMax", config().pointingMax};
-  ParameterRef<double> m_mom_asym_min{this, "momAsymMin", config().momAsymMin};
-  ParameterRef<double> m_mass_window{this, "massWindow", config().massWindow};
+  ParameterRef<double> m_opening_angle_max{this, "openingAngleMax", config().openingAngleMax,
+                                           "maximum opening angle between the daughters [rad]"};
+  ParameterRef<double> m_pair_theta_max{this, "pairThetaMax", config().pairThetaMax,
+                                        "maximum polar angle of the summed pair momentum [rad]"};
+  ParameterRef<double> m_dca_max{this, "dcaMax", config().dcaMax,
+                                 "maximum distance of closest approach of the track lines [mm]"};
+  ParameterRef<double> m_vertex_z_min{this, "vertexZMin", config().vertexZMin,
+                                      "minimum z of the decay-vertex proxy [mm]"};
+  ParameterRef<double> m_vertex_z_max{this, "vertexZMax", config().vertexZMax,
+                                      "maximum z of the decay-vertex proxy [mm]"};
+  ParameterRef<double> m_pointing_max{this, "pointingMax", config().pointingMax,
+                                      "maximum pointing angle to the decay-vertex proxy [rad]"};
+  ParameterRef<double> m_mom_asym_min{this, "momAsymMin", config().momAsymMin,
+                                      "minimum momentum asymmetry (p_p - p_pi)/(p_p + p_pi)"};
+  ParameterRef<double> m_mass_window{this, "massWindow", config().massWindow,
+                                     "half-width of the invariant-mass window [GeV]"};
 
   Service<AlgorithmsInit_service> m_algorithmsInit{this};
 

--- a/src/factories/reco/ChargedLambdaReconstruction_factory.h
+++ b/src/factories/reco/ChargedLambdaReconstruction_factory.h
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dmitry Romanov
+
+#pragma once
+
+#include "algorithms/reco/ChargedLambdaReconstruction.h"
+#include "algorithms/reco/ChargedLambdaReconstructionConfig.h"
+#include "extensions/jana/JOmniFactory.h"
+#include "services/algorithms_init/AlgorithmsInit_service.h"
+
+namespace eicrecon {
+
+class ChargedLambdaReconstruction_factory
+    : public JOmniFactory<ChargedLambdaReconstruction_factory, ChargedLambdaReconstructionConfig> {
+
+public:
+  using AlgoT = eicrecon::ChargedLambdaReconstruction;
+
+private:
+  std::unique_ptr<AlgoT> m_algo;
+
+  PodioInput<edm4eic::ReconstructedParticle> m_charged_input{this};
+  PodioInput<edm4eic::ReconstructedParticle> m_roman_pot_input{this};
+  PodioInput<edm4eic::ReconstructedParticle> m_off_momentum_input{this};
+
+  PodioOutput<edm4eic::ReconstructedParticle> m_lambda_output{this};
+
+  ParameterRef<double> m_opening_angle_max{this, "openingAngleMax", config().openingAngleMax};
+  ParameterRef<double> m_pair_theta_max{this, "pairThetaMax", config().pairThetaMax};
+  ParameterRef<double> m_dca_max{this, "dcaMax", config().dcaMax};
+  ParameterRef<double> m_vertex_z_min{this, "vertexZMin", config().vertexZMin};
+  ParameterRef<double> m_vertex_z_max{this, "vertexZMax", config().vertexZMax};
+  ParameterRef<double> m_pointing_max{this, "pointingMax", config().pointingMax};
+  ParameterRef<double> m_mom_asym_min{this, "momAsymMin", config().momAsymMin};
+  ParameterRef<double> m_mass_window{this, "massWindow", config().massWindow};
+
+  Service<AlgorithmsInit_service> m_algorithmsInit{this};
+
+public:
+  void Configure() {
+    m_algo = std::make_unique<AlgoT>(GetPrefix());
+    m_algo->level((algorithms::LogLevel)logger()->level());
+
+    m_algo->applyConfig(config());
+    m_algo->init();
+  }
+
+  void Process(int32_t /* run_number */, uint64_t /* event_number */) {
+    m_algo->process({m_charged_input(), m_roman_pot_input(), m_off_momentum_input()},
+                    {m_lambda_output().get()});
+  }
+};
+
+} // namespace eicrecon

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -31,6 +31,7 @@
 #include "factories/meta/CollectionCollector_factory.h"
 #include "factories/meta/FilterMatching_factory.h"
 #include "factories/meta/SortSubsetCollection_factory.h"
+#include "factories/reco/ChargedLambdaReconstruction_factory.h"
 #include "factories/reco/ChargedReconstructedParticleSelector_factory.h"
 #include "factories/reco/ClustersToParticles_factory.h"
 #include "factories/reco/FarForwardNeutralsReconstruction_factory.h"
@@ -274,6 +275,17 @@ void InitPlugin(JApplication* app) {
        .pi0Window              = 0.1,
        .iterations             = 10},
       app));
+
+  app->Add(new JOmniFactoryGeneratorT<ChargedLambdaReconstruction_factory>(
+      "ReconstructedChargedLambdas",
+      {"ReconstructedChargedParticles", "ForwardRomanPotRecParticles", "ForwardOffMRecParticles"},
+      {"ReconstructedChargedLambdas"}, {}, app));
+
+  app->Add(new JOmniFactoryGeneratorT<ChargedLambdaReconstruction_factory>(
+      "ReconstructedTruthSeededChargedLambdas",
+      {"ReconstructedTruthSeededChargedParticles", "ForwardRomanPotRecParticles",
+       "ForwardOffMRecParticles"},
+      {"ReconstructedTruthSeededChargedLambdas"}, {}, app));
 
   app->Add(new JOmniFactoryGeneratorT<HadronicFinalState_factory<HadronicFinalState>>(
       "HadronicFinalState",

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -469,6 +469,8 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       "ReconstructedLFHCALNeutrals",
       "ReconstructedLambdas",
       "ReconstructedLambdaDecayProductsCM",
+      "ReconstructedChargedLambdas",
+      "ReconstructedTruthSeededChargedLambdas",
 
       // DIRC
       "DIRCRawHits",

--- a/src/tests/algorithms_test/CMakeLists.txt
+++ b/src/tests/algorithms_test/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(
   pid_MergeParticleID.cc
   pid_lut_PIDLookup.cc
   meta_SortSubsetCollection.cc
+  reco_ChargedLambdaReconstruction.cc
   reco_ClustersToParticles.cc)
 
 # Add Acts version definitions to test executable

--- a/src/tests/algorithms_test/reco_ChargedLambdaReconstruction.cc
+++ b/src/tests/algorithms_test/reco_ChargedLambdaReconstruction.cc
@@ -41,10 +41,11 @@ DaughterMomenta lambdaDecayDaughters(double lambda_p, double theta_star) {
   const double gamma      = e_lambda / m_lambda;
   const double beta_gamma = lambda_p / m_lambda;
 
-  const double m2 = m_lambda * m_lambda;
-  const double q =
-      std::sqrt((m2 - std::pow(m_proton + m_pion, 2)) * (m2 - std::pow(m_proton - m_pion, 2))) /
-      (2 * m_lambda);
+  // two-body breakup momentum q of the daughters in the Lambda rest frame
+  const double m_lambda2 = m_lambda * m_lambda;
+  const double q         = std::sqrt((m_lambda2 - std::pow(m_proton + m_pion, 2)) *
+                                     (m_lambda2 - std::pow(m_proton - m_pion, 2))) /
+                           (2 * m_lambda);
   const double e_p_star  = std::hypot(q, m_proton);
   const double e_pi_star = std::hypot(q, m_pion);
 
@@ -72,7 +73,7 @@ TEST_CASE("ChargedLambdaReconstruction finds a true p pi- pair", "[ChargedLambda
   const auto daughters = lambdaDecayDaughters(100.0 * edm4eic::unit::GeV, std::numbers::pi / 2);
 
   // proton comes in through the Roman-Pot input, pion through tracking
-  edm4eic::ReconstructedParticleCollection charged;
+  edm4eic::ReconstructedParticleCollection charged_particles;
   edm4eic::ReconstructedParticleCollection roman_pots;
   edm4eic::ReconstructedParticleCollection off_momentum;
 
@@ -81,13 +82,13 @@ TEST_CASE("ChargedLambdaReconstruction finds a true p pi- pair", "[ChargedLambda
   proton.setMomentum(daughters.proton);
   proton.setReferencePoint(decay_vertex);
 
-  auto pion = charged.create();
+  auto pion = charged_particles.create();
   pion.setCharge(-1);
   pion.setMomentum(daughters.pion);
   pion.setReferencePoint(decay_vertex);
 
   edm4eic::ReconstructedParticleCollection lambdas;
-  algo.process({&charged, &roman_pots, &off_momentum}, {&lambdas});
+  algo.process({&charged_particles, &roman_pots, &off_momentum}, {&lambdas});
 
   REQUIRE(lambdas.size() == 1);
   const auto lambda = lambdas[0];
@@ -106,7 +107,7 @@ TEST_CASE("ChargedLambdaReconstruction rejects a wide-angle pairing",
   ChargedLambdaReconstruction algo("ChargedLambdaReconstruction");
   setupAlgo(algo);
 
-  edm4eic::ReconstructedParticleCollection charged;
+  edm4eic::ReconstructedParticleCollection charged_particles;
   edm4eic::ReconstructedParticleCollection roman_pots;
   edm4eic::ReconstructedParticleCollection off_momentum;
 
@@ -116,13 +117,13 @@ TEST_CASE("ChargedLambdaReconstruction rejects a wide-angle pairing",
   proton.setReferencePoint({0.F, 0.F, 0.F});
 
   // ~100 mrad away from the proton: no forward Lambda decays this wide
-  auto pion = charged.create();
+  auto pion = charged_particles.create();
   pion.setCharge(-1);
   pion.setMomentum({1.F, 0.F, 10.F});
   pion.setReferencePoint({0.F, 0.F, 0.F});
 
   edm4eic::ReconstructedParticleCollection lambdas;
-  algo.process({&charged, &roman_pots, &off_momentum}, {&lambdas});
+  algo.process({&charged_particles, &roman_pots, &off_momentum}, {&lambdas});
 
   CHECK(lambdas.empty());
 }
@@ -134,7 +135,7 @@ TEST_CASE("ChargedLambdaReconstruction pairs only opposite charges",
 
   const auto daughters = lambdaDecayDaughters(100.0 * edm4eic::unit::GeV, std::numbers::pi / 2);
 
-  edm4eic::ReconstructedParticleCollection charged;
+  edm4eic::ReconstructedParticleCollection charged_particles;
   edm4eic::ReconstructedParticleCollection roman_pots;
   edm4eic::ReconstructedParticleCollection off_momentum;
 
@@ -145,13 +146,13 @@ TEST_CASE("ChargedLambdaReconstruction pairs only opposite charges",
 
   // same kinematics as a real pion daughter, but reconstructed as positive:
   // it must not enter the pion pool
-  auto not_a_pion = charged.create();
+  auto not_a_pion = charged_particles.create();
   not_a_pion.setCharge(1);
   not_a_pion.setMomentum(daughters.pion);
   not_a_pion.setReferencePoint({0.F, 0.F, 6000.F});
 
   edm4eic::ReconstructedParticleCollection lambdas;
-  algo.process({&charged, &roman_pots, &off_momentum}, {&lambdas});
+  algo.process({&charged_particles, &roman_pots, &off_momentum}, {&lambdas});
 
   CHECK(lambdas.empty());
 }
@@ -165,7 +166,7 @@ TEST_CASE("ChargedLambdaReconstruction honors the configured mass window",
 
   const auto daughters = lambdaDecayDaughters(100.0 * edm4eic::unit::GeV, std::numbers::pi / 2);
 
-  edm4eic::ReconstructedParticleCollection charged;
+  edm4eic::ReconstructedParticleCollection charged_particles;
   edm4eic::ReconstructedParticleCollection roman_pots;
   edm4eic::ReconstructedParticleCollection off_momentum;
 
@@ -174,13 +175,13 @@ TEST_CASE("ChargedLambdaReconstruction honors the configured mass window",
   proton.setMomentum(daughters.proton);
   proton.setReferencePoint({0.F, 0.F, 6000.F});
 
-  auto pion = charged.create();
+  auto pion = charged_particles.create();
   pion.setCharge(-1);
   pion.setMomentum(daughters.pion);
   pion.setReferencePoint({0.F, 0.F, 6000.F});
 
   edm4eic::ReconstructedParticleCollection lambdas;
-  algo.process({&charged, &roman_pots, &off_momentum}, {&lambdas});
+  algo.process({&charged_particles, &roman_pots, &off_momentum}, {&lambdas});
 
   CHECK(lambdas.empty());
 }

--- a/src/tests/algorithms_test/reco_ChargedLambdaReconstruction.cc
+++ b/src/tests/algorithms_test/reco_ChargedLambdaReconstruction.cc
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dmitry Romanov
+
+#include <algorithms/logger.h>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <edm4eic/ReconstructedParticleCollection.h>
+#include <edm4hep/Vector3f.h>
+#include <cmath>
+
+#include "algorithms/reco/ChargedLambdaReconstruction.h"
+#include "algorithms/reco/ChargedLambdaReconstructionConfig.h"
+
+using eicrecon::ChargedLambdaReconstruction;
+using eicrecon::ChargedLambdaReconstructionConfig;
+
+namespace {
+
+constexpr double M_LAMBDA = 1.115683;
+constexpr double M_PROTON = 0.9382720813;
+constexpr double M_PION   = 0.13957039;
+
+struct DaughterMomenta {
+  edm4hep::Vector3f proton;
+  edm4hep::Vector3f pion;
+};
+
+/** Two-body decay Lambda -> p pi- of a Lambda moving along +z with momentum
+ * lambda_p [GeV]; theta_star is the proton polar angle in the Lambda rest frame,
+ * the decay plane is x-z. */
+DaughterMomenta lambdaDecayDaughters(double lambda_p, double theta_star) {
+  const double e_lambda   = std::hypot(lambda_p, M_LAMBDA);
+  const double gamma      = e_lambda / M_LAMBDA;
+  const double beta_gamma = lambda_p / M_LAMBDA;
+
+  const double m2 = M_LAMBDA * M_LAMBDA;
+  const double q =
+      std::sqrt((m2 - std::pow(M_PROTON + M_PION, 2)) * (m2 - std::pow(M_PROTON - M_PION, 2))) /
+      (2 * M_LAMBDA);
+  const double e_p_star  = std::hypot(q, M_PROTON);
+  const double e_pi_star = std::hypot(q, M_PION);
+
+  const double qz = q * std::cos(theta_star);
+  const double qx = q * std::sin(theta_star);
+
+  return {{static_cast<float>(qx), 0.F, static_cast<float>(gamma * qz + beta_gamma * e_p_star)},
+          {static_cast<float>(-qx), 0.F, static_cast<float>(-gamma * qz + beta_gamma * e_pi_star)}};
+}
+
+void setupAlgo(ChargedLambdaReconstruction& algo,
+               const ChargedLambdaReconstructionConfig& cfg = {}) {
+  algo.level(algorithms::LogLevel::kDebug);
+  algo.applyConfig(cfg);
+  algo.init();
+}
+
+} // namespace
+
+TEST_CASE("ChargedLambdaReconstruction finds a true p pi- pair", "[ChargedLambdaReconstruction]") {
+  ChargedLambdaReconstruction algo("ChargedLambdaReconstruction");
+  setupAlgo(algo);
+
+  const edm4hep::Vector3f decay_vertex{0.F, 0.F, 6000.F}; // [mm], meters downstream of the IP
+  const auto daughters = lambdaDecayDaughters(100.0, M_PI / 2);
+
+  // proton comes in through the Roman-Pot input, pion through tracking
+  edm4eic::ReconstructedParticleCollection charged;
+  edm4eic::ReconstructedParticleCollection roman_pots;
+  edm4eic::ReconstructedParticleCollection off_momentum;
+
+  auto proton = roman_pots.create();
+  proton.setCharge(1);
+  proton.setMomentum(daughters.proton);
+  proton.setReferencePoint(decay_vertex);
+
+  auto pion = charged.create();
+  pion.setCharge(-1);
+  pion.setMomentum(daughters.pion);
+  pion.setReferencePoint(decay_vertex);
+
+  edm4eic::ReconstructedParticleCollection lambdas;
+  algo.process({&charged, &roman_pots, &off_momentum}, {&lambdas});
+
+  REQUIRE(lambdas.size() == 1);
+  const auto lambda = lambdas[0];
+  CHECK(lambda.getPDG() == 3122);
+  CHECK(lambda.getCharge() == 0);
+  // tolerance is dominated by the float storage of ~85 GeV daughter momenta
+  CHECK_THAT(lambda.getMass(), Catch::Matchers::WithinAbs(M_LAMBDA, 2e-3));
+  CHECK_THAT(lambda.getReferencePoint().z, Catch::Matchers::WithinAbs(decay_vertex.z, 1.0));
+  REQUIRE(lambda.particles_size() == 2);
+  CHECK(lambda.getParticles(0) == proton);
+  CHECK(lambda.getParticles(1) == pion);
+}
+
+TEST_CASE("ChargedLambdaReconstruction rejects a wide-angle pairing",
+          "[ChargedLambdaReconstruction]") {
+  ChargedLambdaReconstruction algo("ChargedLambdaReconstruction");
+  setupAlgo(algo);
+
+  edm4eic::ReconstructedParticleCollection charged;
+  edm4eic::ReconstructedParticleCollection roman_pots;
+  edm4eic::ReconstructedParticleCollection off_momentum;
+
+  auto proton = roman_pots.create();
+  proton.setCharge(1);
+  proton.setMomentum({0.F, 0.F, 80.F});
+  proton.setReferencePoint({0.F, 0.F, 0.F});
+
+  // ~100 mrad away from the proton: no forward Lambda decays this wide
+  auto pion = charged.create();
+  pion.setCharge(-1);
+  pion.setMomentum({1.F, 0.F, 10.F});
+  pion.setReferencePoint({0.F, 0.F, 0.F});
+
+  edm4eic::ReconstructedParticleCollection lambdas;
+  algo.process({&charged, &roman_pots, &off_momentum}, {&lambdas});
+
+  CHECK(lambdas.empty());
+}
+
+TEST_CASE("ChargedLambdaReconstruction pairs only opposite charges",
+          "[ChargedLambdaReconstruction]") {
+  ChargedLambdaReconstruction algo("ChargedLambdaReconstruction");
+  setupAlgo(algo);
+
+  const auto daughters = lambdaDecayDaughters(100.0, M_PI / 2);
+
+  edm4eic::ReconstructedParticleCollection charged;
+  edm4eic::ReconstructedParticleCollection roman_pots;
+  edm4eic::ReconstructedParticleCollection off_momentum;
+
+  auto proton = roman_pots.create();
+  proton.setCharge(1);
+  proton.setMomentum(daughters.proton);
+  proton.setReferencePoint({0.F, 0.F, 6000.F});
+
+  // same kinematics as a real pion daughter, but reconstructed as positive:
+  // it must not enter the pion pool
+  auto not_a_pion = charged.create();
+  not_a_pion.setCharge(1);
+  not_a_pion.setMomentum(daughters.pion);
+  not_a_pion.setReferencePoint({0.F, 0.F, 6000.F});
+
+  edm4eic::ReconstructedParticleCollection lambdas;
+  algo.process({&charged, &roman_pots, &off_momentum}, {&lambdas});
+
+  CHECK(lambdas.empty());
+}
+
+TEST_CASE("ChargedLambdaReconstruction honors the configured mass window",
+          "[ChargedLambdaReconstruction]") {
+  ChargedLambdaReconstructionConfig cfg;
+  cfg.massWindow = 1e-9; // narrower than the float-precision kinematics of the test pair
+  ChargedLambdaReconstruction algo("ChargedLambdaReconstruction");
+  setupAlgo(algo, cfg);
+
+  const auto daughters = lambdaDecayDaughters(100.0, M_PI / 2);
+
+  edm4eic::ReconstructedParticleCollection charged;
+  edm4eic::ReconstructedParticleCollection roman_pots;
+  edm4eic::ReconstructedParticleCollection off_momentum;
+
+  auto proton = roman_pots.create();
+  proton.setCharge(1);
+  proton.setMomentum(daughters.proton);
+  proton.setReferencePoint({0.F, 0.F, 6000.F});
+
+  auto pion = charged.create();
+  pion.setCharge(-1);
+  pion.setMomentum(daughters.pion);
+  pion.setReferencePoint({0.F, 0.F, 6000.F});
+
+  edm4eic::ReconstructedParticleCollection lambdas;
+  algo.process({&charged, &roman_pots, &off_momentum}, {&lambdas});
+
+  CHECK(lambdas.empty());
+}

--- a/src/tests/algorithms_test/reco_ChargedLambdaReconstruction.cc
+++ b/src/tests/algorithms_test/reco_ChargedLambdaReconstruction.cc
@@ -6,20 +6,24 @@
 #include <catch2/matchers/catch_matchers.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <edm4eic/ReconstructedParticleCollection.h>
+#include <edm4eic/unit_system.h>
 #include <edm4hep/Vector3f.h>
 #include <cmath>
+#include <numbers>
 
 #include "algorithms/reco/ChargedLambdaReconstruction.h"
 #include "algorithms/reco/ChargedLambdaReconstructionConfig.h"
+#include "services/particle/ParticleSvc.h"
 
 using eicrecon::ChargedLambdaReconstruction;
 using eicrecon::ChargedLambdaReconstructionConfig;
 
 namespace {
 
-constexpr double M_LAMBDA = 1.115683;
-constexpr double M_PROTON = 0.9382720813;
-constexpr double M_PION   = 0.13957039;
+// fetched at call time: the ParticleSvc singleton is not usable during static init
+double lambdaMass() { return algorithms::ParticleSvc::instance().particle(3122).mass; }
+double protonMass() { return algorithms::ParticleSvc::instance().particle(2212).mass; }
+double pionMass() { return algorithms::ParticleSvc::instance().particle(211).mass; }
 
 struct DaughterMomenta {
   edm4hep::Vector3f proton;
@@ -30,16 +34,19 @@ struct DaughterMomenta {
  * lambda_p [GeV]; theta_star is the proton polar angle in the Lambda rest frame,
  * the decay plane is x-z. */
 DaughterMomenta lambdaDecayDaughters(double lambda_p, double theta_star) {
-  const double e_lambda   = std::hypot(lambda_p, M_LAMBDA);
-  const double gamma      = e_lambda / M_LAMBDA;
-  const double beta_gamma = lambda_p / M_LAMBDA;
+  const double m_lambda   = lambdaMass();
+  const double m_proton   = protonMass();
+  const double m_pion     = pionMass();
+  const double e_lambda   = std::hypot(lambda_p, m_lambda);
+  const double gamma      = e_lambda / m_lambda;
+  const double beta_gamma = lambda_p / m_lambda;
 
-  const double m2 = M_LAMBDA * M_LAMBDA;
+  const double m2 = m_lambda * m_lambda;
   const double q =
-      std::sqrt((m2 - std::pow(M_PROTON + M_PION, 2)) * (m2 - std::pow(M_PROTON - M_PION, 2))) /
-      (2 * M_LAMBDA);
-  const double e_p_star  = std::hypot(q, M_PROTON);
-  const double e_pi_star = std::hypot(q, M_PION);
+      std::sqrt((m2 - std::pow(m_proton + m_pion, 2)) * (m2 - std::pow(m_proton - m_pion, 2))) /
+      (2 * m_lambda);
+  const double e_p_star  = std::hypot(q, m_proton);
+  const double e_pi_star = std::hypot(q, m_pion);
 
   const double qz = q * std::cos(theta_star);
   const double qx = q * std::sin(theta_star);
@@ -61,8 +68,8 @@ TEST_CASE("ChargedLambdaReconstruction finds a true p pi- pair", "[ChargedLambda
   ChargedLambdaReconstruction algo("ChargedLambdaReconstruction");
   setupAlgo(algo);
 
-  const edm4hep::Vector3f decay_vertex{0.F, 0.F, 6000.F}; // [mm], meters downstream of the IP
-  const auto daughters = lambdaDecayDaughters(100.0, M_PI / 2);
+  const edm4hep::Vector3f decay_vertex{0.F, 0.F, 6000.F * edm4eic::unit::mm}; // meters downstream
+  const auto daughters = lambdaDecayDaughters(100.0 * edm4eic::unit::GeV, std::numbers::pi / 2);
 
   // proton comes in through the Roman-Pot input, pion through tracking
   edm4eic::ReconstructedParticleCollection charged;
@@ -87,7 +94,7 @@ TEST_CASE("ChargedLambdaReconstruction finds a true p pi- pair", "[ChargedLambda
   CHECK(lambda.getPDG() == 3122);
   CHECK(lambda.getCharge() == 0);
   // tolerance is dominated by the float storage of ~85 GeV daughter momenta
-  CHECK_THAT(lambda.getMass(), Catch::Matchers::WithinAbs(M_LAMBDA, 2e-3));
+  CHECK_THAT(lambda.getMass(), Catch::Matchers::WithinAbs(lambdaMass(), 2e-3));
   CHECK_THAT(lambda.getReferencePoint().z, Catch::Matchers::WithinAbs(decay_vertex.z, 1.0));
   REQUIRE(lambda.particles_size() == 2);
   CHECK(lambda.getParticles(0) == proton);
@@ -125,7 +132,7 @@ TEST_CASE("ChargedLambdaReconstruction pairs only opposite charges",
   ChargedLambdaReconstruction algo("ChargedLambdaReconstruction");
   setupAlgo(algo);
 
-  const auto daughters = lambdaDecayDaughters(100.0, M_PI / 2);
+  const auto daughters = lambdaDecayDaughters(100.0 * edm4eic::unit::GeV, std::numbers::pi / 2);
 
   edm4eic::ReconstructedParticleCollection charged;
   edm4eic::ReconstructedParticleCollection roman_pots;
@@ -152,11 +159,11 @@ TEST_CASE("ChargedLambdaReconstruction pairs only opposite charges",
 TEST_CASE("ChargedLambdaReconstruction honors the configured mass window",
           "[ChargedLambdaReconstruction]") {
   ChargedLambdaReconstructionConfig cfg;
-  cfg.massWindow = 1e-9; // narrower than the float-precision kinematics of the test pair
+  cfg.massWindow = 1.0 * edm4eic::unit::eV; // narrower than the float-precision test kinematics
   ChargedLambdaReconstruction algo("ChargedLambdaReconstruction");
   setupAlgo(algo, cfg);
 
-  const auto daughters = lambdaDecayDaughters(100.0, M_PI / 2);
+  const auto daughters = lambdaDecayDaughters(100.0 * edm4eic::unit::GeV, std::numbers::pi / 2);
 
   edm4eic::ReconstructedParticleCollection charged;
   edm4eic::ReconstructedParticleCollection roman_pots;

--- a/src/tests/algorithms_test/reco_ChargedLambdaReconstruction.cc
+++ b/src/tests/algorithms_test/reco_ChargedLambdaReconstruction.cc
@@ -113,13 +113,13 @@ TEST_CASE("ChargedLambdaReconstruction rejects a wide-angle pairing",
 
   auto proton = roman_pots.create();
   proton.setCharge(1);
-  proton.setMomentum({0.F, 0.F, 80.F});
+  proton.setMomentum({0.F, 0.F, 80.F * edm4eic::unit::GeV});
   proton.setReferencePoint({0.F, 0.F, 0.F});
 
   // ~100 mrad away from the proton: no forward Lambda decays this wide
   auto pion = charged_particles.create();
   pion.setCharge(-1);
-  pion.setMomentum({1.F, 0.F, 10.F});
+  pion.setMomentum({1.F * edm4eic::unit::GeV, 0.F, 10.F * edm4eic::unit::GeV});
   pion.setReferencePoint({0.F, 0.F, 0.F});
 
   edm4eic::ReconstructedParticleCollection lambdas;
@@ -142,14 +142,14 @@ TEST_CASE("ChargedLambdaReconstruction pairs only opposite charges",
   auto proton = roman_pots.create();
   proton.setCharge(1);
   proton.setMomentum(daughters.proton);
-  proton.setReferencePoint({0.F, 0.F, 6000.F});
+  proton.setReferencePoint({0.F, 0.F, 6000.F * edm4eic::unit::mm});
 
   // same kinematics as a real pion daughter, but reconstructed as positive:
   // it must not enter the pion pool
   auto not_a_pion = charged_particles.create();
   not_a_pion.setCharge(1);
   not_a_pion.setMomentum(daughters.pion);
-  not_a_pion.setReferencePoint({0.F, 0.F, 6000.F});
+  not_a_pion.setReferencePoint({0.F, 0.F, 6000.F * edm4eic::unit::mm});
 
   edm4eic::ReconstructedParticleCollection lambdas;
   algo.process({&charged_particles, &roman_pots, &off_momentum}, {&lambdas});
@@ -173,12 +173,12 @@ TEST_CASE("ChargedLambdaReconstruction honors the configured mass window",
   auto proton = roman_pots.create();
   proton.setCharge(1);
   proton.setMomentum(daughters.proton);
-  proton.setReferencePoint({0.F, 0.F, 6000.F});
+  proton.setReferencePoint({0.F, 0.F, 6000.F * edm4eic::unit::mm});
 
   auto pion = charged_particles.create();
   pion.setCharge(-1);
   pion.setMomentum(daughters.pion);
-  pion.setReferencePoint({0.F, 0.F, 6000.F});
+  pion.setReferencePoint({0.F, 0.F, 6000.F * edm4eic::unit::mm});
 
   edm4eic::ReconstructedParticleCollection lambdas;
   algo.process({&charged_particles, &roman_pots, &off_momentum}, {&lambdas});


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

Adds `ChargedLambdaReconstruction`, a charged-channel sibling of
`LambdaReconstruction` (Lambda -> n pi0). It reconstructs Lambda -> p pi-
candidates by pairing proton candidates (positive tracking particles, all
Roman-Pot and off-momentum candidates — both are transfer-matrix
reconstructions under the proton hypothesis) with pi- candidates (negative
tracking particles) and keeping pairs that pass a classic V0 selection:

- opening angle and pair polar angle (forward Lambda);
- distance of closest approach of the two straight track lines and the z of the
  closest-approach midpoint (decay-vertex proxy);
- momentum asymmetry (the proton carries ~m_p/m_Lambda of the Lambda momentum);
- invariant-mass window around the Lambda mass (default ±25 MeV) under the
  (m_p, m_pi) hypothesis.

Every surviving pairing is stored — no best-candidate choice — with the
daughters attached through the `particles` relation, so analyses keep the full
candidate set and the sidebands within the window. Two factories are wired:

| collection | inputs |
|---|---|
| `ReconstructedChargedLambdas` | `ReconstructedChargedParticles` + `ForwardRomanPotRecParticles` + `ForwardOffMRecParticles` |
| `ReconstructedTruthSeededChargedLambdas` | same with `ReconstructedTruthSeededChargedParticles` |

All cut values are configuration parameters. Defaults come from a
Sullivan-process study on the meson-structure campaign (5x41-9x275, cuts fixed
at 99% marginal signal efficiency each on a train split; 92% signal efficiency
at 99.9% background-pair rejection on the test split, before the mass window).

Closes #2925 (it carries the physics motivation,
validation plots and the two seeding gaps that currently limit the real-seeded
collection).

New files:
- `src/algorithms/reco/ChargedLambdaReconstruction.{h,cc}`,
  `ChargedLambdaReconstructionConfig.h`
- `src/factories/reco/ChargedLambdaReconstruction_factory.h`
- `src/tests/algorithms_test/reco_ChargedLambdaReconstruction.cc` — four catch2
  cases: a kinematically exact Lambda decay is found (mass, vertex proxy,
  daughter links), a wide-angle pairing is rejected, charge routing is enforced,
  the mass window follows the configuration.

Touched files: registration in `src/global/reco/reco.cc`, output list in
`JEventProcessorPODIO.cc`, test list in `src/tests/algorithms_test/CMakeLists.txt`.

Validation on meson-structure 9x130 (2000 events, truth-seeded chain with the
vertex acceptance opened to the far-forward decay region):

| configuration | `ReconstructedChargedLambdas` | `ReconstructedTruthSeededChargedLambdas` |
|---|---|---|
| stock parameters | 0 | 7 (7 truth-matched) |
| truth-seed vertex acceptance opened to 30 m | 0 | 118 (110 truth-matched) |

The truth-seeded collection shows a clean Lambda peak (mu = 1117 MeV,
sigma = 8.6 MeV) and its vertex proxy follows the true decay z up to the B0
reach (~6 m); plots are in the linked issue. The real-seeded collection is
empty because B0 seeding currently produces no tracks (see the issue) — the
factory is wired now so the collection fills as soon as seeding is fixed, with
no further changes here.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #2925)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

AI usage: the algorithm, factory, tests and this description were prepared with
Claude Code under the author's direction; the cut selection and validation
numbers come from the author's meson-structure Lambda study, and all code was
reviewed, built and validated by the author.

Adds two new output collections (`ReconstructedChargedLambdas`,
`ReconstructedTruthSeededChargedLambdas`); no existing collection or default
changes.
