### PR TITLE
fix: use MCBeamHadrons instead of MCBeamProtons in kinematics factories

### DIFF
--- a/src/algorithms/reco/HadronicFinalState.cc
+++ b/src/algorithms/reco/HadronicFinalState.cc
@@ -27,7 +27,7 @@ void HadronicFinalState::init() {}
 void HadronicFinalState::process(const HadronicFinalState::Input& input,
                                  const HadronicFinalState::Output& output) const {
 
-  const auto [mc_beam_electrons, mc_beam_protons, mcparts, rcparts, rcassoc] = input;
+  const auto [mc_beam_electrons, mc_beam_hadrons, mcparts, rcparts, rcassoc] = input;
   auto [hadronicfinalstate]                                                  = output;
 
   // Get first (should be only) beam electron
@@ -40,12 +40,12 @@ void HadronicFinalState::process(const HadronicFinalState::Input& input,
                                                   m_particleSvc.particle(ei_particle.getPDG()).mass,
                                                   electron_beam_pz_set, 0.0));
 
-  // Get first (should be only) beam proton
-  if (mc_beam_protons->empty()) {
+  // Get first (should be only) beam hadron
+  if (mc_beam_hadrons->empty()) {
     debug("No beam hadron found");
     return;
   }
-  const auto& pi_particle = (*mc_beam_protons)[0];
+  const auto& pi_particle = (*mc_beam_hadrons)[0];
   const PxPyPzEVector pi(round_beam_four_momentum(pi_particle.getMomentum(),
                                                   m_particleSvc.particle(pi_particle.getPDG()).mass,
                                                   hadron_beam_pz_set, m_crossingAngle));

--- a/src/algorithms/reco/HadronicFinalState.h
+++ b/src/algorithms/reco/HadronicFinalState.h
@@ -27,7 +27,7 @@ class HadronicFinalState : public HadronicFinalStateAlgorithm, public WithPodCon
 public:
   HadronicFinalState(std::string_view name)
       : HadronicFinalStateAlgorithm{name,
-                                    {"MCBeamElectrons", "MCBeamProtons", "MCParticles",
+                                    {"MCBeamElectrons", "MCBeamHadrons", "MCParticles",
                                      "inputParticles", "inputAssociations"},
                                     {"hadronicFinalState"},
                                     "Calculate summed quantities of the hadronic final state."} {}

--- a/src/algorithms/reco/InclusiveKinematicsDA.cc
+++ b/src/algorithms/reco/InclusiveKinematicsDA.cc
@@ -24,7 +24,7 @@ void InclusiveKinematicsDA::init() {}
 void InclusiveKinematicsDA::process(const InclusiveKinematicsDA::Input& input,
                                     const InclusiveKinematicsDA::Output& output) const {
 
-  const auto [mc_beam_electrons, mc_beam_protons, escat, hfs] = input;
+  const auto [mc_beam_electrons, mc_beam_hadrons, escat, hfs] = input;
   auto [out_kinematics]                                       = output;
 
   // Get first (should be only) beam electron
@@ -37,12 +37,12 @@ void InclusiveKinematicsDA::process(const InclusiveKinematicsDA::Input& input,
                                                   m_particleSvc.particle(ei_particle.getPDG()).mass,
                                                   electron_beam_pz_set, 0.0));
 
-  // Get first (should be only) beam proton
-  if (mc_beam_protons->empty()) {
+  // Get first (should be only) beam hadron
+  if (mc_beam_hadrons->empty()) {
     debug("No beam hadron found");
     return;
   }
-  const auto& pi_particle = (*mc_beam_protons)[0];
+  const auto& pi_particle = (*mc_beam_hadrons)[0];
   const PxPyPzEVector pi(round_beam_four_momentum(pi_particle.getMomentum(),
                                                   m_particleSvc.particle(pi_particle.getPDG()).mass,
                                                   hadron_beam_pz_set, m_crossingAngle));

--- a/src/algorithms/reco/InclusiveKinematicsDA.h
+++ b/src/algorithms/reco/InclusiveKinematicsDA.h
@@ -29,7 +29,7 @@ public:
   InclusiveKinematicsDA(std::string_view name)
       : InclusiveKinematicsDAAlgorithm{
             name,
-            {"MCBeamElectrons", "MCBeamProtons", "scatteredElectron", "hadronicFinalState"},
+            {"MCBeamElectrons", "MCBeamHadrons", "scatteredElectron", "hadronicFinalState"},
             {"inclusiveKinematics"},
             "Determine inclusive kinematics using double-angle method."} {}
 

--- a/src/algorithms/reco/InclusiveKinematicsESigma.cc
+++ b/src/algorithms/reco/InclusiveKinematicsESigma.cc
@@ -24,7 +24,7 @@ void InclusiveKinematicsESigma::init() {}
 void InclusiveKinematicsESigma::process(const InclusiveKinematicsESigma::Input& input,
                                         const InclusiveKinematicsESigma::Output& output) const {
 
-  const auto [mc_beam_electrons, mc_beam_protons, escat, hfs] = input;
+  const auto [mc_beam_electrons, mc_beam_hadrons, escat, hfs] = input;
   auto [out_kinematics]                                       = output;
 
   // Get first (should be only) beam electron
@@ -37,12 +37,12 @@ void InclusiveKinematicsESigma::process(const InclusiveKinematicsESigma::Input& 
                                                   m_particleSvc.particle(ei_particle.getPDG()).mass,
                                                   electron_beam_pz_set, 0.0));
 
-  // Get first (should be only) beam proton
-  if (mc_beam_protons->empty()) {
+  // Get first (should be only) beam hadron
+  if (mc_beam_hadrons->empty()) {
     debug("No beam hadron found");
     return;
   }
-  const auto& pi_particle = (*mc_beam_protons)[0];
+  const auto& pi_particle = (*mc_beam_hadrons)[0];
   const PxPyPzEVector pi(round_beam_four_momentum(pi_particle.getMomentum(),
                                                   m_particleSvc.particle(pi_particle.getPDG()).mass,
                                                   hadron_beam_pz_set, m_crossingAngle));

--- a/src/algorithms/reco/InclusiveKinematicsESigma.h
+++ b/src/algorithms/reco/InclusiveKinematicsESigma.h
@@ -29,7 +29,7 @@ public:
   InclusiveKinematicsESigma(std::string_view name)
       : InclusiveKinematicsESigmaAlgorithm{
             name,
-            {"MCBeamElectrons", "MCBeamProtons", "scatteredElectron", "hadronicFinalState"},
+            {"MCBeamElectrons", "MCBeamHadrons", "scatteredElectron", "hadronicFinalState"},
             {"inclusiveKinematics"},
             "Determine inclusive kinematics using e-Sigma method."} {}
 

--- a/src/algorithms/reco/InclusiveKinematicsElectron.cc
+++ b/src/algorithms/reco/InclusiveKinematicsElectron.cc
@@ -24,7 +24,7 @@ void InclusiveKinematicsElectron::init() {}
 void InclusiveKinematicsElectron::process(const InclusiveKinematicsElectron::Input& input,
                                           const InclusiveKinematicsElectron::Output& output) const {
 
-  const auto [mc_beam_electrons, mc_beam_protons, escat, hfs] = input;
+  const auto [mc_beam_electrons, mc_beam_hadrons, escat, hfs] = input;
   auto [kinematics]                                           = output;
 
   // Get first (should be only) beam electron
@@ -37,12 +37,12 @@ void InclusiveKinematicsElectron::process(const InclusiveKinematicsElectron::Inp
                                                   m_particleSvc.particle(ei_particle.getPDG()).mass,
                                                   electron_beam_pz_set, 0.0));
 
-  // Get first (should be only) beam proton
-  if (mc_beam_protons->empty()) {
+  // Get first (should be only) beam hadron
+  if (mc_beam_hadrons->empty()) {
     debug("No beam hadron found");
     return;
   }
-  const auto& pi_particle = (*mc_beam_protons)[0];
+  const auto& pi_particle = (*mc_beam_hadrons)[0];
   const PxPyPzEVector pi(round_beam_four_momentum(pi_particle.getMomentum(),
                                                   m_particleSvc.particle(pi_particle.getPDG()).mass,
                                                   hadron_beam_pz_set, m_crossingAngle));

--- a/src/algorithms/reco/InclusiveKinematicsElectron.h
+++ b/src/algorithms/reco/InclusiveKinematicsElectron.h
@@ -29,7 +29,7 @@ public:
   InclusiveKinematicsElectron(std::string_view name)
       : InclusiveKinematicsElectronAlgorithm{
             name,
-            {"MCBeamElectrons", "MCBeamProtons", "scatteredElectron", "hadronicFinalState"},
+            {"MCBeamElectrons", "MCBeamHadrons", "scatteredElectron", "hadronicFinalState"},
             {"inclusiveKinematics"},
             "Determine inclusive kinematics using electron method."} {}
 

--- a/src/algorithms/reco/InclusiveKinematicsJB.cc
+++ b/src/algorithms/reco/InclusiveKinematicsJB.cc
@@ -21,7 +21,7 @@ void InclusiveKinematicsJB::init() {}
 void InclusiveKinematicsJB::process(const InclusiveKinematicsJB::Input& input,
                                     const InclusiveKinematicsJB::Output& output) const {
 
-  const auto [mc_beam_electrons, mc_beam_protons, escat, hfs] = input;
+  const auto [mc_beam_electrons, mc_beam_hadrons, escat, hfs] = input;
   auto [out_kinematics]                                       = output;
 
   // Get first (should be only) beam electron
@@ -34,12 +34,12 @@ void InclusiveKinematicsJB::process(const InclusiveKinematicsJB::Input& input,
                                                   m_particleSvc.particle(ei_particle.getPDG()).mass,
                                                   electron_beam_pz_set, 0.0));
 
-  // Get first (should be only) beam proton
-  if (mc_beam_protons->empty()) {
+  // Get first (should be only) beam hadron
+  if (mc_beam_hadrons->empty()) {
     debug("No beam hadron found");
     return;
   }
-  const auto& pi_particle = (*mc_beam_protons)[0];
+  const auto& pi_particle = (*mc_beam_hadrons)[0];
   const PxPyPzEVector pi(round_beam_four_momentum(pi_particle.getMomentum(),
                                                   m_particleSvc.particle(pi_particle.getPDG()).mass,
                                                   hadron_beam_pz_set, m_crossingAngle));

--- a/src/algorithms/reco/InclusiveKinematicsJB.h
+++ b/src/algorithms/reco/InclusiveKinematicsJB.h
@@ -29,7 +29,7 @@ public:
   InclusiveKinematicsJB(std::string_view name)
       : InclusiveKinematicsJBAlgorithm{
             name,
-            {"MCBeamElectrons", "MCBeamProtons", "scatteredElectron", "hadronicFinalState"},
+            {"MCBeamElectrons", "MCBeamHadrons", "scatteredElectron", "hadronicFinalState"},
             {"inclusiveKinematics"},
             "Determine inclusive kinematics using Jacquet-Blondel method."} {}
 

--- a/src/algorithms/reco/InclusiveKinematicsSigma.cc
+++ b/src/algorithms/reco/InclusiveKinematicsSigma.cc
@@ -23,7 +23,7 @@ void InclusiveKinematicsSigma::init() {}
 void InclusiveKinematicsSigma::process(const InclusiveKinematicsSigma::Input& input,
                                        const InclusiveKinematicsSigma::Output& output) const {
 
-  const auto [mc_beam_electrons, mc_beam_protons, escat, hfs] = input;
+  const auto [mc_beam_electrons, mc_beam_hadrons, escat, hfs] = input;
   auto [out_kinematics]                                       = output;
 
   // Get first (should be only) beam electron
@@ -36,12 +36,12 @@ void InclusiveKinematicsSigma::process(const InclusiveKinematicsSigma::Input& in
                                                   m_particleSvc.particle(ei_particle.getPDG()).mass,
                                                   electron_beam_pz_set, 0.0));
 
-  // Get first (should be only) beam proton
-  if (mc_beam_protons->empty()) {
+  // Get first (should be only) beam hadron
+  if (mc_beam_hadrons->empty()) {
     debug("No beam hadron found");
     return;
   }
-  const auto& pi_particle = (*mc_beam_protons)[0];
+  const auto& pi_particle = (*mc_beam_hadrons)[0];
   const PxPyPzEVector pi(round_beam_four_momentum(pi_particle.getMomentum(),
                                                   m_particleSvc.particle(pi_particle.getPDG()).mass,
                                                   hadron_beam_pz_set, m_crossingAngle));

--- a/src/algorithms/reco/InclusiveKinematicsSigma.h
+++ b/src/algorithms/reco/InclusiveKinematicsSigma.h
@@ -29,7 +29,7 @@ public:
   InclusiveKinematicsSigma(std::string_view name)
       : InclusiveKinematicsSigmaAlgorithm{
             name,
-            {"MCBeamElectrons", "MCBeamProtons", "scatteredElectron", "hadronicFinalState"},
+            {"MCBeamElectrons", "MCBeamHadrons", "scatteredElectron", "hadronicFinalState"},
             {"inclusiveKinematics"},
             "Determine inclusive kinematics using Sigma method."} {}
 

--- a/src/global/reco/reco.cc
+++ b/src/global/reco/reco.cc
@@ -111,25 +111,25 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<
            InclusiveKinematicsReconstructed_factory<InclusiveKinematicsElectron>>(
       "InclusiveKinematicsElectron",
-      {"MCBeamElectrons", "MCBeamProtons", "ScatteredElectronsTruth", "HadronicFinalState"},
+      {"MCBeamElectrons", "MCBeamHadrons", "ScatteredElectronsTruth", "HadronicFinalState"},
       {"InclusiveKinematicsElectron"}, app));
 
   app->Add(
       new JOmniFactoryGeneratorT<InclusiveKinematicsReconstructed_factory<InclusiveKinematicsJB>>(
           "InclusiveKinematicsJB",
-          {"MCBeamElectrons", "MCBeamProtons", "ScatteredElectronsTruth", "HadronicFinalState"},
+          {"MCBeamElectrons", "MCBeamHadrons", "ScatteredElectronsTruth", "HadronicFinalState"},
           {"InclusiveKinematicsJB"}, app));
 
   app->Add(
       new JOmniFactoryGeneratorT<InclusiveKinematicsReconstructed_factory<InclusiveKinematicsDA>>(
           "InclusiveKinematicsDA",
-          {"MCBeamElectrons", "MCBeamProtons", "ScatteredElectronsTruth", "HadronicFinalState"},
+          {"MCBeamElectrons", "MCBeamHadrons", "ScatteredElectronsTruth", "HadronicFinalState"},
           {"InclusiveKinematicsDA"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<
            InclusiveKinematicsReconstructed_factory<InclusiveKinematicsESigma>>(
       "InclusiveKinematicsESigma",
-      {"MCBeamElectrons", "MCBeamProtons", "ScatteredElectronsTruth", "HadronicFinalState"},
+      {"MCBeamElectrons", "MCBeamHadrons", "ScatteredElectronsTruth", "HadronicFinalState"},
       {"InclusiveKinematicsESigma"}, app));
 
   // InclusiveKinematicseSigma is deprecated and will be removed, use InclusiveKinematicsESigma instead
@@ -140,7 +140,7 @@ void InitPlugin(JApplication* app) {
   app->Add(new JOmniFactoryGeneratorT<
            InclusiveKinematicsReconstructed_factory<InclusiveKinematicsSigma>>(
       "InclusiveKinematicsSigma",
-      {"MCBeamElectrons", "MCBeamProtons", "ScatteredElectronsTruth", "HadronicFinalState"},
+      {"MCBeamElectrons", "MCBeamHadrons", "ScatteredElectronsTruth", "HadronicFinalState"},
       {"InclusiveKinematicsSigma"}, app));
 
   app->Add(new JOmniFactoryGeneratorT<InclusiveKinematicsML_factory>(
@@ -277,7 +277,7 @@ void InitPlugin(JApplication* app) {
 
   app->Add(new JOmniFactoryGeneratorT<HadronicFinalState_factory<HadronicFinalState>>(
       "HadronicFinalState",
-      {"MCBeamElectrons", "MCBeamProtons", "MCParticles", "ReconstructedParticles",
+      {"MCBeamElectrons", "MCBeamHadrons", "MCParticles", "ReconstructedParticles",
        "ReconstructedParticleAssociations"},
       {"HadronicFinalState"}, app));
 


### PR DESCRIPTION
## Problem

`HadronicFinalState` and all `InclusiveKinematics*` factories took `MCBeamProtons` as their beam hadron input. For ion beams such as He3, BeAGLE emits the **struck nucleon** (a neutron) as the beam particle with `generatorStatus=4`, so `MCBeamProtons` is empty and `MCBeamNeutrons` is populated instead. This caused all kinematics algorithms to early-return with "No beam hadron found" for every event in He3 datasets.

## Fix

Switch the beam hadron input from `MCBeamProtons` to `MCBeamHadrons` in:
- `HadronicFinalState` (header + impl + factory registration in `reco.cc`)
- `InclusiveKinematicsElectron`, `DA`, `JB`, `Sigma`, `ESigma` (same three locations each)

`MCBeamHadrons` is the union of `MCBeamProtons` and `MCBeamNeutrons`, produced by the `CollectionCollector` in `beam.cc`, so it correctly covers both proton and neutron/ion beam configurations with no change to existing proton-beam event processing.

## Related

Companion to #2956 (which adds He3 per-nucleon momenta to `hadron_beam_pz_set` so `round_beam_four_momentum` does not throw for the spectator proton case).