### PR TITLE
Change FF LGAD resolution from 8ns to 30ps

### DIFF
--- a/src/detectors/B0TRK/B0TRK.cc
+++ b/src/detectors/B0TRK/B0TRK.cc
@@ -8,6 +8,7 @@
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <vector>
+#include <edm4eic/unit_system.h>
 
 #include "extensions/jana/JOmniFactoryGeneratorT.h"
 #include "factories/digi/SiliconTrackerDigi_factory.h"
@@ -25,7 +26,7 @@ void InitPlugin(JApplication* app) {
       {"B0TrackerRawHits", "B0TrackerRawHitLinks", "B0TrackerRawHitAssociations"},
       {
           .threshold      = 10.0 * dd4hep::keV,
-          .timeResolution = 30 * dd4hep::picosecond,
+          .timeResolution = 30 * edm4eic::unit::ps,
       },
       app));
 
@@ -33,7 +34,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<TrackerHitReconstruction_factory>(
       "B0TrackerRecHits", {"B0TrackerRawHits"}, {"B0TrackerRecHits"},
       {
-          .timeResolution = 30 * dd4hep::picosecond,
+          .timeResolution = 30 * edm4eic::unit::ps,
       },
       app));
 }

--- a/src/detectors/B0TRK/B0TRK.cc
+++ b/src/detectors/B0TRK/B0TRK.cc
@@ -25,7 +25,7 @@ void InitPlugin(JApplication* app) {
       {"B0TrackerRawHits", "B0TrackerRawHitLinks", "B0TrackerRawHitAssociations"},
       {
           .threshold      = 10.0 * dd4hep::keV,
-          .timeResolution = 8,
+          .timeResolution = 30 * dd4hep::picosecond,
       },
       app));
 
@@ -33,7 +33,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<TrackerHitReconstruction_factory>(
       "B0TrackerRecHits", {"B0TrackerRawHits"}, {"B0TrackerRecHits"},
       {
-          .timeResolution = 8,
+          .timeResolution = 30 * dd4hep::picosecond,
       },
       app));
 }

--- a/src/detectors/FOFFMTRK/FOFFMTRK.cc
+++ b/src/detectors/FOFFMTRK/FOFFMTRK.cc
@@ -27,14 +27,14 @@ void InitPlugin(JApplication* app) {
        "ForwardOffMTrackerRawHitAssociations"},
       {
           .threshold      = 10.0 * dd4hep::keV,
-          .timeResolution = 8,
+          .timeResolution = 30 * dd4hep::picosecond,
       },
       app));
 
   app->Add(new JOmniFactoryGeneratorT<TrackerHitReconstruction_factory>(
       "ForwardOffMTrackerRecHits", {"ForwardOffMTrackerRawHits"}, {"ForwardOffMTrackerRecHits"},
       {
-          .timeResolution = 8,
+          .timeResolution = 30 * dd4hep::picosecond,
       },
       app));
 

--- a/src/detectors/FOFFMTRK/FOFFMTRK.cc
+++ b/src/detectors/FOFFMTRK/FOFFMTRK.cc
@@ -8,6 +8,7 @@
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <vector>
+#include <edm4eic/unit_system.h>
 
 #include "algorithms/fardetectors/MatrixTransferStaticConfig.h"
 #include "extensions/jana/JOmniFactoryGeneratorT.h"
@@ -27,14 +28,14 @@ void InitPlugin(JApplication* app) {
        "ForwardOffMTrackerRawHitAssociations"},
       {
           .threshold      = 10.0 * dd4hep::keV,
-          .timeResolution = 30 * dd4hep::picosecond,
+          .timeResolution = 30 * edm4eic::unit::ps,
       },
       app));
 
   app->Add(new JOmniFactoryGeneratorT<TrackerHitReconstruction_factory>(
       "ForwardOffMTrackerRecHits", {"ForwardOffMTrackerRawHits"}, {"ForwardOffMTrackerRecHits"},
       {
-          .timeResolution = 30 * dd4hep::picosecond,
+          .timeResolution = 30 * edm4eic::unit::ps,
       },
       app));
 

