### PR TITLE
fix: link log_library in dump_flags plugin to fix macOS typeinfo linker error

### DIFF
--- a/src/utilities/dump_flags/CMakeLists.txt
+++ b/src/utilities/dump_flags/CMakeLists.txt
@@ -11,3 +11,4 @@ plugin_add(${PLUGIN_NAME})
 # correctly sets sources for ${_name}_plugin and ${_name}_library targets Adds
 # headers to the correct installation directory
 plugin_glob_all(${PLUGIN_NAME})
+plugin_link_libraries(${PLUGIN_NAME} log_library)


### PR DESCRIPTION
## Summary

Fixes macOS linker error:
```
Undefined symbols for architecture arm64:
    "typeinfo for Log_service", referenced from:
        std::__1::shared_ptr<Log_service> JServiceLocator::get<Log_service>() in DumpFlags_processor.cc.o
  ld: symbol(s) not found for architecture arm64
```

## Root Cause

The `dump_flags` plugin uses `SpdlogMixin`, which calls `app->GetService<Log_service>()`. The `JServiceLocator::get<Log_service>()` template instantiation requires RTTI `typeinfo for Log_service`.

On Linux, the dynamic linker resolves symbols transitively across all loaded shared libraries, so `typeinfo for Log_service` (defined in `log_library`) was found at runtime even without an explicit link. On **macOS**, the two-level namespace linker requires each shared library to explicitly declare all its dependencies — transitive resolution does not occur — so the symbol is missing at link time.

## Fix

Add `plugin_link_libraries(${PLUGIN_NAME} log_library)` to `src/utilities/dump_flags/CMakeLists.txt`. This is already done by every other plugin that uses `SpdlogMixin` (e.g. all detector plugins).

## References

- Failing CI: https://github.com/eic/eic-spack/actions/runs/34703638286/job/103580177689?pr=1034