### PR TITLE
fix: add He3 per-nucleon beam momenta to hadron_beam_pz_set

### DIFF
--- a/src/algorithms/reco/Beam.h
+++ b/src/algorithms/reco/Beam.h
@@ -62,7 +62,12 @@ inline auto find_first_scattered_electron(const edm4eic::ReconstructedParticleCo
 // Electron beam: negative pz (beam goes in -z direction).
 inline const std::vector<float> electron_beam_pz_set{-5.0, -9.0, -10.0, -18.0};
 // Hadron beam: positive pz (beam goes in +z direction).
-inline const std::vector<float> hadron_beam_pz_set{41.0, 100.0, 130.0, 250.0, 275.0};
+// Proton entries: 41, 100, 130, 250, 275 GeV.
+// He-3 entries (Z=2, A=3): per-nucleon momenta = proton × (Z/A) = × 2/3.
+//   He-3 at proton-250-equivalent rigidity: 250 × 2/3 ≈ 166.7 GeV/nucleon (e.g. 9×166 GeV).
+//   He-3 at proton-275-equivalent rigidity: 275 × 2/3 ≈ 183.3 GeV/nucleon.
+// Add further ion/nucleon momenta here as new beam configurations are commissioned.
+inline const std::vector<float> hadron_beam_pz_set{41.0, 100.0, 130.0, 166.7, 183.3, 250.0, 275.0};
 
 template <typename Vector3>
 PxPyPzEVector round_beam_four_momentum(const Vector3& p_in, const float mass,


### PR DESCRIPTION
## Problem

Processing BeAGLE He3 DIS events (e.g. 9×166 GeV) causes a segfault in `podio::ROOTWriter::resetBranches`. The underlying cause is that every kinematics algorithm (`InclusiveKinematicsElectron`, `DA`, `JB`, `Sigma`, `ESigma`, `HadronicFinalState`) throws `std::runtime_error` from `round_beam_four_momentum` when it encounters the He3 beam.

In BeAGLE He3 events, a **spectator proton** from the He3 nucleus appears in `MCParticles` with `generatorStatus=4` and pz ≈ 166 GeV/nucleon — the per-nucleon beam momentum at the same magnetic rigidity as the proton-250-GeV configuration (250 × Z/A = 250 × 2/3 ≈ 166.7 GeV). This momentum was absent from `hadron_beam_pz_set = {41, 100, 130, 250, 275}`, so the 10% matching tolerance check always failed.

Events without a status=4 proton (pure neutron beam events) worked fine; only events where BeAGLE emitted a spectator proton triggered the crash.

## Fix

Add the He3 per-nucleon momenta to `hadron_beam_pz_set`:
- **166.7 GeV** — He-3 at proton-250-GeV-equivalent rigidity (e.g. the 9×166 GeV configuration)
- **183.3 GeV** — He-3 at proton-275-GeV-equivalent rigidity

The formula is: `p_nucleon = p_proton × Z/A = p_proton × 2/3`.