### PR TITLE
BUGFIX: digitize with noise for EcalBarrelScFiNCALOROCHits, update PulseNoiseConfig and digi thresh.

### DIFF
--- a/src/detectors/BEMC/BEMC.cc
+++ b/src/detectors/BEMC/BEMC.cc
@@ -75,14 +75,14 @@ void InitPlugin(JApplication* app) {
   decltype(PulseCombinerConfig::combine_field) EcalBarrelScFi_combine_field           = {"grid"};
   decltype(PulseCombinerConfig::minimum_separation) EcalBarrelScFi_minimum_separation = {
       100 * edm4eic::unit::ns};
-  decltype(PulseNoiseConfig::poles) EcalBarrelScFi_poles                  = {2};
-  decltype(PulseNoiseConfig::variance) EcalBarrelScFi_variance            = {0.5};
-  decltype(PulseNoiseConfig::alpha) EcalBarrelScFi_alpha                  = {0};
-  decltype(PulseNoiseConfig::scale) EcalBarrelScFi_scale                  = {5.4e-5};
-  decltype(PulseNoiseConfig::pedestal) EcalBarrelScFi_pedestal            = {1.6e-4};
+  decltype(PulseNoiseConfig::poles) EcalBarrelScFi_poles                  = {5};
+  decltype(PulseNoiseConfig::variance) EcalBarrelScFi_variance            = {1.0};
+  decltype(PulseNoiseConfig::alpha) EcalBarrelScFi_alpha                  = {1.8};
+  decltype(PulseNoiseConfig::scale) EcalBarrelScFi_scale                  = {0.35};
+  decltype(PulseNoiseConfig::pedestal) EcalBarrelScFi_pedestal            = {6.1};
   decltype(CALOROCDigitizationConfig::adc_phase) EcalBarrelScFi_adc_phase = {10 *
                                                                              edm4eic::unit::ns};
-  decltype(CALOROCDigitizationConfig::toa_thres) EcalBarrelScFi_toa_thres = {7};
+  decltype(CALOROCDigitizationConfig::toa_thres) EcalBarrelScFi_toa_thres = {13.1};
   decltype(CALOROCDigitizationConfig::tot_thres) EcalBarrelScFi_tot_thres = {200};
   decltype(CALOROCDigitizationConfig::dyRangeSingleGainADC) EcalBarrelScFi_dyRangeSingleGainADC = {
       250};
@@ -222,7 +222,7 @@ void InitPlugin(JApplication* app) {
       app // TODO: Remove me once fixed
       ));
   app->Add(new JOmniFactoryGeneratorT<CALOROCDigitization_factory>(
-      "EcalBarrelScFiNCALOROCHits", {"EcalBarrelScFiNCombinedPulses"},
+      "EcalBarrelScFiNCALOROCHits", {"EcalBarrelScFiNCombinedPulsesWithNoise"},
       {"EcalBarrelScFiNCALOROCHits"},
       {
           .adc_phase            = EcalBarrelScFi_adc_phase,


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

Since the `EdepToNpeConversion` algorithm is now used for BIC digitization, configuration variables of `PulseNoise` in `BEMC.cc` need to be updated accordingly. This update is based on the study presented in [Slides](https://indico.bnl.gov/event/33882/contributions/128014/attachments/72155/123529/BIC20260819_calo_WG.pdf). The `toa_thres` in `CALOROCDigitization` is also updated taking into account the change in `pedestal`.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [x] Optimization (issue #2909)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
