### PR TITLE
ci: detect under-linked service libraries via ldd -r

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -211,8 +211,7 @@ jobs:
             echo "Checking $lib..."
             readelf -d $lib
             # Check for undefined symbols (hide intentionally undefined symbols for asan and ubsan)
-            # Also filter service typeinfo symbols (_ZTI*_service) which are resolved at plugin load time
-            UNDEFINED=$(ldd -r $lib 2>&1 | grep -v __asan | grep -v __ubsan | grep -v __tsan | grep -v "_ZTI.*_service" | grep "undefined symbol" || true)
+            UNDEFINED=$(ldd -r $lib 2>&1 | grep -v __asan | grep -v __ubsan | grep -v __tsan | grep "undefined symbol" || true)
             if [ -n "$UNDEFINED" ]; then
               echo "ERROR: Found undefined symbols in $lib:"
               echo "$UNDEFINED"

--- a/src/detectors/DRICH/CMakeLists.txt
+++ b/src/detectors/DRICH/CMakeLists.txt
@@ -22,6 +22,7 @@ plugin_add_acts(${PLUGIN_NAME})
 plugin_link_libraries(
   ${PLUGIN_NAME}
   log_library
+  acts_library
   algorithms_tracking_library
   particle_service_library
   algorithms_pid_lut_library

--- a/src/detectors/MPGD/CMakeLists.txt
+++ b/src/detectors/MPGD/CMakeLists.txt
@@ -23,5 +23,6 @@ plugin_glob_all(${PLUGIN_NAME})
 
 # Add libraries (same as target_include_directories but for both plugin and
 # library)
-plugin_link_libraries(${PLUGIN_NAME} algorithms_digi_library
-                      algorithms_tracking_library log_library dd4hep_library)
+plugin_link_libraries(
+  ${PLUGIN_NAME} algorithms_digi_library algorithms_tracking_library
+  log_library dd4hep_library acts_library)

--- a/src/global/particle_flow/CMakeLists.txt
+++ b/src/global/particle_flow/CMakeLists.txt
@@ -20,4 +20,5 @@ plugin_add_event_model(${PLUGIN_NAME})
 # plugin_include_directories(${PLUGIN_NAME} SYSTEM PUBLIC ...)
 
 # Add libraries (works same as target_include_directories)
-plugin_link_libraries(${PLUGIN_NAME} algorithms_particle_flow_library)
+plugin_link_libraries(${PLUGIN_NAME} algorithms_particle_flow_library
+                      log_library)

--- a/src/global/tracking/CMakeLists.txt
+++ b/src/global/tracking/CMakeLists.txt
@@ -22,7 +22,7 @@ plugin_add_event_model(${PLUGIN_NAME})
 # library)
 plugin_link_libraries(
   ${PLUGIN_NAME} algorithms_digi_library algorithms_tracking_library
-  dd4hep_library evaluator_library)
+  dd4hep_library evaluator_library acts_library)
 #
 # plugin_add_acts(${PLUGIN_NAME})
 #

--- a/src/services/algorithms_init/CMakeLists.txt
+++ b/src/services/algorithms_init/CMakeLists.txt
@@ -17,4 +17,4 @@ plugin_add_algorithms(${PLUGIN_NAME})
 plugin_add_dd4hep(${PLUGIN_NAME})
 plugin_add_event_model(${PLUGIN_NAME})
 plugin_link_libraries(${PLUGIN_NAME} particle_service_library dd4hep_library
-                      log_library)
+                      log_library acts_library)

--- a/src/utilities/dump_flags/CMakeLists.txt
+++ b/src/utilities/dump_flags/CMakeLists.txt
@@ -11,3 +11,5 @@ plugin_add(${PLUGIN_NAME})
 # correctly sets sources for ${_name}_plugin and ${_name}_library targets Adds
 # headers to the correct installation directory
 plugin_glob_all(${PLUGIN_NAME})
+
+plugin_link_libraries(${PLUGIN_NAME} log_library)


### PR DESCRIPTION
## Summary

Tightens the existing "Check dynamic library loader paths" CI step to catch **under-linking** of EICrecon service libraries on Linux — the same class of bug that causes hard linker failures on macOS (see #2958).

## Root Cause

The CI step already ran `ldd -r` on every plugin `.so`, but a `grep -v "_ZTI.*_service"` filter suppressed all C++ typeinfo undefined-symbol errors for service classes. This masked the same class of bug as #2958.

Two service types were affected:

**`Log_service`** (`_ZTILog_service`): Instantiated in every plugin via `JOmniFactory::Init()` → `m_app->GetService<Log_service>()`. The typeinfo lives in `log_library.so`.

**`ACTSGeo_service`** (`_ZTI15ACTSGeo_service`): Instantiated in plugins that include tracking/PID factory headers (e.g. `CKFTracking_factory.h`, `RichTrack_factory.h`, `MPGDTrackerDigi_factory.h`) or `AlgorithmsInit_service.h`. The typeinfo lives in `acts_library.so`.

On Linux the flat dynamic linker resolves these silently at runtime (the service `.so` is already loaded), so the bug goes undetected until a macOS build.

## Changes

### 1. Remove the suppression filter (`linux-eic-shell.yml`)

```diff
-# Also filter service typeinfo symbols (_ZTI*_service) which are resolved at plugin load time
-UNDEFINED=$(ldd -r $lib 2>&1 | grep -v __asan | grep -v __ubsan | grep -v __tsan | grep -v "_ZTI.*_service" | grep "undefined symbol" || true)
+UNDEFINED=$(ldd -r $lib 2>&1 | grep -v __asan | grep -v __ubsan | grep -v __tsan | grep "undefined symbol" || true)
```

### 2. Fix all plugins that were relying on the suppressed filter

| Plugin | Missing link | Root cause |
|---|---|---|
| `src/utilities/dump_flags` | `log_library` | Uses `SpdlogMixin` → `GetService<Log_service>()` (same fix as #2958) |
| `src/global/particle_flow` | `log_library` | Uses `JOmniFactoryGeneratorT` which instantiates `JOmniFactory::Init()` → `GetService<Log_service>()`; `algorithms_particle_flow_library` has no transitive path to `log_library` |
| `src/detectors/DRICH` | `acts_library` | `RichTrack_factory.h` → `GetService<ACTSGeo_service>()` |
| `src/detectors/MPGD` | `acts_library` | `MPGDTrackerDigi_factory.h` → `GetService<ACTSGeo_service>()` |
| `src/global/tracking` | `acts_library` | `CKFTracking_factory.h` and other tracking factories |
| `src/services/algorithms_init` | `acts_library` | `AlgorithmsInit_service.h` directly calls `srv_locator->get<ACTSGeo_service>()` |

All other plugins either link the required libraries explicitly or get them transitively (e.g. `dd4hep_library` → `log_library`).

## Verification

- Without the fixes: CI fails reporting `undefined symbol: _ZTILog_service` and `undefined symbol: _ZTI15ACTSGeo_service`
- With all fixes applied: `ldd -r` resolves all service typeinfos and the step passes

This is a follow-up to #2958.
