### PR TITLE
tests: fix missing plugin_link_libraries for macOS (backport of #2944)

### DIFF
--- a/src/services/geometry/acts/CMakeLists.txt
+++ b/src/services/geometry/acts/CMakeLists.txt
@@ -5,7 +5,7 @@ get_filename_component(PLUGIN_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
 
 # Function creates ${PLUGIN_NAME}_plugin and ${PLUGIN_NAME}_library targets
 # Setting default includes, libraries and installation paths
-plugin_add(${PLUGIN_NAME})
+plugin_add(${PLUGIN_NAME} WITH_SHARED_LIBRARY)
 
 # The macro grabs sources as *.cc *.cpp *.c and headers as *.h *.hh *.hpp Then
 # correctly sets sources for ${_name}_plugin and ${_name}_library targets Adds

--- a/src/tests/geometry_navigation_test/CMakeLists.txt
+++ b/src/tests/geometry_navigation_test/CMakeLists.txt
@@ -23,4 +23,4 @@ plugin_glob_all(${PLUGIN_NAME})
 
 # Add libraries (same as target_include_directories but for both plugin and
 # library)
-plugin_link_libraries(${PLUGIN_NAME} log_library)
+plugin_link_libraries(${PLUGIN_NAME} log_library acts_library)

--- a/src/tests/tracking_test/CMakeLists.txt
+++ b/src/tests/tracking_test/CMakeLists.txt
@@ -22,4 +22,5 @@ plugin_glob_all(${PLUGIN_NAME})
 # plugin_include_directories(${PLUGIN_NAME} SYSTEM PUBLIC ... )
 
 # Add libraries (same as target_include_directories but for both plugin and
-# library) plugin_link_libraries(${PLUGIN_NAME} ...)
+# library)
+plugin_link_libraries(${PLUGIN_NAME} log_library)


### PR DESCRIPTION
## Summary
- `tracking_test` uses `Log_service` (`app->GetService<Log_service>()`) but its `CMakeLists.txt` never calls `plugin_link_libraries` at all.
- `geometry_navigation_test` uses `ACTSGeo_service` but only links `log_library`, not `acts_library` (which defines `ACTSGeo_service`).
- Both build fine on Linux, where a shared library can carry undefined symbols resolved lazily at load time, but fail to link on macOS:
  ```
  Undefined symbols for architecture arm64:
"typeinfo for Log_service", referenced from: ... in TrackingTest_processor.cc.o
"typeinfo for ACTSGeo_service", referenced from: ... in GeometryNavigationSteps_processor.cc.o
  ld: symbol(s) not found for architecture arm64
  ```
Seen building `eicrecon@1.40.0` on macOS in [eic-spack CI](https://github.com/eic/eic-spack/actions/runs/34177222129/job/101911085222).

## Fix
Link the libraries that actually define these services, matching the pattern already used by `track_propagation_test`
(`plugin_link_libraries(${PLUGIN_NAME} dd4hep_library log_library algorithms_tracking_library)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---------
