### PR TITLE
fix(cmake): explicitly specify which components of DD4hep required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,7 +241,7 @@ if(EDM4EIC_INTERFACE_COMPILE_DEFINITIONS)
 endif()
 
 # DD4Hep is required for the most of the part
-find_package(DD4hep ${DD4hep_VERSION_MIN} REQUIRED)
+find_package(DD4hep ${DD4hep_VERSION_MIN} REQUIRED COMPONENTS DDCore DDRec)
 
 # ACTS cmake-lint: disable=C0103
 find_package(Acts REQUIRED COMPONENTS Core PluginDD4hep PluginJson)

--- a/cmake/jana_plugin.cmake
+++ b/cmake/jana_plugin.cmake
@@ -258,7 +258,7 @@ endmacro()
 macro(plugin_add_dd4hep _name)
 
   if(NOT DD4hep_FOUND)
-    find_package(DD4hep ${DD4hep_VERSION_MIN} REQUIRED)
+    find_package(DD4hep ${DD4hep_VERSION_MIN} REQUIRED COMPONENTS DDCore DDRec)
   endif()
 
   plugin_link_libraries(${_name} DD4hep::DDCore DD4hep::DDRec)


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This pull request updates the way DD4hep is found in the build configuration to specify required components. This ensures that both `DDCore` and `DDRec` are available, which can help prevent build issues related to missing DD4hep functionality.

Build configuration improvements:

* Updated the `find_package` call for `DD4hep` in `CMakeLists.txt` to explicitly require the `DDCore` and `DDRec` components.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ ] Medium
- [x] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: ensure we have DDRec)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

AI-generated PR description