### PR TITLE
BUGFIX: avoid flaky round_beam_four_momentum exceptions

### DIFF
--- a/src/algorithms/reco/HadronicFinalState.cc
+++ b/src/algorithms/reco/HadronicFinalState.cc
@@ -12,6 +12,7 @@
 #include <podio/ObjectID.h>
 #include <algorithm>
 #include <cmath>
+#include <exception>
 #include <tuple>
 
 #include "Beam.h"

--- a/src/algorithms/reco/HadronicFinalState.cc
+++ b/src/algorithms/reco/HadronicFinalState.cc
@@ -36,9 +36,6 @@ void HadronicFinalState::process(const HadronicFinalState::Input& input,
     return;
   }
   const auto& ei_particle = (*mc_beam_electrons)[0];
-  const PxPyPzEVector ei(round_beam_four_momentum(ei_particle.getMomentum(),
-                                                  m_particleSvc.particle(ei_particle.getPDG()).mass,
-                                                  electron_beam_pz_set, 0.0));
 
   // Get first (should be only) beam proton
   if (mc_beam_protons->empty()) {
@@ -46,9 +43,21 @@ void HadronicFinalState::process(const HadronicFinalState::Input& input,
     return;
   }
   const auto& pi_particle = (*mc_beam_protons)[0];
-  const PxPyPzEVector pi(round_beam_four_momentum(pi_particle.getMomentum(),
-                                                  m_particleSvc.particle(pi_particle.getPDG()).mass,
-                                                  hadron_beam_pz_set, m_crossingAngle));
+
+  // Round beam momenta to nearest nominal beam energy; skip event if no match
+  PxPyPzEVector ei;
+  PxPyPzEVector pi;
+  try {
+    ei = round_beam_four_momentum(ei_particle.getMomentum(),
+                                  m_particleSvc.particle(ei_particle.getPDG()).mass,
+                                  electron_beam_pz_set, 0.0);
+    pi = round_beam_four_momentum(pi_particle.getMomentum(),
+                                  m_particleSvc.particle(pi_particle.getPDG()).mass,
+                                  hadron_beam_pz_set, m_crossingAngle);
+  } catch (const std::exception& e) {
+    debug(e.what());
+    return;
+  }
 
   // Get first scattered electron from full MCParticles collection
   if (mcparts == nullptr) {

--- a/src/algorithms/reco/InclusiveKinematicsDA.cc
+++ b/src/algorithms/reco/InclusiveKinematicsDA.cc
@@ -33,9 +33,6 @@ void InclusiveKinematicsDA::process(const InclusiveKinematicsDA::Input& input,
     return;
   }
   const auto& ei_particle = (*mc_beam_electrons)[0];
-  const PxPyPzEVector ei(round_beam_four_momentum(ei_particle.getMomentum(),
-                                                  m_particleSvc.particle(ei_particle.getPDG()).mass,
-                                                  electron_beam_pz_set, 0.0));
 
   // Get first (should be only) beam proton
   if (mc_beam_protons->empty()) {
@@ -43,9 +40,21 @@ void InclusiveKinematicsDA::process(const InclusiveKinematicsDA::Input& input,
     return;
   }
   const auto& pi_particle = (*mc_beam_protons)[0];
-  const PxPyPzEVector pi(round_beam_four_momentum(pi_particle.getMomentum(),
-                                                  m_particleSvc.particle(pi_particle.getPDG()).mass,
-                                                  hadron_beam_pz_set, m_crossingAngle));
+
+  // Round beam momenta to nearest nominal beam energy; skip event if no match
+  PxPyPzEVector ei;
+  PxPyPzEVector pi;
+  try {
+    ei = round_beam_four_momentum(ei_particle.getMomentum(),
+                                  m_particleSvc.particle(ei_particle.getPDG()).mass,
+                                  electron_beam_pz_set, 0.0);
+    pi = round_beam_four_momentum(pi_particle.getMomentum(),
+                                  m_particleSvc.particle(pi_particle.getPDG()).mass,
+                                  hadron_beam_pz_set, m_crossingAngle);
+  } catch (const std::exception& e) {
+    debug(e.what());
+    return;
+  }
 
   // Get boost to colinear frame
   auto boost = determine_boost(ei, pi);

--- a/src/algorithms/reco/InclusiveKinematicsDA.cc
+++ b/src/algorithms/reco/InclusiveKinematicsDA.cc
@@ -9,6 +9,7 @@
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <cmath>
+#include <exception>
 #include <tuple>
 
 #include "Beam.h"

--- a/src/algorithms/reco/InclusiveKinematicsESigma.cc
+++ b/src/algorithms/reco/InclusiveKinematicsESigma.cc
@@ -9,6 +9,7 @@
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <cmath>
+#include <exception>
 #include <tuple>
 
 #include "Beam.h"

--- a/src/algorithms/reco/InclusiveKinematicsESigma.cc
+++ b/src/algorithms/reco/InclusiveKinematicsESigma.cc
@@ -33,9 +33,6 @@ void InclusiveKinematicsESigma::process(const InclusiveKinematicsESigma::Input& 
     return;
   }
   const auto& ei_particle = (*mc_beam_electrons)[0];
-  const PxPyPzEVector ei(round_beam_four_momentum(ei_particle.getMomentum(),
-                                                  m_particleSvc.particle(ei_particle.getPDG()).mass,
-                                                  electron_beam_pz_set, 0.0));
 
   // Get first (should be only) beam proton
   if (mc_beam_protons->empty()) {
@@ -43,9 +40,21 @@ void InclusiveKinematicsESigma::process(const InclusiveKinematicsESigma::Input& 
     return;
   }
   const auto& pi_particle = (*mc_beam_protons)[0];
-  const PxPyPzEVector pi(round_beam_four_momentum(pi_particle.getMomentum(),
-                                                  m_particleSvc.particle(pi_particle.getPDG()).mass,
-                                                  hadron_beam_pz_set, m_crossingAngle));
+
+  // Round beam momenta to nearest nominal beam energy; skip event if no match
+  PxPyPzEVector ei;
+  PxPyPzEVector pi;
+  try {
+    ei = round_beam_four_momentum(ei_particle.getMomentum(),
+                                  m_particleSvc.particle(ei_particle.getPDG()).mass,
+                                  electron_beam_pz_set, 0.0);
+    pi = round_beam_four_momentum(pi_particle.getMomentum(),
+                                  m_particleSvc.particle(pi_particle.getPDG()).mass,
+                                  hadron_beam_pz_set, m_crossingAngle);
+  } catch (const std::exception& e) {
+    debug(e.what());
+    return;
+  }
 
   // Get boost to colinear frame
   auto boost = determine_boost(ei, pi);

--- a/src/algorithms/reco/InclusiveKinematicsElectron.cc
+++ b/src/algorithms/reco/InclusiveKinematicsElectron.cc
@@ -9,6 +9,7 @@
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <cmath>
+#include <exception>
 #include <tuple>
 #include <vector>
 

--- a/src/algorithms/reco/InclusiveKinematicsElectron.cc
+++ b/src/algorithms/reco/InclusiveKinematicsElectron.cc
@@ -33,9 +33,6 @@ void InclusiveKinematicsElectron::process(const InclusiveKinematicsElectron::Inp
     return;
   }
   const auto& ei_particle = (*mc_beam_electrons)[0];
-  const PxPyPzEVector ei(round_beam_four_momentum(ei_particle.getMomentum(),
-                                                  m_particleSvc.particle(ei_particle.getPDG()).mass,
-                                                  electron_beam_pz_set, 0.0));
 
   // Get first (should be only) beam proton
   if (mc_beam_protons->empty()) {
@@ -43,9 +40,21 @@ void InclusiveKinematicsElectron::process(const InclusiveKinematicsElectron::Inp
     return;
   }
   const auto& pi_particle = (*mc_beam_protons)[0];
-  const PxPyPzEVector pi(round_beam_four_momentum(pi_particle.getMomentum(),
-                                                  m_particleSvc.particle(pi_particle.getPDG()).mass,
-                                                  hadron_beam_pz_set, m_crossingAngle));
+
+  // Round beam momenta to nearest nominal beam energy; skip event if no match
+  PxPyPzEVector ei;
+  PxPyPzEVector pi;
+  try {
+    ei = round_beam_four_momentum(ei_particle.getMomentum(),
+                                  m_particleSvc.particle(ei_particle.getPDG()).mass,
+                                  electron_beam_pz_set, 0.0);
+    pi = round_beam_four_momentum(pi_particle.getMomentum(),
+                                  m_particleSvc.particle(pi_particle.getPDG()).mass,
+                                  hadron_beam_pz_set, m_crossingAngle);
+  } catch (const std::exception& e) {
+    debug(e.what());
+    return;
+  }
 
   // Get scattered electron
   std::vector<PxPyPzEVector> electrons;

--- a/src/algorithms/reco/InclusiveKinematicsJB.cc
+++ b/src/algorithms/reco/InclusiveKinematicsJB.cc
@@ -7,6 +7,7 @@
 #include <edm4eic/HadronicFinalStateCollection.h>
 #include <edm4eic/InclusiveKinematicsCollection.h>
 #include <cmath>
+#include <exception>
 #include <tuple>
 
 #include "Beam.h"

--- a/src/algorithms/reco/InclusiveKinematicsJB.cc
+++ b/src/algorithms/reco/InclusiveKinematicsJB.cc
@@ -30,9 +30,6 @@ void InclusiveKinematicsJB::process(const InclusiveKinematicsJB::Input& input,
     return;
   }
   const auto& ei_particle = (*mc_beam_electrons)[0];
-  const PxPyPzEVector ei(round_beam_four_momentum(ei_particle.getMomentum(),
-                                                  m_particleSvc.particle(ei_particle.getPDG()).mass,
-                                                  electron_beam_pz_set, 0.0));
 
   // Get first (should be only) beam proton
   if (mc_beam_protons->empty()) {
@@ -40,9 +37,21 @@ void InclusiveKinematicsJB::process(const InclusiveKinematicsJB::Input& input,
     return;
   }
   const auto& pi_particle = (*mc_beam_protons)[0];
-  const PxPyPzEVector pi(round_beam_four_momentum(pi_particle.getMomentum(),
-                                                  m_particleSvc.particle(pi_particle.getPDG()).mass,
-                                                  hadron_beam_pz_set, m_crossingAngle));
+
+  // Round beam momenta to nearest nominal beam energy; skip event if no match
+  PxPyPzEVector ei;
+  PxPyPzEVector pi;
+  try {
+    ei = round_beam_four_momentum(ei_particle.getMomentum(),
+                                  m_particleSvc.particle(ei_particle.getPDG()).mass,
+                                  electron_beam_pz_set, 0.0);
+    pi = round_beam_four_momentum(pi_particle.getMomentum(),
+                                  m_particleSvc.particle(pi_particle.getPDG()).mass,
+                                  hadron_beam_pz_set, m_crossingAngle);
+  } catch (const std::exception& e) {
+    debug(e.what());
+    return;
+  }
 
   // Get hadronic final state variables
   if (hfs->empty()) {

--- a/src/algorithms/reco/InclusiveKinematicsSigma.cc
+++ b/src/algorithms/reco/InclusiveKinematicsSigma.cc
@@ -8,6 +8,7 @@
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/Vector3f.h>
 #include <cmath>
+#include <exception>
 #include <tuple>
 
 #include "Beam.h"

--- a/src/algorithms/reco/InclusiveKinematicsSigma.cc
+++ b/src/algorithms/reco/InclusiveKinematicsSigma.cc
@@ -32,9 +32,6 @@ void InclusiveKinematicsSigma::process(const InclusiveKinematicsSigma::Input& in
     return;
   }
   const auto& ei_particle = (*mc_beam_electrons)[0];
-  const PxPyPzEVector ei(round_beam_four_momentum(ei_particle.getMomentum(),
-                                                  m_particleSvc.particle(ei_particle.getPDG()).mass,
-                                                  electron_beam_pz_set, 0.0));
 
   // Get first (should be only) beam proton
   if (mc_beam_protons->empty()) {
@@ -42,9 +39,21 @@ void InclusiveKinematicsSigma::process(const InclusiveKinematicsSigma::Input& in
     return;
   }
   const auto& pi_particle = (*mc_beam_protons)[0];
-  const PxPyPzEVector pi(round_beam_four_momentum(pi_particle.getMomentum(),
-                                                  m_particleSvc.particle(pi_particle.getPDG()).mass,
-                                                  hadron_beam_pz_set, m_crossingAngle));
+
+  // Round beam momenta to nearest nominal beam energy; skip event if no match
+  PxPyPzEVector ei;
+  PxPyPzEVector pi;
+  try {
+    ei = round_beam_four_momentum(ei_particle.getMomentum(),
+                                  m_particleSvc.particle(ei_particle.getPDG()).mass,
+                                  electron_beam_pz_set, 0.0);
+    pi = round_beam_four_momentum(pi_particle.getMomentum(),
+                                  m_particleSvc.particle(pi_particle.getPDG()).mass,
+                                  hadron_beam_pz_set, m_crossingAngle);
+  } catch (const std::exception& e) {
+    debug(e.what());
+    return;
+  }
 
   // Get boost to colinear frame
   auto boost = determine_boost(ei, pi);

--- a/src/algorithms/reco/TransformBreitFrame.cc
+++ b/src/algorithms/reco/TransformBreitFrame.cc
@@ -35,19 +35,27 @@ void TransformBreitFrame::process(const TransformBreitFrame::Input& input,
     debug("No beam electron found");
     return;
   }
-  const PxPyPzEVector e_initial(round_beam_four_momentum(
-      ei_coll[0].getMomentum(), m_particleSvc.particle(ei_coll[0].getPDG()).mass,
-      electron_beam_pz_set, 0.0));
-
   // Get incoming hadron beam
   const auto pi_coll = find_first_beam_hadron(mcpart);
   if (pi_coll.empty()) {
     debug("No beam hadron found");
     return;
   }
-  const PxPyPzEVector p_initial(round_beam_four_momentum(
-      pi_coll[0].getMomentum(), m_particleSvc.particle(pi_coll[0].getPDG()).mass,
-      hadron_beam_pz_set, m_crossingAngle));
+
+  // Round beam momenta to nearest nominal beam energy; skip event if no match
+  PxPyPzEVector e_initial;
+  PxPyPzEVector p_initial;
+  try {
+    e_initial = round_beam_four_momentum(ei_coll[0].getMomentum(),
+                                         m_particleSvc.particle(ei_coll[0].getPDG()).mass,
+                                         electron_beam_pz_set, 0.0);
+    p_initial = round_beam_four_momentum(pi_coll[0].getMomentum(),
+                                         m_particleSvc.particle(pi_coll[0].getPDG()).mass,
+                                         hadron_beam_pz_set, m_crossingAngle);
+  } catch (const std::exception& e) {
+    debug(e.what());
+    return;
+  }
 
   debug("electron energy, proton energy = {},{}", e_initial.E(), p_initial.E());
 

--- a/src/algorithms/reco/TransformBreitFrame.cc
+++ b/src/algorithms/reco/TransformBreitFrame.cc
@@ -14,6 +14,7 @@
 #include <edm4eic/Vertex.h>
 #include <edm4hep/Vector3f.h>
 #include <edm4hep/utils/kinematics.h>
+#include <exception>
 #include <tuple>
 
 #include "Beam.h"


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

`round_beam_four_momentum` depends on numerical tolerance window when it decides to throw. Upstream, on the side of `JEventProcessorPODIO` we can't be supplying inconsistent frames to `PODIO` - that leads to segfaults in `podio::ROOTWriter::resetBranches`.


### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated parameters, constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR requires changes to geometry (epic PR: __)
- [ ] This PR requires changes to EDM4eic (EDM PR: __)
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.
  claude