### PR TITLE
Remove -Wno-error=maybe-uninitialized from gcc build

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -98,8 +98,7 @@ jobs:
         include:
           - CXX: g++
             # TODO(#2524): remove -Wno-error=deprecated-declarations once seeding migrates to Acts Seeding2 (Acts v46 deprecations)
-            # -Wno-error=maybe-uninitialized for GCC only as it has issues with /usr/include/c++/12/bits/std_function.h
-            CXXFLAGS: -Werror -Wall -Wextra -Wundef -Wno-error=deprecated-declarations -Wno-error=maybe-uninitialized
+            CXXFLAGS: -Werror -Wall -Wextra -Wundef -Wno-error=deprecated-declarations
           - CXX: clang++
             # TODO(#2524): remove -Wno-error=deprecated-declarations once seeding migrates to Acts Seeding2 (Acts v46 deprecations)
             CXXFLAGS: -Werror -Wall -Wextra -Wundef -Wno-error=deprecated-declarations -ftime-trace

--- a/src/algorithms/interfaces/LinkTruthUtils.h
+++ b/src/algorithms/interfaces/LinkTruthUtils.h
@@ -7,7 +7,7 @@
 #include <edm4hep/MCParticle.h>
 #include <gsl/pointers>
 #include <podio/LinkNavigator.h>
-#include <optional>
+#include <memory>
 #include <utility>
 
 namespace eicrecon::truth {
@@ -17,19 +17,19 @@ public:
   explicit EventLinkNavigator(const LinkCollectionT* links)
       : m_enabled(links != nullptr && !links->empty()) {
     if (m_enabled) {
-      m_nav.emplace(*links);
+      m_nav = std::make_unique<podio::LinkNavigator<LinkCollectionT>>(*links);
     }
   }
 
   bool enabled() const { return m_enabled; }
   template <typename SrcT> auto linked(const SrcT& src) const {
     using ReturnT = decltype(std::declval<podio::LinkNavigator<LinkCollectionT>>().getLinked(src));
-    return m_enabled ? m_nav->getLinked(src) : ReturnT{};
+    return m_nav ? m_nav->getLinked(src) : ReturnT{};
   }
 
 private:
   bool m_enabled = false;
-  std::optional<podio::LinkNavigator<LinkCollectionT>> m_nav;
+  std::unique_ptr<podio::LinkNavigator<LinkCollectionT>> m_nav;
 };
 
 template <typename RecT, typename SimT, typename LinkCollT, typename AssocCollT>

--- a/src/algorithms/interfaces/LinkTruthUtils.h
+++ b/src/algorithms/interfaces/LinkTruthUtils.h
@@ -14,21 +14,19 @@ namespace eicrecon::truth {
 
 template <typename LinkCollectionT> class EventLinkNavigator {
 public:
-  explicit EventLinkNavigator(const LinkCollectionT* links)
-      : m_enabled(links != nullptr && !links->empty()) {
-    if (m_enabled) {
+  explicit EventLinkNavigator(const LinkCollectionT* links) {
+    if (links != nullptr && !links->empty()) {
       m_nav = std::make_unique<podio::LinkNavigator<LinkCollectionT>>(*links);
     }
   }
 
-  bool enabled() const { return m_enabled; }
+  bool enabled() const { return m_nav != nullptr; }
   template <typename SrcT> auto linked(const SrcT& src) const {
     using ReturnT = decltype(std::declval<podio::LinkNavigator<LinkCollectionT>>().getLinked(src));
     return m_nav ? m_nav->getLinked(src) : ReturnT{};
   }
 
 private:
-  bool m_enabled = false;
   std::unique_ptr<podio::LinkNavigator<LinkCollectionT>> m_nav;
 };
 

--- a/src/algorithms/interfaces/LinkTruthUtils.h
+++ b/src/algorithms/interfaces/LinkTruthUtils.h
@@ -16,18 +16,18 @@ template <typename LinkCollectionT> class EventLinkNavigator {
 public:
   explicit EventLinkNavigator(const LinkCollectionT* links) {
     if (links != nullptr && !links->empty()) {
-      m_nav = std::make_unique<podio::LinkNavigator<LinkCollectionT>>(*links);
+      m_nav = std::make_unique<const podio::LinkNavigator<LinkCollectionT>>(*links);
     }
   }
 
   bool enabled() const { return m_nav != nullptr; }
   template <typename SrcT> auto linked(const SrcT& src) const {
-    using ReturnT = decltype(std::declval<podio::LinkNavigator<LinkCollectionT>>().getLinked(src));
+    using ReturnT = decltype(std::declval<const podio::LinkNavigator<LinkCollectionT>>().getLinked(src));
     return m_nav ? m_nav->getLinked(src) : ReturnT{};
   }
 
 private:
-  std::unique_ptr<podio::LinkNavigator<LinkCollectionT>> m_nav;
+  std::unique_ptr<const podio::LinkNavigator<LinkCollectionT>> m_nav;
 };
 
 template <typename RecT, typename SimT, typename LinkCollT, typename AssocCollT>

--- a/src/algorithms/interfaces/LinkTruthUtils.h
+++ b/src/algorithms/interfaces/LinkTruthUtils.h
@@ -22,7 +22,8 @@ public:
 
   bool enabled() const { return m_nav != nullptr; }
   template <typename SrcT> auto linked(const SrcT& src) const {
-    using ReturnT = decltype(std::declval<const podio::LinkNavigator<LinkCollectionT>>().getLinked(src));
+    using ReturnT =
+        decltype(std::declval<const podio::LinkNavigator<LinkCollectionT>>().getLinked(src));
     return m_nav ? m_nav->getLinked(src) : ReturnT{};
   }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR addresses https://github.com/eic/epic/issues/1104 which is filed there but actually applies to code in https://github.com/eic/epic/pull/865 that is copied from here. So, it applies to here... It is likely not necessary anymore since we don't have gcc-12 systems we build on anymore.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: tech debt paydown)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

### Follow-up fix for GCC 14 CI failure
After removing `-Wno-error=maybe-uninitialized`, GCC 14 started failing in `CalorimeterParticleIDPostML` with a `-Wmaybe-uninitialized` diagnostic in libstdc++ (`stl_tree.h`) triggered through `std::optional<podio::LinkNavigator<...>>` in `EventLinkNavigator`.

This PR now includes a code-side workaround in `src/algorithms/interfaces/LinkTruthUtils.h`: `EventLinkNavigator` stores the navigator as `std::unique_ptr<podio::LinkNavigator<...>>` and only allocates it when input links are present. This preserves behavior while avoiding the false-positive warning path in `std::optional` destruction on GCC 14.