--- a/src/detectors/RPOTS/RPOTS.cc
+++ b/src/detectors/RPOTS/RPOTS.cc
@@ -32,7 +32,7 @@ void InitPlugin(JApplication* app) {
       {"ForwardRomanPotRawHits", "ForwardRomanPotRawHitLinks", "ForwardRomanPotRawHitAssociations"},
       {
           .threshold      = 10.0 * dd4hep::keV,
-          .timeResolution = 30 * edm4eic::unit::ps, 
+          .timeResolution = 30 * edm4eic::unit::ps,
       },
       app));
 

--- a/src/detectors/RPOTS/RPOTS.cc
+++ b/src/detectors/RPOTS/RPOTS.cc
@@ -31,7 +31,7 @@ void InitPlugin(JApplication* app) {
       {"ForwardRomanPotRawHits", "ForwardRomanPotRawHitLinks", "ForwardRomanPotRawHitAssociations"},
       {
           .threshold      = 10.0 * dd4hep::keV,
-          .timeResolution = 30 * dd4hep::picosecond, 
+          .timeResolution = 30 * dd4hep::picosecond,
       },
       app));
 

--- a/src/detectors/RPOTS/RPOTS.cc
+++ b/src/detectors/RPOTS/RPOTS.cc
@@ -8,6 +8,7 @@
 #include <JANA/Utils/JTypeInfo.h>
 #include <string>
 #include <vector>
+#include <edm4eic/unit_system.h>
 
 #include "algorithms/fardetectors/MatrixTransferStaticConfig.h"
 #include "algorithms/fardetectors/PolynomialMatrixReconstructionConfig.h"
@@ -31,14 +32,14 @@ void InitPlugin(JApplication* app) {
       {"ForwardRomanPotRawHits", "ForwardRomanPotRawHitLinks", "ForwardRomanPotRawHitAssociations"},
       {
           .threshold      = 10.0 * dd4hep::keV,
-          .timeResolution = 30 * dd4hep::picosecond,
+          .timeResolution = 30 * edm4eic::unit::ps, 
       },
       app));
 
   app->Add(new JOmniFactoryGeneratorT<TrackerHitReconstruction_factory>(
       "ForwardRomanPotRecHits", {"ForwardRomanPotRawHits"}, {"ForwardRomanPotRecHits"},
       {
-          .timeResolution = 30 * dd4hep::picosecond,
+          .timeResolution = 30 * edm4eic::unit::ps,
       },
       app));
 

--- a/src/detectors/RPOTS/RPOTS.cc
+++ b/src/detectors/RPOTS/RPOTS.cc
@@ -31,14 +31,14 @@ void InitPlugin(JApplication* app) {
       {"ForwardRomanPotRawHits", "ForwardRomanPotRawHitLinks", "ForwardRomanPotRawHitAssociations"},
       {
           .threshold      = 10.0 * dd4hep::keV,
-          .timeResolution = 8,
+          .timeResolution = 30 * dd4hep::picosecond, 
       },
       app));
 
   app->Add(new JOmniFactoryGeneratorT<TrackerHitReconstruction_factory>(
       "ForwardRomanPotRecHits", {"ForwardRomanPotRawHits"}, {"ForwardRomanPotRecHits"},
       {
-          .timeResolution = 8,
+          .timeResolution = 30 * dd4hep::picosecond,
       },
       app));
 


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
Updates the FF tracker timing resolution from 8ns which was the default for all detectors when introduced to the 30ps expected by the sensor (referenced from the now quite old digitization spreadsheet https://docs.google.com/spreadsheets/d/1s8oXj36SqIh7TJeHFH89gQ_ayU1_SVEpWQNkx6sETKs/edit?gid=238482234#gid=238482234)

Studies by @Garypenman highlighted looking for coincidences between the FF protons and FB electrons was being smeared out significantly more than anticipated. @ajentsch 

A more detailed digitization approach and the correctness of the resolution value of other detectors are not being considered in this PR

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
