### PR TITLE
Refine particle acceptance criteria for truth seeds

### DIFF
--- a/src/algorithms/tracking/TrackParamTruthInit.cc
+++ b/src/algorithms/tracking/TrackParamTruthInit.cc
@@ -39,11 +39,11 @@ void TrackParamTruthInit::process(const Input& input, const Output& output) cons
   // Loop over input particles
   for (const auto& mcparticle : *mcparticles) {
 
-    // Accept all generated particles that been transported in simulation. 
-    // Both primary / decayed signal or beam background particles can produce truth seeds. 
-    // SimulatorStatus will stay 0 for intermediate partons, resonances, or any particles 
+    // Accept all generated particles that been transported in simulation.
+    // Both primary / decayed signal or beam background particles can produce truth seeds.
+    // SimulatorStatus will stay 0 for intermediate partons, resonances, or any particles
     // that are not transported in simulation hence have no chance to leave hits.
-    if (mcparticle.getSimulatorStatus()==0) {
+    if (mcparticle.getSimulatorStatus() == 0) {
       trace("ignoring particle with generatorStatus = {}, simulatorStatus = {}",
             mcparticle.getGeneratorStatus(), mcparticle.getSimulatorStatus());
       continue;

--- a/src/algorithms/tracking/TrackParamTruthInit.cc
+++ b/src/algorithms/tracking/TrackParamTruthInit.cc
@@ -39,9 +39,11 @@ void TrackParamTruthInit::process(const Input& input, const Output& output) cons
   // Loop over input particles
   for (const auto& mcparticle : *mcparticles) {
 
-    // accept generator-stable particles (HepMC3/DDSim gun) or Geant4-produced
-    // secondaries; reject generator intermediates (partons, resonances, beams)
-    if (!(mcparticle.getGeneratorStatus() == 1 || mcparticle.getSimulatorStatus() != 0)) {
+    // Accept all generated particles that been transported in simulation. 
+    // Both primary / decayed signal or beam background particles can produce truth seeds. 
+    // SimulatorStatus will stay 0 for intermediate partons, resonances, or any particles 
+    // that are not transported in simulation hence have no chance to leave hits.
+    if (mcparticle.getSimulatorStatus()==0) {
       trace("ignoring particle with generatorStatus = {}, simulatorStatus = {}",
             mcparticle.getGeneratorStatus(), mcparticle.getSimulatorStatus());
       continue;


### PR DESCRIPTION
Updated particle acceptance criteria to include all generated particles that have been transported in simulation, clarifying the conditions for truth seed production.

### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This change use the simulation status (nonzero if the particle is transported by the simulation) as the only cut to reject mcparticles that have no chance to leave hits.  It will accept both primary/secondary beam background and signal particles so it's proper for background studies. 

This change makes the code clearer but effectively have NO impact on the actual truth seeding behavior, because the previous "or" cut on generator status of 1 does not add anything in our current simulation setting: all generator status=1 particles are transported.  Any observed issue with truth seeding will remain and require separate investigations.


### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ ] Medium
- [x ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [x ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
