### PR TITLE
fix: remove dependency on build for pragma, clang-tidy, iwyu

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -264,7 +264,6 @@ jobs:
 
   clang-tidy-iwyu:
     runs-on: ubuntu-24.04
-    needs: build
     permissions:
       contents: write  # for peter-evans/create-pull-request to push fixes
       pull-requests: write  # for commenting and creating PRs
@@ -273,13 +272,6 @@ jobs:
       with:
         filter: "tree:0"
     - uses: cvmfs-contrib/github-action-cvmfs@v5
-    - name: Download build artifact
-      uses: actions/download-artifact@v8
-      with:
-        name: build-${{ env.clang-tidy-iwyu-CXX }}-eic-shell-${{ env.clang-tidy-iwyu-CMAKE_BUILD_TYPE }}-${{ env.platform }}-${{ env.release }}
-        path: .
-    - name: Uncompress build artifact
-      run: tar -xaf build.tar.zst
     - name: Check for pragma once in changed files
       if: ${{ github.event_name == 'pull_request' }}
       run: |
@@ -290,6 +282,13 @@ jobs:
       run: |
         missing_pragma_headers=$(find src -name "*.h" | xargs -n 1 grep -L 'pragma once')
         test -z "${missing_pragma_headers}"
+    - name: Run clang-tidy on changed files
+      uses: eic/run-cvmfs-osg-eic-shell@main
+      with:
+        organization: "${{ env.organization }}"
+        platform-release: "${{ env.platform }}:${{ env.release }}"
+        run: |
+          cmake -B build -S .
     - name: Run clang-tidy on changed files
       uses: eic/run-cvmfs-osg-eic-shell@main
       if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -262,11 +262,8 @@ jobs:
         path: build.tar.zst
         if-no-files-found: error
 
-  clang-tidy-iwyu:
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write  # for peter-evans/create-pull-request to push fixes
-      pull-requests: write  # for commenting and creating PRs
+  pragma:
+    runs-on: ubuntu-slim
     steps:
     - uses: actions/checkout@v7
       with:
@@ -282,13 +279,24 @@ jobs:
       run: |
         missing_pragma_headers=$(find src -name "*.h" | xargs -n 1 grep -L 'pragma once')
         test -z "${missing_pragma_headers}"
-    - name: Run clang-tidy on changed files
+
+  clang-tidy:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to push fixes
+      pull-requests: write  # for commenting and creating PRs
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        filter: "tree:0"
+    - uses: cvmfs-contrib/github-action-cvmfs@v5
+    - name: Configure CMake
       uses: eic/run-cvmfs-osg-eic-shell@main
       with:
         organization: "${{ env.organization }}"
         platform-release: "${{ env.platform }}:${{ env.release }}"
         run: |
-          cmake -B build -S .
+          CXX=${{ env.clang-tidy-iwyu-CXX }} cmake -B build -S .
     - name: Run clang-tidy on changed files
       uses: eic/run-cvmfs-osg-eic-shell@main
       if: ${{ github.event_name == 'pull_request' }}
@@ -319,6 +327,24 @@ jobs:
         clang_tidy_fixes: clang_tidy_fixes.yaml
         request_changes: true
         suggestions_per_comment: 10
+
+  iwyu:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to push fixes
+      pull-requests: write  # for commenting and creating PRs
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        filter: "tree:0"
+    - uses: cvmfs-contrib/github-action-cvmfs@v5
+    - name: Configure CMake
+      uses: eic/run-cvmfs-osg-eic-shell@main
+      with:
+        organization: "${{ env.organization }}"
+        platform-release: "${{ env.platform }}:${{ env.release }}"
+        run: |
+          CXX=${{ env.clang-tidy-iwyu-CXX }} cmake -B build -S .
     - name: Run include-what-you-use (iwyu) on changed files
       uses: eic/run-cvmfs-osg-eic-shell@main
       if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -268,7 +268,6 @@ jobs:
     - uses: actions/checkout@v7
       with:
         filter: "tree:0"
-    - uses: cvmfs-contrib/github-action-cvmfs@v5
     - name: Check for pragma once in changed files
       if: ${{ github.event_name == 'pull_request' }}
       run: |

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -296,7 +296,7 @@ jobs:
         organization: "${{ env.organization }}"
         platform-release: "${{ env.platform }}:${{ env.release }}"
         run: |
-          CXX=${{ env.clang-tidy-iwyu-CXX }} cmake -B build -S .
+          CXX=${{ env.clang-tidy-iwyu-CXX }} cmake -B build -S . -DCMAKE_BUILD_TYPE=${{ env.clang-tidy-iwyu-CMAKE_BUILD_TYPE }}
     - name: Run clang-tidy on changed files
       uses: eic/run-cvmfs-osg-eic-shell@main
       if: ${{ github.event_name == 'pull_request' }}
@@ -344,7 +344,7 @@ jobs:
         organization: "${{ env.organization }}"
         platform-release: "${{ env.platform }}:${{ env.release }}"
         run: |
-          CXX=${{ env.clang-tidy-iwyu-CXX }} cmake -B build -S .
+          CXX=${{ env.clang-tidy-iwyu-CXX }} cmake -B build -S . -DCMAKE_BUILD_TYPE=${{ env.clang-tidy-iwyu-CMAKE_BUILD_TYPE }}
     - name: Run include-what-you-use (iwyu) on changed files
       uses: eic/run-cvmfs-osg-eic-shell@main
       if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
The `clang-tidy-iwyu` job does not actually need a full build. This PR removes the dependency so it can start sooner, and splits it in pragma (on ubuntu-slim), clang-tidy, and iwyu so they can run parallel.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [x] Optimization (issue: earlier start, earlier report)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
