### PR TITLE
Implement Reco-Only Equivalent to `MatchClusters` (EFZB)

### DIFF
--- a/src/global/particle_flow/particle_flow.cc
+++ b/src/global/particle_flow/particle_flow.cc
@@ -47,52 +47,63 @@ void InitPlugin(JApplication* app) {
   // EFZ (B) using only reco info
   // --------------------------------------------------------------------
 
-  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::TrackClusterMatch, false>>(
-      "EcalTrackClusterMatches",
-      {"EcalEndcapNTrackClusterMatches", "EcalBarrelTrackClusterMatches", "EcalEndcapPTrackClusterMatches"},
-      {"EcalTrackClusterMatches"}, app));
+  app->Add(
+      new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::TrackClusterMatch, false>>(
+          "EcalTrackClusterMatches",
+          {"EcalEndcapNTrackClusterMatches", "EcalBarrelTrackClusterMatches",
+           "EcalEndcapPTrackClusterMatches"},
+          {"EcalTrackClusterMatches"}, app));
+
+  app->Add(
+      new JOmniFactoryGeneratorT<FilterMatching_factory<
+          edm4eic::Cluster, [](auto* obj) { return obj->getObjectID(); },
+          edm4eic::TrackClusterMatch, [](auto* obj) { return obj->getCluster().getObjectID(); }>>(
+          "MatchedEcalClusters", {"EcalClusters", "EcalTrackClusterMatches"},
+          {"MatchedEcalClusters", "UnmatchedEcalClusters"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<FilterMatching_factory<
-               edm4eic::Cluster, [](auto* obj) { return obj->getObjectID(); },
-               edm4eic::TrackClusterMatch, [](auto* obj) { return obj->getCluster().getObjectID(); }>>(
-      "MatchedEcalClusters", {"EcalClusters", "EcalTrackClusterMatches"},
-      {"MatchedEcalClusters", "UnmatchedEcalClusters"}, app));
-
-  app->Add(new JOmniFactoryGeneratorT<FilterMatching_factory<
-               edm4eic::MCRecoClusterParticleAssociation, [](auto* obj) { return obj->getRec().getObjectID(); },
-               edm4eic::TrackClusterMatch, [](auto* obj) { return obj->getCluster().getObjectID(); }>>(
+               edm4eic::MCRecoClusterParticleAssociation,
+               [](auto* obj) { return obj->getRec().getObjectID(); }, edm4eic::TrackClusterMatch,
+               [](auto* obj) { return obj->getCluster().getObjectID(); }>>(
       "MatchedEcalClusterAssociations", {"EcalClusterAssociations", "EcalTrackClusterMatches"},
       {"MatchedEcalClusterAssociations", "UnmatchedEcalClusterAssociations"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<ClustersToParticles_factory>(
-      "ReconstructedNeutralParticlesZero", {"UnmatchedEcalClusters", "UnmatchedEcalClusterAssociations"},
+      "ReconstructedNeutralParticlesZero",
+      {"UnmatchedEcalClusters", "UnmatchedEcalClusterAssociations"},
       {"ReconstructedNeutralParticlesZero", "ReconstructedNeutralParticleZeroLinks",
        "ReconstructedNeutralParticleZeroAssociations"},
       app));
 
-  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::ReconstructedParticle, false>>(
+  app->Add(new JOmniFactoryGeneratorT<
+           CollectionCollector_factory<edm4eic::ReconstructedParticle, false>>(
       "ReconstructedParticlesZeroSubset",
       {"ReconstructedChargedParticles", "ReconstructedNeutralParticlesZero"},
       {"ReconstructedParticlesZeroSubset"}, app));
 
-  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::MCRecoParticleLink, false>>(
-      "ReconstructedParticleZeroLinksSubset",
-      {"ReconstructedChargedParticleLinks", "ReconstructedNeutralParticleZeroLinks"},
-      {"ReconstructedParticleZeroLinksSubset"}, app));
+  app->Add(
+      new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::MCRecoParticleLink, false>>(
+          "ReconstructedParticleZeroLinksSubset",
+          {"ReconstructedChargedParticleLinks", "ReconstructedNeutralParticleZeroLinks"},
+          {"ReconstructedParticleZeroLinksSubset"}, app));
 
-  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::MCRecoParticleAssociation, false>>(
+  app->Add(new JOmniFactoryGeneratorT<
+           CollectionCollector_factory<edm4eic::MCRecoParticleAssociation, false>>(
       "ReconstructedParticleZeroAssociationsSubset",
       {"ReconstructedChargedParticleAssociations", "ReconstructedNeutralParticleZeroAssociations"},
       {"ReconstructedParticleZeroAssociationsSubset"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<Cloner_factory<edm4eic::ReconstructedParticle>>(
-      "ReconstructedParticlesZero", {"ReconstructedParticlesZeroSubset"}, {"ReconstructedParticlesZero"}, app));
+      "ReconstructedParticlesZero", {"ReconstructedParticlesZeroSubset"},
+      {"ReconstructedParticlesZero"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<Cloner_factory<edm4eic::MCRecoParticleLink>>(
-      "ReconstructedParticleZeroLinks", {"ReconstructedParticleZeroLinksSubset"}, {"ReconstructedParticleZeroLinks"}, app));
+      "ReconstructedParticleZeroLinks", {"ReconstructedParticleZeroLinksSubset"},
+      {"ReconstructedParticleZeroLinks"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<Cloner_factory<edm4eic::MCRecoParticleAssociation>>(
-      "ReconstructedParticleZeroAssociations", {"ReconstructedParticleZeroAssociationsSubset"}, {"ReconstructedParticleZeroAssociations"}, app));
+      "ReconstructedParticleZeroAssociations", {"ReconstructedParticleZeroAssociationsSubset"},
+      {"ReconstructedParticleZeroAssociations"}, app));
 
   // ====================================================================
   // PFAlpha: baseline PF implementation

--- a/src/global/particle_flow/particle_flow.cc
+++ b/src/global/particle_flow/particle_flow.cc
@@ -5,6 +5,10 @@
 #include <JANA/JApplicationFwd.h>
 #include <JANA/Utils/JTypeInfo.h>
 #include <edm4eic/Cluster.h>
+#include <edm4eic/MCRecoClusterParticleAssociation.h>
+#include <edm4eic/MCRecoParticleAssociation.h>
+#include <edm4eic/MCRecoParticleLinkCollection.h>
+#include <edm4eic/ReconstructedParticle.h>
 #include <edm4eic/TrackClusterMatch.h>
 #include <edm4eic/TrackPoint.h>
 #include <edm4eic/TrackSegment.h>
@@ -17,12 +21,15 @@
 #include <vector>
 
 #include "extensions/jana/JOmniFactoryGeneratorT.h"
+#include "factories/meta/Cloner_factory.h"
 #include "factories/meta/CollectionCollector_factory.h"
+#include "factories/meta/FilterMatching_factory.h"
 #include "factories/meta/SubDivideCollection_factory.h"
 #include "factories/particle_flow/CaloRemnantCombiner_factory.h"
 #include "factories/particle_flow/ChargedCandidateMaker_factory.h"
 #include "factories/particle_flow/TrackClusterSubtractor_factory.h"
 #include "factories/particle_flow/TrackProtoClusterMatchPromoter_factory.h"
+#include "factories/reco/ClustersToParticles_factory.h"
 
 extern "C" {
 
@@ -31,6 +38,61 @@ void InitPlugin(JApplication* app) {
   using namespace eicrecon;
 
   InitJANAPlugin(app);
+
+  // ====================================================================
+  // EFZero: minimal reference EF
+  // ====================================================================
+
+  // --------------------------------------------------------------------
+  // EFZ (B) using only reco info
+  // --------------------------------------------------------------------
+
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::TrackClusterMatch, false>>(
+      "EcalTrackClusterMatches",
+      {"EcalEndcapNTrackClusterMatches", "EcalBarrelTrackClusterMatches", "EcalEndcapPTrackClusterMatches"},
+      {"EcalTrackClusterMatches"}, app));
+
+  app->Add(new JOmniFactoryGeneratorT<FilterMatching_factory<
+               edm4eic::Cluster, [](auto* obj) { return obj->getObjectID(); },
+               edm4eic::TrackClusterMatch, [](auto* obj) { return obj->getCluster().getObjectID(); }>>(
+      "MatchedEcalClusters", {"EcalClusters", "EcalTrackClusterMatches"},
+      {"MatchedEcalClusters", "UnmatchedEcalClusters"}, app));
+
+  app->Add(new JOmniFactoryGeneratorT<FilterMatching_factory<
+               edm4eic::MCRecoClusterParticleAssociation, [](auto* obj) { return obj->getRec().getObjectID(); },
+               edm4eic::TrackClusterMatch, [](auto* obj) { return obj->getCluster().getObjectID(); }>>(
+      "MatchedEcalClusterAssociations", {"EcalClusterAssociations", "EcalTrackClusterMatches"},
+      {"MatchedEcalClusterAssociations", "UnmatchedEcalClusterAssociations"}, app));
+
+  app->Add(new JOmniFactoryGeneratorT<ClustersToParticles_factory>(
+      "ReconstructedNeutralParticlesZero", {"UnmatchedEcalClusters", "UnmatchedEcalClusterAssociations"},
+      {"ReconstructedNeutralParticlesZero", "ReconstructedNeutralParticleZeroLinks",
+       "ReconstructedNeutralParticleZeroAssociations"},
+      app));
+
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::ReconstructedParticle, false>>(
+      "ReconstructedParticlesZeroSubset",
+      {"ReconstructedChargedParticles", "ReconstructedNeutralParticlesZero"},
+      {"ReconstructedParticlesZeroSubset"}, app));
+
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::MCRecoParticleLink, false>>(
+      "ReconstructedParticleZeroLinksSubset",
+      {"ReconstructedChargedParticleLinks", "ReconstructedNeutralParticleZeroLinks"},
+      {"ReconstructedParticleZeroLinksSubset"}, app));
+
+  app->Add(new JOmniFactoryGeneratorT<CollectionCollector_factory<edm4eic::MCRecoParticleAssociation, false>>(
+      "ReconstructedParticleZeroAssociationsSubset",
+      {"ReconstructedChargedParticleAssociations", "ReconstructedNeutralParticleZeroAssociations"},
+      {"ReconstructedParticleZeroAssociationsSubset"}, app));
+
+  app->Add(new JOmniFactoryGeneratorT<Cloner_factory<edm4eic::ReconstructedParticle>>(
+      "ReconstructedParticlesZero", {"ReconstructedParticlesZeroSubset"}, {"ReconstructedParticlesZero"}, app));
+
+  app->Add(new JOmniFactoryGeneratorT<Cloner_factory<edm4eic::MCRecoParticleLink>>(
+      "ReconstructedParticleZeroLinks", {"ReconstructedParticleZeroLinksSubset"}, {"ReconstructedParticleZeroLinks"}, app));
+
+  app->Add(new JOmniFactoryGeneratorT<Cloner_factory<edm4eic::MCRecoParticleAssociation>>(
+      "ReconstructedParticleZeroAssociations", {"ReconstructedParticleZeroAssociationsSubset"}, {"ReconstructedParticleZeroAssociations"}, app));
 
   // ====================================================================
   // PFAlpha: baseline PF implementation

--- a/src/services/io/podio/JEventProcessorPODIO.cc
+++ b/src/services/io/podio/JEventProcessorPODIO.cc
@@ -483,6 +483,14 @@ JEventProcessorPODIO::JEventProcessorPODIO() {
       "EcalEndcapNTrackClusterMatches",
       "HcalEndcapNTrackClusterMatches",
 
+      // energy flow
+      "ReconstructedNeutralParticlesZero",
+      "ReconstructedNeutralParticleZeroAssociations",
+      "ReconstructedNeutralParticleZeroLinks",
+      "ReconstructedParticlesZero",
+      "ReconstructedParticleZeroAssociations",
+      "ReconstructedParticleZeroLinks",
+
       // particle flow
       "EcalBarrelRemnantClusters",
       "EcalBarrelExpectedClusters",


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

This PR implements the sequence of algorithms illustrated below, which is intended to be a reco-only equivalent to the `MatchClusters` algorithm.
```mermaid
flowchart TB
    tcm([Track-Cluster Matches]) --> fmc(Filter Matched Clusters)
    clu([Clusters]) --> fmc
    fmc --> umc([Unmatched Clusters])
    umc --> c2p(Convert Clusters to Particles)
    c2p --> neu([Neutral Reconstructed Particles])
    chr([Charged Reconstructed Particles]) --> col(Collect Collections)
    neu --> col
    col --> sub([Reconstructed Particles subset])
    sub --> clo(Clone)
    clo --> par([Reconstructed Particles])
```

For easier comparison, this workflow is referred to as "Energy-Flow Zero (EFZero)" since this is (1) a simple energy flow algorithm, and (2) a 0th order "baseline-to-the-baseline" comparison for PFAlpha. Outputs are labeled with "Zero" to distinguish them from defaults.

**Note:** as this is intended as the reco-only equivalent to `MatchClusters`, only EMCal clusters are utilized. Integrating HCal clusters is one of the goals of PFAlpha.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ ] Medium
- [x] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #1956 )
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [x] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

The collections `ReconstructedNeutralParticlesZero`, `ReconstructedParticlesZero`, and relevant associations/links will now appear in the default output.